### PR TITLE
Fixed some bugs in documentation and made it look consistent

### DIFF
--- a/include/croutine.h
+++ b/include/croutine.h
@@ -58,12 +58,13 @@ typedef struct corCoRoutineControlBlock
 
 /**
  * croutine. h
- *<pre>
+<pre>
  BaseType_t xCoRoutineCreate(
                                  crCOROUTINE_CODE pxCoRoutineCode,
                                  UBaseType_t uxPriority,
                                  UBaseType_t uxIndex
-                               );</pre>
+                               );
+</pre>
  *
  * Create a new co-routine and add it to the list of co-routines that are
  * ready to run.
@@ -83,7 +84,7 @@ typedef struct corCoRoutineControlBlock
  * list, otherwise an error code defined with ProjDefs.h.
  *
  * Example usage:
-   <pre>
+<pre>
  // Co-routine to be created.
  void vFlashCoRoutine( CoRoutineHandle_t xHandle, UBaseType_t uxIndex )
  {
@@ -124,7 +125,7 @@ typedef struct corCoRoutineControlBlock
          xCoRoutineCreate( vFlashCoRoutine, 0, uxIndex );
      }
  }
-   </pre>
+</pre>
  * \defgroup xCoRoutineCreate xCoRoutineCreate
  * \ingroup Tasks
  */
