### PR TITLE
* Renamed trace point in prvNotifyQueueSetContainer() so it isn't a d…

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -460,6 +460,10 @@ hold explicit before calling the code. */
 	#define traceQUEUE_SEND( pxQueue )
 #endif
 
+#ifndef traceQUEUE_SET_SEND
+	#define traceQUEUE_SET_SEND( pxQueue )
+#endif
+
 #ifndef traceQUEUE_SEND_FAILED
 	#define traceQUEUE_SEND_FAILED( pxQueue )
 #endif

--- a/queue.c
+++ b/queue.c
@@ -2893,7 +2893,7 @@ Queue_t * const pxQueue = xQueue;
 		{
 			const int8_t cTxLock = pxQueueSetContainer->cTxLock;
 
-			traceQUEUE_SEND( pxQueueSetContainer );
+			traceQUEUE_SET_SEND( pxQueueSetContainer );
 
 			/* The data copied is the handle of the queue that contains data. */
 			xReturn = prvCopyDataToQueue( pxQueueSetContainer, &pxQueue, queueSEND_TO_BACK );


### PR DESCRIPTION
…uplicate of the trace point in xQueueGenericSend()

Duplicate trace points

Description
-----------
The trace point traceQUEUE_SEND is used in two different functions (assume copy/paste at some point), causing issues for trace gathering

Test Steps
-----------
N/A

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
