### PR TITLE
[RFC] tasks.c: disable interrupts in critical section only if scheduler is started

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -4291,10 +4291,10 @@ static void prvResetNextTaskUnblockTime( void )
 
 	void vTaskEnterCritical( void )
 	{
-		portDISABLE_INTERRUPTS();
-
 		if( xSchedulerRunning != pdFALSE )
 		{
+			portDISABLE_INTERRUPTS();
+
 			( pxCurrentTCB->uxCriticalNesting )++;
 
 			/* This is not the interrupt safe version of the enter critical


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Behaviour of `vTaskEnterCritical` and `vTaskExitCritical` was asymmetrical,
in the sense, if these APIs were invoked prior to scheduler start condition
then one would disable interrupts but other would not re-enable again.
This commit ensure that behaviour is symmetrical for pre-scheduler start
condition.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Ensured that prior to scheduler start situation, calling `vTaskEnterCritical` followed by `vTaskExitCritical` does not affect interrupt enable status.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