@@ -133,8 +134,9 @@ BaseType_t xCoRoutineCreate( crCOROUTINE_CODE pxCoRoutineCode, UBaseType_t uxPri
 
 /**
  * croutine. h
- *<pre>
- void vCoRoutineSchedule( void );</pre>
+<pre>
+ void vCoRoutineSchedule( void );
+</pre>
  *
  * Run a co-routine.
  *
@@ -148,7 +150,7 @@ BaseType_t xCoRoutineCreate( crCOROUTINE_CODE pxCoRoutineCode, UBaseType_t uxPri
  * hook).
  *
  * Example usage:
-   <pre>
+<pre>
  // This idle task hook will schedule a co-routine each time it is called.
  // The rest of the idle task will execute between co-routine calls.
  void vApplicationIdleHook( void )
@@ -166,7 +168,7 @@ BaseType_t xCoRoutineCreate( crCOROUTINE_CODE pxCoRoutineCode, UBaseType_t uxPri
         vCoRoutineSchedule();
     }
  }
- </pre>
+</pre>
  * \defgroup vCoRoutineSchedule vCoRoutineSchedule
  * \ingroup Tasks
  */
@@ -174,8 +176,9 @@ void vCoRoutineSchedule( void );
 
 /**
  * croutine. h
- * <pre>
- crSTART( CoRoutineHandle_t xHandle );</pre>
+<pre>
+ crSTART( CoRoutineHandle_t xHandle );
+</pre>
  *
  * This macro MUST always be called at the start of a co-routine function.
  *
@@ -197,7 +200,8 @@ void vCoRoutineSchedule( void );
 
      // Must end every co-routine with a call to crEND();
      crEND();
- }</pre>
+ }
+</pre>
  * \defgroup crSTART crSTART
  * \ingroup Tasks
  */
@@ -205,13 +209,14 @@ void vCoRoutineSchedule( void );
 
 /**
  * croutine. h
- * <pre>
- crEND();</pre>
+<pre>
+ crEND();
+</pre>
  *
  * This macro MUST always be called at the end of a co-routine function.
  *
  * Example usage:
-   <pre>
+<pre>
  // Co-routine to be created.
  void vACoRoutine( CoRoutineHandle_t xHandle, UBaseType_t uxIndex )
  {
@@ -228,7 +233,8 @@ void vCoRoutineSchedule( void );
 
      // Must end every co-routine with a call to crEND();
      crEND();
- }</pre>
+ }
+</pre>
  * \defgroup crSTART crSTART
  * \ingroup Tasks
  */
@@ -243,8 +249,9 @@ void vCoRoutineSchedule( void );
 
 /**
  * croutine. h
- *<pre>
- crDELAY( CoRoutineHandle_t xHandle, TickType_t xTicksToDelay );</pre>
+<pre>
+ crDELAY( CoRoutineHandle_t xHandle, TickType_t xTicksToDelay );
+</pre>
  *
  * Delay a co-routine for a fixed period of time.
  *
@@ -261,7 +268,7 @@ void vCoRoutineSchedule( void );
  * can be used to convert ticks to milliseconds.
  *
  * Example usage:
-   <pre>
+<pre>
  // Co-routine to be created.
  void vACoRoutine( CoRoutineHandle_t xHandle, UBaseType_t uxIndex )
  {
@@ -283,7 +290,8 @@ void vCoRoutineSchedule( void );
 
      // Must end every co-routine with a call to crEND();
      crEND();
- }</pre>
+ }
+</pre>
  * \defgroup crDELAY crDELAY
  * \ingroup Tasks
  */
@@ -295,14 +303,15 @@ void vCoRoutineSchedule( void );
 	crSET_STATE0( ( xHandle ) );
 
 /**
- * <pre>
+<pre>
  crQUEUE_SEND(
                   CoRoutineHandle_t xHandle,
                   QueueHandle_t pxQueue,
                   void *pvItemToQueue,
                   TickType_t xTicksToWait,
                   BaseType_t *pxResult
-             )</pre>
+             );
+</pre>
  *
  * The macro's crQUEUE_SEND() and crQUEUE_RECEIVE() are the co-routine
  * equivalent to the xQueueSend() and xQueueReceive() functions used by tasks.
@@ -342,7 +351,7 @@ void vCoRoutineSchedule( void );
  * error defined within ProjDefs.h.
  *
  * Example usage:
-   <pre>
+<pre>
  // Co-routine function that blocks for a fixed period then posts a number onto
  // a queue.
  static void prvCoRoutineFlashTask( CoRoutineHandle_t xHandle, UBaseType_t uxIndex )
@@ -373,7 +382,8 @@ void vCoRoutineSchedule( void );
 
     // Co-routines must end with a call to crEND().
     crEND();
- }</pre>
+ }
+</pre>
  * \defgroup crQUEUE_SEND crQUEUE_SEND
  * \ingroup Tasks
  */
@@ -394,14 +404,15 @@ void vCoRoutineSchedule( void );
 
 /**
  * croutine. h
- * <pre>
+<pre>
   crQUEUE_RECEIVE(
                      CoRoutineHandle_t xHandle,
                      QueueHandle_t pxQueue,
                      void *pvBuffer,
                      TickType_t xTicksToWait,
                      BaseType_t *pxResult
-                 )</pre>
+                 );
+</pre>
  *
  * The macro's crQUEUE_SEND() and crQUEUE_RECEIVE() are the co-routine
  * equivalent to the xQueueSend() and xQueueReceive() functions used by tasks.
@@ -440,7 +451,7 @@ void vCoRoutineSchedule( void );
  * an error code as defined within ProjDefs.h.
  *
  * Example usage:
- <pre>
+<pre>
  // A co-routine receives the number of an LED to flash from a queue.  It
  // blocks on the queue until the number is received.
  static void prvCoRoutineFlashWorkTask( CoRoutineHandle_t xHandle, UBaseType_t uxIndex )
@@ -465,7 +476,8 @@ void vCoRoutineSchedule( void );
     }
 
     crEND();
- }</pre>
+ }
+</pre>
  * \defgroup crQUEUE_RECEIVE crQUEUE_RECEIVE
  * \ingroup Tasks
  */
@@ -486,12 +498,13 @@ void vCoRoutineSchedule( void );
 
 /**
  * croutine. h
- * <pre>
+<pre>
   crQUEUE_SEND_FROM_ISR(
                             QueueHandle_t pxQueue,
                             void *pvItemToQueue,
                             BaseType_t xCoRoutinePreviouslyWoken
-                       )</pre>
+                       );
+</pre>
  *
  * The macro's crQUEUE_SEND_FROM_ISR() and crQUEUE_RECEIVE_FROM_ISR() are the
  * co-routine equivalent to the xQueueSendFromISR() and xQueueReceiveFromISR()
@@ -526,7 +539,7 @@ void vCoRoutineSchedule( void );
  * the ISR.
  *
  * Example usage:
- <pre>
+<pre>
  // A co-routine that blocks on a queue waiting for characters to be received.
  static void vReceivingCoRoutine( CoRoutineHandle_t xHandle, UBaseType_t uxIndex )
  {
@@ -574,7 +587,8 @@ void vCoRoutineSchedule( void );
          // many characters are posted to the queue.
          xCRWokenByPost = crQUEUE_SEND_FROM_ISR( xCommsRxQueue, &cRxedChar, xCRWokenByPost );
      }
- }</pre>
+ }
+</pre>
  * \defgroup crQUEUE_SEND_FROM_ISR crQUEUE_SEND_FROM_ISR
  * \ingroup Tasks
  */
@@ -583,12 +597,13 @@ void vCoRoutineSchedule( void );
 
 /**
  * croutine. h
- * <pre>
+<pre>
   crQUEUE_SEND_FROM_ISR(
                             QueueHandle_t pxQueue,
                             void *pvBuffer,
                             BaseType_t * pxCoRoutineWoken
-                       )</pre>
+                       );
+</pre>
  *
  * The macro's crQUEUE_SEND_FROM_ISR() and crQUEUE_RECEIVE_FROM_ISR() are the
  * co-routine equivalent to the xQueueSendFromISR() and xQueueReceiveFromISR()
@@ -623,7 +638,7 @@ void vCoRoutineSchedule( void );
  * pdFALSE.
  *
  * Example usage:
- <pre>
+<pre>
  // A co-routine that posts a character to a queue then blocks for a fixed
  // period.  The character is incremented each time.
  static void vSendingCoRoutine( CoRoutineHandle_t xHandle, UBaseType_t uxIndex )
@@ -687,7 +702,8 @@ void vCoRoutineSchedule( void );
 			 SEND_CHARACTER( cCharToTx );
 		 }
      }
- }</pre>
+ }
+</pre>
  * \defgroup crQUEUE_RECEIVE_FROM_ISR crQUEUE_RECEIVE_FROM_ISR
  * \ingroup Tasks
  */

--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -93,9 +93,9 @@ typedef TickType_t EventBits_t;
 
 /**
  * event_groups.h
- *<pre>
+<pre>
  EventGroupHandle_t xEventGroupCreate( void );
- </pre>
+</pre>
  *
  * Create a new event group.
  *
@@ -122,7 +122,7 @@ typedef TickType_t EventBits_t;
  * event group then NULL is returned.  See http://www.freertos.org/a00111.html
  *
  * Example usage:
-   <pre>
+<pre>
 	// Declare a variable to hold the created event group.
 	EventGroupHandle_t xCreatedEventGroup;
 
@@ -139,7 +139,7 @@ typedef TickType_t EventBits_t;
 	{
 		// The event group was created.
 	}
-   </pre>
+</pre>
  * \defgroup xEventGroupCreate xEventGroupCreate
  * \ingroup EventGroup
  */
@@ -149,9 +149,9 @@ typedef TickType_t EventBits_t;
 
 /**
  * event_groups.h
- *<pre>
+<pre>
  EventGroupHandle_t xEventGroupCreateStatic( EventGroupHandle_t * pxEventGroupBuffer );
- </pre>
+</pre>
  *
  * Create a new event group.
  *
@@ -202,13 +202,13 @@ typedef TickType_t EventBits_t;
 
 /**
  * event_groups.h
- *<pre>
+<pre>
 	EventBits_t xEventGroupWaitBits( 	EventGroupHandle_t xEventGroup,
 										const EventBits_t uxBitsToWaitFor,
 										const BaseType_t xClearOnExit,
 										const BaseType_t xWaitForAllBits,
 										const TickType_t xTicksToWait );
- </pre>
+</pre>
  *
  * [Potentially] block to wait for one or more bits to be set within a
  * previously created event group.
@@ -252,7 +252,7 @@ typedef TickType_t EventBits_t;
  * pdTRUE.
  *
  * Example usage:
-   <pre>
+<pre>
    #define BIT_0	( 1 << 0 )
    #define BIT_4	( 1 << 4 )
 
@@ -288,7 +288,7 @@ typedef TickType_t EventBits_t;
 			// without either BIT_0 or BIT_4 becoming set.
 		}
    }
-   </pre>
+</pre>
  * \defgroup xEventGroupWaitBits xEventGroupWaitBits
  * \ingroup EventGroup
  */
@@ -296,9 +296,9 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup, const EventBits
 
 /**
  * event_groups.h
- *<pre>
+<pre>
 	EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToClear );
- </pre>
+</pre>
  *
  * Clear bits within an event group.  This function cannot be called from an
  * interrupt.
@@ -353,9 +353,9 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBit
 
 /**
  * event_groups.h
- *<pre>
+<pre>
 	BaseType_t xEventGroupClearBitsFromISR( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet );
- </pre>
+</pre>
  *
  * A version of xEventGroupClearBits() that can be called from an interrupt.
  *
@@ -380,7 +380,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBit
  * if the timer service queue was full.
  *
  * Example usage:
-   <pre>
+<pre>
    #define BIT_0	( 1 << 0 )
    #define BIT_4	( 1 << 4 )
 
@@ -399,8 +399,8 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBit
 		{
 			// The message was posted successfully.
 		}
-  }
-   </pre>
+   }
+</pre>
  * \defgroup xEventGroupClearBitsFromISR xEventGroupClearBitsFromISR
  * \ingroup EventGroup
  */
@@ -412,9 +412,9 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBit
 
 /**
  * event_groups.h
- *<pre>
-	EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet );
- </pre>
+<pre>
+ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet );
+</pre>
  *
  * Set bits within an event group.
  * This function cannot be called from an interrupt.  xEventGroupSetBitsFromISR()
@@ -440,7 +440,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBit
  * event group value before the call to xEventGroupSetBits() returns.
  *
  * Example usage:
-   <pre>
+<pre>
    #define BIT_0	( 1 << 0 )
    #define BIT_4	( 1 << 4 )
 
@@ -478,7 +478,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBit
 			// cleared as the task left the Blocked state.
 		}
    }
-   </pre>
+</pre>
  * \defgroup xEventGroupSetBits xEventGroupSetBits
  * \ingroup EventGroup
  */
@@ -486,9 +486,9 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_
 
 /**
  * event_groups.h
- *<pre>
-	BaseType_t xEventGroupSetBitsFromISR( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet, BaseType_t *pxHigherPriorityTaskWoken );
- </pre>
+<pre>
+ BaseType_t xEventGroupSetBitsFromISR( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet, BaseType_t *pxHigherPriorityTaskWoken );
+</pre>
  *
  * A version of xEventGroupSetBits() that can be called from an interrupt.
  *
@@ -564,12 +564,12 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_
 
 /**
  * event_groups.h
- *<pre>
+<pre>
 	EventBits_t xEventGroupSync(	EventGroupHandle_t xEventGroup,
 									const EventBits_t uxBitsToSet,
 									const EventBits_t uxBitsToWaitFor,
 									TickType_t xTicksToWait );
- </pre>
+</pre>
  *
  * Atomically set bits within an event group, then wait for a combination of
  * bits to be set within the same event group.  This functionality is typically
@@ -608,7 +608,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_
  * automatically cleared.
  *
  * Example usage:
- <pre>
+<pre>
  // Bits used by the three tasks.
  #define TASK_0_BIT		( 1 << 0 )
  #define TASK_1_BIT		( 1 << 1 )
@@ -682,7 +682,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_
 	}
  }
 
- </pre>
+</pre>
  * \defgroup xEventGroupSync xEventGroupSync
  * \ingroup EventGroup
  */
@@ -691,9 +691,9 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup, const EventBits_t u
 
 /**
  * event_groups.h
- *<pre>
-	EventBits_t xEventGroupGetBits( EventGroupHandle_t xEventGroup );
- </pre>
+<pre>
+ EventBits_t xEventGroupGetBits( EventGroupHandle_t xEventGroup );
+</pre>
  *
  * Returns the current value of the bits in an event group.  This function
  * cannot be used from an interrupt.
@@ -709,9 +709,9 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup, const EventBits_t u
 
 /**
  * event_groups.h
- *<pre>
-	EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup );
- </pre>
+<pre>
+ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup );
+</pre>
  *
  * A version of xEventGroupGetBits() that can be called from an ISR.
  *
@@ -726,9 +726,9 @@ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup ) PRIVILEG
 
 /**
  * event_groups.h
- *<pre>
-	void xEventGroupDelete( EventGroupHandle_t xEventGroup );
- </pre>
+<pre>
+ void xEventGroupDelete( EventGroupHandle_t xEventGroup );
+</pre>
  *
  * Delete an event group that was previously created by a call to
  * xEventGroupCreate().  Tasks that are blocked on the event group will be

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -215,7 +215,7 @@ size_t xMessageBufferSend( MessageBufferHandle_t xMessageBuffer,
                            const void *pvTxData,
                            size_t xDataLengthBytes,
                            TickType_t xTicksToWait );
-<pre>
+</pre>
  *
  * Sends a discrete message to the message buffer.  The message can be any
  * length that fits within the buffer's free space, and is copied into the
@@ -314,7 +314,7 @@ size_t xMessageBufferSendFromISR( MessageBufferHandle_t xMessageBuffer,
                                   const void *pvTxData,
                                   size_t xDataLengthBytes,
                                   BaseType_t *pxHigherPriorityTaskWoken );
-<pre>
+</pre>
  *
  * Interrupt safe version of the API function that sends a discrete message to
  * the message buffer.  The message can be any length that fits within the

--- a/include/queue.h
+++ b/include/queue.h
@@ -76,12 +76,12 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 /**
  * queue. h
- * <pre>
+<pre>
  QueueHandle_t xQueueCreate(
 							  UBaseType_t uxQueueLength,
 							  UBaseType_t uxItemSize
 						  );
- * </pre>
+</pre>
  *
  * Creates a new queue instance, and returns a handle by which the new queue
  * can be referenced.
@@ -110,7 +110,7 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
  * returned.
  *
  * Example usage:
-   <pre>
+<pre>
  struct AMessage
  {
 	char ucMessageID;
@@ -138,7 +138,7 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 	// ... Rest of task code.
  }
- </pre>
+</pre>
  * \defgroup xQueueCreate xQueueCreate
  * \ingroup QueueManagement
  */
@@ -148,14 +148,14 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 /**
  * queue. h
- * <pre>
+<pre>
  QueueHandle_t xQueueCreateStatic(
 							  UBaseType_t uxQueueLength,
 							  UBaseType_t uxItemSize,
 							  uint8_t *pucQueueStorageBuffer,
 							  StaticQueue_t *pxQueueBuffer
 						  );
- * </pre>
+</pre>
  *
  * Creates a new queue instance, and returns a handle by which the new queue
  * can be referenced.
@@ -192,7 +192,7 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
  * returned.  If pxQueueBuffer is NULL then NULL is returned.
  *
  * Example usage:
-   <pre>
+<pre>
  struct AMessage
  {
 	char ucMessageID;
@@ -224,7 +224,7 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 	// ... Rest of task code.
  }
- </pre>
+</pre>
  * \defgroup xQueueCreateStatic xQueueCreateStatic
  * \ingroup QueueManagement
  */
@@ -234,13 +234,13 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueSendToToFront(
 								   QueueHandle_t	xQueue,
 								   const void		*pvItemToQueue,
 								   TickType_t		xTicksToWait
 							   );
- * </pre>
+</pre>
  *
  * Post an item to the front of a queue.  The item is queued by copy, not by
  * reference.  This function must not be called from an interrupt service
@@ -314,13 +314,13 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueSendToBack(
 								   QueueHandle_t	xQueue,
 								   const void		*pvItemToQueue,
 								   TickType_t		xTicksToWait
 							   );
- * </pre>
+</pre>
  *
  * This is a macro that calls xQueueGenericSend().
  *
@@ -396,13 +396,13 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueSend(
 							  QueueHandle_t xQueue,
 							  const void * pvItemToQueue,
 							  TickType_t xTicksToWait
 						 );
- * </pre>
+</pre>
  *
  * This is a macro that calls xQueueGenericSend().  It is included for
  * backward compatibility with versions of FreeRTOS.org that did not
@@ -480,12 +480,12 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueOverwrite(
 							  QueueHandle_t xQueue,
 							  const void * pvItemToQueue
 						 );
- * </pre>
+</pre>
  *
  * Only for use with queues that have a length of one - so the queue is either
  * empty or full.
@@ -564,14 +564,14 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueGenericSend(
 									QueueHandle_t xQueue,
 									const void * pvItemToQueue,
 									TickType_t xTicksToWait
 									BaseType_t xCopyPosition
 								);
- * </pre>
+</pre>
  *
  * It is preferred that the macros xQueueSend(), xQueueSendToFront() and
  * xQueueSendToBack() are used in place of calling this function directly.
@@ -600,7 +600,7 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
  * @return pdTRUE if the item was successfully posted, otherwise errQUEUE_FULL.
  *
  * Example usage:
-   <pre>
+<pre>
  struct AMessage
  {
 	char ucMessageID;
@@ -643,7 +643,7 @@ typedef struct QueueDefinition * QueueSetMemberHandle_t;
 
 	// ... Rest of task code.
  }
- </pre>
+</pre>
  * \defgroup xQueueSend xQueueSend
  * \ingroup QueueManagement
  */
@@ -651,12 +651,13 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue, const void * const pvItemToQ
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueuePeek(
 							 QueueHandle_t xQueue,
 							 void * const pvBuffer,
 							 TickType_t xTicksToWait
-						 );</pre>
+						 );
+</pre>
  *
  * Receive an item from a queue without removing the item from the queue.
  * The item is received by copy so a buffer of adequate size must be
