### PR TITLE
Error in ARM_CM0 port compiled with IAR 8.50.5.

### DIFF
--- a/portable/IAR/ARM_CM0/port.c
+++ b/portable/IAR/ARM_CM0/port.c
@@ -96,7 +96,6 @@ static UBaseType_t uxCriticalNesting = 0xaaaaaaaa;
  * file is weak to allow application writers to change the timer used to
  * generate the tick interrupt.
  */
-#pragma weak vPortSetupTimerInterrupt
 void vPortSetupTimerInterrupt( void );
 
 /*
@@ -242,7 +241,7 @@ void xPortSysTickHandler( void )
  * Setup the systick timer to generate the tick interrupts at the required
  * frequency.
  */
-void vPortSetupTimerInterrupt( void )
+__weak void vPortSetupTimerInterrupt( void )
 {
     /* Calculate the constants required to configure the tick interrupt. */
     #if ( configUSE_TICKLESS_IDLE == 1 )


### PR DESCRIPTION
IAR EW in release 8.50.5 modified behaviour of weak declaration "#pragma weak".

Description
-----------
IAR EW release 8.50.5 causing build error in case of FreeRTOS  IAR ARM_CM0 port.

Error[Li006]: duplicate definitions for "vPortSetupTimerInterrupt"; in "c:test\boards\<someM0board>\rtos_examples\freertos_tickless\cm0plus\iar\debug\obj\fsl_tickless_lptmr.o", and "c:test\boards\someM0board\rtos_examples\freertos_tickless\cm0plus\iar\debug\obj\port.o"

To fix the issue use __weak in function definition instead.

Test Steps
-----------
Build FreeRTOS with ARM_CM0 port in IAR 8.50.5 with custom non-weak declaration of vPortSetupTimerInterrupt in application.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
