### PR TITLE
Place privileged symbols correctly

### DIFF
--- a/list.c
+++ b/list.c
@@ -27,8 +27,20 @@
 
 
 #include <stdlib.h>
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE prevents task.h from redefining
+ * all the API functions to use the MPU wrappers.  That should only be done when
+ * task.h is included from an application file. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
 #include "FreeRTOS.h"
 #include "list.h"
+
+/* Lint e9021, e961 and e750 are suppressed as a MISRA exception justified
+ * because the MPU ports require MPU_WRAPPERS_INCLUDED_FROM_API_FILE to be
+ * defined for the header files above, but not in this file, in order to
+ * generate the correct privileged Vs unprivileged linkage and placement. */
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE /*lint !e961 !e750 !e9021. */
 
 /*-----------------------------------------------------------
 * PUBLIC LIST API documented in list.h

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -350,7 +350,7 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
  * @brief Each task maintains its own interrupt status in the critical nesting
  * variable.
  */
-static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 
 #if ( configENABLE_TRUSTZONE == 1 )
 
@@ -358,7 +358,7 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
  * @brief Saved as part of the task context to indicate which context the
  * task is using on the secure side.
  */
-    portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
 #endif /* configENABLE_TRUSTZONE */
 
 #if ( configUSE_TICKLESS_IDLE == 1 )
@@ -366,19 +366,19 @@ static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
 /**
  * @brief The number of SysTick increments that make up one tick period.
  */
-    static uint32_t ulTimerCountsForOneTick = 0;
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
 
 /**
  * @brief The maximum number of tick periods that can be suppressed is
  * limited by the 24 bit resolution of the SysTick timer.
  */
-    static uint32_t xMaximumPossibleSuppressedTicks = 0;
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
 
 /**
  * @brief Compensate for the CPU cycles that pass while the SysTick is
  * stopped (low power functionality only).
  */
-    static uint32_t ulStoppedTimerCompensation = 0;
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
 #endif /* configUSE_TICKLESS_IDLE */
 /*-----------------------------------------------------------*/
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -62,7 +62,7 @@
 * heap - probably so it can be placed in a special segment or address. */
     extern uint8_t ucHeap[ configTOTAL_HEAP_SIZE ];
 #else
-    static uint8_t ucHeap[ configTOTAL_HEAP_SIZE ];
+    PRIVILEGED_DATA static uint8_t ucHeap[ configTOTAL_HEAP_SIZE ];
 #endif /* configAPPLICATION_ALLOCATED_HEAP */
 
 /* Define the linked list structure.  This is used to link free blocks in order
@@ -81,13 +81,13 @@ typedef struct A_BLOCK_LINK
  * the block in front it and/or the block behind it if the memory blocks are
  * adjacent to each other.
  */
-static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert );
+static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) PRIVILEGED_FUNCTION;
 
 /*
  * Called automatically to setup the required heap structures the first time
  * pvPortMalloc() is called.
  */
-static void prvHeapInit( void );
+static void prvHeapInit( void ) PRIVILEGED_FUNCTION;
 
 /*-----------------------------------------------------------*/
 
@@ -96,20 +96,20 @@ static void prvHeapInit( void );
 static const size_t xHeapStructSize = ( sizeof( BlockLink_t ) + ( ( size_t ) ( portBYTE_ALIGNMENT - 1 ) ) ) & ~( ( size_t ) portBYTE_ALIGNMENT_MASK );
 
 /* Create a couple of list links to mark the start and end of the list. */
-static BlockLink_t xStart, * pxEnd = NULL;
+PRIVILEGED_DATA static BlockLink_t xStart, * pxEnd = NULL;
 
 /* Keeps track of the number of calls to allocate and free memory as well as the
  * number of free bytes remaining, but says nothing about fragmentation. */
-static size_t xFreeBytesRemaining = 0U;
-static size_t xMinimumEverFreeBytesRemaining = 0U;
-static size_t xNumberOfSuccessfulAllocations = 0;
-static size_t xNumberOfSuccessfulFrees = 0;
+PRIVILEGED_DATA static size_t xFreeBytesRemaining = 0U;
+PRIVILEGED_DATA static size_t xMinimumEverFreeBytesRemaining = 0U;
+PRIVILEGED_DATA static size_t xNumberOfSuccessfulAllocations = 0;
+PRIVILEGED_DATA static size_t xNumberOfSuccessfulFrees = 0;
 
 /* Gets set to the top bit of an size_t type.  When this bit in the xBlockSize
  * member of an BlockLink_t structure is set then the block belongs to the
  * application.  When the bit is free the block is still part of the free heap
  * space. */
-static size_t xBlockAllocatedBit = 0;
+PRIVILEGED_DATA static size_t xBlockAllocatedBit = 0;
 
 /*-----------------------------------------------------------*/
 
@@ -332,7 +332,7 @@ void vPortInitialiseBlocks( void )
 }
 /*-----------------------------------------------------------*/
 
-static void prvHeapInit( void )
+static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 {
     BlockLink_t * pxFirstFreeBlock;
     uint8_t * pucAlignedHeap;
@@ -380,7 +380,7 @@ static void prvHeapInit( void )
 }
 /*-----------------------------------------------------------*/
 
-static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert )
+static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVILEGED_FUNCTION */
 {
     BlockLink_t * pxIterator;
     uint8_t * puc;

--- a/tasks.c
+++ b/tasks.c
@@ -455,7 +455,7 @@ static void prvInitialiseTaskLists( void ) PRIVILEGED_FUNCTION;
  * void prvIdleTask( void *pvParameters );
  *
  */
-static portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters );
+static portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
 
 /*
  * Utility to free all memory allocated by the scheduler to hold a TCB,
@@ -541,7 +541,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  * Set xNextTaskUnblockTime to the time at which the next Blocked state task
  * will exit the Blocked state.
  */
-static void prvResetNextTaskUnblockTime( void );
+static void prvResetNextTaskUnblockTime( void ) PRIVILEGED_FUNCTION;
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
 

--- a/timers.c
+++ b/timers.c
@@ -981,8 +981,8 @@
                     {
                         /* The timer queue is allocated statically in case
                          * configSUPPORT_DYNAMIC_ALLOCATION is 0. */
-                        static StaticQueue_t xStaticTimerQueue;                                                                          /*lint !e956 Ok to declare in this manner to prevent additional conditional compilation guards in other locations. */
-                        static uint8_t ucStaticTimerQueueStorage[ ( size_t ) configTIMER_QUEUE_LENGTH * sizeof( DaemonTaskMessage_t ) ]; /*lint !e956 Ok to declare in this manner to prevent additional conditional compilation guards in other locations. */
+                        PRIVILEGED_DATA static StaticQueue_t xStaticTimerQueue;                                                                          /*lint !e956 Ok to declare in this manner to prevent additional conditional compilation guards in other locations. */
+                        PRIVILEGED_DATA static uint8_t ucStaticTimerQueueStorage[ ( size_t ) configTIMER_QUEUE_LENGTH * sizeof( DaemonTaskMessage_t ) ]; /*lint !e956 Ok to declare in this manner to prevent additional conditional compilation guards in other locations. */
 
                         xTimerQueue = xQueueCreateStatic( ( UBaseType_t ) configTIMER_QUEUE_LENGTH, ( UBaseType_t ) sizeof( DaemonTaskMessage_t ), &( ucStaticTimerQueueStorage[ 0 ] ), &xStaticTimerQueue );
                     }


### PR DESCRIPTION

Description
-----------

Some of the privileged symbols were not being placed in their respective sections. This commit addresses those and places them in privileged_functions or privileged_data section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