@@ -745,11 +746,12 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue, void * const pvBuffer, TickType_t x
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueuePeekFromISR(
 									QueueHandle_t xQueue,
 									void *pvBuffer,
-								);</pre>
+								);
+</pre>
  *
  * A version of xQueuePeek() that can be called from an interrupt service
  * routine (ISR).
@@ -778,12 +780,13 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue, void * const pvBuffer ) PRIV
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueReceive(
 								 QueueHandle_t xQueue,
 								 void *pvBuffer,
 								 TickType_t xTicksToWait
-							);</pre>
+							);
+</pre>
  *
  * Receive an item from a queue.  The item is received by copy so a buffer of
  * adequate size must be provided.  The number of bytes copied into the buffer
@@ -869,7 +872,9 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue, void * const pvBuffer, TickType_
 
 /**
  * queue. h
- * <pre>UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue );</pre>
+<pre>
+ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue );
+</pre>
  *
  * Return the number of messages stored in a queue.
  *
@@ -884,7 +889,9 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue ) PRIVILEGED_FUNC
 
 /**
  * queue. h
- * <pre>UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue );</pre>
+<pre>
+ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue );
+</pre>
  *
  * Return the number of free spaces available in a queue.  This is equal to the
  * number of items that can be sent to the queue before the queue becomes full
@@ -901,7 +908,9 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue ) PRIVILEGED_FUNC
 
 /**
  * queue. h
- * <pre>void vQueueDelete( QueueHandle_t xQueue );</pre>
+<pre>
+ void vQueueDelete( QueueHandle_t xQueue );
+</pre>
  *
  * Delete a queue - freeing all the memory allocated for storing of items
  * placed on the queue.
@@ -915,13 +924,13 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueSendToFrontFromISR(
 										 QueueHandle_t xQueue,
 										 const void *pvItemToQueue,
 										 BaseType_t *pxHigherPriorityTaskWoken
 									  );
- </pre>
+</pre>
  *
  * This is a macro that calls xQueueGenericSendFromISR().
  *
@@ -976,7 +985,7 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
 		taskYIELD ();
 	}
  }
- </pre>
+</pre>
  *
  * \defgroup xQueueSendFromISR xQueueSendFromISR
  * \ingroup QueueManagement
@@ -986,13 +995,13 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueSendToBackFromISR(
 										 QueueHandle_t xQueue,
 										 const void *pvItemToQueue,
 										 BaseType_t *pxHigherPriorityTaskWoken
 									  );
- </pre>
+</pre>
  *
  * This is a macro that calls xQueueGenericSendFromISR().
  *
@@ -1056,13 +1065,13 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueOverwriteFromISR(
 							  QueueHandle_t xQueue,
 							  const void * pvItemToQueue,
 							  BaseType_t *pxHigherPriorityTaskWoken
 						 );
- * </pre>
+</pre>
  *
  * A version of xQueueOverwrite() that can be used in an interrupt service
  * routine (ISR).
@@ -1093,7 +1102,7 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
  * the queue is already full.
  *
  * Example usage:
-   <pre>
+<pre>
 
  QueueHandle_t xQueue;
 
@@ -1104,13 +1113,13 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
 	// contain more than one value, and doing so will trigger an assertion
 	// if configASSERT() is defined.
 	xQueue = xQueueCreate( 1, sizeof( uint32_t ) );
-}
+ }
 
-void vAnInterruptHandler( void )
-{
-// xHigherPriorityTaskWoken must be set to pdFALSE before it is used.
-BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-uint32_t ulVarToSend, ulValReceived;
+ void vAnInterruptHandler( void )
+ {
+ // xHigherPriorityTaskWoken must be set to pdFALSE before it is used.
+ BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+ uint32_t ulVarToSend, ulValReceived;
 
 	// Write the value 10 to the queue using xQueueOverwriteFromISR().
 	ulVarToSend = 10;
@@ -1134,8 +1143,8 @@ uint32_t ulVarToSend, ulValReceived;
 		// switch so this interrupt returns directly to the unblocked task.
 		portYIELD_FROM_ISR(); // or portEND_SWITCHING_ISR() depending on the port.
 	}
-}
- </pre>
+ }
+</pre>
  * \defgroup xQueueOverwriteFromISR xQueueOverwriteFromISR
  * \ingroup QueueManagement
  */
