### PR TITLE
Fix Valgrind errors

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -281,13 +281,13 @@ struct sigaction sigtick;
 	itimer.it_value.tv_sec = 0;
 	itimer.it_value.tv_usec = 0;
 
-        itimer.it_interval.tv_sec = 0;
-        itimer.it_interval.tv_usec = 0;  
+	itimer.it_interval.tv_sec = 0;
+	itimer.it_interval.tv_usec = 0;  
 	(void)setitimer( ITIMER_REAL, &itimer, NULL );
 
 	sigtick.sa_flags = 0;
 	sigtick.sa_handler = SIG_IGN;
-        sigemptyset( &sigtick.sa_mask ); 
+	sigemptyset( &sigtick.sa_mask ); 
 	sigaction( SIGALRM, &sigtick, NULL );
 
 	/* Signal the scheduler to exit its loop. */

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -280,10 +280,14 @@ struct sigaction sigtick;
 	 * up running on the main thread when it is resumed. */
 	itimer.it_value.tv_sec = 0;
 	itimer.it_value.tv_usec = 0;
+
+        itimer.it_interval.tv_sec = 0;
+        itimer.it_interval.tv_usec = 0;  
 	(void)setitimer( ITIMER_REAL, &itimer, NULL );
 
 	sigtick.sa_flags = 0;
 	sigtick.sa_handler = SIG_IGN;
+        sigemptyset( &sigtick.sa_mask ); 
 	sigaction( SIGALRM, &sigtick, NULL );
 
 	/* Signal the scheduler to exit its loop. */


### PR DESCRIPTION
Fix Valgrind uninitialized variable errors

Description
-----------
==7996== Syscall param setitimer(&value->it_interval) points to uninitialised byte(s)
and
==7996== Syscall param rt_sigaction(act->sa_mask) points to uninitialised byte(s)
Test Steps
-----------
Run the port from FreeRTOS Demo similar to the one described in issue 1876


Related Issue
-----------
https://github.com/aws/amazon-freertos/issues/1876

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
