### PR TITLE
Add definition of portDONT_DISCARD to ARMv7-M ports

### DIFF
--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -73,6 +73,7 @@ typedef unsigned long UBaseType_t;
 #define portSTACK_GROWTH			( -1 )
 #define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT			8
+#define portDONT_DISCARD			__attribute__(( used ))
 /*-----------------------------------------------------------*/
 
 

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -73,6 +73,7 @@ typedef unsigned long UBaseType_t;
 #define portSTACK_GROWTH			( -1 )
 #define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT			8
+#define portDONT_DISCARD			__attribute__(( used ))
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -109,6 +109,7 @@ typedef struct MPU_SETTINGS
 #define portSTACK_GROWTH			( -1 )
 #define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT			8
+#define portDONT_DISCARD			__attribute__(( used ))
 /*-----------------------------------------------------------*/
 
 /* SVC numbers for various services. */

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -73,6 +73,7 @@ typedef unsigned long UBaseType_t;
 #define portSTACK_GROWTH			( -1 )
 #define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT			8
+#define portDONT_DISCARD			__attribute__(( used ))
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -109,6 +109,7 @@ typedef struct MPU_SETTINGS
 #define portSTACK_GROWTH			( -1 )
 #define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT			8
+#define portDONT_DISCARD			__attribute__(( used ))
 /*-----------------------------------------------------------*/
 
 /* SVC numbers for various services. */

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -73,6 +73,7 @@ typedef unsigned long UBaseType_t;
 #define portSTACK_GROWTH			( -1 )
 #define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT			8
+#define portDONT_DISCARD			__attribute__(( used ))
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */


### PR DESCRIPTION
Description
-----------
Enabling Link Time Optimization (LTO) causes some of the functions used in assembly to be incorrectly stripped off, resulting in linker error. To avoid this, these functions are marked with ```portDONT_DISCARD``` macro, definition of which is port specific. This commit adds the definition
of ```portDONT_DISCARD``` for ARMv7-M ports.

Signed-off-by: Gaurav Aggarwal <aggarg@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
