### PR TITLE
Feature: vTaskGetCurrentBlocker + companion list API functions

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -167,7 +167,8 @@ typedef struct xLIST
 	volatile UBaseType_t uxNumberOfItems;
 	ListItem_t * configLIST_VOLATILE pxIndex;			/*< Used to walk through the list.  Points to the last item returned by a call to listGET_OWNER_OF_NEXT_ENTRY (). */
 	MiniListItem_t xListEnd;							/*< List item that contains the maximum possible item value meaning it is always at the end of the list and is therefore used as a marker. */
-	listSECOND_LIST_INTEGRITY_CHECK_VALUE				/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
+    void* pvOwner;                                      /* Pointer to the object that owns the list (normally an RTOS object) */
+    listSECOND_LIST_INTEGRITY_CHECK_VALUE				/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
 } List_t;
 
 /*
@@ -215,6 +216,24 @@ typedef struct xLIST
  * \ingroup LinkedList
  */
 #define listGET_ITEM_VALUE_OF_HEAD_ENTRY( pxList )	( ( ( pxList )->xListEnd ).pxNext->xItemValue )
+
+/*
+* Access macro to set the owner of a list. The owner of a list
+* is the object(usually an RTOS object) that contains the list, such as semaphores.
+*
+* \page listSET_LIST_OWNER listSET_LIST_OWNER
+* \ingroup LinkedList
+*/
+#define listSET_LIST_OWNER( pxList , pxOwner ) ( ( pxList )->pvOwner = (void * ) ( pxOwner ) )
+ 
+/*
+ * Access macro to get the owner of a list.  The owner of a list
+ * is the object(usually an RTOS object) that contains the list, such as semaphores.
+ *
+ * \page listGET_LIST_OWNER listGET_LIST_OWNER
+ * \ingroup LinkedList
+ */
+#define listGET_LIST_OWNER( pxList )	( ( pxList )->pvOwner )
 
 /*
  * Return the list item at the head of the list.

--- a/include/list.h
+++ b/include/list.h
@@ -167,8 +167,8 @@ typedef struct xLIST
 	volatile UBaseType_t uxNumberOfItems;
 	ListItem_t * configLIST_VOLATILE pxIndex;			/*< Used to walk through the list.  Points to the last item returned by a call to listGET_OWNER_OF_NEXT_ENTRY (). */
 	MiniListItem_t xListEnd;							/*< List item that contains the maximum possible item value meaning it is always at the end of the list and is therefore used as a marker. */