@@ -1143,13 +1152,13 @@ uint32_t ulVarToSend, ulValReceived;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueSendFromISR(
 									 QueueHandle_t xQueue,
 									 const void *pvItemToQueue,
 									 BaseType_t *pxHigherPriorityTaskWoken
 								);
- </pre>
+</pre>
  *
  * This is a macro that calls xQueueGenericSendFromISR().  It is included
  * for backward compatibility with versions of FreeRTOS.org that did not
@@ -1181,7 +1190,7 @@ uint32_t ulVarToSend, ulValReceived;
  *
  * Example usage for buffered IO (where the ISR can obtain more than one value
  * per call):
-   <pre>
+<pre>
  void vBufferISR( void )
  {
  char cIn;
@@ -1208,7 +1217,7 @@ uint32_t ulVarToSend, ulValReceived;
 		portYIELD_FROM_ISR ();
 	}
  }
- </pre>
+</pre>
  *
  * \defgroup xQueueSendFromISR xQueueSendFromISR
  * \ingroup QueueManagement
@@ -1217,14 +1226,14 @@ uint32_t ulVarToSend, ulValReceived;
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueGenericSendFromISR(
 										   QueueHandle_t		xQueue,
 										   const	void	*pvItemToQueue,
 										   BaseType_t	*pxHigherPriorityTaskWoken,
 										   BaseType_t	xCopyPosition
 									   );
- </pre>
+</pre>
  *
  * It is preferred that the macros xQueueSendFromISR(),
  * xQueueSendToFrontFromISR() and xQueueSendToBackFromISR() be used in place
@@ -1260,7 +1269,7 @@ uint32_t ulVarToSend, ulValReceived;
  *
  * Example usage for buffered IO (where the ISR can obtain more than one value
  * per call):
