### PR TITLE
updates FreeRTOS.h to handle new usages of task notify

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -637,7 +637,7 @@ hold explicit before calling the code. */
 #endif
 
 #ifndef traceTASK_NOTIFY_TAKE
-	#define traceTASK_NOTIFY_TAKE()
+	#define traceTASK_NOTIFY_TAKE( uxIndexToWait )
 #endif
 
 #ifndef traceTASK_NOTIFY_WAIT_BLOCK
@@ -645,7 +645,7 @@ hold explicit before calling the code. */
 #endif
 
 #ifndef traceTASK_NOTIFY_WAIT
-	#define traceTASK_NOTIFY_WAIT()
+	#define traceTASK_NOTIFY_WAIT( uxIndexToWait )
 #endif
 
 #ifndef traceTASK_NOTIFY


### PR DESCRIPTION
Fix for failure to build tasks.c at f2081af03066a41cc218435a3c61d4ed90c87c77

Description
-----------
I don't have an implementation of `traceTASK_NOTIFY_TAKE` or `traceTASK_NOTIFY_WAIT`, so they are implemented by `FreeRTOS.h` -- under gcc 9 (at least), tasks.c fails.
Presumably this is because the toolchain thinks the call to `traceTASK_NOTIFY_WAIT( uxIndexToWait );` is an undeclared function, rather than our `traceTASK_NOTIFY_WAIT` macro implementation.

Test Steps
-----------
Clone at f2081af03066a41cc218435a3c61d4ed90c87c77, build under arm-none-eabi-gcc 9.2.1

Related Issue
-----------
#63 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
