### PR TITLE
Adding url to direct users to FreeRTOS-Kernel github page.

### DIFF
--- a/GitHub-FreeRTOS-Kernel-Home.url
+++ b/GitHub-FreeRTOS-Kernel-Home.url
@@ -1,0 +1,8 @@
+[{000214A0-0000-0000-C000-000000000046}]
+Prop3=19,2
+[InternetShortcut]
+URL=https://github.com/FreeRTOS/FreeRTOS-Kernel
+IconIndex=0
+IDList=
+HotKey=0
+


### PR DESCRIPTION
Description
-----------
Adding URL to direct user to GitHub FreeRTOS-Kernel home page. 

Test Steps
-----------
Tried with Safari, works fine. Keeping the same format from other .url, so should be good.

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
