### PR TITLE
Xtensa_ESP32: Change _iram_end to _iram_text_end

### DIFF
--- a/portable/ThirdParty/GCC/Xtensa_ESP32/xtensa_loadstore_handler.S
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/xtensa_loadstore_handler.S
@@ -86,7 +86,7 @@ LoadStoreErrorHandler:
 
     /* Check whether the address lies in the valid range */
     rsr     a3, excvaddr
-    movi    a4, _iram_end                       // End of code section of IRAM
+    movi    a4, _iram_text_end                  // End of code section of IRAM
     bge     a3, a4, 1f
     movi    a4, SOC_CACHE_APP_LOW               // Check if in APP cache region
     blt     a3, a4, .LS_wrong_opcode
@@ -280,7 +280,7 @@ AlignmentErrorHandler:
 
     /* Check whether the address lies in the valid range */
     rsr     a3, excvaddr
-    movi    a4, _iram_end                       // End of code section of IRAM
+    movi    a4, _iram_text_end                  // End of code section of IRAM
     bge     a3, a4, 1f
     movi    a4, SOC_CACHE_APP_LOW               // Check if in APP cache region
     blt     a3, a4, .LS_wrong_opcode


### PR DESCRIPTION
xtensa_loadstore_handler.S uses _iram_end to prevent modification of IRAM
code. With the LoadStore exception handler in place, IRAM can also be
used for .bss and .data section. Hence the sanity check should be based
upon _iram_text_end and not _iram_end