### PR TITLE
Fix Coverity warnings where to xTaskResumeAll() calls don't use the returned value.

### DIFF
--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -474,7 +474,7 @@ size_t xBlocks = 0, xMaxSize = 0, xMinSize = portMAX_DELAY; /* portMAX_DELAY use
 			} while( pxBlock != pxEnd );
 		}
 	}
-	xTaskResumeAll();
+	( void ) xTaskResumeAll();
 
 	pxHeapStats->xSizeOfLargestFreeBlockInBytes = xMaxSize;
 	pxHeapStats->xSizeOfSmallestFreeBlockInBytes = xMinSize;

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -529,7 +529,7 @@ size_t xBlocks = 0, xMaxSize = 0, xMinSize = portMAX_DELAY; /* portMAX_DELAY use
 			} while( pxBlock != pxEnd );
 		}
 	}
-	xTaskResumeAll();
+	( void ) xTaskResumeAll();
 
 	pxHeapStats->xSizeOfLargestFreeBlockInBytes = xMaxSize;
 	pxHeapStats->xSizeOfSmallestFreeBlockInBytes = xMinSize;


### PR DESCRIPTION
Fix Coverity warnings:  In most cases the return value of xTaskResumeAll() is cast to void when it is not needed.  This PR fixes a couple of instances in the heap_n.c implementations where that was not the case.