### PR TITLE
Feature: Add task top/end of stack to task info report

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -144,6 +144,8 @@ typedef struct xTASK_STATUS
 	UBaseType_t uxBasePriority;		/* The priority to which the task will return if the task's current priority has been inherited to avoid unbounded priority inversion when obtaining a mutex.  Only valid if configUSE_MUTEXES is defined as 1 in FreeRTOSConfig.h. */
 	uint32_t ulRunTimeCounter;		/* The total run time allocated to the task so far, as defined by the run time stats clock.  See http://www.freertos.org/rtos-run-time-stats.html.  Only valid when configGENERATE_RUN_TIME_STATS is defined as 1 in FreeRTOSConfig.h. */
 	StackType_t *pxStackBase;		/* Points to the lowest address of the task's stack area. */
+	StackType_t *pxTopOfStack;		/* Points to the top address of the task's stack area. */
+	StackType_t *pxEndOfStack;	    /* Points to the end address of the task's stack area. */
 	configSTACK_DEPTH_TYPE usStackHighWaterMark;	/* The minimum amount of stack space that has remained for the task since the task was created.  The closer this value is to zero the closer the task has come to overflowing its stack. */
 } TaskStatus_t;
 

--- a/tasks.c
+++ b/tasks.c
@@ -3684,6 +3684,8 @@ static void prvCheckTasksWaitingTermination( void )
 		pxTaskStatus->pcTaskName = ( const char * ) &( pxTCB->pcTaskName [ 0 ] );
 		pxTaskStatus->uxCurrentPriority = pxTCB->uxPriority;
 		pxTaskStatus->pxStackBase = pxTCB->pxStack;
+		pxTaskStatus->pxTopOfStack = (StackType_t *)pxTCB->pxTopOfStack;
+		pxTaskStatus->pxEndOfStack = pxTCB->pxEndOfStack;
 		pxTaskStatus->xTaskNumber = pxTCB->uxTCBNumber;
 
 		#if ( configUSE_MUTEXES == 1 )


### PR DESCRIPTION
<!--- Title -->

This is super useful if you want to generate a stack trace of all the tasks in your system, whether there's a hardfault or a watchdog etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
