### PR TITLE
Add support for 16 MPU regions to Cortex-M4 MPU ports

### DIFF
--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -81,15 +81,21 @@
     #define portMPU_REGION_CACHEABLE_BUFFERABLE                      ( 0x07UL << 16UL )
     #define portMPU_REGION_EXECUTE_NEVER                             ( 0x01UL << 28UL )
 
+    /* MPU settings that can be overriden in FreeRTOSConfig.h. */
+    #ifndef configTOTAL_MPU_REGIONS
+        /* Define to 8 for backward compatibility. */
+        #define configTOTAL_MPU_REGIONS                              ( 8UL )
+    #endif
+
     #define portUNPRIVILEGED_FLASH_REGION                            ( 0UL )
     #define portPRIVILEGED_FLASH_REGION                              ( 1UL )
     #define portPRIVILEGED_RAM_REGION                                ( 2UL )
     #define portGENERAL_PERIPHERALS_REGION                           ( 3UL )
     #define portSTACK_REGION                                         ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                            ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                             ( 7UL )
-    #define portNUM_CONFIGURABLE_REGIONS                             ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
-    #define portTOTAL_NUM_REGIONS                                    ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus one to make space for the stack region. */
+    #define portTOTAL_NUM_REGIONS                                    ( configTOTAL_MPU_REGIONS )
+    #define portNUM_CONFIGURABLE_REGIONS                             ( portTOTAL_NUM_REGIONS - portFIRST_CONFIGURABLE_REGION )
+    #define portLAST_CONFIGURABLE_REGION                             ( portTOTAL_NUM_REGIONS - 1 )
 
     #define portSWITCH_TO_USER_MODE()    __asm volatile ( " mrs r0, control \n orr r0, #1 \n msr control, r0 " ::: "r0", "memory" )
 

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -76,7 +76,7 @@
 #define portMPU_REGION_BASE_ADDRESS_REG           ( *( ( volatile uint32_t * ) 0xe000ed9C ) )
 #define portMPU_REGION_ATTRIBUTE_REG              ( *( ( volatile uint32_t * ) 0xe000edA0 ) )
 #define portMPU_CTRL_REG                          ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portEXPECTED_MPU_TYPE_VALUE               ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE               ( portTOTAL_NUM_REGIONS << 8UL )
 #define portMPU_ENABLE                            ( 0x01UL )
 #define portMPU_BACKGROUND_ENABLE                 ( 1UL << 2UL )
 #define portPRIVILEGED_EXECUTION_START_ADDRESS    ( 0UL )
@@ -526,6 +526,12 @@ static void prvSetupMPU( void )
     extern uint32_t __FLASH_segment_end__[];
     extern uint32_t __privileged_data_start__[];
     extern uint32_t __privileged_data_end__[];
+
+    /* The only permitted number of regions are 8 or 16. */
+    configASSERT( ( portTOTAL_NUM_REGIONS == 8 ) || ( portTOTAL_NUM_REGIONS == 16 ) );
+
+    /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+    configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
     /* Check the expected MPU is present. */
     if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )

--- a/portable/IAR/ARM_CM4F_MPU/portasm.s
+++ b/portable/IAR/ARM_CM4F_MPU/portasm.s
@@ -91,10 +91,23 @@ xPortPendSVHandler:
 
 	/* Region Base Address register. */
 	ldr r2, =0xe000ed9c
-	/* Read 4 sets of MPU registers. */
+	/* Read 4 sets of MPU registers [MPU Region # 4 - 7]. */
 	ldmia r1!, {r4-r11}
-	/* Write 4 sets of MPU registers. */
-	stmia r2!, {r4-r11}
+	/* Write 4 sets of MPU registers [MPU Region # 4 - 7]. */
+	stmia r2, {r4-r11}
+
+	#ifdef configTOTAL_MPU_REGIONS
+		#if ( configTOTAL_MPU_REGIONS == 16 )
+			/* Read 4 sets of MPU registers [MPU Region # 8 - 11]. */
+			ldmia r1!, {r4-r11}
+			/* Write 4 sets of MPU registers. [MPU Region # 8 - 11]. */
+			stmia r2, {r4-r11}
+			/* Read 4 sets of MPU registers [MPU Region # 12 - 15]. */
+			ldmia r1!, {r4-r11}
+			/* Write 4 sets of MPU registers. [MPU Region # 12 - 15]. */
+			stmia r2, {r4-r11}
+		#endif /* configTOTAL_MPU_REGIONS == 16. */
+	#endif /* configTOTAL_MPU_REGIONS */
 
 	ldr r2, =0xe000ed94	/* MPU_CTRL register. */
 	ldr r3, [r2]		/* Read the value of MPU_CTRL. */
@@ -178,10 +191,23 @@ vPortRestoreContextOfFirstTask:
 
 	/* Region Base Address register. */
 	ldr r2, =0xe000ed9c
-	/* Read 4 sets of MPU registers. */
+	/* Read 4 sets of MPU registers [MPU Region # 4 - 7]. */
 	ldmia r1!, {r4-r11}
