### PR TITLE
Removing vPortEndScheduler() implementation in ATmega port

### DIFF
--- a/portable/ThirdParty/GCC/ATmega/port.c
+++ b/portable/ThirdParty/GCC/ATmega/port.c
@@ -619,16 +619,7 @@ BaseType_t xPortStartScheduler( void )
 
 void vPortEndScheduler( void )
 {
-    /* It is unlikely that the AVR port will get stopped.  If required simply
-    disable the tick interrupt here. */
-
-#if defined (portUSE_WDTO)
-        wdt_disable();                                          /* disable Watchdog Timer */
-
-#elif defined( portUSE_TIMER0 )
-        portTIMSK &= ~( _BV(OCIE0B)|_BV(OCIE0A)|_BV(TOIE0) );   /* disable all Timer0 interrupts */
-
-#endif
+	/* It is unlikely that the ATmega port will get stopped. */
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
Removing ```vPortEndScheduler()``` implementation, since it's not implemented to spec. 
Also, there's little chance we need to return to the point of bare metal environment. Thus removing instead of implementing. 

Refer to https://www.freertos.org/a00133.html for kernel API ```vTaskEndScheduler()``` requirements.  The none port specific part of the logic is here https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/master/tasks.c#L2099-L2106. 

The issue with ```vPortEndScheduler()``` implementation is that, if only stop kernel tick the program will keep executing current task. The desired behavior is to at least return/jump to the next instruction after vTaskStartScheduler(). And if it's required to call ```vTaskStartScheduler()``` again, we need to clean up all tasks including idle and timer task. Since ```vTaskStartScheduler()``` will create these two again. 

Test Steps
-----------
N/A, there's nothing calling ```vTaskStartScheduler()```.  

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
