### PR TITLE
projdefs.h - resolve TickType_t overflow

### DIFF
--- a/include/projdefs.h
+++ b/include/projdefs.h
@@ -38,7 +38,7 @@ typedef void (*TaskFunction_t)( void * );
 overridden by a macro of the same name defined in FreeRTOSConfig.h in case the
 definition here is not suitable for your application. */
 #ifndef pdMS_TO_TICKS
-	#define pdMS_TO_TICKS( xTimeInMs ) ( ( TickType_t ) ( ( ( TickType_t ) ( xTimeInMs ) * ( TickType_t ) configTICK_RATE_HZ ) / ( TickType_t ) 1000 ) )
+	#define pdMS_TO_TICKS( xTimeInMs ) ( ( TickType_t ) ( ( ( xTimeInMs ) * (uint32_t) configTICK_RATE_HZ ) / 1000 ) )
 #endif
 
 #define pdFALSE			( ( BaseType_t ) 0 )


### PR DESCRIPTION
Where `TickType_t` is `uint16_t` the calculation overflows.
This proposal was used to resolve [`feilipu/Arduino_FreeRTOS_Library` #61](https://github.com/feilipu/Arduino_FreeRTOS_Library/issues/61)