### PR TITLE
Remove unused local variable in prvResetNextTaskUnblockTime(). 

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3948,8 +3948,6 @@ static void prvCheckTasksWaitingTermination( void )
 
 static void prvResetNextTaskUnblockTime( void )
 {
-TCB_t *pxTCB;
-
 	if( listLIST_IS_EMPTY( pxDelayedTaskList ) != pdFALSE )
 	{
 		/* The new current delayed list is empty.  Set xNextTaskUnblockTime to


### PR DESCRIPTION
Description
-----------
Since PR #22 has removed the need of local variable pxTCB, cleaning up. 

Test Steps
-----------
Tested in combine with PR #22 on hw. 

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
