### PR TITLE
Obey strict aliasing rule in linked lists

### DIFF
--- a/event_groups.c
+++ b/event_groups.c
@@ -518,8 +518,8 @@ EventBits_t uxReturn;
 
 EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet )
 {
-ListItem_t *pxListItem, *pxNext;
-ListItem_t const *pxListEnd;
+MiniListItem_t *pxListItem, *pxNext;
+MiniListItem_t const *pxListEnd;
 List_t const * pxList;
 EventBits_t uxBitsToClear = 0, uxBitsWaitedFor, uxControlBits;
 EventGroup_t *pxEventBits = xEventGroup;
@@ -545,7 +545,7 @@ BaseType_t xMatchFound = pdFALSE;
 		while( pxListItem != pxListEnd )
 		{
 			pxNext = listGET_NEXT( pxListItem );
-			uxBitsWaitedFor = listGET_LIST_ITEM_VALUE( pxListItem );
+			uxBitsWaitedFor = listGET_LIST_ITEM_VALUE( ( ListItem_t * ) pxListItem );
 			xMatchFound = pdFALSE;
 
 			/* Split the bits waited for from the control bits. */
@@ -591,7 +591,7 @@ BaseType_t xMatchFound = pdFALSE;
 				eventUNBLOCKED_DUE_TO_BIT_SET bit is set so the task knows
 				that is was unblocked due to its required bits matching, rather
 				than because it timed out. */
-				vTaskRemoveFromUnorderedEventList( pxListItem, pxEventBits->uxEventBits | eventUNBLOCKED_DUE_TO_BIT_SET );
+				vTaskRemoveFromUnorderedEventList( ( ListItem_t * ) pxListItem, pxEventBits->uxEventBits | eventUNBLOCKED_DUE_TO_BIT_SET );
 			}
 
 			/* Move onto the next list item.  Note pxListItem->pxNext is not
@@ -624,7 +624,7 @@ const List_t *pxTasksWaitingForBits = &( pxEventBits->xTasksWaitingForBits );
 			/* Unblock the task, returning 0 as the event list is being deleted
 			and cannot therefore have any bits set. */
 			configASSERT( pxTasksWaitingForBits->xListEnd.pxNext != ( const ListItem_t * ) &( pxTasksWaitingForBits->xListEnd ) );
-			vTaskRemoveFromUnorderedEventList( pxTasksWaitingForBits->xListEnd.pxNext, eventUNBLOCKED_DUE_TO_BIT_SET );
+			vTaskRemoveFromUnorderedEventList( (ListItem_t *) pxTasksWaitingForBits->xListEnd.pxNext, eventUNBLOCKED_DUE_TO_BIT_SET );
 		}
 
 		#if( ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 0 ) )

--- a/include/list.h
+++ b/include/list.h
@@ -137,26 +137,24 @@ use of FreeRTOS.*/
  * Definition of the only type of object that a list can contain.
  */
 struct xLIST;
-struct xLIST_ITEM
-{
-	listFIRST_LIST_ITEM_INTEGRITY_CHECK_VALUE			/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
-	configLIST_VOLATILE TickType_t xItemValue;			/*< The value being listed.  In most cases this is used to sort the list in descending order. */
-	struct xLIST_ITEM * configLIST_VOLATILE pxNext;		/*< Pointer to the next ListItem_t in the list. */
-	struct xLIST_ITEM * configLIST_VOLATILE pxPrevious;	/*< Pointer to the previous ListItem_t in the list. */
-	void * pvOwner;										/*< Pointer to the object (normally a TCB) that contains the list item.  There is therefore a two way link between the object containing the list item and the list item itself. */
-	struct xLIST * configLIST_VOLATILE pxContainer;		/*< Pointer to the list in which this list item is placed (if any). */
-	listSECOND_LIST_ITEM_INTEGRITY_CHECK_VALUE			/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
-};
-typedef struct xLIST_ITEM ListItem_t;					/* For some reason lint wants this as two separate definitions. */
 
 struct xMINI_LIST_ITEM
 {
 	listFIRST_LIST_ITEM_INTEGRITY_CHECK_VALUE			/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
 	configLIST_VOLATILE TickType_t xItemValue;
-	struct xLIST_ITEM * configLIST_VOLATILE pxNext;
-	struct xLIST_ITEM * configLIST_VOLATILE pxPrevious;
+	struct xMINI_LIST_ITEM * configLIST_VOLATILE pxNext;
+	struct xMINI_LIST_ITEM * configLIST_VOLATILE pxPrevious;
 };
 typedef struct xMINI_LIST_ITEM MiniListItem_t;
