### PR TITLE
Adding volatile to tasks.c's runtime information to protect against…

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -393,7 +393,7 @@ PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerSuspended	= ( UBaseType_t
 	/* Do not move these variables to function scope as doing so prevents the
 	code working with debuggers that need to remove the static qualifier. */
 	PRIVILEGED_DATA static uint32_t ulTaskSwitchedInTime = 0UL;	/*< Holds the value of a timer/counter the last time a task was switched in. */
-	PRIVILEGED_DATA static uint32_t ulTotalRunTime = 0UL;		/*< Holds the total amount of execution time as defined by the run time counter clock. */
+	PRIVILEGED_DATA static volatile uint32_t ulTotalRunTime = 0UL;		/*< Holds the total amount of execution time as defined by the run time counter clock. */
 
 #endif
 


### PR DESCRIPTION
…compiler optimization

As diskussed in https://forums.freertos.org/t/make-runtime-stats-working-with-compiler-optimization-enabled/9846 and on lined out on https://blog.the78mole.de/freertos-debugging-on-stm32-cpu-usage/, this makes run-time stats working with compiler optimizations.

<!--- Title -->

Description
-----------
Protecting the runtime information against compiler optimizations, it needs some volatile added.

Test Steps
-----------
Build FreeRTOS with GENERATE_RUN_TIME_STATS and try to extract it. It will not contain valid/useful data, because the variable for total run-time was not read correctly.

Related Issue
-----------
none


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