-   <pre>
+<pre>
  void vBufferISR( void )
  {
  char cIn;
@@ -1287,7 +1296,7 @@ uint32_t ulVarToSend, ulValReceived;
 		portYIELD_FROM_ISR();
 	}
  }
- </pre>
+</pre>
  *
  * \defgroup xQueueSendFromISR xQueueSendFromISR
  * \ingroup QueueManagement
@@ -1297,13 +1306,13 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue, BaseType_t * const pxHigherP
 
 /**
  * queue. h
- * <pre>
+<pre>
  BaseType_t xQueueReceiveFromISR(
 									   QueueHandle_t	xQueue,
 									   void	*pvBuffer,
 									   BaseType_t *pxTaskWoken
 								   );
- * </pre>
+</pre>
  *
  * Receive an item from a queue.  It is safe to use this function from within an
  * interrupt service routine.
@@ -1323,7 +1332,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue, BaseType_t * const pxHigherP
  * otherwise pdFALSE.
  *
  * Example usage:
-   <pre>
+<pre>
 
  QueueHandle_t xQueue;
 
@@ -1378,7 +1387,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue, BaseType_t * const pxHigherP
 		taskYIELD ();
 	}
  }
- </pre>
+</pre>
  * \defgroup xQueueReceiveFromISR xQueueReceiveFromISR
  * \ingroup QueueManagement
  */

--- a/include/semphr.h
+++ b/include/semphr.h
@@ -43,7 +43,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>vSemaphoreCreateBinary( SemaphoreHandle_t xSemaphore )</pre>
+<pre>
+ vSemaphoreCreateBinary( SemaphoreHandle_t xSemaphore );
+</pre>
  *
  * In many usage scenarios it is faster and more memory efficient to use a
  * direct to task notification in place of a binary semaphore!
@@ -71,7 +73,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * @param xSemaphore Handle to the created semaphore.  Should be of type SemaphoreHandle_t.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore = NULL;
 
  void vATask( void * pvParameters )
@@ -103,7 +105,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateBinary( void )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateBinary( void );
+</pre>
  *
  * Creates a new binary semaphore instance, and returns a handle by which the
  * new semaphore can be referenced.
@@ -164,7 +168,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateBinaryStatic( StaticSemaphore_t *pxSemaphoreBuffer )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateBinaryStatic( StaticSemaphore_t *pxSemaphoreBuffer );
+</pre>
  *
  * Creates a new binary semaphore instance, and returns a handle by which the
  * new semaphore can be referenced.
@@ -197,7 +203,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * returned.  If pxSemaphoreBuffer is NULL then NULL is returned.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore = NULL;
  StaticSemaphore_t xSemaphoreBuffer;
 
@@ -213,7 +219,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
     // Rest of task code goes here.
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreCreateBinaryStatic xSemaphoreCreateBinaryStatic
  * \ingroup Semaphores
  */
@@ -223,10 +229,12 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>xSemaphoreTake(
- *                   SemaphoreHandle_t xSemaphore,
- *                   TickType_t xBlockTime
- *               )</pre>
+<pre>
+ xSemaphoreTake(
+                    SemaphoreHandle_t xSemaphore,
+                    TickType_t xBlockTime
+                );
+</pre>
  *
  * <i>Macro</i> to obtain a semaphore.  The semaphore must have previously been
  * created with a call to xSemaphoreCreateBinary(), xSemaphoreCreateMutex() or
@@ -245,7 +253,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * if xBlockTime expired without the semaphore becoming available.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore = NULL;
 
  // A task that creates a semaphore.
@@ -282,7 +290,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
         }
     }
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreTake xSemaphoreTake
  * \ingroup Semaphores
  */
@@ -290,10 +298,12 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * xSemaphoreTakeRecursive(
- *                          SemaphoreHandle_t xMutex,
- *                          TickType_t xBlockTime
- *                        )
+<pre>
+ xSemaphoreTakeRecursive(
+                          SemaphoreHandle_t xMutex,
+                          TickType_t xBlockTime
+                        );
+</pre>
  *
  * <i>Macro</i> to recursively obtain, or 'take', a mutex type semaphore.
  * The mutex must have previously been created using a call to
@@ -324,7 +334,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * expired without the semaphore becoming available.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xMutex = NULL;
 
  // A task that creates a mutex.
@@ -375,7 +385,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
         }
     }
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreTakeRecursive xSemaphoreTakeRecursive
  * \ingroup Semaphores
  */
@@ -385,7 +395,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>xSemaphoreGive( SemaphoreHandle_t xSemaphore )</pre>
+<pre>
+ xSemaphoreGive( SemaphoreHandle_t xSemaphore );
+</pre>
  *
  * <i>Macro</i> to release a semaphore.  The semaphore must have previously been
  * created with a call to xSemaphoreCreateBinary(), xSemaphoreCreateMutex() or
@@ -406,7 +418,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * semaphore was not first obtained correctly.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore = NULL;
 
  void vATask( void * pvParameters )
@@ -440,7 +452,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
         }
     }
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreGive xSemaphoreGive
  * \ingroup Semaphores
  */
@@ -448,7 +460,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>xSemaphoreGiveRecursive( SemaphoreHandle_t xMutex )</pre>
+<pre>
+ xSemaphoreGiveRecursive( SemaphoreHandle_t xMutex );
+</pre>
  *
  * <i>Macro</i> to recursively release, or 'give', a mutex type semaphore.
  * The mutex must have previously been created using a call to
@@ -472,7 +486,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * @return pdTRUE if the semaphore was given.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xMutex = NULL;
 
  // A task that creates a mutex.
@@ -534,11 +548,12 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>
+<pre>
  xSemaphoreGiveFromISR(
                           SemaphoreHandle_t xSemaphore,
                           BaseType_t *pxHigherPriorityTaskWoken
-                      )</pre>
+                      );
+</pre>
  *
  * <i>Macro</i> to  release a semaphore.  The semaphore must have previously been
  * created with a call to xSemaphoreCreateBinary() or xSemaphoreCreateCounting().
@@ -560,7 +575,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * @return pdTRUE if the semaphore was successfully given, otherwise errQUEUE_FULL.
  *
  * Example usage:
- <pre>
+<pre>
  \#define LONG_TIME 0xffff
  \#define TICKS_TO_WAIT	10
  SemaphoreHandle_t xSemaphore = NULL;
@@ -617,7 +632,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
         // to find the syntax required.
     }
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreGiveFromISR xSemaphoreGiveFromISR
  * \ingroup Semaphores
  */
@@ -625,11 +640,12 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>
+<pre>
  xSemaphoreTakeFromISR(
                           SemaphoreHandle_t xSemaphore,
                           BaseType_t *pxHigherPriorityTaskWoken
-                      )</pre>
+                      );
+</pre>
  *
  * <i>Macro</i> to  take a semaphore from an ISR.  The semaphore must have
  * previously been created with a call to xSemaphoreCreateBinary() or
@@ -659,7 +675,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateMutex( void )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateMutex( void );
+</pre>
  *
  * Creates a new mutex type semaphore instance, and returns a handle by which
  * the new mutex can be referenced.
