### PR TITLE
Remove obsolete variable from Win32 port.

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -641,11 +641,10 @@ void vPortEnterCritical( void )
 
 void vPortExitCritical( void )
 {
-int32_t lMutexNeedsReleasing, lWaitForYield = pdFALSE;
+int32_t lMutexNeedsReleasing;
 
 	/* The interrupt event mutex should already be held by this thread as it was
 	obtained on entry to the critical section. */
-
 	lMutexNeedsReleasing = pdTRUE;
 
 	if( ulCriticalNesting > portNO_CRITICAL_NESTING )
@@ -677,7 +676,6 @@ int32_t lMutexNeedsReleasing, lWaitForYield = pdFALSE;
 				critical section is exited - so make sure the event is not
 				already signaled. */
 				ResetEvent( pxThreadState->pvYieldEvent );
-				lWaitForYield = pdTRUE;
 
 				/* Mutex will be released now so the (simulated) interrupt can
 				execute, so does not require releasing on function exit. */


### PR DESCRIPTION
The Windows port layer is built with both MSVC and GCC.  GCC generated a warning relating to the variable lWaitForYield being set but not used.  This change removes the variable.