+
+struct xLIST_ITEM
+{
+	MiniListItem_t xMiniItem;                           /*< The item value and next and previous pointers. */
+	void * pvOwner;										/*< Pointer to the object (normally a TCB) that contains the list item.  There is therefore a two way link between the object containing the list item and the list item itself. */
+	struct xLIST * configLIST_VOLATILE pxContainer;		/*< Pointer to the list in which this list item is placed (if any). */
+	listSECOND_LIST_ITEM_INTEGRITY_CHECK_VALUE			/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
+};
+typedef struct xLIST_ITEM ListItem_t;					/* For some reason lint wants this as two separate definitions. */
 
 /*
  * Definition of the type of queue used by the scheduler.
@@ -165,7 +163,7 @@ typedef struct xLIST
 {
 	listFIRST_LIST_INTEGRITY_CHECK_VALUE				/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
 	volatile UBaseType_t uxNumberOfItems;
-	ListItem_t * configLIST_VOLATILE pxIndex;			/*< Used to walk through the list.  Points to the last item returned by a call to listGET_OWNER_OF_NEXT_ENTRY (). */
+	MiniListItem_t * configLIST_VOLATILE pxIndex;			/*< Used to walk through the list.  Points to the last item returned by a call to listGET_OWNER_OF_NEXT_ENTRY (). */
 	MiniListItem_t xListEnd;							/*< List item that contains the maximum possible item value meaning it is always at the end of the list and is therefore used as a marker. */
 	listSECOND_LIST_INTEGRITY_CHECK_VALUE				/*< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
 } List_t;
@@ -195,7 +193,7 @@ typedef struct xLIST
  * \page listSET_LIST_ITEM_VALUE listSET_LIST_ITEM_VALUE
  * \ingroup LinkedList
  */
-#define listSET_LIST_ITEM_VALUE( pxListItem, xValue )	( ( pxListItem )->xItemValue = ( xValue ) )
+#define listSET_LIST_ITEM_VALUE( pxListItem, xValue )	( ( pxListItem )->xMiniItem.xItemValue = ( xValue ) )
 
 /*
  * Access macro to retrieve the value of the list item.  The value can
@@ -205,7 +203,7 @@ typedef struct xLIST
  * \page listGET_LIST_ITEM_VALUE listGET_LIST_ITEM_VALUE
  * \ingroup LinkedList
  */
-#define listGET_LIST_ITEM_VALUE( pxListItem )	( ( pxListItem )->xItemValue )
+#define listGET_LIST_ITEM_VALUE( pxListItem )	( ( pxListItem )->xMiniItem.xItemValue )
 
 /*
  * Access macro to retrieve the value of the list item at the head of a given
@@ -238,7 +236,7 @@ typedef struct xLIST
  * \page listGET_END_MARKER listGET_END_MARKER
  * \ingroup LinkedList
  */
-#define listGET_END_MARKER( pxList )	( ( ListItem_t const * ) ( &( ( pxList )->xListEnd ) ) )
+#define listGET_END_MARKER( pxList )	( ( MiniListItem_t const * ) ( &( ( pxList )->xListEnd ) ) )
 
 /*
  * Access macro to determine if a list contains any items.  The macro will
@@ -284,7 +282,7 @@ List_t * const pxConstList = ( pxList );													\
 	{																						\
 		( pxConstList )->pxIndex = ( pxConstList )->pxIndex->pxNext;						\
 	}																						\
-	( pxTCB ) = ( pxConstList )->pxIndex->pvOwner;											\
+	( pxTCB ) = ( ( ListItem_t * ) ( pxConstList )->pxIndex )->pvOwner;							\
 }
 
 
@@ -304,7 +302,7 @@ List_t * const pxConstList = ( pxList );													\
  * \page listGET_OWNER_OF_HEAD_ENTRY listGET_OWNER_OF_HEAD_ENTRY
  * \ingroup LinkedList
  */
-#define listGET_OWNER_OF_HEAD_ENTRY( pxList )  ( (&( ( pxList )->xListEnd ))->pxNext->pvOwner )
+#define listGET_OWNER_OF_HEAD_ENTRY( pxList )  ( ( ( ListItem_t * ) (&( ( pxList )->xListEnd ))->pxNext )->pvOwner )
 
 /*
  * Check to see if a list item is within a list.  The list item maintains a


### PR DESCRIPTION
Description
-----------
ISO C’s “strict aliasing” rule says (roughly speaking) that the same memory must only be accessed either as the type it really is, or via a pointer to `char`. For example, an `int` can be accessed as an `int` or via a `char*`, but not via a `short*`. FreeRTOS breaks this rule: an object of type `List_t` contains an object of type `MiniListItem_t` (specifically `xListEnd`), but sometimes it is accessed via pointers of type `ListItem_t *` (not `MiniListItem_t *`). An example of this is in `uxListRemove` where, if removing the first item in the list, `pxItemToRemove->pxPrevious` is a `ListItem_t *` which points at `xListEnd`, and that pointer is written through in order to set `pxItemToRemove->pxPrevious->pxNext`, in violation of the strict aliasing rule.

Using aggressive optimizations in GCC 9, this generates bad code in `xTaskResumeAll` where `pxTCB` is not reloaded on each iteration of the first loop iterating over `xPendingReadyList`, resulting in the same TCB being added to the ready list more than once.

To fix this, replace the first four members of `ListItem_t` with an instance of `MiniListItem_t`.

Test Steps
-----------
Build with `armv7m-none-eabihf-gcc-9.3.0 -O3 -ggdb -g3 -fno-common -fno-math-errno -fstrict-aliasing -std=c99 -nostdlib -mabi=aapcs -fno-exceptions -ffreestanding -mslow-flash-data -flto=jobserver -mfloat-abi=hard -mcpu=cortex-m7 -mfpu=fpv5-sp-d16 -mthumb`. Prior to this PR, `xTaskResumeAll` would not work properly.

Related Issue
-----------
Fixes GH-53.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.