@@ -693,7 +711,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * data structures then NULL is returned.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore;
 
  void vATask( void * pvParameters )
@@ -708,7 +726,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
         // The semaphore can now be used.
     }
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreCreateMutex xSemaphoreCreateMutex
  * \ingroup Semaphores
  */
@@ -718,7 +736,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateMutexStatic( StaticSemaphore_t *pxMutexBuffer )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateMutexStatic( StaticSemaphore_t *pxMutexBuffer );
+</pre>
  *
  * Creates a new mutex type semaphore instance, and returns a handle by which
  * the new mutex can be referenced.
@@ -755,7 +775,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * mutex is returned.  If pxMutexBuffer was NULL then NULL is returned.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore;
  StaticSemaphore_t xMutexBuffer;
 
@@ -769,7 +789,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
     // As no dynamic memory allocation was performed, xSemaphore cannot be NULL,
     // so there is no need to check it.
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreCreateMutexStatic xSemaphoreCreateMutexStatic
  * \ingroup Semaphores
  */
@@ -780,7 +800,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateRecursiveMutex( void )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateRecursiveMutex( void );
+</pre>
  *
  * Creates a new recursive mutex type semaphore instance, and returns a handle
  * by which the new recursive mutex can be referenced.
@@ -822,7 +844,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * SemaphoreHandle_t.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore;
 
  void vATask( void * pvParameters )
@@ -837,7 +859,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
         // The semaphore can now be used.
     }
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreCreateRecursiveMutex xSemaphoreCreateRecursiveMutex
  * \ingroup Semaphores
  */
@@ -847,7 +869,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateRecursiveMutexStatic( StaticSemaphore_t *pxMutexBuffer )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateRecursiveMutexStatic( StaticSemaphore_t *pxMutexBuffer );
+</pre>
  *
  * Creates a new recursive mutex type semaphore instance, and returns a handle
  * by which the new recursive mutex can be referenced.
@@ -894,7 +918,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * returned.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore;
  StaticSemaphore_t xMutexBuffer;
 
@@ -910,7 +934,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
     // As no dynamic memory allocation was performed, xSemaphore cannot be NULL,
     // so there is no need to check it.
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreCreateRecursiveMutexStatic xSemaphoreCreateRecursiveMutexStatic
  * \ingroup Semaphores
  */
@@ -920,7 +944,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateCounting( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateCounting( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount );
+</pre>
  *
  * Creates a new counting semaphore instance, and returns a handle by which the
  * new counting semaphore can be referenced.
@@ -972,7 +998,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  *         created.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore;
 
  void vATask( void * pvParameters )
@@ -990,7 +1016,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
         // The semaphore can now be used.
     }
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreCreateCounting xSemaphoreCreateCounting
  * \ingroup Semaphores
  */
@@ -1000,7 +1026,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateCountingStatic( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount, StaticSemaphore_t *pxSemaphoreBuffer )</pre>
+<pre>
+ SemaphoreHandle_t xSemaphoreCreateCountingStatic( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount, StaticSemaphore_t *pxSemaphoreBuffer );
+</pre>
  *
  * Creates a new counting semaphore instance, and returns a handle by which the
  * new counting semaphore can be referenced.
@@ -1056,7 +1084,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * then NULL is returned.
  *
  * Example usage:
- <pre>
+<pre>
  SemaphoreHandle_t xSemaphore;
  StaticSemaphore_t xSemaphoreBuffer;
 
@@ -1075,7 +1103,7 @@ typedef QueueHandle_t SemaphoreHandle_t;
     // No memory allocation was attempted so xSemaphore cannot be NULL, so there
     // is no need to check its value.
  }
- </pre>
+</pre>
  * \defgroup xSemaphoreCreateCountingStatic xSemaphoreCreateCountingStatic
  * \ingroup Semaphores
  */
@@ -1085,7 +1113,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>void vSemaphoreDelete( SemaphoreHandle_t xSemaphore );</pre>
+<pre>
+ void vSemaphoreDelete( SemaphoreHandle_t xSemaphore );
+</pre>
  *
  * Delete a semaphore.  This function must be used with care.  For example,
  * do not delete a mutex type semaphore if the mutex is held by a task.
@@ -1099,7 +1129,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr.h
- * <pre>TaskHandle_t xSemaphoreGetMutexHolder( SemaphoreHandle_t xMutex );</pre>
+<pre>
+ TaskHandle_t xSemaphoreGetMutexHolder( SemaphoreHandle_t xMutex );
+</pre>
  *
  * If xMutex is indeed a mutex type semaphore, return the current mutex holder.
  * If xMutex is not a mutex type semaphore, or the mutex is available (not held
@@ -1114,7 +1146,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr.h
- * <pre>TaskHandle_t xSemaphoreGetMutexHolderFromISR( SemaphoreHandle_t xMutex );</pre>
+<pre>
+ TaskHandle_t xSemaphoreGetMutexHolderFromISR( SemaphoreHandle_t xMutex );
+</pre>
  *
  * If xMutex is indeed a mutex type semaphore, return the current mutex holder.
  * If xMutex is not a mutex type semaphore, or the mutex is available (not held
@@ -1125,7 +1159,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr.h
- * <pre>UBaseType_t uxSemaphoreGetCount( SemaphoreHandle_t xSemaphore );</pre>
+<pre>
+ UBaseType_t uxSemaphoreGetCount( SemaphoreHandle_t xSemaphore );
+</pre>
  *
  * If the semaphore is a counting semaphore then uxSemaphoreGetCount() returns
  * its current count value.  If the semaphore is a binary semaphore then

--- a/include/task.h
+++ b/include/task.h
@@ -242,7 +242,7 @@ is used in assert() statements. */
 
 /**
  * task. h
- *<pre>
+<pre>
  BaseType_t xTaskCreate(
 							  TaskFunction_t pvTaskCode,
 							  const char * const pcName,
@@ -250,7 +250,8 @@ is used in assert() statements. */
 							  void *pvParameters,
 							  UBaseType_t uxPriority,
 							  TaskHandle_t *pvCreatedTask
-						  );</pre>
+						  );
+</pre>
  *
  * Create a new task and add it to the list of tasks that are ready to run.
  *
