### PR TITLE
Improvement to O.F. protections

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -1095,7 +1095,7 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was posted while it was locked. */
-				configASSERT( pxQueue->cTxLock != INT8_MAX );
+				configASSERT( cTxLock != INT8_MAX );
 
 				pxQueue->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}
@@ -1262,7 +1262,7 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was posted while it was locked. */
-				configASSERT( pxQueue->cTxLock != INT8_MAX );
+				configASSERT( cTxLock != INT8_MAX );
 
 				pxQueue->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}
@@ -1863,7 +1863,7 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was removed while it was locked. */
-				configASSERT( pxQueue->cRxLock != INT8_MAX );
+				configASSERT( cRxLock != INT8_MAX );
 
 				pxQueue->cRxLock = ( int8_t ) ( cRxLock + 1 );
 			}
@@ -2928,7 +2928,7 @@ Queue_t * const pxQueue = xQueue;
 			}
 			else
 			{
-				configASSERT( pxQueueSetContainer->cTxLock != INT8_MAX );
+				configASSERT( cTxLock != INT8_MAX );
 
 				pxQueueSetContainer->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}

--- a/queue.c
+++ b/queue.c
@@ -51,6 +51,7 @@ correct privileged Vs unprivileged linkage and placement. */
 /* Constants used with the cRxLock and cTxLock structure members. */
 #define queueUNLOCKED					( ( int8_t ) -1 )
 #define queueLOCKED_UNMODIFIED			( ( int8_t ) 0 )
+#define queueINT8_MAX					( ( int8_t ) 127 )
 
 /* When the Queue_t structure is used to represent a base queue its pcHead and
 pcTail members are used as pointers into the queue storage area.  When the
@@ -1095,7 +1096,7 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was posted while it was locked. */
-				configASSERT( cTxLock != INT8_MAX );
+				configASSERT( cTxLock != queueINT8_MAX);
 
 				pxQueue->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}
@@ -1262,7 +1263,7 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was posted while it was locked. */
-				configASSERT( cTxLock != INT8_MAX );
+				configASSERT( cTxLock != queueINT8_MAX);
 
 				pxQueue->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}
@@ -1863,7 +1864,7 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was removed while it was locked. */
-				configASSERT( cRxLock != INT8_MAX );
+				configASSERT( cRxLock != queueINT8_MAX);
 
 				pxQueue->cRxLock = ( int8_t ) ( cRxLock + 1 );
 			}
@@ -2928,7 +2929,7 @@ Queue_t * const pxQueue = xQueue;
 			}
 			else
 			{
-				configASSERT( cTxLock != INT8_MAX );
+				configASSERT( cTxLock != queueINT8_MAX);
 
 				pxQueueSetContainer->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}

--- a/queue.c
+++ b/queue.c
@@ -378,7 +378,7 @@ Queue_t * const pxQueue = xQueue;
 		zero in the case the queue is used as a semaphore. */
 		xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
-		/* Check for multiplication overflow */
+		/* Check for multiplication overflow. */
 		configASSERT( uxItemSize == 0 || uxQueueLength == xQueueSizeInBytes / uxItemSize );
 
 		/* Allocate the queue and storage area.  Justification for MISRA

--- a/queue.c
+++ b/queue.c
@@ -1095,6 +1095,8 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was posted while it was locked. */
+				configASSERT( pxQueue->cTxLock != INT8_MAX );
+
 				pxQueue->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}
 
@@ -1260,6 +1262,8 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was posted while it was locked. */
+				configASSERT( pxQueue->cTxLock != INT8_MAX );
+
 				pxQueue->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}
 
@@ -1859,6 +1863,8 @@ Queue_t * const pxQueue = xQueue;
 			{
 				/* Increment the lock count so the task that unlocks the queue
 				knows that data was removed while it was locked. */
+				configASSERT( pxQueue->cRxLock != INT8_MAX );
+
 				pxQueue->cRxLock = ( int8_t ) ( cRxLock + 1 );
 			}
 
@@ -2922,6 +2928,8 @@ Queue_t * const pxQueue = xQueue;
 			}
 			else
 			{
+				configASSERT( pxQueueSetContainer->cTxLock != INT8_MAX );
+
 				pxQueueSetContainer->cTxLock = ( int8_t ) ( cTxLock + 1 );
 			}
 		}

--- a/queue.c
+++ b/queue.c
@@ -378,6 +378,9 @@ Queue_t * const pxQueue = xQueue;
 		zero in the case the queue is used as a semaphore. */
 		xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
+		/* Check for multiplication overflow */
+		configASSERT( uxItemSize == 0 || uxQueueLength == xQueueSizeInBytes / uxItemSize );
+
 		/* Allocate the queue and storage area.  Justification for MISRA
 		deviation as follows:  pvPortMalloc() always ensures returned memory
 		blocks are aligned per the requirements of the MCU stack.  In this case

--- a/queue.c
+++ b/queue.c
@@ -379,7 +379,7 @@ Queue_t * const pxQueue = xQueue;
 		xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
 		/* Check for multiplication overflow. */
-		configASSERT( uxItemSize == 0 || uxQueueLength == xQueueSizeInBytes / uxItemSize );
+		configASSERT( ( uxItemSize == 0 ) || ( uxQueueLength == ( xQueueSizeInBytes / uxItemSize ) ) );
 
 		/* Allocate the queue and storage area.  Justification for MISRA
 		deviation as follows:  pvPortMalloc() always ensures returned memory


### PR DESCRIPTION
Enhanced overflow protection. 

Description
-----------
- Prevent mismatching metadata after attempt to dynamically create a queue with size > 2^32 bytes.
- Prevent invalid state change that could occur from int8 overflow if ISR is being fired unreasonably fast, while a queue is locked.

Test Steps
-----------

- Attempt to create queue with > 2^32. Observe assertion.
- Second one is harder to exercise. Implemented preventively, as it is theoretically possible per CBMC. Could likely be exercised by NOT clearing interrupt flag and allowing ISR to continuously fire back-to-back with calls to `xQueueGenericSendFromISR` 


Related Issue
-----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
