### PR TITLE
Fix out of offset errors when LTO is enabled

### DIFF
--- a/portable/GCC/ARM_CM3/port.c
+++ b/portable/GCC/ARM_CM3/port.c
@@ -247,6 +247,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg				\n"
 				);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -451,6 +451,7 @@ BaseType_t xPortStartScheduler( void )
 					" isb					\n"
 					" svc %0				\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg				\n"
 					:: "i" (portSVC_START_SCHEDULER) : "memory" );
 
 	/* Should not get here! */

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -277,6 +277,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg				\n"
 				);
 }
 /*-----------------------------------------------------------*/
@@ -707,7 +708,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"	.ltorg						\n"
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -480,6 +480,7 @@ BaseType_t xPortStartScheduler( void )
 					" isb					\n"
 					" svc %0				\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg				\n"
 					:: "i" (portSVC_START_SCHEDULER) : "memory" );
 
 	/* Should not get here! */
@@ -630,7 +631,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"	.ltorg						\n"
 	);
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -271,6 +271,7 @@ static void prvPortStartFirstTask( void )
 					" isb					\n"
 					" svc 0					\n" /* System call to start first task. */
 					" nop					\n"
+					" .ltorg				\n"
 				);
 }
 /*-----------------------------------------------------------*/
@@ -697,7 +698,8 @@ static void vPortEnableVFP( void )
 		"								\n"
 		"	orr r1, r1, #( 0xf << 20 )	\n" /* Enable CP10 and CP11 coprocessors, then save back. */
 		"	str r1, [r0]				\n"
-		"	bx r14						"
+		"	bx r14						\n"
+		"	.ltorg						\n"
 	);
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------
When Link Time Optimization (LTO) is enabled, some of the LDR instructions result in out of range access. The reason is that the default generated literal pool is too far and not within the permissible
range of 4K.

This commit adds LTORG assembly instructions at required places to ensure that access to literals remain in the permissible range of 4K.

Test Steps
-----------
The changes were tested with GNU Arm Embedded Toolchain 9-2020-q2-update. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