-    void* pvOwner;                                      /* Pointer to the object that owns the list (normally an RTOS object) */
-    listSECOND_LIST_INTEGRITY_CHECK_VALUE				/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
+	void * pvOwner;                                      /* Pointer to the object that owns the list (normally an RTOS object) */
+	listSECOND_LIST_INTEGRITY_CHECK_VALUE				/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
 } List_t;
 
 /*

--- a/include/queue.h
+++ b/include/queue.h
@@ -38,7 +38,6 @@ extern "C" {
 #endif
 
 #include "task.h"
-#include "list.h"
 
 /**
  * Type by which queues are referenced.  For example, a call to xQueueCreate()

--- a/include/queue.h
+++ b/include/queue.h
@@ -38,6 +38,7 @@ extern "C" {
 #endif
 
 #include "task.h"
+#include "list.h"
 
 /**
  * Type by which queues are referenced.  For example, a call to xQueueCreate()

--- a/include/task.h
+++ b/include/task.h
@@ -162,7 +162,7 @@ typedef struct XTASK_BLOCKED_STATUS
     eBlockedStatus eStatus;
     union
     { 
-        List_t    *pxEventList;
+        List_t const *pxEventList;
         TickType_t xUntilTick;
     };
 } TaskBlockedStatus_t;
@@ -1812,6 +1812,9 @@ uint32_t ulTaskGetIdleRunTimeCounter( void ) PRIVILEGED_FUNCTION;
  * and the task is waiting for a notification. If the task is blocked but neither eBlockedForEvent nor eBlockedForNotification, 
  * eStatus will be eBlockedForTime and xUntilTick will be assigned the tick value at which the task can exit the blocked state. 
  * list. If the task is not blocked, eStatus will be eNotBlocked.
+ *
+ * Some RTOS objects establish ownership of their event lists, such as semaphores. To retrieve the owner of the event list, 
+ * you can call listGET_LIST_OWNER() to get a void * pointer to the 
  * 
  * @param xTask The handle of the task to query. If xTask == NULL, the current running task is evaluated.
  * 

--- a/include/task.h
+++ b/include/task.h
@@ -156,7 +156,7 @@ typedef enum
     eNotBlocked
 } eBlockedStatus;
 
-/* Used with eTaskGetCurrentBlocker to return either a pointer or a integer */
+/* Used with vTaskGetCurrentBlocker to return details on what is blocking a task */
 typedef struct XTASK_BLOCKED_STATUS
 {
     eBlockedStatus eStatus;
@@ -1799,22 +1799,22 @@ uint32_t ulTaskGetIdleRunTimeCounter( void ) PRIVILEGED_FUNCTION;
  * INCLUDE_vTaskGetCurrentBlocker must be defined as 1 for this function to be available.
  * See the configuration section for more information.
  *
- * Note, if xTask is NULL or is the running task this function the return eStatus will always be eNotBlocked because
+ * Note, if xTask is NULL or is the running task eStatus will always be eNotBlocked because
  * the task can not be blocked if it is running. 
  * 
- * TaskBlockedStatus_t holds an eStatus member and both pxEventList in xUntilTick in union. eStatus will always be 
+ * TaskBlockedStatus_t holds an eStatus member and a union containing pxEventList and xUntilTick. eStatus will always be 
  * be set, however pxEventList will only ever be assigned the blocking event list when the task is eBlockedForEvent.
  * When the the task is eBlockedForTime, xUntilTick will be assigned the tick index at which the task can exit
  * the Blocked state.
  *
  * eStatus will be eBlockedForEvent if the task is blocked and waiting on a RTOS object event list.
- * If it is not eBlockedEvent, eStatus will be eBlockedForNotification if config_USENOTIFICATIONS is set to 1 
+ * If it is not eBlockedEvent, eStatus will be eBlockedForNotification if configUSE_TASK_NOTIFICATIONS is set to 1 
  * and the task is waiting for a notification. If the task is blocked but neither eBlockedForEvent nor eBlockedForNotification, 
  * eStatus will be eBlockedForTime and xUntilTick will be assigned the tick value at which the task can exit the blocked state. 
  * list. If the task is not blocked, eStatus will be eNotBlocked.
  *
  * Some RTOS objects establish ownership of their event lists, such as semaphores. To retrieve the owner of the event list, 
- * you can call listGET_LIST_OWNER() to get a void * pointer to the 
+ * you can call listGET_LIST_OWNER() to get a void * pointer to the owner, in the case of semaphores the owner would be a SemaphoreHandle_t.
  * 
  * @param xTask The handle of the task to query. If xTask == NULL, the current running task is evaluated.
  * 
@@ -1824,7 +1824,6 @@ uint32_t ulTaskGetIdleRunTimeCounter( void ) PRIVILEGED_FUNCTION;
  * \ingroup TaskUtils
  *
  */
-
 void vTaskGetCurrentBlocker( TaskHandle_t xTask, TaskBlockedStatus_t * pxBlockedStatus ) PRIVILEGED_FUNCTION;
 
 /**

--- a/list.c
+++ b/list.c
@@ -36,6 +36,9 @@
 
 void vListInitialise( List_t * const pxList )
 {
+	/* Ownership of a list is claimed/queried via listLIST_SET_OWNER and listLIST_GET_OWNER*/
+	pxList->pvOwner = NULL;
+
 	/* The list structure contains a list item which is used to mark the
 	end of the list.  To initialise the list the list end is inserted
 	as the only list entry. */

--- a/list.c
+++ b/list.c
@@ -36,7 +36,7 @@
 
 void vListInitialise( List_t * const pxList )
 {
-	/* Ownership of a list is claimed/queried via listLIST_SET_OWNER and listLIST_GET_OWNER*/
+	/* Ownership of a list is claimed/queried via listSET_LIST_OWNER and listGET_LIST_OWNER*/
 	pxList->pvOwner = NULL;
 
 	/* The list structure contains a list item which is used to mark the

--- a/queue.c
+++ b/queue.c
@@ -445,6 +445,10 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength, const UBaseT
 	pxNewQueue->uxItemSize = uxItemSize;
 	( void ) xQueueGenericReset( pxNewQueue, pdTRUE );
 
+	/* Establish two-way link with event lists */
+	listSET_LIST_OWNER(&pxNewQueue->xTasksWaitingToReceive, pxNewQueue);
+	listSET_LIST_OWNER(&pxNewQueue->xTasksWaitingToSend, pxNewQueue);
+
 	#if ( configUSE_TRACE_FACILITY == 1 )
 	{
 		pxNewQueue->ucQueueType = ucQueueType;

--- a/queue.c
+++ b/queue.c
@@ -446,8 +446,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength, const UBaseT
 	( void ) xQueueGenericReset( pxNewQueue, pdTRUE );
 
 	/* Establish two-way link with event lists */
-	listSET_LIST_OWNER(&pxNewQueue->xTasksWaitingToReceive, pxNewQueue);
-	listSET_LIST_OWNER(&pxNewQueue->xTasksWaitingToSend, pxNewQueue);
+	listSET_LIST_OWNER( &pxNewQueue->xTasksWaitingToReceive, pxNewQueue );
+	listSET_LIST_OWNER( &pxNewQueue->xTasksWaitingToSend, pxNewQueue );
 
 	#if ( configUSE_TRACE_FACILITY == 1 )
 	{

--- a/tasks.c
+++ b/tasks.c
@@ -5177,10 +5177,10 @@ TickType_t uxReturn;
 #endif
 /*-----------------------------------------------------------*/
 
-#if ( INCLUDE_eTaskGetBlocker == 1 )
+#if ( INCLUDE_vTaskGetCurrentBlocker == 1 )
 	void vTaskGetCurrentBlocker(TaskHandle_t xTask, TaskBlockedStatus_t* pxBlockedStatus)
 	{ 
-	List_t const *pxStateList, * pxEventList, * pxDelayedList, * pxOverflowDelayedList
+	List_t const* pxStateList, * pxEventList, * pxDelayedList, * pxOverflowDelayedList;
 	const TCB_t * const pxTCB = xTask;
 	TickType_t xStateListItemValue = 0u;
     #if (configUSE_TASK_NOTIFICATIONS == 1)
@@ -5188,7 +5188,7 @@ TickType_t uxReturn;
 	#endif
 
 		memset(pxBlockedStatus, 0u, sizeof(TaskBlockedStatus_t));
-		pxBlockedStatus = eNotBlocked;
+		pxBlockedStatus->eStatus = eNotBlocked;
 
 		/* Per convention NULL operates for current task. 
 		Current task can't be blocked if its running this function */
@@ -5201,7 +5201,7 @@ TickType_t uxReturn;
 				pxEventList = listLIST_ITEM_CONTAINER(&(pxTCB->xEventListItem));
 				pxDelayedList = pxDelayedTaskList;
 				pxOverflowDelayedList = pxOverflowDelayedTaskList;
-				xStateListItemValue = pxTCB->xStateListItem->xItemValue;
+				xStateListItemValue = pxTCB->xStateListItem.xItemValue;
 				#if (configUSE_TASK_NOTIFICATIONS == 1)
 				{
 					ucNotifyState = pxTCB->ucNotifyState;
@@ -5240,15 +5240,15 @@ TickType_t uxReturn;
 					block indefinitely and is instead placed on the xSuspendTaskList. */
 					if (pxEventList != NULL)
 					{
-						eBlockedStatus->eStatus = eBlockedForEvent;
-						eBlockedStatus->eEventList = pxEventList;
+						pxBlockedStatus->eStatus = eBlockedForEvent;
+						pxBlockedStatus->pxEventList = pxEventList;
 					}
 					else
 					{
 						#if (configUSE_TASK_NOTIFICATIONS)
 							if (ucNotifyState == taskWAITING_NOTIFICATION)
 							{
-								eBlockedStatus = eBlockedForNotification;
+								pxBlockedStatus->eStatus = eBlockedForNotification;
 							}
 							else
 							{

--- a/tasks.c
+++ b/tasks.c
@@ -5183,7 +5183,7 @@ TickType_t uxReturn;
 	List_t const* pxStateList, * pxEventList, * pxDelayedList, * pxOverflowDelayedList;
 	const TCB_t * const pxTCB = xTask;
 	TickType_t xStateListItemValue = 0u;
-    #if (configUSE_TASK_NOTIFICATIONS == 1)
+	#if (configUSE_TASK_NOTIFICATIONS == 1)
 		uint8_t ucNotifyState = 0u;
 	#endif
 

--- a/tasks.c
+++ b/tasks.c
@@ -5178,31 +5178,31 @@ TickType_t uxReturn;
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskGetCurrentBlocker == 1 )
-	void vTaskGetCurrentBlocker(TaskHandle_t xTask, TaskBlockedStatus_t* pxBlockedStatus)
+	void vTaskGetCurrentBlocker( TaskHandle_t xTask, TaskBlockedStatus_t * pxBlockedStatus )
 	{ 
-	List_t const* pxStateList, * pxEventList, * pxDelayedList, * pxOverflowDelayedList;
+	List_t const * pxStateList, * pxEventList, * pxDelayedList, * pxOverflowDelayedList;
 	const TCB_t * const pxTCB = xTask;
 	TickType_t xStateListItemValue = 0u;
-	#if (configUSE_TASK_NOTIFICATIONS == 1)
+	#if ( configUSE_TASK_NOTIFICATIONS == 1 )
 		uint8_t ucNotifyState = 0u;
 	#endif
 
-		memset(pxBlockedStatus, 0u, sizeof(TaskBlockedStatus_t));
+		memset( pxBlockedStatus, 0u, sizeof( TaskBlockedStatus_t ) );
 		pxBlockedStatus->eStatus = eNotBlocked;
 
 		/* Per convention NULL operates for current task. 
 		Current task can't be blocked if its running this function */
-		if (pxTCB != pxCurrentTCB &&  pxTCB != NULL)
+		if ( pxTCB != pxCurrentTCB &&  pxTCB != NULL )
 		{
 			/* Take a snapshot of data that could otherwise change during this function call */
 			taskENTER_CRITICAL();
 			{
-				pxStateList = listLIST_ITEM_CONTAINER(&(pxTCB->xStateListItem));
-				pxEventList = listLIST_ITEM_CONTAINER(&(pxTCB->xEventListItem));
+				pxStateList = listLIST_ITEM_CONTAINER( &( pxTCB->xStateListItem ) );
+				pxEventList = listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) );
 				pxDelayedList = pxDelayedTaskList;
 				pxOverflowDelayedList = pxOverflowDelayedTaskList;
 				xStateListItemValue = pxTCB->xStateListItem.xItemValue;
-				#if (configUSE_TASK_NOTIFICATIONS == 1)
+				#if ( configUSE_TASK_NOTIFICATIONS == 1 )
 				{
 					ucNotifyState = pxTCB->ucNotifyState;
 				}
@@ -5210,16 +5210,16 @@ TickType_t uxReturn;
 			}
 			taskEXIT_CRITICAL();
 
-			if (pxStateList == pxDelayedList || pxStateList == pxOverflowDelayedList)
+			if ( pxStateList == pxDelayedList || pxStateList == pxOverflowDelayedList )
 			{
-				if (pxEventList != NULL)
+				if ( pxEventList != NULL )
 				{
 					/* Blocked waiting for event*/
 					pxBlockedStatus->eStatus = eBlockedForEvent;
 					pxBlockedStatus->pxEventList = pxEventList;
 				} 
-				#if (configUSE_TASK_NOTIFICATIONS == 1)
-					else if (ucNotifyState == taskWAITING_NOTIFICATION)
+				#if ( configUSE_TASK_NOTIFICATIONS == 1 )
+					else if ( ucNotifyState == taskWAITING_NOTIFICATION )
 					{
 						/* Blocked waiting for notification*/
 						pxBlockedStatus->eStatus = eBlockedForNotification;
@@ -5233,20 +5233,20 @@ TickType_t uxReturn;
 					pxBlockedStatus->xUntilTick = xStateListItemValue;
 				}
 			} 
-			#if (INCLUDE_vTaskSuspend == 1)
-				else if (pxStateList == &xSuspendedTaskList)
+			#if ( INCLUDE_vTaskSuspend == 1 )
+				else if ( pxStateList == &xSuspendedTaskList )
 				{
 					/* When prvAddCurrentTaskToDelayedLists(portMAX_DELAY, pdTRUE) and INCLUDE_vTaskSuspend == 1, the task can
 					block indefinitely and is instead placed on the xSuspendTaskList. */
-					if (pxEventList != NULL)
+					if ( pxEventList != NULL )
 					{
 						pxBlockedStatus->eStatus = eBlockedForEvent;
 						pxBlockedStatus->pxEventList = pxEventList;
 					}
 					else
 					{
-						#if (configUSE_TASK_NOTIFICATIONS)
-							if (ucNotifyState == taskWAITING_NOTIFICATION)
+						#if ( configUSE_TASK_NOTIFICATIONS )
+							if ( ucNotifyState == taskWAITING_NOTIFICATION )
 							{
 								pxBlockedStatus->eStatus = eBlockedForNotification;
 							}


### PR DESCRIPTION
<!--- Title -->
Add a method to get object a task is blocked on

-----------
<!--- Describe your changes in detail. -->
vTaskGetCurrentBlocker can be used to get a reference to the event list that a task is waiting on or to get the tick at which the task can unblock. 

New data and methods have been added to list.h to allow List_t to have a two-way link with an owner. Ownership is then implemented by semaphores. So, user can retrieve an event list that a task is blocked on then link back up to the semaphore by calling listGET_LIST_OWNER

More details in the task.h doxygen comment for vTaskGetCurrentBlocker and internally shared quip

Test Steps
-----------
There is a VisualStudio project I setup for testing this. You can find it in the `test/vTaskGetCurrentBlocker` branch of [my FreeRTOS fork](https://github.com/dachalco/FreeRTOS). Within that branch, the test project is located at `FreeRTOS/FreeRTOS/Test/WIN32-MSVC-vTaskGetCurrentBlocker`

Related Issue
-----------
Internal ticket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
