### PR TITLE
Update tasks.c

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -4229,7 +4229,7 @@ TCB_t *pxTCB;
 					/* Disinherit the priority, remembering the previous
 					priority to facilitate determining the subject task's
 					state. */
-					traceTASK_PRIORITY_DISINHERIT( pxTCB, pxTCB->uxBasePriority );
+					traceTASK_PRIORITY_DISINHERIT( pxTCB, uxPriorityToUse );
 					uxPriorityUsedOnEntry = pxTCB->uxPriority;
 					pxTCB->uxPriority = uxPriorityToUse;
 


### PR DESCRIPTION
An error on trace argument.
In "**xTaskPriorityDisinherit**", the disinherit priority should be "**pxTCB->uxBasePriority**".
And, in "**vTaskPriorityDisinheritAfterTimeout**", the disinherit priority should be "**uxPriorityToUse**", which might not be "**pxTCB->uxBasePriority**".