### PR TITLE
Enable ARMv7-M MPU ports to place FreeRTOS kernel code outside of flash

### DIFF
--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -584,6 +584,7 @@ __attribute__(( weak )) void vPortSetupTimerInterrupt( void )
 
 static void prvSetupMPU( void )
 {
+extern uint32_t __privileged_functions_start__[];
 extern uint32_t __privileged_functions_end__[];
 extern uint32_t __FLASH_segment_start__[];
 extern uint32_t __FLASH_segment_end__[];
@@ -593,7 +594,7 @@ extern uint32_t __privileged_data_end__[];
 	/* Check the expected MPU is present. */
 	if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
 	{
-		/* First setup the entire flash for unprivileged read only access. */
+		/* First setup the unprivileged flash for unprivileged read only access. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portUNPRIVILEGED_FLASH_REGION );
@@ -603,16 +604,15 @@ extern uint32_t __privileged_data_end__[];
 										( prvGetMPURegionSizeSetting( ( uint32_t ) __FLASH_segment_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
-		/* Setup the first 16K for privileged only access (even though less
-		 * than 10K is actually being used).  This is where the kernel code is
-		 * placed. */
-		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
+		/* Setup the privileged flash for privileged only access.  This is where
+		 * the kernel code is * placed. */
+		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __privileged_functions_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portPRIVILEGED_FLASH_REGION );
 
 		portMPU_REGION_ATTRIBUTE_REG =	( portMPU_REGION_PRIVILEGED_READ_ONLY ) |
 										( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
-										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
+										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
 		/* Setup the privileged data RAM region.  This is where the kernel data

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -640,6 +640,7 @@ static void prvSetupMPU( void )
 #if defined( __ARMCC_VERSION )
 	/* Declaration when these variable are defined in code instead of being
 	 * exported from linker scripts. */
+	extern uint32_t * __privileged_functions_start__;
 	extern uint32_t * __privileged_functions_end__;
 	extern uint32_t * __FLASH_segment_start__;
 	extern uint32_t * __FLASH_segment_end__;
@@ -647,6 +648,7 @@ static void prvSetupMPU( void )
 	extern uint32_t * __privileged_data_end__;
 #else
 	/* Declaration when these variable are exported from linker scripts. */
+	extern uint32_t __privileged_functions_start__[];
 	extern uint32_t __privileged_functions_end__[];
 	extern uint32_t __FLASH_segment_start__[];
 	extern uint32_t __FLASH_segment_end__[];
@@ -656,7 +658,7 @@ static void prvSetupMPU( void )
 	/* Check the expected MPU is present. */
 	if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
 	{
-		/* First setup the entire flash for unprivileged read only access. */
+		/* First setup the unprivileged flash for unprivileged read only access. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portUNPRIVILEGED_FLASH_REGION );
@@ -666,16 +668,15 @@ static void prvSetupMPU( void )
 										( prvGetMPURegionSizeSetting( ( uint32_t ) __FLASH_segment_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
-		/* Setup the first nK for privileged only access (even though less
-		than 10K is actually being used).  This is where the kernel code is
-		placed. */
-		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
+		/* Setup the privileged flash for privileged only access.  This is where
+		the kernel code is placed. */
+		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __privileged_functions_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portPRIVILEGED_FLASH_REGION );
 
 		portMPU_REGION_ATTRIBUTE_REG =	( portMPU_REGION_PRIVILEGED_READ_ONLY ) |
 										( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
-										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
+										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
 		/* Setup the privileged data RAM region.  This is where the kernel data

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -506,6 +506,7 @@ __weak void vPortSetupTimerInterrupt( void )
 
 static void prvSetupMPU( void )
 {
+extern uint32_t __privileged_functions_start__[];
 extern uint32_t __privileged_functions_end__[];
 extern uint32_t __FLASH_segment_start__[];
 extern uint32_t __FLASH_segment_end__[];
@@ -515,7 +516,7 @@ extern uint32_t __privileged_data_end__[];
 	/* Check the expected MPU is present. */
 	if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
 	{
-		/* First setup the entire flash for unprivileged read only access. */
+		/* First setup the unprivileged flash for unprivileged read only access. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portUNPRIVILEGED_FLASH_REGION );
@@ -525,16 +526,15 @@ extern uint32_t __privileged_data_end__[];
 										( prvGetMPURegionSizeSetting( ( uint32_t ) __FLASH_segment_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
-		/* Setup the first 16K for privileged only access (even though less
-		 * than 10K is actually being used).  This is where the kernel code is
-		 * placed. */
-		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
+		/* Setup the privileged flash for privileged only access.  This is where
+		 * the kernel code is placed. */
+		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __privileged_functions_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portPRIVILEGED_FLASH_REGION );
 
 		portMPU_REGION_ATTRIBUTE_REG =	( portMPU_REGION_PRIVILEGED_READ_ONLY ) |
 										( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
-										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
+										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
 		/* Setup the privileged data RAM region.  This is where the kernel data

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -638,6 +638,7 @@ __asm void vPortEnableVFP( void )
 
 static void prvSetupMPU( void )
 {
+extern uint32_t __privileged_functions_start__;
 extern uint32_t __privileged_functions_end__;
 extern uint32_t __FLASH_segment_start__;
 extern uint32_t __FLASH_segment_end__;
@@ -647,7 +648,7 @@ extern uint32_t __privileged_data_end__;
 	/* Check the expected MPU is present. */
 	if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
 	{
-		/* First setup the entire flash for unprivileged read only access. */
+		/* First setup the unprivileged flash for unprivileged read only access. */
 		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portUNPRIVILEGED_FLASH_REGION );
@@ -657,16 +658,15 @@ extern uint32_t __privileged_data_end__;
 										( prvGetMPURegionSizeSetting( ( uint32_t ) __FLASH_segment_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
-		/* Setup the first 16K for privileged only access (even though less
-		 * than 10K is actually being used).  This is where the kernel code is
-		 * placed. */
-		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __FLASH_segment_start__ ) | /* Base address. */
+		/* Setup the privileged flash for privileged only access.  This is where
+		 * the kernel code is placed. */
+		portMPU_REGION_BASE_ADDRESS_REG =	( ( uint32_t ) __privileged_functions_start__ ) | /* Base address. */
 											( portMPU_REGION_VALID ) |
 											( portPRIVILEGED_FLASH_REGION );
 
 		portMPU_REGION_ATTRIBUTE_REG =	( portMPU_REGION_PRIVILEGED_READ_ONLY ) |
 										( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
-										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
+										( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__ ) ) |
 										( portMPU_REGION_ENABLE );
 
 		/* Setup the privileged data RAM region.  This is where the kernel data


### PR DESCRIPTION
## Problem Description
The current flash organization in ARMv7-M MPU ports looks as follows:

```
__FLASH_segment_start__ ------->+-----------+<----- __FLASH_segment_start__
                                |  Vector   |
                                |   Table   |
                                |     +     |
                                |   Kernel  |
                                |    Code   |
                                +-----------+<-----  __privileged_functions_end__
                                |           |
                                |           |
                                |           |
                                |   Other   |
                                |   Code    |
                                |           |
                                |           |
                                |           |
   __FLASH_segment_end__ ------>+-----------+
```

The FreeRTOS kernel sets up the following MPU regions:

* Unprivileged Code - \_\_FLASH\_segment\_start\_\_ to \_\_FLASH\_segment\_end\_\_.
* Privileged Code - \_\_FLASH\_segment\_start\_\_ to \_\_privileged\_functions\_end\_\_.

The above setup assumes that the FreeRTOS kernel code (i.e. privileged_functions) is placed at the beginning of the flash and, therefore, uses \_\_FLASH\_segment\_start\_\_ as the starting location of the privileged code. This prevents a user from placing the FreeRTOS kernel code outside of flash (say to an external RAM) and still have vector table at the beginning of flash (which is many times a hardware requirement).

## Solution
This commit addresses the above limitation by using a new variable \_\_privileged\_functions\_start\_\_ as the starting location of the privileged code. This enables users to place the FreeRTOS kernel code wherever they choose.

The FreeRTOS kernel now sets up the following MPU regions:

* Unprivileged Code - \_\_FLASH\_segment\_start\_\_ to \_\_FLASH\_segment\_end\_\_.
* Privileged Code - \_\_privileged\_functions\_start\_\_ to \_\_privileged\_functions\_end\_\_.

As a result, a user can now place the kernel code to an external RAM. A possible organization is:

```
                                 Flash              External RAM
                              +------------+        +-----------+<------ __privileged_functions_start__
                              |   Vector   |        |           |
                              |   Table    |        |           |
                              |            |        |           |
__FLASH_segment_start__ ----->+------------+        |   Kernel  |
                              |            |        |    Code   |
                              |            |        |           |
                              |            |        |           |
                              |            |        |           |
                              |   Other    |        |           |
                              |    Code    |        +-----------+<------ __privileged_functions_end__
                              |            |
                              |            |
                              |            |
  __FLASH_segment_end__ ----->+------------+
```

Note that the above configuration places the vector table in an unmapped region. This is okay because we enable the background region, and so the vector table will still be accessible to the privileged code and not accessible to the unprivileged code (vector table is only needed by the
privileged code).

## Backward Compatibility
The FreeRTOS kernel code now uses a new variable, namely \_\_privileged\_functions\_start\_\_, which needs to be exported from linker script to indicate the starting location of the privileged code. All of our existing demos already export this variable and therefore, they will continue to work.

If a user has created a project which does not export this variable, they will get a linker error for unresolved symbol \_\_privileged\_functions\_start\_\_. They need to export a variable \_\_privileged\_functions\_start\_\_ with the value equal to \_\_FLASH\_segment\_start\_\_.

## Issue
https://sourceforge.net/p/freertos/feature-requests/56/

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