@@ -344,14 +345,15 @@ is used in assert() statements. */
 
 /**
  * task. h
- *<pre>
+<pre>
  TaskHandle_t xTaskCreateStatic( TaskFunction_t pvTaskCode,
 								 const char * const pcName,
 								 uint32_t ulStackDepth,
 								 void *pvParameters,
 								 UBaseType_t uxPriority,
 								 StackType_t *pxStackBuffer,
-								 StaticTask_t *pxTaskBuffer );</pre>
+								 StaticTask_t *pxTaskBuffer );
+</pre>
  *
  * Create a new task and add it to the list of tasks that are ready to run.
  *
@@ -461,8 +463,9 @@ is used in assert() statements. */
 
 /**
  * task. h
- *<pre>
- BaseType_t xTaskCreateRestricted( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );</pre>
+<pre>
+ BaseType_t xTaskCreateRestricted( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );
+</pre>
  *
  * Only available when configSUPPORT_DYNAMIC_ALLOCATION is set to 1.
  *
@@ -537,8 +540,9 @@ TaskHandle_t xHandle;
 
 /**
  * task. h
- *<pre>
- BaseType_t xTaskCreateRestrictedStatic( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );</pre>
+<pre>
+ BaseType_t xTaskCreateRestrictedStatic( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );
+</pre>
  *
  * Only available when configSUPPORT_STATIC_ALLOCATION is set to 1.
  *
@@ -625,8 +629,9 @@ TaskHandle_t xHandle;
 
 /**
  * task. h
- *<pre>
- void vTaskAllocateMPURegions( TaskHandle_t xTask, const MemoryRegion_t * const pxRegions );</pre>
+<pre>
+ void vTaskAllocateMPURegions( TaskHandle_t xTask, const MemoryRegion_t * const pxRegions );
+</pre>
  *
  * Memory regions are assigned to a restricted task when the task is created by
  * a call to xTaskCreateRestricted().  These regions can be redefined using
@@ -673,7 +678,9 @@ void vTaskAllocateMPURegions( TaskHandle_t xTask, const MemoryRegion_t * const p
 
 /**
  * task. h
- * <pre>void vTaskDelete( TaskHandle_t xTask );</pre>
+<pre>
+ void vTaskDelete( TaskHandle_t xTask );
+</pre>
  *
  * INCLUDE_vTaskDelete must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -718,7 +725,9 @@ void vTaskDelete( TaskHandle_t xTaskToDelete ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskDelay( const TickType_t xTicksToDelay );</pre>
+<pre>
+ void vTaskDelay( const TickType_t xTicksToDelay );
+</pre>
  *
  * Delay a task for a given number of ticks.  The actual time that the
  * task remains blocked depends on the tick rate.  The constant
@@ -766,7 +775,9 @@ void vTaskDelay( const TickType_t xTicksToDelay ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskDelayUntil( TickType_t *pxPreviousWakeTime, const TickType_t xTimeIncrement );</pre>
+<pre>
+ void vTaskDelayUntil( TickType_t *pxPreviousWakeTime, const TickType_t xTimeIncrement );
+</pre>
  *
  * INCLUDE_vTaskDelayUntil must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -825,7 +836,9 @@ void vTaskDelayUntil( TickType_t * const pxPreviousWakeTime, const TickType_t xT
 
 /**
  * task. h
- * <pre>BaseType_t xTaskAbortDelay( TaskHandle_t xTask );</pre>
+<pre>
+ BaseType_t xTaskAbortDelay( TaskHandle_t xTask );
+</pre>
  *
  * INCLUDE_xTaskAbortDelay must be defined as 1 in FreeRTOSConfig.h for this
  * function to be available.
@@ -855,7 +868,9 @@ BaseType_t xTaskAbortDelay( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>UBaseType_t uxTaskPriorityGet( const TaskHandle_t xTask );</pre>
+<pre>
+ UBaseType_t uxTaskPriorityGet( const TaskHandle_t xTask );
+</pre>
  *
  * INCLUDE_uxTaskPriorityGet must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -902,7 +917,9 @@ UBaseType_t uxTaskPriorityGet( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>UBaseType_t uxTaskPriorityGetFromISR( const TaskHandle_t xTask );</pre>
+<pre>
+ UBaseType_t uxTaskPriorityGetFromISR( const TaskHandle_t xTask );
+</pre>
  *
  * A version of uxTaskPriorityGet() that can be used from an ISR.
  */