-	/* Write 4 sets of MPU registers. */
-	stmia r2!, {r4-r11}
+	/* Write 4 sets of MPU registers [MPU Region # 4 - 7]. */
+	stmia r2, {r4-r11}
+
+	#ifdef configTOTAL_MPU_REGIONS
+		#if ( configTOTAL_MPU_REGIONS == 16 )
+			/* Read 4 sets of MPU registers [MPU Region # 8 - 11]. */
+			ldmia r1!, {r4-r11}
+			/* Write 4 sets of MPU registers. [MPU Region # 8 - 11]. */
+			stmia r2, {r4-r11}
+			/* Read 4 sets of MPU registers [MPU Region # 12 - 15]. */
+			ldmia r1!, {r4-r11}
+			/* Write 4 sets of MPU registers. [MPU Region # 12 - 15]. */
+			stmia r2, {r4-r11}
+		#endif /* configTOTAL_MPU_REGIONS == 16. */
+	#endif /* configTOTAL_MPU_REGIONS */
 
 	ldr r2, =0xe000ed94	/* MPU_CTRL register. */
 	ldr r3, [r2]		/* Read the value of MPU_CTRL. */

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -84,15 +84,21 @@
     #define portMPU_REGION_CACHEABLE_BUFFERABLE                      ( 0x07UL << 16UL )
     #define portMPU_REGION_EXECUTE_NEVER                             ( 0x01UL << 28UL )
 
+    /* MPU settings that can be overriden in FreeRTOSConfig.h. */
+    #ifndef configTOTAL_MPU_REGIONS
+        /* Define to 8 for backward compatibility. */
+        #define configTOTAL_MPU_REGIONS                              ( 8UL )
+    #endif
+
     #define portUNPRIVILEGED_FLASH_REGION                            ( 0UL )
     #define portPRIVILEGED_FLASH_REGION                              ( 1UL )
     #define portPRIVILEGED_RAM_REGION                                ( 2UL )
     #define portGENERAL_PERIPHERALS_REGION                           ( 3UL )
     #define portSTACK_REGION                                         ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                            ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                             ( 7UL )
-    #define portNUM_CONFIGURABLE_REGIONS                             ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
-    #define portTOTAL_NUM_REGIONS                                    ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus one to make space for the stack region. */
+    #define portTOTAL_NUM_REGIONS                                    ( configTOTAL_MPU_REGIONS )
+    #define portNUM_CONFIGURABLE_REGIONS                             ( portTOTAL_NUM_REGIONS - portFIRST_CONFIGURABLE_REGION )
+    #define portLAST_CONFIGURABLE_REGION                             ( portTOTAL_NUM_REGIONS - 1UL )
 
     #define portSWITCH_TO_USER_MODE()    __asm volatile ( " mrs r0, control \n orr r0, r0, #1 \n msr control, r0 " ::: "r0", "memory" )
 

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -81,15 +81,21 @@
     #define portMPU_REGION_CACHEABLE_BUFFERABLE                      ( 0x07UL << 16UL )
     #define portMPU_REGION_EXECUTE_NEVER                             ( 0x01UL << 28UL )
 
+    /* MPU settings that can be overriden in FreeRTOSConfig.h. */
+    #ifndef configTOTAL_MPU_REGIONS
+        /* Define to 8 for backward compatibility. */
+        #define configTOTAL_MPU_REGIONS                              ( 8UL )
+    #endif
+
     #define portUNPRIVILEGED_FLASH_REGION                            ( 0UL )
     #define portPRIVILEGED_FLASH_REGION                              ( 1UL )
     #define portPRIVILEGED_RAM_REGION                                ( 2UL )
     #define portGENERAL_PERIPHERALS_REGION                           ( 3UL )
     #define portSTACK_REGION                                         ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                            ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                             ( 7UL )
-    #define portNUM_CONFIGURABLE_REGIONS                             ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
-    #define portTOTAL_NUM_REGIONS                                    ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus one to make space for the stack region. */
+    #define portTOTAL_NUM_REGIONS                                    ( configTOTAL_MPU_REGIONS )
+    #define portNUM_CONFIGURABLE_REGIONS                             ( portTOTAL_NUM_REGIONS - portFIRST_CONFIGURABLE_REGION )
+    #define portLAST_CONFIGURABLE_REGION                             ( portTOTAL_NUM_REGIONS - 1 )
 
     void vPortSwitchToUserMode( void );
     #define portSWITCH_TO_USER_MODE()    vPortSwitchToUserMode()


### PR DESCRIPTION
Description
-----------

ARMv7-M supports 8 or 16 MPU regions. FreeRTOS Cortex-M4 MPU ports so far assumed 8 regions. This change adds support for 16 MPU regions. The hardware with 16 MPU regions must define `configTOTAL_MPU_REGIONS` to 16 in their FreeRTOSConfig.h.

If left undefined, `configTOTAL_MPU_REGIONS` defaults to 8 for backward compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
