### PR TITLE
Cortex-A9 port: Adding stack alignment directive to assembly code

### DIFF
--- a/portable/GCC/ARM_CA9/portASM.S
+++ b/portable/GCC/ARM_CA9/portASM.S
@@ -24,7 +24,7 @@
  *
  * 1 tab == 4 spaces!
  */
-
+	.eabi_attribute Tag_ABI_align_preserved, 1
 	.text
 	.arm
 


### PR DESCRIPTION
Hello,
Cortex-A9 port should have eabi_attribute TAG_ABI_Align_preserved set in order to enable smooth object linking between different toolchains.

I believe that [explanation written on this link](http://www.support.code-red-tech.com/CodeRedWiki/Preserve8) summaries the problem well enough. In most cases linker only generates a warning if this attribute is not present but there can also be link errors when using strict project settings.

Assembly code from portASM.S maintains alignment so this attribute is safe to add.

Vladimir