@@ -910,7 +927,9 @@ UBaseType_t uxTaskPriorityGetFromISR( const TaskHandle_t xTask ) PRIVILEGED_FUNC
 
 /**
  * task. h
- * <pre>eTaskState eTaskGetState( TaskHandle_t xTask );</pre>
+<pre>
+ eTaskState eTaskGetState( TaskHandle_t xTask );
+</pre>
  *
  * INCLUDE_eTaskGetState must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -928,7 +947,9 @@ eTaskState eTaskGetState( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskGetInfo( TaskHandle_t xTask, TaskStatus_t *pxTaskStatus, BaseType_t xGetFreeStackSpace, eTaskState eState );</pre>
+<pre>
+ void vTaskGetInfo( TaskHandle_t xTask, TaskStatus_t *pxTaskStatus, BaseType_t xGetFreeStackSpace, eTaskState eState );
+</pre>
  *
  * configUSE_TRACE_FACILITY must be defined as 1 for this function to be
  * available.  See the configuration section for more information.
@@ -984,7 +1005,9 @@ void vTaskGetInfo( TaskHandle_t xTask, TaskStatus_t *pxTaskStatus, BaseType_t xG
 
 /**
  * task. h
- * <pre>void vTaskPrioritySet( TaskHandle_t xTask, UBaseType_t uxNewPriority );</pre>
+<pre>
+ void vTaskPrioritySet( TaskHandle_t xTask, UBaseType_t uxNewPriority );
+</pre>
  *
  * INCLUDE_vTaskPrioritySet must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -1026,7 +1049,9 @@ void vTaskPrioritySet( TaskHandle_t xTask, UBaseType_t uxNewPriority ) PRIVILEGE
 
 /**
  * task. h
- * <pre>void vTaskSuspend( TaskHandle_t xTaskToSuspend );</pre>
+<pre>
+ void vTaskSuspend( TaskHandle_t xTaskToSuspend );
+</pre>
  *
  * INCLUDE_vTaskSuspend must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -1077,7 +1102,9 @@ void vTaskSuspend( TaskHandle_t xTaskToSuspend ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskResume( TaskHandle_t xTaskToResume );</pre>
+<pre>
+ void vTaskResume( TaskHandle_t xTaskToResume );
+</pre>
  *
  * INCLUDE_vTaskSuspend must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -1126,7 +1153,9 @@ void vTaskResume( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void xTaskResumeFromISR( TaskHandle_t xTaskToResume );</pre>
+<pre>
+ void xTaskResumeFromISR( TaskHandle_t xTaskToResume );
+</pre>
  *
  * INCLUDE_xTaskResumeFromISR must be defined as 1 for this function to be
  * available.  See the configuration section for more information.
@@ -1159,7 +1188,9 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskStartScheduler( void );</pre>
+<pre>
+ void vTaskStartScheduler( void );
+</pre>
  *
  * Starts the real time kernel tick processing.  After calling the kernel
  * has control over which tasks are executed and when.
@@ -1188,7 +1219,9 @@ void vTaskStartScheduler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskEndScheduler( void );</pre>
+<pre>
+ void vTaskEndScheduler( void );
+</pre>
  *
  * NOTE:  At the time of writing only the x86 real mode port, which runs on a PC
  * in place of DOS, implements this function.
@@ -1244,7 +1277,9 @@ void vTaskEndScheduler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskSuspendAll( void );</pre>
+<pre>
+ void vTaskSuspendAll( void );
+</pre>
  *
  * Suspends the scheduler without disabling interrupts.  Context switches will
  * not occur while the scheduler is suspended.
@@ -1295,7 +1330,9 @@ void vTaskSuspendAll( void ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>BaseType_t xTaskResumeAll( void );</pre>
+<pre>
+ BaseType_t xTaskResumeAll( void );
+</pre>
  *
  * Resumes scheduler activity after it was suspended by a call to
  * vTaskSuspendAll().
@@ -1485,7 +1522,9 @@ constant. */
 	#if configUSE_APPLICATION_TASK_TAG == 1
 		/**
 		 * task.h
-		 * <pre>void vTaskSetApplicationTaskTag( TaskHandle_t xTask, TaskHookFunction_t pxHookFunction );</pre>
+<pre>
+ void vTaskSetApplicationTaskTag( TaskHandle_t xTask, TaskHookFunction_t pxHookFunction );
+</pre>
 		 *
 		 * Sets pxHookFunction to be the task hook function used by the task xTask.
 		 * Passing xTask as NULL has the effect of setting the calling tasks hook
@@ -1495,7 +1534,9 @@ constant. */
 
 		/**
 		 * task.h
-		 * <pre>void xTaskGetApplicationTaskTag( TaskHandle_t xTask );</pre>
+<pre>
+ void xTaskGetApplicationTaskTag( TaskHandle_t xTask );
+</pre>
 		 *
 		 * Returns the pxHookFunction value assigned to the task xTask.  Do not
 		 * call from an interrupt service routine - call
@@ -1505,7 +1546,9 @@ constant. */
 
 		/**
 		 * task.h
-		 * <pre>void xTaskGetApplicationTaskTagFromISR( TaskHandle_t xTask );</pre>
+<pre>
+ void xTaskGetApplicationTaskTagFromISR( TaskHandle_t xTask );
+</pre>
 		 *
 		 * Returns the pxHookFunction value assigned to the task xTask.  Can
 		 * be called from an interrupt service routine.
@@ -1528,7 +1571,9 @@ constant. */
 
 /**
  * task.h
- * <pre>BaseType_t xTaskCallApplicationTaskHook( TaskHandle_t xTask, void *pvParameter );</pre>
+<pre>
+ BaseType_t xTaskCallApplicationTaskHook( TaskHandle_t xTask, void *pvParameter );
+</pre>
  *
  * Calls the hook function associated with xTask.  Passing xTask as NULL has
  * the effect of calling the Running tasks (the calling task) hook function.
@@ -2056,8 +2101,12 @@ BaseType_t xTaskGenericNotifyFromISR( TaskHandle_t xTaskToNotify, UBaseType_t ux
 
 /**
  * task. h
- * <PRE>BaseType_t xTaskNotifyWaitIndexed( UBaseType_t uxIndexToWaitOn, uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );</pre>
- * <PRE>BaseType_t xTaskNotifyWait( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );</pre>
+<pre>
+ BaseType_t xTaskNotifyWaitIndexed( UBaseType_t uxIndexToWaitOn, uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );
+</pre>
+<pre>
+ BaseType_t xTaskNotifyWait( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );
+</pre>
  *
  * Waits for a direct to task notification to be pending at a given index within
  * an array of direct to task notifications.
@@ -2315,8 +2364,12 @@ void vTaskGenericNotifyGiveFromISR( TaskHandle_t xTaskToNotify, UBaseType_t uxIn
 
 /**
  * task. h
- * <PRE>uint32_t ulTaskNotifyTakeIndexed( UBaseType_t uxIndexToWaitOn, BaseType_t xClearCountOnExit, TickType_t xTicksToWait );</pre>
- * <PRE>uint32_t ulTaskNotifyTake( BaseType_t xClearCountOnExit, TickType_t xTicksToWait );</pre>
+<pre>
+ uint32_t ulTaskNotifyTakeIndexed( UBaseType_t uxIndexToWaitOn, BaseType_t xClearCountOnExit, TickType_t xTicksToWait );
+</pre>
+<pre>
+ uint32_t ulTaskNotifyTake( BaseType_t xClearCountOnExit, TickType_t xTicksToWait );
+</pre>
  *
  * Waits for a direct to task notification on a particular index in the calling
  * task's notification array in a manner similar to taking a counting semaphore.
@@ -2414,8 +2467,12 @@ uint32_t ulTaskGenericNotifyTake( UBaseType_t uxIndexToWaitOn, BaseType_t xClear
 
 /**
  * task. h
- * <PRE>BaseType_t xTaskNotifyStateClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToCLear );</pre>
- * <PRE>BaseType_t xTaskNotifyStateClear( TaskHandle_t xTask );</pre>
+<pre>
+ BaseType_t xTaskNotifyStateClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToCLear );
+</pre>
+<pre>
+ BaseType_t xTaskNotifyStateClear( TaskHandle_t xTask );
+</pre>
  *
  * See http://www.FreeRTOS.org/RTOS-task-notifications.html for details.
  *
@@ -2472,8 +2529,12 @@ BaseType_t xTaskGenericNotifyStateClear( TaskHandle_t xTask, UBaseType_t uxIndex
 
 /**
  * task. h
- * <PRE>uint32_t ulTaskNotifyValueClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToClear, uint32_t ulBitsToClear );</pre>
- * <PRE>uint32_t ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear );</pre>
+<pre>
+ uint32_t ulTaskNotifyValueClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToClear, uint32_t ulBitsToClear );
+</pre>
+<pre>
+ uint32_t ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear );
+</pre>
  *
  * See http://www.FreeRTOS.org/RTOS-task-notifications.html for details.
  *
@@ -2531,7 +2592,9 @@ uint32_t ulTaskGenericNotifyValueClear( TaskHandle_t xTask, UBaseType_t uxIndexT
 
 /**
  * task.h
- * <pre>void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )</pre>
+<pre>
+ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut );
+</pre>
  *
  * Capture the current time for future use with xTaskCheckForTimeOut().
  *
@@ -2545,7 +2608,9 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNCTION;
 
 /**
  * task.h
- * <pre>BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait );</pre>
+<pre>
+ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait );
+</pre>
  *
  * Determines if pxTicksToWait ticks has passed since a time was captured
  * using a call to vTaskSetTimeOutState().  The captured time includes the tick
@@ -2628,7 +2693,9 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const
 
 /**
  * task.h
- * <pre>BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp );</pre>
+<pre>
+ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp );
+</pre>
  *
  * This function corrects the tick count value after the application code has held
  * interrupts disabled for an extended period resulting in tick interrupts having


### PR DESCRIPTION
Fixed some documentation bugs. 

Description
-----------
There have been some double-opened `<pre>` tags resulting in parts of documentation not being rendered. Many patch lines are only clean code, but some of them are real documentation bugs. 

Test Steps
-----------
One example is for xMessageBufferSend that had no signature in doxygen generated documentation:
https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/4b353bfd7aa009d553f31b4e47dfb49a9f3c75b1/include/message_buffer.h#L213-L218

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
