### PR TITLE
Update to AVR_Mega0 and AVR_Dx GCC ports + addition of their IAR equivalents

### DIFF
--- a/portable/GCC/AVR_AVRDx/port.c
+++ b/portable/GCC/AVR_AVRDx/port.c
@@ -38,7 +38,7 @@
  *----------------------------------------------------------*/
 
 /* Start tasks with interrupts enables. */
-#define portFLAGS_INT_ENABLED				((StackType_t) 0x80)
+#define portFLAGS_INT_ENABLED               ((StackType_t) 0x80)
 
 /*-----------------------------------------------------------*/
 
@@ -63,103 +63,102 @@ extern volatile RTOS_TCB_t *volatile pxCurrentTCB;
  *
  * The interrupts will have been disabled during the call to portSAVE_CONTEXT()
  * so we need not worry about reading/writing to the stack pointer.
-
  */
 
-#define portSAVE_CONTEXT()	\
-	asm volatile("push	r0						\n\t"	\
-	             "in	r0, __SREG__			\n\t"	\
-	             "cli							\n\t"	\
-	             "push	r0						\n\t"	\
-                 "in    r0, __RAMPZ__           \n\t"   \
-                 "push  r0                      \n\t"   \
-	             "push	r1						\n\t"	\
-	             "clr	r1						\n\t"	\
-	             "push	r2						\n\t"	\
-	             "push	r3						\n\t"	\
-	             "push	r4						\n\t"	\
-	             "push	r5						\n\t"	\
-	             "push	r6						\n\t"	\
-	             "push	r7						\n\t"	\
-	             "push	r8						\n\t"	\
-	             "push	r9						\n\t"	\
-	             "push	r10						\n\t"	\
-	             "push	r11						\n\t"	\
-	             "push	r12						\n\t"	\
-	             "push	r13						\n\t"	\
-	             "push	r14						\n\t"	\
-	             "push	r15						\n\t"	\
-	             "push	r16						\n\t"	\
-	             "push	r17						\n\t"	\
-	             "push	r18						\n\t"	\
-	             "push	r19						\n\t"	\
-	             "push	r20						\n\t"	\
-	             "push	r21						\n\t"	\
-	             "push	r22						\n\t"	\
-	             "push	r23						\n\t"	\
-	             "push	r24						\n\t"	\
-	             "push	r25						\n\t"	\
-	             "push	r26						\n\t"	\
-	             "push	r27						\n\t"	\
-	             "push	r28						\n\t"	\
-	             "push	r29						\n\t"	\
-	             "push	r30						\n\t"	\
-	             "push	r31						\n\t"	\
-	             "lds	r26, pxCurrentTCB		\n\t"	\
-	             "lds	r27, pxCurrentTCB + 1	\n\t"	\
-	             "in	r0, __SP_L__			\n\t"	\
-	             "st	x+, r0					\n\t"	\
-	             "in	r0, __SP_H__			\n\t"	\
-	             "st	x+, r0					\n\t");
+#define portSAVE_CONTEXT() \
+    asm volatile("push  r0                      \n\t" \
+                 "in    r0, __SREG__            \n\t" \
+                 "cli                           \n\t" \
+                 "push  r0                      \n\t" \
+                 "in    r0, __RAMPZ__           \n\t" \
+                 "push  r0                      \n\t" \
+                 "push  r1                      \n\t" \
+                 "clr   r1                      \n\t" \
+                 "push  r2                      \n\t" \
+                 "push  r3                      \n\t" \
+                 "push  r4                      \n\t" \
+                 "push  r5                      \n\t" \
+                 "push  r6                      \n\t" \
+                 "push  r7                      \n\t" \
+                 "push  r8                      \n\t" \
+                 "push  r9                      \n\t" \
+                 "push  r10                     \n\t" \
+                 "push  r11                     \n\t" \
+                 "push  r12                     \n\t" \
+                 "push  r13                     \n\t" \
+                 "push  r14                     \n\t" \
+                 "push  r15                     \n\t" \
+                 "push  r16                     \n\t" \
+                 "push  r17                     \n\t" \
+                 "push  r18                     \n\t" \
+                 "push  r19                     \n\t" \
+                 "push  r20                     \n\t" \
+                 "push  r21                     \n\t" \
+                 "push  r22                     \n\t" \
+                 "push  r23                     \n\t" \
+                 "push  r24                     \n\t" \
+                 "push  r25                     \n\t" \
+                 "push  r26                     \n\t" \
+                 "push  r27                     \n\t" \
+                 "push  r28                     \n\t" \
+                 "push  r29                     \n\t" \
+                 "push  r30                     \n\t" \
+                 "push  r31                     \n\t" \
+                 "lds   r26, pxCurrentTCB       \n\t" \
+                 "lds   r27, pxCurrentTCB + 1   \n\t" \
+                 "in    r0, __SP_L__            \n\t" \
+                 "st    x+, r0                  \n\t" \
+                 "in    r0, __SP_H__            \n\t" \
+                 "st    x+, r0                  \n\t");
 
 /*
  * Opposite to portSAVE_CONTEXT().  Interrupts will have been disabled during
  * the context save so we can write to the stack pointer.
  */
 
-#define portRESTORE_CONTEXT()	\
-	asm volatile("lds	r26, pxCurrentTCB		\n\t"	\
-	             "lds	r27, pxCurrentTCB + 1	\n\t"	\
-	             "ld	r28, x+					\n\t"	\
-	             "out	__SP_L__, r28			\n\t"	\
-	             "ld	r29, x+					\n\t"	\
-	             "out	__SP_H__, r29			\n\t"	\
-	             "pop	r31						\n\t"	\
-	             "pop	r30						\n\t"	\
-	             "pop	r29						\n\t"	\
-	             "pop	r28						\n\t"	\
-	             "pop	r27						\n\t"	\
-	             "pop	r26						\n\t"	\
-	             "pop	r25						\n\t"	\
-	             "pop	r24						\n\t"	\
-	             "pop	r23						\n\t"	\
-	             "pop	r22						\n\t"	\
-	             "pop	r21						\n\t"	\
-	             "pop	r20						\n\t"	\
-	             "pop	r19						\n\t"	\
-	             "pop	r18						\n\t"	\
-	             "pop	r17						\n\t"	\
-	             "pop	r16						\n\t"	\
-	             "pop	r15						\n\t"	\
-	             "pop	r14						\n\t"	\
-	             "pop	r13						\n\t"	\
-	             "pop	r12						\n\t"	\
-	             "pop	r11						\n\t"	\
-	             "pop	r10						\n\t"	\
-	             "pop	r9						\n\t"	\
-	             "pop	r8						\n\t"	\
-	             "pop	r7						\n\t"	\
-	             "pop	r6						\n\t"	\
-	             "pop	r5						\n\t"	\
-	             "pop	r4						\n\t"	\
-	             "pop	r3						\n\t"	\
-	             "pop	r2						\n\t"	\
-	             "pop	r1						\n\t"	\
-                 "pop   r0                      \n\t"	\
-                 "out   __RAMPZ__, r0           \n\t"	\
-	             "pop	r0						\n\t"	\
-	             "out	__SREG__, r0			\n\t"	\
-	             "pop	r0						\n\t");
+#define portRESTORE_CONTEXT() \
+    asm volatile("lds   r26, pxCurrentTCB       \n\t" \
+                 "lds   r27, pxCurrentTCB + 1   \n\t" \
+                 "ld    r28, x+                 \n\t" \
+                 "out   __SP_L__, r28           \n\t" \
+                 "ld    r29, x+                 \n\t" \
+                 "out   __SP_H__, r29           \n\t" \
+                 "pop   r31                     \n\t" \
+                 "pop   r30                     \n\t" \
+                 "pop   r29                     \n\t" \
+                 "pop   r28                     \n\t" \
+                 "pop   r27                     \n\t" \
+                 "pop   r26                     \n\t" \
+                 "pop   r25                     \n\t" \
+                 "pop   r24                     \n\t" \
+                 "pop   r23                     \n\t" \
+                 "pop   r22                     \n\t" \
+                 "pop   r21                     \n\t" \
+                 "pop   r20                     \n\t" \
+                 "pop   r19                     \n\t" \
+                 "pop   r18                     \n\t" \
+                 "pop   r17                     \n\t" \
+                 "pop   r16                     \n\t" \
+                 "pop   r15                     \n\t" \
+                 "pop   r14                     \n\t" \
+                 "pop   r13                     \n\t" \
+                 "pop   r12                     \n\t" \
+                 "pop   r11                     \n\t" \
+                 "pop   r10                     \n\t" \
+                 "pop   r9                      \n\t" \
+                 "pop   r8                      \n\t" \
+                 "pop   r7                      \n\t" \
+                 "pop   r6                      \n\t" \
+                 "pop   r5                      \n\t" \
+                 "pop   r4                      \n\t" \
+                 "pop   r3                      \n\t" \
+                 "pop   r2                      \n\t" \
+                 "pop   r1                      \n\t" \
+                 "pop   r0                      \n\t" \
+                 "out   __RAMPZ__, r0           \n\t" \
+                 "pop   r0                      \n\t" \
+                 "out   __SREG__, r0            \n\t" \
+                 "pop   r0                      \n\t");
 
 /*-----------------------------------------------------------*/
 
@@ -174,11 +173,11 @@ static void prvSetupTimerInterrupt(void);
  */
 StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters)
 {
-	uint16_t usAddress;
+    uint16_t usAddress;
 
-	/*lint -e950 -e611 -e923 Lint doesn't like this much - but nothing I can do about it. */
+    /*lint -e950 -e611 -e923 Lint doesn't like this much - but nothing I can do about it. */
 
-	/* Place a few bytes of known values on the bottom of the stack.
+    /* Place a few bytes of known values on the bottom of the stack.
     This is just useful for debugging. Uncomment if needed. */
     // *pxTopOfStack = 0x11;
     // pxTopOfStack--;
@@ -187,70 +186,70 @@ StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack, TaskFunction_t pxC
     // *pxTopOfStack = 0x33; 
     // pxTopOfStack--;
 
-	/* The start of the task code will be popped off the stack last, so place
-	it on first. */
-	usAddress     = (uint16_t)pxCode;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
-	pxTopOfStack--;
+    /* The start of the task code will be popped off the stack last, so place
+    it on first. */
+    usAddress     = (uint16_t)pxCode;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    pxTopOfStack--;
 
-	usAddress >>= 8;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
-	pxTopOfStack--;
+    usAddress >>= 8;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    pxTopOfStack--;
 
-	/* Next simulate the stack as if after a call to portSAVE_CONTEXT().
-	portSAVE_CONTEXT places the flags on the stack immediately after r0
-	to ensure the interrupts get disabled as soon as possible, and so ensuring
-	the stack use is minimal should a context switch interrupt occur. */
-	*pxTopOfStack = (StackType_t)0x00; /* R0 */
-	pxTopOfStack--;
-	*pxTopOfStack = portFLAGS_INT_ENABLED;
-	pxTopOfStack--;
-	*pxTopOfStack = ( StackType_t ) 0x00;	/* RAMPZ */
-	pxTopOfStack--;
-	
-	/* Now the remaining registers.   The compiler expects R1 to be 0. */
-	*pxTopOfStack = (StackType_t)0x00; /* R1 */
+    /* Next simulate the stack as if after a call to portSAVE_CONTEXT().
+    portSAVE_CONTEXT places the flags on the stack immediately after r0
+    to ensure the interrupts get disabled as soon as possible, and so ensuring
+    the stack use is minimal should a context switch interrupt occur. */
+    *pxTopOfStack = (StackType_t)0x00; /* R0 */
+    pxTopOfStack--;
+    *pxTopOfStack = portFLAGS_INT_ENABLED;
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x00;	/* RAMPZ */
+    pxTopOfStack--;
+    
+    /* Now the remaining registers.   The compiler expects R1 to be 0. */
+    *pxTopOfStack = (StackType_t)0x00; /* R1 */
 
-	/* Leave R2 - R23 untouched */
-	pxTopOfStack -= 23;
+    /* Leave R2 - R23 untouched */
+    pxTopOfStack -= 23;
 
-	/* Place the parameter on the stack in the expected location. */
-	usAddress     = (uint16_t)pvParameters;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
-	pxTopOfStack--;
+    /* Place the parameter on the stack in the expected location. */
+    usAddress     = (uint16_t)pvParameters;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    pxTopOfStack--;
 
-	usAddress >>= 8;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    usAddress >>= 8;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
 
-	/* Leave register R26 - R31 untouched */
-	pxTopOfStack -= 7;
+    /* Leave register R26 - R31 untouched */
+    pxTopOfStack -= 7;
 
-	/*lint +e950 +e611 +e923 */
+    /*lint +e950 +e611 +e923 */
 
-	return pxTopOfStack;
+    return pxTopOfStack;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xPortStartScheduler(void)
 {
-	/* Setup the hardware to generate the tick. */
-	prvSetupTimerInterrupt();
+    /* Setup the hardware to generate the tick. */
+    prvSetupTimerInterrupt();
 
-	/* Restore the context of the first task that is going to run. */
-	portRESTORE_CONTEXT();
+    /* Restore the context of the first task that is going to run. */
+    portRESTORE_CONTEXT();
 
-	/* Simulate a function call end as generated by the compiler.  We will now
-	jump to the start of the task the context of which we have just restored. */
-	asm volatile("ret");
+    /* Simulate a function call end as generated by the compiler.  We will now
+    jump to the start of the task the context of which we have just restored. */
+    asm volatile("ret");
 
-	/* Should not get here. */
-	return pdTRUE;
+    /* Should not get here. */
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 
 void vPortEndScheduler(void)
 {
-	/* vPortEndScheduler is not implemented in this port. */
+    /* vPortEndScheduler is not implemented in this port. */
 }
 /*-----------------------------------------------------------*/
 
@@ -261,10 +260,10 @@ void vPortEndScheduler(void)
 void vPortYield(void) __attribute__((naked));
 void vPortYield(void)
 {
-	portSAVE_CONTEXT();
-	vTaskSwitchContext();
-	portRESTORE_CONTEXT();
-	asm volatile("ret");
+    portSAVE_CONTEXT();
+    vTaskSwitchContext();
+    portRESTORE_CONTEXT();
+    asm volatile("ret");
 }
 /*-----------------------------------------------------------*/
 
@@ -275,10 +274,10 @@ void vPortYield(void)
 void vPortYieldFromISR(void) __attribute__((naked));
 void vPortYieldFromISR(void)
 {
-	portSAVE_CONTEXT();
-	vTaskSwitchContext();
-	portRESTORE_CONTEXT();
-	asm volatile("reti");
+    portSAVE_CONTEXT();
+    vTaskSwitchContext();
+    portRESTORE_CONTEXT();
+    asm volatile("reti");
 }
 /*-----------------------------------------------------------*/
 
@@ -291,15 +290,14 @@ void vPortYieldFromISR(void)
 void vPortYieldFromTick(void) __attribute__((naked));
 void vPortYieldFromTick(void)
 {
-	portSAVE_CONTEXT();
-	
-	if (xTaskIncrementTick() != pdFALSE) {
-		vTaskSwitchContext();
-	}
+    portSAVE_CONTEXT();
+    if (xTaskIncrementTick() != pdFALSE) {
+        vTaskSwitchContext();
+    }
 
-	portRESTORE_CONTEXT();
+    portRESTORE_CONTEXT();
 
-	asm volatile("reti");
+    asm volatile("reti");
 }
 /*-----------------------------------------------------------*/
 
@@ -308,7 +306,7 @@ void vPortYieldFromTick(void)
  */
 static void prvSetupTimerInterrupt(void)
 {
-	TICK_init();
+    TICK_init();
 }
 /*-----------------------------------------------------------*/
 
@@ -319,17 +317,15 @@ static void prvSetupTimerInterrupt(void)
  * the context is saved at the start of vPortYieldFromTick().  The tick
  * count is incremented after the context is saved.
  */
-
 ISR(TICK_INT_vect, ISR_NAKED)
 {
-	/* Clear tick interrupt flag. */
-	CLR_INT(INT_FLAGS, INT_MASK);
+    /* Clear tick interrupt flag. */
+    CLR_INT(INT_FLAGS, INT_MASK);
 
-	vPortYieldFromTick();
+    vPortYieldFromTick();
 
-	asm volatile("reti");
+    asm volatile("reti");
 }
-
 #else
 
 /*
@@ -337,14 +333,10 @@ ISR(TICK_INT_vect, ISR_NAKED)
  * tick count.  We don't need to switch context, this can only be done by
  * manual calls to taskYIELD();
  */
-
 ISR(TICK_INT_vect)
 {
-	/* Clear tick interrupt flag. */
-	INT_FLAGS = INT_MASK;
-	
-	xTaskIncrementTick();
+    /* Clear tick interrupt flag. */
+    INT_FLAGS = INT_MASK;
+    xTaskIncrementTick();
 }
-
-
 #endif

--- a/portable/GCC/AVR_AVRDx/porthardware.h
+++ b/portable/GCC/AVR_AVRDx/porthardware.h
@@ -6,121 +6,96 @@
 /*-----------------------------------------------------------*/
 
 #define CLR_INT(FLAG_REG, FLAG_MASK) \
-		asm volatile(	"push r16\n\t" \
-		"ldi r16, %1\n\t" \
-		"sts %0, r16\n\t" \
-		"pop r16\n\t" \
-		: \
-		: "i"(_SFR_MEM_ADDR(FLAG_REG)),"i"((uint8_t)(FLAG_MASK)) \
-		);
+        asm volatile( \
+            "push r16\n\t" \
+            "ldi r16, %1\n\t" \
+            "sts %0, r16\n\t" \
+            "pop r16\n\t" \
+            : \
+            : "i"(_SFR_MEM_ADDR(FLAG_REG)),"i"((uint8_t)(FLAG_MASK)) \
+        );
 
 #if ( configUSE_TIMER_INSTANCE == 0 )
 
-	#define TICK_INT_vect			TCB0_INT_vect
-	#define INT_FLAGS				TCB0_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
-	
-	#define TICK_init()				{ \
-									TCB0.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB0.INTCTRL = TCB_CAPT_bm; \
-									TCB0.CTRLA   = TCB_ENABLE_bm; \
-									}
-									
-	#define TICK_stop()				{ \
-									TCB0.INTCTRL &= ~TCB_CAPT_bm;\
-									TCB0.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
+    #define TICK_INT_vect       TCB0_INT_vect
+    #define INT_FLAGS           TCB0_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+
+    #define TICK_init()         { \
+                                TCB0.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB0.INTCTRL = TCB_CAPT_bm; \
+                                TCB0.CTRLA   = TCB_ENABLE_bm; \
+                                }
 
 #elif ( configUSE_TIMER_INSTANCE == 1 )
 
-	#define TICK_INT_vect			TCB1_INT_vect
-	#define INT_FLAGS				TCB1_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
-	
-	#define TICK_init()				{ \
-									TCB1.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB1.INTCTRL = TCB_CAPT_bm; \
-									TCB1.CTRLA   = TCB_ENABLE_bm; \
-									}
-		
+    #define TICK_INT_vect       TCB1_INT_vect
+    #define INT_FLAGS           TCB1_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+
+    #define TICK_init()         { \
+                                TCB1.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB1.INTCTRL = TCB_CAPT_bm; \
+                                TCB1.CTRLA   = TCB_ENABLE_bm; \
+                                }
+        
 #elif ( configUSE_TIMER_INSTANCE == 2 )
 
-	#define TICK_INT_vect			TCB2_INT_vect
-	#define INT_FLAGS				TCB2_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
+    #define TICK_INT_vect       TCB2_INT_vect
+    #define INT_FLAGS           TCB2_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
 
-	#define TICK_init()				{ \
-									TCB2.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB2.INTCTRL = TCB_CAPT_bm; \
-									TCB2.CTRLA   = TCB_ENABLE_bm; \
-									}
-									
-	#define TICK_stop()				{ \
-									TCB2.INTCTRL &= ~TCB_CAPT_bm; \
-									TCB2.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
-		
+    #define TICK_init()         { \
+                                TCB2.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB2.INTCTRL = TCB_CAPT_bm; \
+                                TCB2.CTRLA   = TCB_ENABLE_bm; \
+                                }
+        
 #elif ( configUSE_TIMER_INSTANCE == 3 )
 
-	#define TICK_INT_vect			TCB3_INT_vect
-	#define INT_FLAGS				TCB3_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
-	
-	#define TICK_init()				{ \
-									TCB3.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB3.INTCTRL = TCB_CAPT_bm; \
-									TCB3.CTRLA   = TCB_ENABLE_bm; \
-									}
-									
-	#define TICK_stop()				{ \
-									TCB3.INTCTRL &= ~TCB_CAPT_bm; \
-									TCB3.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
-	
+    #define TICK_INT_vect       TCB3_INT_vect
+    #define INT_FLAGS           TCB3_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+
+    #define TICK_init()         { \
+                                TCB3.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB3.INTCTRL = TCB_CAPT_bm; \
+                                TCB3.CTRLA   = TCB_ENABLE_bm; \
+                                }
+    
 #elif ( configUSE_TIMER_INSTANCE == 4 )
 
-	#define TICK_INT_vect			TCB4_INT_vect
-	#define INT_FLAGS				TCB4_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
-	
-	#define TICK_init()				{ \
-									TCB4.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB4.INTCTRL = TCB_CAPT_bm; \
-									TCB4.CTRLA   = TCB_ENABLE_bm; \
-									}
-		
-	#define TICK_stop()				{ \
-									TCB4.INTCTRL &= ~TCB_CAPT_bm; \
-									TCB4.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
-	
+    #define TICK_INT_vect       TCB4_INT_vect
+    #define INT_FLAGS           TCB4_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+
+    #define TICK_init()         { \
+                                TCB4.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB4.INTCTRL = TCB_CAPT_bm; \
+                                TCB4.CTRLA   = TCB_ENABLE_bm; \
+                                }
+
 #elif ( configUSE_TIMER_INSTANCE == 5 )
-	
-	/* Hertz to period for RTC setup */
-	#define RTC_PERIOD_HZ(x)		(32768 * ((1.0 / x)))
-	
-	#define TICK_INT_vect			RTC_CNT_vect
-	#define INT_FLAGS				RTC_INTFLAGS
-	#define INT_MASK				RTC_OVF_bm
-	
-	#define TICK_init()				{ \
-									while (RTC.STATUS > 0); \
-									RTC.CTRLA    = RTC_PRESCALER_DIV1_gc | 1 << RTC_RTCEN_bp; \
-									RTC.PER      = RTC_PERIOD_HZ(configTICK_RATE_HZ); \
-									RTC.INTCTRL  |= 1 << RTC_OVF_bp; \
-									}
-	
-	#define TICK_stop()				{ \
-									RTC.CTRLA	 &= ~(1 << RTC_RTCEN_bp); \
-									RTC.INTCTRL	 &= ~(1 << RTC_OVF_bp); \
-									}
+
+    #define TICK_INT_vect       RTC_CNT_vect
+    #define INT_FLAGS           RTC_INTFLAGS
+    #define INT_MASK            RTC_OVF_bm
+
+    /* Hertz to period for RTC setup */
+    #define RTC_PERIOD_HZ(x)    ( 32768 * ( ( 1.0 / x ) ) )
+    #define TICK_init()         { \
+                                while (RTC.STATUS > 0); \
+                                RTC.CTRLA    = RTC_PRESCALER_DIV1_gc | 1 << RTC_RTCEN_bp; \
+                                RTC.PER      = RTC_PERIOD_HZ(configTICK_RATE_HZ); \
+                                RTC.INTCTRL  |= 1 << RTC_OVF_bp; \
+                                }
 
 #else
-	#undef TICK_INT_vect
-	#undef INT_FLAGS
-	#undef INT_MASK
-	#undef TICK_init()
-	#error Invalid timer setting.
+    #undef TICK_INT_vect
+    #undef INT_FLAGS
+    #undef INT_MASK
+    #undef TICK_init()
+    #error Invalid timer setting.
 #endif
 
 /*-----------------------------------------------------------*/

--- a/portable/GCC/AVR_AVRDx/porthardware.h
+++ b/portable/GCC/AVR_AVRDx/porthardware.h
@@ -42,11 +42,6 @@
 									TCB1.INTCTRL = TCB_CAPT_bm; \
 									TCB1.CTRLA   = TCB_ENABLE_bm; \
 									}
-									
-	#define TICK_stop()				{ \
-									TCB1.INTCTRL &= ~TCB_CAPT_bm; \
-									TCB1.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
 		
 #elif ( configUSE_TIMER_INSTANCE == 2 )
 

--- a/portable/GCC/AVR_AVRDx/portmacro.h
+++ b/portable/GCC/AVR_AVRDx/portmacro.h
@@ -64,18 +64,17 @@ typedef uint16_t TickType_t;
 typedef uint32_t TickType_t;
 #define portMAX_DELAY (TickType_t)0xffffffffUL
 #endif
-
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */
 #define portENTER_CRITICAL()                                                                                           \
-	asm volatile("in __tmp_reg__, __SREG__");                                                                          \
-	asm volatile("cli");                                                                                               \
-	asm volatile("push __tmp_reg__")
+    asm volatile("in __tmp_reg__, __SREG__");                                                                          \
+    asm volatile("cli");                                                                                               \
+    asm volatile("push __tmp_reg__")
 
 #define portEXIT_CRITICAL()                                                                                            \
-	asm volatile("pop __tmp_reg__");                                                                                   \
-	asm volatile("out __SREG__, __tmp_reg__")
+    asm volatile("pop __tmp_reg__");                                                                                   \
+    asm volatile("out __SREG__, __tmp_reg__")
 
 #define portDISABLE_INTERRUPTS() asm volatile("cli" ::);
 #define portENABLE_INTERRUPTS() asm volatile("sei" ::);

--- a/portable/GCC/AVR_Mega0/port.c
+++ b/portable/GCC/AVR_Mega0/port.c
@@ -29,9 +29,7 @@
 #include <stdlib.h>
 
 #include <avr/interrupt.h>
-
 #include "porthardware.h"
-
 #include "FreeRTOS.h"
 #include "task.h"
 
@@ -40,7 +38,7 @@
  *----------------------------------------------------------*/
 
 /* Start tasks with interrupts enables. */
-#define portFLAGS_INT_ENABLED				((StackType_t) 0x80)
+#define portFLAGS_INT_ENABLED               ((StackType_t) 0x80)
 
 /*-----------------------------------------------------------*/
 
@@ -67,96 +65,96 @@ extern volatile RTOS_TCB_t *volatile pxCurrentTCB;
  * so we need not worry about reading/writing to the stack pointer.
  */
 
-#define portSAVE_CONTEXT()                                                                                                             \
-	asm volatile("push	r0						\n\t"                                                                                  \
-	             "in	r0, __SREG__			\n\t"                                                                                  \
-	             "cli							\n\t"                                                                                  \
-	             "push	r0						\n\t"                                                                                  \
-	             "push	r1						\n\t"                                                                                  \
-	             "clr	r1						\n\t"                                                                                  \
-	             "push	r2						\n\t"                                                                                  \
-	             "push	r3						\n\t"                                                                                  \
-	             "push	r4						\n\t"                                                                                  \
-	             "push	r5						\n\t"                                                                                  \
-	             "push	r6						\n\t"                                                                                  \
-	             "push	r7						\n\t"                                                                                  \
-	             "push	r8						\n\t"                                                                                  \
-	             "push	r9						\n\t"                                                                                  \
-	             "push	r10						\n\t"                                                                                  \
-	             "push	r11						\n\t"                                                                                  \
-	             "push	r12						\n\t"                                                                                  \
-	             "push	r13						\n\t"                                                                                  \
-	             "push	r14						\n\t"                                                                                  \
-	             "push	r15						\n\t"                                                                                  \
-	             "push	r16						\n\t"                                                                                  \
-	             "push	r17						\n\t"                                                                                  \
-	             "push	r18						\n\t"                                                                                  \
-	             "push	r19						\n\t"                                                                                  \
-	             "push	r20						\n\t"                                                                                  \
-	             "push	r21						\n\t"                                                                                  \
-	             "push	r22						\n\t"                                                                                  \
-	             "push	r23						\n\t"                                                                                  \
-	             "push	r24						\n\t"                                                                                  \
-	             "push	r25						\n\t"                                                                                  \
-	             "push	r26						\n\t"                                                                                  \
-	             "push	r27						\n\t"                                                                                  \
-	             "push	r28						\n\t"                                                                                  \
-	             "push	r29						\n\t"                                                                                  \
-	             "push	r30						\n\t"                                                                                  \
-	             "push	r31						\n\t"                                                                                  \
-	             "lds	r26, pxCurrentTCB		\n\t"                                                                                  \
-	             "lds	r27, pxCurrentTCB + 1	\n\t"                                                                                  \
-	             "in	r0, __SP_L__			\n\t"                                                                                  \
-	             "st	x+, r0					\n\t"                                                                                  \
-	             "in	r0, __SP_H__			\n\t"                                                                                  \
-	             "st	x+, r0					\n\t");
+#define portSAVE_CONTEXT() \
+    asm volatile("push  r0                      \n\t" \
+                 "in    r0, __SREG__            \n\t" \
+                 "cli                           \n\t" \
+                 "push  r0                      \n\t" \
+                 "push  r1                      \n\t" \
+                 "clr   r1                      \n\t" \
+                 "push  r2                      \n\t" \
+                 "push  r3                      \n\t" \
+                 "push  r4                      \n\t" \
+                 "push  r5                      \n\t" \
+                 "push  r6                      \n\t" \
+                 "push  r7                      \n\t" \
+                 "push  r8                      \n\t" \
+                 "push  r9                      \n\t" \
+                 "push  r10                     \n\t" \
+                 "push  r11                     \n\t" \
+                 "push  r12                     \n\t" \
+                 "push  r13                     \n\t" \
+                 "push  r14                     \n\t" \
+                 "push  r15                     \n\t" \
+                 "push  r16                     \n\t" \
+                 "push  r17                     \n\t" \
+                 "push  r18                     \n\t" \
+                 "push  r19                     \n\t" \
+                 "push  r20                     \n\t" \
+                 "push  r21                     \n\t" \
+                 "push  r22                     \n\t" \
+                 "push  r23                     \n\t" \
+                 "push  r24                     \n\t" \
+                 "push  r25                     \n\t" \
+                 "push  r26                     \n\t" \
+                 "push  r27                     \n\t" \
+                 "push  r28                     \n\t" \
+                 "push  r29                     \n\t" \
+                 "push  r30                     \n\t" \
+                 "push  r31                     \n\t" \
+                 "lds   r26, pxCurrentTCB       \n\t" \
+                 "lds   r27, pxCurrentTCB + 1   \n\t" \
+                 "in    r0, __SP_L__            \n\t" \
+                 "st    x+, r0                  \n\t" \
+                 "in    r0, __SP_H__            \n\t" \
+                 "st    x+, r0                  \n\t");
 
 /*
  * Opposite to portSAVE_CONTEXT().  Interrupts will have been disabled during
  * the context save so we can write to the stack pointer.
  */
 
-#define portRESTORE_CONTEXT()                                                                                                           \
-	asm volatile("lds	r26, pxCurrentTCB		\n\t"                                                                                   \
-	             "lds	r27, pxCurrentTCB + 1	\n\t"                                                                                   \
-	             "ld	r28, x+					\n\t"                                                                                   \
-	             "out	__SP_L__, r28			\n\t"                                                                                   \
-	             "ld	r29, x+					\n\t"                                                                                   \
-	             "out	__SP_H__, r29			\n\t"                                                                                   \
-	             "pop	r31						\n\t"                                                                                   \
-	             "pop	r30						\n\t"                                                                                   \
-	             "pop	r29						\n\t"                                                                                   \
-	             "pop	r28						\n\t"                                                                                   \
-	             "pop	r27						\n\t"                                                                                   \
-	             "pop	r26						\n\t"                                                                                   \
-	             "pop	r25						\n\t"                                                                                   \
-	             "pop	r24						\n\t"                                                                                   \
-	             "pop	r23						\n\t"                                                                                   \
-	             "pop	r22						\n\t"                                                                                   \
-	             "pop	r21						\n\t"                                                                                   \
-	             "pop	r20						\n\t"                                                                                   \
-	             "pop	r19						\n\t"                                                                                   \
-	             "pop	r18						\n\t"                                                                                   \
-	             "pop	r17						\n\t"                                                                                   \
-	             "pop	r16						\n\t"                                                                                   \
-	             "pop	r15						\n\t"                                                                                   \
-	             "pop	r14						\n\t"                                                                                   \
-	             "pop	r13						\n\t"                                                                                   \
-	             "pop	r12						\n\t"                                                                                   \
-	             "pop	r11						\n\t"                                                                                   \
-	             "pop	r10						\n\t"                                                                                   \
-	             "pop	r9						\n\t"                                                                                   \
-	             "pop	r8						\n\t"                                                                                   \
-	             "pop	r7						\n\t"                                                                                   \
-	             "pop	r6						\n\t"                                                                                   \
-	             "pop	r5						\n\t"                                                                                   \
-	             "pop	r4						\n\t"                                                                                   \
-	             "pop	r3						\n\t"                                                                                   \
-	             "pop	r2						\n\t"                                                                                   \
-	             "pop	r1						\n\t"                                                                                   \
-	             "pop	r0						\n\t"                                                                                   \
-	             "out	__SREG__, r0			\n\t"                                                                                   \
-	             "pop	r0						\n\t");
+#define portRESTORE_CONTEXT() \
+    asm volatile("lds   r26, pxCurrentTCB       \n\t" \
+                 "lds   r27, pxCurrentTCB + 1   \n\t" \
+                 "ld    r28, x+                 \n\t" \
+                 "out   __SP_L__, r28           \n\t" \
+                 "ld    r29, x+                 \n\t" \
+                 "out   __SP_H__, r29           \n\t" \
+                 "pop   r31                     \n\t" \
+                 "pop   r30                     \n\t" \
+                 "pop   r29                     \n\t" \
+                 "pop   r28                     \n\t" \
+                 "pop   r27                     \n\t" \
+                 "pop   r26                     \n\t" \
+                 "pop   r25                     \n\t" \
+                 "pop   r24                     \n\t" \
+                 "pop   r23                     \n\t" \
+                 "pop   r22                     \n\t" \
+                 "pop   r21                     \n\t" \
+                 "pop   r20                     \n\t" \
+                 "pop   r19                     \n\t" \
+                 "pop   r18                     \n\t" \
+                 "pop   r17                     \n\t" \
+                 "pop   r16                     \n\t" \
+                 "pop   r15                     \n\t" \
+                 "pop   r14                     \n\t" \
+                 "pop   r13                     \n\t" \
+                 "pop   r12                     \n\t" \
+                 "pop   r11                     \n\t" \
+                 "pop   r10                     \n\t" \
+                 "pop   r9                      \n\t" \
+                 "pop   r8                      \n\t" \
+                 "pop   r7                      \n\t" \
+                 "pop   r6                      \n\t" \
+                 "pop   r5                      \n\t" \
+                 "pop   r4                      \n\t" \
+                 "pop   r3                      \n\t" \
+                 "pop   r2                      \n\t" \
+                 "pop   r1                      \n\t" \
+                 "pop   r0                      \n\t" \
+                 "out   __SREG__, r0            \n\t" \
+                 "pop   r0                      \n\t");
 
 /*-----------------------------------------------------------*/
 
@@ -171,81 +169,81 @@ static void prvSetupTimerInterrupt(void);
  */
 StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters)
 {
-	uint16_t usAddress;
+    uint16_t usAddress;
 
-	/*lint -e950 -e611 -e923 Lint doesn't like this much - but nothing I can do about it. */
-	
-	/* Place a few bytes of known values on the bottom of the stack.
-	This is just useful for debugging. Uncomment if needed. */
-	// *pxTopOfStack = 0x11;
+    /*lint -e950 -e611 -e923 Lint doesn't like this much - but nothing I can do about it. */
+    
+    /* Place a few bytes of known values on the bottom of the stack.
+    This is just useful for debugging. Uncomment if needed. */
+    // *pxTopOfStack = 0x11;
     // pxTopOfStack--;
     // *pxTopOfStack = 0x22;
     // pxTopOfStack--;
     // *pxTopOfStack = 0x33; 
     // pxTopOfStack--;
 
-	/* The start of the task code will be popped off the stack last, so place
-	it on first. */
-	usAddress     = (uint16_t)pxCode;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
-	pxTopOfStack--;
+    /* The start of the task code will be popped off the stack last, so place
+    it on first. */
+    usAddress     = (uint16_t)pxCode;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    pxTopOfStack--;
 
-	usAddress >>= 8;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
-	pxTopOfStack--;
+    usAddress >>= 8;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    pxTopOfStack--;
 
-	/* Next simulate the stack as if after a call to portSAVE_CONTEXT().
-	portSAVE_CONTEXT places the flags on the stack immediately after r0
-	to ensure the interrupts get disabled as soon as possible, and so ensuring
-	the stack use is minimal should a context switch interrupt occur. */
-	*pxTopOfStack = (StackType_t)0x00; /* R0 */
-	pxTopOfStack--;
-	*pxTopOfStack = portFLAGS_INT_ENABLED;
-	pxTopOfStack--;
+    /* Next simulate the stack as if after a call to portSAVE_CONTEXT().
+    portSAVE_CONTEXT places the flags on the stack immediately after r0
+    to ensure the interrupts get disabled as soon as possible, and so ensuring
+    the stack use is minimal should a context switch interrupt occur. */
+    *pxTopOfStack = (StackType_t)0x00; /* R0 */
+    pxTopOfStack--;
+    *pxTopOfStack = portFLAGS_INT_ENABLED;
+    pxTopOfStack--;
 
-	/* Now the remaining registers.   The compiler expects R1 to be 0. */
-	*pxTopOfStack = (StackType_t)0x00; /* R1 */
+    /* Now the remaining registers.   The compiler expects R1 to be 0. */
+    *pxTopOfStack = (StackType_t)0x00; /* R1 */
 
-	/* Leave R2 - R23 untouched */
-	pxTopOfStack -= 23;
+    /* Leave R2 - R23 untouched */
+    pxTopOfStack -= 23;
 
-	/* Place the parameter on the stack in the expected location. */
-	usAddress     = (uint16_t)pvParameters;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
-	pxTopOfStack--;
+    /* Place the parameter on the stack in the expected location. */
+    usAddress     = (uint16_t)pvParameters;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    pxTopOfStack--;
 
-	usAddress >>= 8;
-	*pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
+    usAddress >>= 8;
+    *pxTopOfStack = (StackType_t)(usAddress & (uint16_t)0x00ff);
 
-	/* Leave register R26 - R31 untouched */
-	pxTopOfStack -= 7;
+    /* Leave register R26 - R31 untouched */
+    pxTopOfStack -= 7;
 
-	/*lint +e950 +e611 +e923 */
+    /*lint +e950 +e611 +e923 */
 
-	return pxTopOfStack;
+    return pxTopOfStack;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xPortStartScheduler(void)
 {
-	/* Setup the hardware to generate the tick. */
-	prvSetupTimerInterrupt();
+    /* Setup the hardware to generate the tick. */
+    prvSetupTimerInterrupt();
 
-	/* Restore the context of the first task that is going to run. */
-	portRESTORE_CONTEXT();
+    /* Restore the context of the first task that is going to run. */
+    portRESTORE_CONTEXT();
 
-	/* Simulate a function call end as generated by the compiler.  We will now
-	jump to the start of the task the context of which we have just restored. */
-	asm volatile("ret");
+    /* Simulate a function call end as generated by the compiler.  We will now
+    jump to the start of the task the context of which we have just restored. */
+    asm volatile("ret");
 
-	/* Should not get here. */
-	return pdTRUE;
+    /* Should not get here. */
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 
 void vPortEndScheduler(void)
 {
-	/* vPortEndScheduler is not implemented in this port. */
+    /* vPortEndScheduler is not implemented in this port. */
 }
 /*-----------------------------------------------------------*/
 
@@ -256,10 +254,10 @@ void vPortEndScheduler(void)
 void vPortYield(void) __attribute__((naked));
 void vPortYield(void)
 {
-	portSAVE_CONTEXT();
-	vTaskSwitchContext();
-	portRESTORE_CONTEXT();
-	asm volatile("ret");
+    portSAVE_CONTEXT();
+    vTaskSwitchContext();
+    portRESTORE_CONTEXT();
+    asm volatile("ret");
 }
 /*-----------------------------------------------------------*/
 
@@ -270,10 +268,10 @@ void vPortYield(void)
 void vPortYieldFromISR(void) __attribute__((naked));
 void vPortYieldFromISR(void)
 {
-	portSAVE_CONTEXT();
-	vTaskSwitchContext();
-	portRESTORE_CONTEXT();
-	asm volatile("reti");
+    portSAVE_CONTEXT();
+    vTaskSwitchContext();
+    portRESTORE_CONTEXT();
+    asm volatile("reti");
 }
 /*-----------------------------------------------------------*/
 
@@ -286,14 +284,14 @@ void vPortYieldFromISR(void)
 void vPortYieldFromTick(void) __attribute__((naked));
 void vPortYieldFromTick(void)
 {
-	portSAVE_CONTEXT();
-	if (xTaskIncrementTick() != pdFALSE) {
-		vTaskSwitchContext();
-	}
+    portSAVE_CONTEXT();
+    if (xTaskIncrementTick() != pdFALSE) {
+        vTaskSwitchContext();
+    }
 
-	portRESTORE_CONTEXT();
+    portRESTORE_CONTEXT();
 
-	asm volatile("reti");
+    asm volatile("reti");
 }
 /*-----------------------------------------------------------*/
 
@@ -302,7 +300,7 @@ void vPortYieldFromTick(void)
  */
 static void prvSetupTimerInterrupt(void)
 {
-	TICK_init();
+    TICK_init();
 }
 /*-----------------------------------------------------------*/
 
@@ -315,12 +313,12 @@ static void prvSetupTimerInterrupt(void)
  */
 ISR(TICK_INT_vect, ISR_NAKED)
 {
-	/* Clear tick interrupt flag. */
-	CLR_INT(INT_FLAGS, INT_MASK);
+    /* Clear tick interrupt flag. */
+    CLR_INT(INT_FLAGS, INT_MASK);
 
-	vPortYieldFromTick();
+    vPortYieldFromTick();
 
-	asm volatile("reti");
+    asm volatile("reti");
 }
 #else
 
@@ -331,8 +329,8 @@ ISR(TICK_INT_vect, ISR_NAKED)
  */
 ISR(TICK_INT_vect)
 {
-	/* Clear tick interrupt flag. */
-	INT_FLAGS = INT_MASK;
-	xTaskIncrementTick();
+    /* Clear tick interrupt flag. */
+    INT_FLAGS = INT_MASK;
+    xTaskIncrementTick();
 }
 #endif

--- a/portable/GCC/AVR_Mega0/porthardware.h
+++ b/portable/GCC/AVR_Mega0/porthardware.h
@@ -6,101 +6,84 @@
 /*-----------------------------------------------------------*/
 
 #define CLR_INT(FLAG_REG, FLAG_MASK) \
-		asm volatile(	"push r16\n\t" \
-		"ldi r16, %1\n\t" \
-		"sts %0, r16\n\t" \
-		"pop r16\n\t" \
-		: \
-		: "i"(_SFR_MEM_ADDR(FLAG_REG)),"i"((uint8_t)(FLAG_MASK)) \
-		);
+        asm volatile( \
+            "push r16\n\t" \
+            "ldi r16, %1\n\t" \
+            "sts %0, r16\n\t" \
+            "pop r16\n\t" \
+            : \
+            : "i"(_SFR_MEM_ADDR(FLAG_REG)),"i"((uint8_t)(FLAG_MASK)) \
+        );
 
 #if ( configUSE_TIMER_INSTANCE == 0 )
 
-	#define TICK_INT_vect			TCB0_INT_vect
-	#define INT_FLAGS				TCB0_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
+    #define TICK_INT_vect       TCB0_INT_vect
+    #define INT_FLAGS           TCB0_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
 
-	#define TICK_init()				{ \
-									TCB0.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB0.INTCTRL = TCB_CAPT_bm; \
-									TCB0.CTRLA   = TCB_ENABLE_bm; \
-									}
-
-	#define TICK_stop()				{ \
-									TCB0.INTCTRL &= ~TCB_CAPT_bm;\
-									TCB0.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
+    #define TICK_init()         { \
+                                TCB0.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB0.INTCTRL = TCB_CAPT_bm; \
+                                TCB0.CTRLA   = TCB_ENABLE_bm; \
+                                }
 
 #elif ( configUSE_TIMER_INSTANCE == 1 )
 
-	#define TICK_INT_vect			TCB1_INT_vect
-	#define INT_FLAGS				TCB1_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
+    #define TICK_INT_vect       TCB1_INT_vect
+    #define INT_FLAGS           TCB1_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
 
-	#define TICK_init()				{ \
-									TCB1.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB1.INTCTRL = TCB_CAPT_bm; \
-									TCB1.CTRLA   = TCB_ENABLE_bm; \
-									}
+    #define TICK_init()         { \
+                                TCB1.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB1.INTCTRL = TCB_CAPT_bm; \
+                                TCB1.CTRLA   = TCB_ENABLE_bm; \
+                                }
 
 #elif ( configUSE_TIMER_INSTANCE == 2 )
 
-	#define TICK_INT_vect			TCB2_INT_vect
-	#define INT_FLAGS				TCB2_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
+    #define TICK_INT_vect       TCB2_INT_vect
+    #define INT_FLAGS           TCB2_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
 
-	#define TICK_init()				{ \
-									TCB2.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB2.INTCTRL = TCB_CAPT_bm; \
-									TCB2.CTRLA   = TCB_ENABLE_bm; \
-									}
-
-	#define TICK_stop()				{ \
-									TCB2.INTCTRL &= ~TCB_CAPT_bm; \
-									TCB2.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
+    #define TICK_init()         { \
+                                TCB2.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB2.INTCTRL = TCB_CAPT_bm; \
+                                TCB2.CTRLA   = TCB_ENABLE_bm; \
+                                }
 
 #elif ( configUSE_TIMER_INSTANCE == 3 )
 
-	#define TICK_INT_vect			TCB3_INT_vect
-	#define INT_FLAGS				TCB3_INTFLAGS
-	#define INT_MASK				TCB_CAPT_bm
+    #define TICK_INT_vect       TCB3_INT_vect
+    #define INT_FLAGS           TCB3_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
 
-	#define TICK_init()				{ \
-									TCB3.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
-									TCB3.INTCTRL = TCB_CAPT_bm; \
-									TCB3.CTRLA   = TCB_ENABLE_bm; \
-									}
-
-	#define TICK_stop() 			{ \
-									TCB3.INTCTRL &= ~TCB_CAPT_bm; \
-									TCB3.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
+    #define TICK_init()         { \
+                                TCB3.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB3.INTCTRL = TCB_CAPT_bm; \
+                                TCB3.CTRLA   = TCB_ENABLE_bm; \
+                                }
 
 #elif ( configUSE_TIMER_INSTANCE == 4 )
 
-	#define TICK_INT_vect			RTC_CNT_vect
-	#define INT_FLAGS				RTC_INTFLAGS
-	#define INT_MASK				RTC_OVF_bm
+    #define TICK_INT_vect       RTC_CNT_vect
+    #define INT_FLAGS           RTC_INTFLAGS
+    #define INT_MASK            RTC_OVF_bm
 
-	#define RTC_PERIOD_HZ(x)		(32768 * ( (1.0 / x) ) )
-	#define TICK_init()				{ \
-									while (RTC.STATUS > 0); \
-									RTC.CTRLA    = RTC_PRESCALER_DIV1_gc | 1 << RTC_RTCEN_bp; \
-									RTC.PER      = RTC_PERIOD_HZ(configTICK_RATE_HZ); \
-									RTC.INTCTRL |= 1 << RTC_OVF_bp; \
-									}
-
-	#define TICK_stop()				{ \
-									RTC.CTRLA   &= ~(1 << RTC_RTCEN_bp); \
-									RTC.INTCTRL &= ~(1 << RTC_OVF_bp); \
-									}
+    /* Hertz to period for RTC setup */
+    #define RTC_PERIOD_HZ(x)    ( 32768 * ( ( 1.0 / x ) ) )
+    #define TICK_init()         { \
+                                while (RTC.STATUS > 0); \
+                                RTC.CTRLA    = RTC_PRESCALER_DIV1_gc | 1 << RTC_RTCEN_bp; \
+                                RTC.PER      = RTC_PERIOD_HZ(configTICK_RATE_HZ); \
+                                RTC.INTCTRL  |= 1 << RTC_OVF_bp; \
+                                }
 
 #else
-#undef TICK_INT_vect
-#undef INT_FLAGS
-#undef INT_MASK
-#error Invalid timer setting
+    #undef TICK_INT_vect
+    #undef INT_FLAGS
+    #undef INT_MASK
+    #undef TICK_init()
+    #error Invalid timer setting.
 #endif
 
 /*-----------------------------------------------------------*/

--- a/portable/GCC/AVR_Mega0/porthardware.h
+++ b/portable/GCC/AVR_Mega0/porthardware.h
@@ -43,11 +43,6 @@
 									TCB1.CTRLA   = TCB_ENABLE_bm; \
 									}
 
-	#define TICK_stop()				{ \
-									TCB1.INTCTRL &= ~TCB_CAPT_bm; \
-									TCB1.CTRLA   &= ~TCB_ENABLE_bm; \
-									}
-
 #elif ( configUSE_TIMER_INSTANCE == 2 )
 
 	#define TICK_INT_vect			TCB2_INT_vect

--- a/portable/GCC/AVR_Mega0/portmacro.h
+++ b/portable/GCC/AVR_Mega0/portmacro.h
@@ -68,13 +68,13 @@ typedef uint32_t TickType_t;
 
 /* Critical section management. */
 #define portENTER_CRITICAL()                                                                                           \
-	asm volatile("in __tmp_reg__, __SREG__");                                                                          \
-	asm volatile("cli");                                                                                               \
-	asm volatile("push __tmp_reg__")
+    asm volatile("in __tmp_reg__, __SREG__");                                                                          \
+    asm volatile("cli");                                                                                               \
+    asm volatile("push __tmp_reg__")
 
 #define portEXIT_CRITICAL()                                                                                            \
-	asm volatile("pop __tmp_reg__");                                                                                   \
-	asm volatile("out __SREG__, __tmp_reg__")
+    asm volatile("pop __tmp_reg__");                                                                                   \
+    asm volatile("out __SREG__, __tmp_reg__")
 
 #define portDISABLE_INTERRUPTS() asm volatile("cli" ::);
 #define portENABLE_INTERRUPTS() asm volatile("sei" ::);
@@ -85,7 +85,6 @@ typedef uint32_t TickType_t;
 #define portTICK_PERIOD_MS ((TickType_t)1000 / configTICK_RATE_HZ)
 #define portBYTE_ALIGNMENT 1
 #define portNOP() asm volatile("nop");
-
 /*-----------------------------------------------------------*/
 
 /* Kernel utilities. */
@@ -94,7 +93,6 @@ extern void vPortYield(void) __attribute__((naked));
 
 extern void vPortYieldFromISR(void) __attribute__((naked));
 #define portYIELD_FROM_ISR() vPortYieldFromISR()
-
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
@@ -106,4 +104,3 @@ extern void vPortYieldFromISR(void) __attribute__((naked));
 #endif
 
 #endif /* PORTMACRO_H */
-

--- a/portable/IAR/AVR_AVRDx/port.c
+++ b/portable/IAR/AVR_AVRDx/port.c
@@ -1,0 +1,293 @@
+/*
+ * FreeRTOS Kernel V10.0.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. If you wish to use our Amazon
+ * FreeRTOS name, please do so in a fair use way that does not cause confusion.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#include <stdlib.h>
+#include "porthardware.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+/*-----------------------------------------------------------
+ * Implementation of functions defined in portable.h for the AVR port.
+ *----------------------------------------------------------*/
+
+/* Start tasks with interrupts enables. */
+#define portFLAGS_INT_ENABLED               ((StackType_t) 0x80)
+
+/*-----------------------------------------------------------*/
+
+
+#define portBYTES_USED_BY_RETURN_ADDRESS    2
+#define portNO_CRITICAL_NESTING             ( ( UBaseType_t ) 0 )
+
+/* Stores the critical section nesting.  This must not be initialised to 0.
+It will be initialised when a task starts. */
+UBaseType_t uxCriticalNesting = 0x50;
+/*
+ * Setup timer to generate a tick interrupt.
+ */
+static void prvSetupTimerInterrupt(void);
+
+/*
+ * The IAR compiler does not have full support for inline assembler, so
+ * these are defined in the portmacro assembler file.
+ */
+extern void vPortYieldFromTick( void );
+extern void vPortStart( void );
+
+/*-----------------------------------------------------------*/
+
+/*
+ * See header file for description.
+ */
+StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters)
+{
+uint16_t usAddress;
+StackType_t *pxTopOfHardwareStack;
+    /* Simulate how the stack would look after a call to vPortYield(). */
+
+    /*lint -e950 -e611 -e923 Lint doesn't like this much - but nothing I can do about it. */
+
+    /* The IAR compiler requires two stacks per task.  First there is the
+    hardware call stack which uses the AVR stack pointer.  Second there is the
+    software stack (local variables, parameter passing, etc.) which uses the
+    AVR Y register.
+    This function places both stacks within the memory block passed in as the
+    first parameter.  The hardware stack is placed at the bottom of the memory
+    block.  A gap is then left for the hardware stack to grow.  Next the software
+    stack is placed.  The amount of space between the software and hardware
+    stacks is defined by configCALL_STACK_SIZE.
+    The first part of the stack is the hardware stack.  Place the start
+    address of the task on the hardware stack. */
+
+    /* Place a few bytes of known values on the bottom of the stack.
+    This is just useful for debugging. */
+    //*pxTopOfStack = 0x11;
+    //pxTopOfStack--;
+    //*pxTopOfStack = 0x22;
+    //pxTopOfStack--;
+    //*pxTopOfStack = 0x33;
+    //pxTopOfStack--;
+    
+    /* Remember where the top of the hardware stack is - this is required
+    below. */
+    pxTopOfHardwareStack = pxTopOfStack;
+
+    usAddress = ( uint16_t ) pxCode;
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+
+    usAddress >>= 8;
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+    
+    /* Leave enough space for the hardware stack before starting the software
+    stack.  The '- 2' is because we have already used two spaces for the
+    address of the start of the task. */
+    pxTopOfStack -= ( configCALL_STACK_SIZE - 2 );
+
+    /* Next simulate the stack as if after a call to portSAVE_CONTEXT().
+    portSAVE_CONTEXT places the flags on the stack immediately after r0
+    to ensure the interrupts get disabled as soon as possible, and so ensuring
+    the stack use is minimal should a context switch interrupt occur. */
+    *pxTopOfStack = ( StackType_t ) 0x00;       /* R0 */
+    pxTopOfStack--;
+    *pxTopOfStack = portFLAGS_INT_ENABLED;
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x00;       /* RAMPZ */
+    pxTopOfStack--;
+    
+    /* Next place the address of the hardware stack.  This is required so
+    the AVR stack pointer can be restored to point to the hardware stack. */
+    pxTopOfHardwareStack -= portBYTES_USED_BY_RETURN_ADDRESS;
+    usAddress = ( uint16_t ) pxTopOfHardwareStack;
+
+    /* SPL */
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+
+    /* SPH */
+    usAddress >>= 8;
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+
+    /* Now the remaining registers. */
+    *pxTopOfStack = ( StackType_t ) 0x01;       /* R1 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x02;       /* R2 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x03;       /* R3 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x04;       /* R4 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x05;       /* R5 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x06;       /* R6 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x07;       /* R7 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x08;       /* R8 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x09;       /* R9 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x10;       /* R10 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x11;       /* R11 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x12;       /* R12 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x13;       /* R13 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x14;       /* R14 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x15;       /* R15 */
+    pxTopOfStack--;
+
+    /* Place the parameter on the stack in the expected location. */
+    usAddress     = (uint16_t) pvParameters;
+    *pxTopOfStack = (StackType_t) (usAddress & (uint16_t) 0x00ff);
+    pxTopOfStack--;
+
+    usAddress >>= 8;
+    *pxTopOfStack = (StackType_t) (usAddress & (uint16_t) 0x00ff);
+    pxTopOfStack--;
+
+    *pxTopOfStack = ( StackType_t ) 0x18;       /* R18 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x19;       /* R19 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x20;       /* R20 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x21;       /* R21 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x22;       /* R22 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x23;       /* R23 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x24;       /* R24 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x25;       /* R25 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x26;       /* R26 X */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x27;       /* R27 */
+    pxTopOfStack--;
+
+    /* The Y register is not stored as it is used as the software stack and
+    gets saved into the task control block. */
+
+    *pxTopOfStack = ( StackType_t ) 0x30;       /* R30 Z */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x031;      /* R31 */
+
+    pxTopOfStack--;
+    *pxTopOfStack = portNO_CRITICAL_NESTING;    /* Critical nesting is zero when the task starts. */
+    
+    /*lint +e950 +e611 +e923 */
+
+    return pxTopOfStack;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortStartScheduler(void)
+{
+    /* Setup the hardware to generate the tick. */
+    prvSetupTimerInterrupt();
+
+    /* Restore the context of the first task that is going to run.
+    Normally we would just call portRESTORE_CONTEXT() here, but as the IAR
+    compiler does not fully support inline assembler we have to make a call.*/
+    vPortStart();
+
+    /* Should not get here. */
+    return pdTRUE;
+}
+/*-----------------------------------------------------------*/
+
+void vPortEndScheduler(void)
+{
+    /* vPortEndScheduler is not implemented in this port. */
+}
+
+/*-----------------------------------------------------------*/
+
+/*
+ * Setup timer to generate a tick interrupt.
+ */
+static void prvSetupTimerInterrupt(void)
+{
+    TICK_init();
+}
+
+/*-----------------------------------------------------------*/
+
+#if configUSE_PREEMPTION == 1
+/*
+ * Tick ISR for preemptive scheduler.  We can use a naked attribute as
+ * the context is saved at the start of vPortYieldFromTick().  The tick
+ * count is incremented after the context is saved.
+ */
+
+__task void TICK_INT(void)
+{
+    vPortYieldFromTick();
+    asm("reti");
+}
+#else
+/*
+ * Tick ISR for the cooperative scheduler.  All this does is increment the
+ * tick count.  We don't need to switch context, this can only be done by
+ * manual calls to taskYIELD();
+ */
+
+__interrupt void TICK_INT(void)
+{
+    /* Clear tick interrupt flag. */
+    INT_FLAGS = INT_MASK;
+
+    xTaskIncrementTick();
+}
+#endif
+
+/*-----------------------------------------------------------*/
+
+void vPortEnterCritical( void )
+{
+    portDISABLE_INTERRUPTS();
+    uxCriticalNesting++;
+}
+
+/*-----------------------------------------------------------*/
+
+void vPortExitCritical( void )
+{
+    uxCriticalNesting--;
+    if( uxCriticalNesting == portNO_CRITICAL_NESTING )
+    {
+        portENABLE_INTERRUPTS();
+    }
+}

--- a/portable/IAR/AVR_AVRDx/porthardware.h
+++ b/portable/IAR/AVR_AVRDx/porthardware.h
@@ -1,0 +1,94 @@
+#ifndef PORTHARDWARE_H
+#define PORTHARDWARE_H
+
+#include <ioavr.h>
+#include "FreeRTOSConfig.h"
+
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMER_INSTANCE == 0 )
+
+    #define TICK_INT_vect       TCB0_INT_vect
+    #define INT_FLAGS           TCB0_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+    
+    #define TICK_init()         { \
+                                TCB0.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB0.INTCTRL = TCB_CAPT_bm; \
+                                TCB0.CTRLA   = TCB_ENABLE_bm; \
+                                }
+
+#elif ( configUSE_TIMER_INSTANCE == 1 )
+
+    #define TICK_INT_vect       TCB1_INT_vect
+    #define INT_FLAGS           TCB1_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+    
+    #define TICK_init()         { \
+                                TCB1.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB1.INTCTRL = TCB_CAPT_bm; \
+                                TCB1.CTRLA   = TCB_ENABLE_bm; \
+                                }
+        
+#elif ( configUSE_TIMER_INSTANCE == 2 )
+
+    #define TICK_INT_vect       TCB2_INT_vect
+    #define INT_FLAGS           TCB2_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+
+    #define TICK_init()         { \
+                                TCB2.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB2.INTCTRL = TCB_CAPT_bm; \
+                                TCB2.CTRLA   = TCB_ENABLE_bm; \
+                                }
+        
+#elif ( configUSE_TIMER_INSTANCE == 3 )
+
+    #define TICK_INT_vect       TCB3_INT_vect
+    #define INT_FLAGS           TCB3_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+    
+    #define TICK_init()         { \
+                                TCB3.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB3.INTCTRL = TCB_CAPT_bm; \
+                                TCB3.CTRLA   = TCB_ENABLE_bm; \
+                                }
+    
+#elif ( configUSE_TIMER_INSTANCE == 4 )
+
+    #define TICK_INT_vect       TCB4_INT_vect
+    #define INT_FLAGS           TCB4_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+    
+    #define TICK_init()         { \
+                                TCB4.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB4.INTCTRL = TCB_CAPT_bm; \
+                                TCB4.CTRLA   = TCB_ENABLE_bm; \
+                                }
+    
+#elif ( configUSE_TIMER_INSTANCE == 5 )
+                                    
+    #define TICK_INT_vect       RTC_CNT_vect
+    #define INT_FLAGS           RTC_INTFLAGS
+    #define INT_MASK            RTC_OVF_bm
+    
+    /* Hertz to period for RTC setup */
+    #define RTC_PERIOD_HZ(x)    ( 32768 * ( ( 1.0 / x ) ) )
+    #define TICK_init()         { \
+                                while (RTC.STATUS > 0); \
+                                RTC.CTRLA    = RTC_PRESCALER_DIV1_gc | 1 << RTC_RTCEN_bp; \
+                                RTC.PER      = RTC_PERIOD_HZ(configTICK_RATE_HZ); \
+                                RTC.INTCTRL |= 1 << RTC_OVF_bp; \
+                                }
+
+#else
+    #undef TICK_INT_vect
+    #undef INT_FLAGS
+    #undef INT_MASK
+    #undef TICK_init()
+    #error Invalid timer setting.
+#endif
+
+/*-----------------------------------------------------------*/
+
+#endif /* PORTHARDWARE_H */

--- a/portable/IAR/AVR_AVRDx/portmacro.h
+++ b/portable/IAR/AVR_AVRDx/portmacro.h
@@ -1,0 +1,105 @@
+/*
+ * FreeRTOS Kernel V10.0.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. If you wish to use our Amazon
+ * FreeRTOS name, please do so in a fair use way that does not cause confusion.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*-----------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the
+ * given hardware and compiler.
+ *
+ * These settings should not be altered.
+ *-----------------------------------------------------------
+ */
+
+/* Type definitions. */
+#define portCHAR                    char
+#define portFLOAT                   float
+#define portDOUBLE                  double
+#define portLONG                    long
+#define portSHORT                   int
+#define portSTACK_TYPE              uint8_t
+#define portBASE_TYPE               char
+
+#define portPOINTER_SIZE_TYPE       uint16_t
+
+typedef portSTACK_TYPE              StackType_t;
+typedef signed char                 BaseType_t;
+typedef unsigned char               UBaseType_t;
+
+#if (configUSE_16_BIT_TICKS == 1)
+  typedef uint16_t                  TickType_t;
+  #define portMAX_DELAY             (TickType_t)0xffff
+#else
+  typedef uint32_t                  TickType_t;
+  #define portMAX_DELAY             (TickType_t)0xffffffffUL
+#endif
+
+/*-----------------------------------------------------------*/
+
+/* Critical section management. */
+extern void vPortEnterCritical( void );
+extern void vPortExitCritical( void );
+
+#define portENTER_CRITICAL()        vPortEnterCritical()
+#define portEXIT_CRITICAL()         vPortExitCritical()
+
+#define portDISABLE_INTERRUPTS()    asm( "cli" )
+#define portENABLE_INTERRUPTS()     asm( "sei" )
+/*-----------------------------------------------------------*/
+
+/* Architecture specifics. */
+#define portSTACK_GROWTH            (-1)
+#define portTICK_PERIOD_MS          ((TickType_t)1000 / configTICK_RATE_HZ)
+#define portBYTE_ALIGNMENT          1
+#define portNOP()                   asm( "nop" )
+/*-----------------------------------------------------------*/
+
+/* Kernel utilities. */
+extern void vPortYield(void);
+#define portYIELD()                 vPortYield()
+
+extern void vPortYieldFromISR(void);
+#define portYIELD_FROM_ISR()        vPortYieldFromISR()
+/*-----------------------------------------------------------*/
+
+/* Task function macros as described on the FreeRTOS.org WEB site. */
+#define portTASK_FUNCTION_PROTO(vFunction, pvParameters) void vFunction(void *pvParameters)
+#define portTASK_FUNCTION(vFunction, pvParameters) void vFunction(void *pvParameters)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTMACRO_H */

--- a/portable/IAR/AVR_AVRDx/portmacro.s90
+++ b/portable/IAR/AVR_AVRDx/portmacro.s90
@@ -1,0 +1,254 @@
+;/*
+; * FreeRTOS Kernel V10.3.1
+; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+; *
+; * Permission is hereby granted, free of charge, to any person obtaining a copy of
+; * this software and associated documentation files (the "Software"), to deal in
+; * the Software without restriction, including without limitation the rights to
+; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+; * the Software, and to permit persons to whom the Software is furnished to do so,
+; * subject to the following conditions:
+; *
+; * The above copyright notice and this permission notice shall be included in all
+; * copies or substantial portions of the Software.
+; *
+; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+; *
+; * http://www.FreeRTOS.org
+; * http://aws.amazon.com/freertos
+; *
+; * 1 tab == 4 spaces!
+; */
+
+#include "porthardware.h"
+
+; Declare all extern symbols here - including any ISRs that are referenced in
+; the vector table.
+
+; ISR functions
+; -------------
+EXTERN TICK_INT
+
+; Functions used by scheduler
+; ---------------------------
+EXTERN vTaskSwitchContext
+EXTERN pxCurrentTCB
+EXTERN xTaskIncrementTick
+EXTERN uxCriticalNesting
+
+; Functions implemented in this file
+; ----------------------------------
+PUBLIC vPortYield
+PUBLIC vPortYieldFromTick
+PUBLIC vPortYieldFromISR
+PUBLIC vPortStart
+
+; Interrupt vector table.
+; -----------------------
+;
+; For simplicity the RTOS tick interrupt routine uses the __task keyword.
+; As the IAR compiler does not permit a function to be declared using both
+; __task and __interrupt, the use of __task necessitates that the interrupt
+; vector table be setup manually.
+;
+; To write an ISR, implement the ISR function using the __interrupt keyword
+; but do not install the interrupt using the "#pragma vector=ABC" method.
+; Instead manually place the name of the ISR in the vector table using an
+; ORG and jmp instruction as demonstrated below.
+; You will also have to add an EXTERN statement at the top of the file.
+
+    ASEG
+
+        ORG TICK_INT_vect                   ; Vector address
+            jmp TICK_INT                    ; ISR
+
+    RSEG CODE
+
+CLR_INT MACRO  FLAG_REG, FLAG_MASK
+        st -y, r16
+        ldi r16, FLAG_MASK
+        sts FLAG_REG, r16
+        ld r16, y+
+        
+        ENDM
+
+; Saving and Restoring a Task Context and Task Switching
+; ------------------------------------------------------
+;
+; The IAR compiler does not fully support inline assembler, so saving and
+; restoring a task context has to be written in an asm file.
+;
+; vPortYield() and vPortYieldFromTick() are usually written in C.  Doing
+; so in this case would required calls to be made to portSAVE_CONTEXT() and
+; portRESTORE_CONTEXT().  This is dis-advantageous as the context switch
+; function would require two extra jump and return instructions over the
+; WinAVR equivalent.
+;
+; To avoid this I have opted to implement both vPortYield() and
+; vPortYieldFromTick() in this assembly file.  For convenience
+; portSAVE_CONTEXT and portRESTORE_CONTEXT are implemented as macros.
+
+portSAVE_CONTEXT MACRO
+    st  -y, r0          ; First save the r0 register - we need to use this.
+    in  r0, SREG        ; Obtain the SREG value so we can disable interrupts...
+    cli                 ; ... as soon as possible.
+    st  -y, r0          ; Store the SREG as it was before we disabled interrupts.
+
+    in  r0, RAMPZ
+    st  -y, r0
+
+    in  r0, SPL         ; Next store the hardware stack pointer.  The IAR...
+    st  -y, r0          ; ... compiler uses the hardware stack as a call stack ...
+    in  r0, SPH         ; ...  only.
+    st  -y, r0
+
+    st  -y, r1          ; Now store the rest of the registers.  Dont store the ...
+    st  -y, r2          ; ... the Y register here as it is used as the software
+    st  -y, r3          ; stack pointer and will get saved into the TCB.
+    st  -y, r4
+    st  -y, r5
+    st  -y, r6
+    st  -y, r7
+    st  -y, r8
+    st  -y, r9
+    st  -y, r10
+    st  -y, r11
+    st  -y, r12
+    st  -y, r13
+    st  -y, r14
+    st  -y, r15
+    st  -y, r16
+    st  -y, r17
+    st  -y, r18
+    st  -y, r19
+    st  -y, r20
+    st  -y, r21
+    st  -y, r22
+    st  -y, r23
+    st  -y, r24
+    st  -y, r25
+    st  -y, r26
+    st  -y, r27
+    st  -y, r30
+    st  -y, r31
+
+    lds r0, uxCriticalNesting
+    st  -y, r0                  ; Store the critical nesting counter.
+
+    lds r26, pxCurrentTCB       ; Finally save the software stack pointer (Y ...
+    lds r27, pxCurrentTCB + 1   ; ... register) into the TCB.
+    st  x+, r28
+    st  x+, r29
+
+    ENDM
+
+
+portRESTORE_CONTEXT MACRO
+    lds r26, pxCurrentTCB
+    lds r27, pxCurrentTCB + 1       ; Restore the software stack pointer from ...
+    ld  r28, x+                     ; the TCB into the software stack pointer (...
+    ld  r29, x+                     ; ... the Y register).
+
+    ld  r0, y+
+    sts uxCriticalNesting, r0
+
+    ld  r31, y+                     ; Restore the registers down to R0.  The Y
+    ld  r30, y+                     ; register is missing from this list as it
+    ld  r27, y+                     ; has already been restored.
+    ld  r26, y+
+    ld  r25, y+
+    ld  r24, y+
+    ld  r23, y+
+    ld  r22, y+
+    ld  r21, y+
+    ld  r20, y+
+    ld  r19, y+
+    ld  r18, y+
+    ld  r17, y+
+    ld  r16, y+
+    ld  r15, y+
+    ld  r14, y+
+    ld  r13, y+
+    ld  r12, y+
+    ld  r11, y+
+    ld  r10, y+
+    ld  r9, y+
+    ld  r8, y+
+    ld  r7, y+
+    ld  r6, y+
+    ld  r5, y+
+    ld  r4, y+
+    ld  r3, y+
+    ld  r2, y+
+    ld  r1, y+
+
+    ld  r0, y+                      ; The next thing on the stack is the ...
+    out SPH, r0                     ; ... hardware stack pointer.
+    ld  r0, y+
+    out SPL, r0
+
+    ld  r0, y+
+    out RAMPZ, r0
+
+    ld  r0, y+                      ; Next there is the SREG register.
+    out SREG, r0
+
+    ld  r0, y+                      ; Finally we have finished with r0, so restore r0.
+
+    ENDM
+
+
+
+; vPortYield(), vPortYieldFromTick() and vPortYieldFromISR()
+; -------------------------------------
+;
+; Manual and preemptive context switch functions respectively.
+; The IAR compiler does not fully support inline assembler,
+; so these are implemented here rather than the more usually
+; place of within port.c.
+
+vPortYield:
+    portSAVE_CONTEXT                ; Save the context of the current task.
+    call vTaskSwitchContext         ; Call the scheduler.
+    portRESTORE_CONTEXT             ; Restore the context of whichever task the ...
+    ret                             ; ... scheduler decided should run.
+
+vPortYieldFromTick:
+    CLR_INT INT_FLAGS, INT_MASK     ; Clear tick interrupt flag
+
+    portSAVE_CONTEXT                ; Save the context of the current task.    
+    call xTaskIncrementTick         ; Call the timer tick function.
+    tst r16
+    breq SkipTaskSwitch
+    call vTaskSwitchContext         ; Call the scheduler.
+
+SkipTaskSwitch:
+    portRESTORE_CONTEXT             ; Restore the context of whichever task the ...
+    reti                            ; ... scheduler decided should run.
+
+vPortYieldFromISR:
+    portSAVE_CONTEXT                ; Save the context of the current task.
+    call vTaskSwitchContext         ; Call the scheduler.
+    portRESTORE_CONTEXT             ; Restore the context of whichever task the ...
+    reti                            ; ... scheduler decided should run.
+
+; vPortStart()
+; ------------
+;
+; Again due to the lack of inline assembler, this is required
+; to get access to the portRESTORE_CONTEXT macro.
+
+vPortStart:
+    portRESTORE_CONTEXT
+    ret
+
+; Just a filler for unused interrupt vectors.
+vNoISR:
+    reti
+
+    END

--- a/portable/IAR/AVR_Mega0/port.c
+++ b/portable/IAR/AVR_Mega0/port.c
@@ -1,0 +1,291 @@
+/*
+ * FreeRTOS Kernel V10.0.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. If you wish to use our Amazon
+ * FreeRTOS name, please do so in a fair use way that does not cause confusion.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#include <stdlib.h>
+#include "porthardware.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+/*-----------------------------------------------------------
+ * Implementation of functions defined in portable.h for the AVR port.
+ *----------------------------------------------------------*/
+
+/* Start tasks with interrupts enables. */
+#define portFLAGS_INT_ENABLED               ((StackType_t) 0x80)
+
+/*-----------------------------------------------------------*/
+
+
+#define portBYTES_USED_BY_RETURN_ADDRESS    2
+#define portNO_CRITICAL_NESTING             ( ( UBaseType_t ) 0 )
+
+/* Stores the critical section nesting.  This must not be initialised to 0.
+It will be initialised when a task starts. */
+UBaseType_t uxCriticalNesting = 0x50;
+/*
+ * Setup timer to generate a tick interrupt.
+ */
+static void prvSetupTimerInterrupt(void);
+
+/*
+ * The IAR compiler does not have full support for inline assembler, so
+ * these are defined in the portmacro assembler file.
+ */
+extern void vPortYieldFromTick( void );
+extern void vPortStart( void );
+
+/*-----------------------------------------------------------*/
+
+/*
+ * See header file for description.
+ */
+StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters)
+{
+uint16_t usAddress;
+StackType_t *pxTopOfHardwareStack;
+    /* Simulate how the stack would look after a call to vPortYield(). */
+
+    /*lint -e950 -e611 -e923 Lint doesn't like this much - but nothing I can do about it. */
+        
+    /* The IAR compiler requires two stacks per task.  First there is the
+    hardware call stack which uses the AVR stack pointer.  Second there is the
+    software stack (local variables, parameter passing, etc.) which uses the
+    AVR Y register.
+    This function places both stacks within the memory block passed in as the
+    first parameter.  The hardware stack is placed at the bottom of the memory
+    block.  A gap is then left for the hardware stack to grow.  Next the software
+    stack is placed.  The amount of space between the software and hardware
+    stacks is defined by configCALL_STACK_SIZE.
+    The first part of the stack is the hardware stack.  Place the start
+    address of the task on the hardware stack. */
+    
+    /* Place a few bytes of known values on the bottom of the stack.
+    This is just useful for debugging. */
+    //*pxTopOfStack = 0x11;
+    //pxTopOfStack--;
+    //*pxTopOfStack = 0x22;
+    //pxTopOfStack--;
+    //*pxTopOfStack = 0x33;
+    //pxTopOfStack--;
+    
+    /* Remember where the top of the hardware stack is - this is required
+    below. */
+    pxTopOfHardwareStack = pxTopOfStack;
+
+    usAddress = ( uint16_t ) pxCode;
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+
+    usAddress >>= 8;
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+
+    /* Leave enough space for the hardware stack before starting the software
+    stack.  The '- 2' is because we have already used two spaces for the
+    address of the start of the task. */
+    pxTopOfStack -= ( configCALL_STACK_SIZE - 2 );
+
+    /* Next simulate the stack as if after a call to portSAVE_CONTEXT().
+    portSAVE_CONTEXT places the flags on the stack immediately after r0
+    to ensure the interrupts get disabled as soon as possible, and so ensuring
+    the stack use is minimal should a context switch interrupt occur. */
+    *pxTopOfStack = ( StackType_t ) 0x00;       /* R0 */
+    pxTopOfStack--;
+    *pxTopOfStack = portFLAGS_INT_ENABLED;
+    pxTopOfStack--;
+
+    /* Next place the address of the hardware stack.  This is required so
+    the AVR stack pointer can be restored to point to the hardware stack. */
+    pxTopOfHardwareStack -= portBYTES_USED_BY_RETURN_ADDRESS;
+    usAddress = ( uint16_t ) pxTopOfHardwareStack;
+
+    /* SPL */
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+
+    /* SPH */
+    usAddress >>= 8;
+    *pxTopOfStack = ( StackType_t ) ( usAddress & ( uint16_t ) 0x00ff );
+    pxTopOfStack--;
+
+    /* Now the remaining registers. */
+    *pxTopOfStack = ( StackType_t ) 0x01;       /* R1 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x02;       /* R2 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x03;       /* R3 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x04;       /* R4 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x05;       /* R5 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x06;       /* R6 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x07;       /* R7 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x08;       /* R8 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x09;       /* R9 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x10;       /* R10 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x11;       /* R11 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x12;       /* R12 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x13;       /* R13 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x14;       /* R14 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x15;       /* R15 */
+    pxTopOfStack--;
+
+    /* Place the parameter on the stack in the expected location. */
+    usAddress     = (uint16_t) pvParameters;
+    *pxTopOfStack = (StackType_t) (usAddress & (uint16_t) 0x00ff);
+    pxTopOfStack--;
+
+    usAddress >>= 8;
+    *pxTopOfStack = (StackType_t) (usAddress & (uint16_t) 0x00ff);
+    pxTopOfStack--;
+
+    *pxTopOfStack = ( StackType_t ) 0x18;       /* R18 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x19;       /* R19 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x20;       /* R20 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x21;       /* R21 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x22;       /* R22 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x23;       /* R23 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x24;       /* R24 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x25;       /* R25 */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x26;       /* R26 X */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x27;       /* R27 */
+    pxTopOfStack--;
+
+    /* The Y register is not stored as it is used as the software stack and
+    gets saved into the task control block. */
+
+    *pxTopOfStack = ( StackType_t ) 0x30;       /* R30 Z */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) 0x031;      /* R31 */
+        
+        pxTopOfStack--;
+    *pxTopOfStack = portNO_CRITICAL_NESTING;    /* Critical nesting is zero when the task starts. */
+
+    /*lint +e950 +e611 +e923 */
+
+    return pxTopOfStack;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortStartScheduler(void)
+{
+    /* Setup the hardware to generate the tick. */
+    prvSetupTimerInterrupt();
+
+    /* Restore the context of the first task that is going to run.
+    Normally we would just call portRESTORE_CONTEXT() here, but as the IAR
+    compiler does not fully support inline assembler we have to make a call.*/
+    vPortStart();
+
+    /* Should not get here. */
+    return pdTRUE;
+}
+/*-----------------------------------------------------------*/
+
+void vPortEndScheduler(void)
+{
+    /* vPortEndScheduler is not implemented in this port. */
+}
+
+/*-----------------------------------------------------------*/
+
+/*
+ * Setup timer to generate a tick interrupt.
+ */
+static void prvSetupTimerInterrupt(void)
+{
+    TICK_init();
+}
+
+/*-----------------------------------------------------------*/
+
+#if configUSE_PREEMPTION == 1
+/*
+ * Tick ISR for preemptive scheduler.  We can use a naked attribute as
+ * the context is saved at the start of vPortYieldFromTick().  The tick
+ * count is incremented after the context is saved.
+ */
+
+__task void TICK_INT(void)
+{
+    vPortYieldFromTick();
+    asm("reti");
+}
+#else
+/*
+ * Tick ISR for the cooperative scheduler.  All this does is increment the
+ * tick count.  We don't need to switch context, this can only be done by
+ * manual calls to taskYIELD();
+ */
+
+__interrupt void TICK_INT(void)
+{
+    /* Clear tick interrupt flag. */
+    INT_FLAGS = INT_MASK;
+        
+    xTaskIncrementTick();
+}
+#endif
+
+/*-----------------------------------------------------------*/
+
+void vPortEnterCritical( void )
+{
+    portDISABLE_INTERRUPTS();
+    uxCriticalNesting++;
+}
+
+/*-----------------------------------------------------------*/
+
+void vPortExitCritical( void )
+{
+    uxCriticalNesting--;
+    if( uxCriticalNesting == portNO_CRITICAL_NESTING )
+    {
+        portENABLE_INTERRUPTS();
+    }
+}

--- a/portable/IAR/AVR_Mega0/porthardware.h
+++ b/portable/IAR/AVR_Mega0/porthardware.h
@@ -1,0 +1,82 @@
+#ifndef PORTHARDWARE_H
+#define PORTHARDWARE_H
+
+#include <ioavr.h>
+#include "FreeRTOSConfig.h"
+
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMER_INSTANCE == 0 )
+
+    #define TICK_INT_vect       TCB0_INT_vect
+    #define INT_FLAGS           TCB0_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+
+    #define TICK_init()         { \
+                                TCB0.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB0.INTCTRL = TCB_CAPT_bm; \
+                                TCB0.CTRLA   = TCB_ENABLE_bm; \
+                                }
+
+#elif ( configUSE_TIMER_INSTANCE == 1 )
+
+    #define TICK_INT_vect       TCB1_INT_vect
+    #define INT_FLAGS           TCB1_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+                                                                        
+    #define TICK_init()         { \
+                                TCB1.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB1.INTCTRL = TCB_CAPT_bm; \
+                                TCB1.CTRLA   = TCB_ENABLE_bm; \
+                                }
+
+#elif ( configUSE_TIMER_INSTANCE == 2 )
+
+    #define TICK_INT_vect       TCB2_INT_vect
+    #define INT_FLAGS           TCB2_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+    
+    #define TICK_init()         { \
+                                TCB2.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB2.INTCTRL = TCB_CAPT_bm; \
+                                TCB2.CTRLA   = TCB_ENABLE_bm; \
+                                }
+                                      
+#elif ( configUSE_TIMER_INSTANCE == 3 )
+
+    #define TICK_INT_vect       TCB3_INT_vect
+    #define INT_FLAGS           TCB3_INTFLAGS
+    #define INT_MASK            TCB_CAPT_bm
+                                      
+    #define TICK_init()         { \
+                                TCB3.CCMP    = configCPU_CLOCK_HZ / configTICK_RATE_HZ; \
+                                TCB3.INTCTRL = TCB_CAPT_bm; \
+                                TCB3.CTRLA   = TCB_ENABLE_bm; \
+                                }
+
+#elif ( configUSE_TIMER_INSTANCE == 4 )
+
+    #define TICK_INT_vect       RTC_CNT_vect
+    #define INT_FLAGS           RTC_INTFLAGS
+    #define INT_MASK            RTC_OVF_bm
+    
+    /* Hertz to period for RTC setup */
+    #define RTC_PERIOD_HZ(x)    ( 32768 * ( ( 1.0 / x ) ) )
+    #define TICK_init()         { \
+                                while (RTC.STATUS > 0); \
+                                RTC.CTRLA    = RTC_PRESCALER_DIV1_gc | 1 << RTC_RTCEN_bp; \
+                                RTC.PER      = RTC_PERIOD_HZ(configTICK_RATE_HZ); \
+                                RTC.INTCTRL |= 1 << RTC_OVF_bp; \
+                                }
+
+#else
+    #undef TICK_INT_vect
+    #undef INT_FLAGS
+    #undef INT_MASK
+    #undef TICK_init()
+    #error Invalid timer setting.
+#endif
+
+/*-----------------------------------------------------------*/
+
+#endif /* PORTHARDWARE_H */

--- a/portable/IAR/AVR_Mega0/portmacro.h
+++ b/portable/IAR/AVR_Mega0/portmacro.h
@@ -1,0 +1,105 @@
+/*
+ * FreeRTOS Kernel V10.0.0
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. If you wish to use our Amazon
+ * FreeRTOS name, please do so in a fair use way that does not cause confusion.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*-----------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the
+ * given hardware and compiler.
+ *
+ * These settings should not be altered.
+ *-----------------------------------------------------------
+ */
+
+/* Type definitions. */
+#define portCHAR                    char
+#define portFLOAT                   float
+#define portDOUBLE                  double
+#define portLONG                    long
+#define portSHORT                   int
+#define portSTACK_TYPE              uint8_t
+#define portBASE_TYPE               char
+
+#define portPOINTER_SIZE_TYPE       uint16_t
+
+typedef portSTACK_TYPE              StackType_t;
+typedef signed char                 BaseType_t;
+typedef unsigned char               UBaseType_t;
+
+#if (configUSE_16_BIT_TICKS == 1)
+  typedef uint16_t                  TickType_t;
+  #define portMAX_DELAY             (TickType_t)0xffff
+#else
+  typedef uint32_t                  TickType_t;
+  #define portMAX_DELAY             (TickType_t)0xffffffffUL
+#endif
+
+/*-----------------------------------------------------------*/
+
+/* Critical section management. */
+extern void vPortEnterCritical( void );
+extern void vPortExitCritical( void );
+
+#define portENTER_CRITICAL()        vPortEnterCritical()
+#define portEXIT_CRITICAL()         vPortExitCritical()
+
+#define portDISABLE_INTERRUPTS()    asm( "cli" )
+#define portENABLE_INTERRUPTS()     asm( "sei" )
+/*-----------------------------------------------------------*/
+
+/* Architecture specifics. */
+#define portSTACK_GROWTH            (-1)
+#define portTICK_PERIOD_MS          ((TickType_t)1000 / configTICK_RATE_HZ)
+#define portBYTE_ALIGNMENT          1
+#define portNOP()                   asm( "nop" )
+/*-----------------------------------------------------------*/
+
+/* Kernel utilities. */
+extern void vPortYield(void);
+#define portYIELD()                 vPortYield()
+
+extern void vPortYieldFromISR(void);
+#define portYIELD_FROM_ISR()        vPortYieldFromISR()
+/*-----------------------------------------------------------*/
+
+/* Task function macros as described on the FreeRTOS.org WEB site. */
+#define portTASK_FUNCTION_PROTO(vFunction, pvParameters) void vFunction(void *pvParameters)
+#define portTASK_FUNCTION(vFunction, pvParameters) void vFunction(void *pvParameters)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTMACRO_H */

--- a/portable/IAR/AVR_Mega0/portmacro.s90
+++ b/portable/IAR/AVR_Mega0/portmacro.s90
@@ -1,0 +1,248 @@
+;/*
+; * FreeRTOS Kernel V10.3.1
+; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+; *
+; * Permission is hereby granted, free of charge, to any person obtaining a copy of
+; * this software and associated documentation files (the "Software"), to deal in
+; * the Software without restriction, including without limitation the rights to
+; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+; * the Software, and to permit persons to whom the Software is furnished to do so,
+; * subject to the following conditions:
+; *
+; * The above copyright notice and this permission notice shall be included in all
+; * copies or substantial portions of the Software.
+; *
+; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+; *
+; * http://www.FreeRTOS.org
+; * http://aws.amazon.com/freertos
+; *
+; * 1 tab == 4 spaces!
+; */
+
+#include "porthardware.h"
+
+; Declare all extern symbols here - including any ISRs that are referenced in
+; the vector table.
+
+; ISR functions
+; -------------
+EXTERN TICK_INT
+
+; Functions used by scheduler
+; ---------------------------
+EXTERN vTaskSwitchContext
+EXTERN pxCurrentTCB
+EXTERN xTaskIncrementTick
+EXTERN uxCriticalNesting
+
+; Functions implemented in this file
+; ----------------------------------
+PUBLIC vPortYield
+PUBLIC vPortYieldFromTick
+PUBLIC vPortYieldFromISR
+PUBLIC vPortStart
+
+; Interrupt vector table.
+; -----------------------
+;
+; For simplicity the RTOS tick interrupt routine uses the __task keyword.
+; As the IAR compiler does not permit a function to be declared using both
+; __task and __interrupt, the use of __task necessitates that the interrupt
+; vector table be setup manually.
+;
+; To write an ISR, implement the ISR function using the __interrupt keyword
+; but do not install the interrupt using the "#pragma vector=ABC" method.
+; Instead manually place the name of the ISR in the vector table using an
+; ORG and jmp instruction as demonstrated below.
+; You will also have to add an EXTERN statement at the top of the file.
+
+    ASEG
+
+    ORG TICK_INT_vect                   ; Vector address
+        jmp TICK_INT                    ; ISR
+
+    RSEG CODE
+
+CLR_INT MACRO  FLAG_REG, FLAG_MASK
+    st -y, r16
+    ldi r16, FLAG_MASK
+    sts FLAG_REG, r16
+    ld r16, y+
+        
+    ENDM
+
+; Saving and Restoring a Task Context and Task Switching
+; ------------------------------------------------------
+;
+; The IAR compiler does not fully support inline assembler, so saving and
+; restoring a task context has to be written in an asm file.
+;
+; vPortYield() and vPortYieldFromTick() are usually written in C.  Doing
+; so in this case would required calls to be made to portSAVE_CONTEXT() and
+; portRESTORE_CONTEXT().  This is dis-advantageous as the context switch
+; function would require two extra jump and return instructions over the
+; WinAVR equivalent.
+;
+; To avoid this I have opted to implement both vPortYield() and
+; vPortYieldFromTick() in this assembly file.  For convenience
+; portSAVE_CONTEXT and portRESTORE_CONTEXT are implemented as macros.
+
+portSAVE_CONTEXT MACRO
+    st  -y, r0          ; First save the r0 register - we need to use this.
+    in  r0, SREG        ; Obtain the SREG value so we can disable interrupts...
+    cli                 ; ... as soon as possible.
+    st  -y, r0          ; Store the SREG as it was before we disabled interrupts.
+
+    in  r0, SPL         ; Next store the hardware stack pointer.  The IAR...
+    st  -y, r0          ; ... compiler uses the hardware stack as a call stack ...
+    in  r0, SPH         ; ...  only.
+    st  -y, r0
+
+    st  -y, r1          ; Now store the rest of the registers.  Dont store the ...
+    st  -y, r2          ; ... the Y register here as it is used as the software
+    st  -y, r3          ; stack pointer and will get saved into the TCB.
+    st  -y, r4
+    st  -y, r5
+    st  -y, r6
+    st  -y, r7
+    st  -y, r8
+    st  -y, r9
+    st  -y, r10
+    st  -y, r11
+    st  -y, r12
+    st  -y, r13
+    st  -y, r14
+    st  -y, r15
+    st  -y, r16
+    st  -y, r17
+    st  -y, r18
+    st  -y, r19
+    st  -y, r20
+    st  -y, r21
+    st  -y, r22
+    st  -y, r23
+    st  -y, r24
+    st  -y, r25
+    st  -y, r26
+    st  -y, r27
+    st  -y, r30
+    st  -y, r31
+        
+    lds r0, uxCriticalNesting
+    st  -y, r0                  ; Store the critical nesting counter.
+
+    lds r26, pxCurrentTCB       ; Finally save the software stack pointer (Y ...
+    lds r27, pxCurrentTCB + 1   ; ... register) into the TCB.
+    st  x+, r28
+    st  x+, r29
+
+    ENDM
+
+
+portRESTORE_CONTEXT MACRO
+    lds r26, pxCurrentTCB
+    lds r27, pxCurrentTCB + 1       ; Restore the software stack pointer from ...
+    ld  r28, x+                     ; the TCB into the software stack pointer (...
+    ld  r29, x+                     ; ... the Y register).
+
+    ld  r0, y+
+    sts uxCriticalNesting, r0
+
+    ld  r31, y+                     ; Restore the registers down to R0.  The Y
+    ld  r30, y+                     ; register is missing from this list as it
+    ld  r27, y+                     ; has already been restored.
+    ld  r26, y+
+    ld  r25, y+
+    ld  r24, y+
+    ld  r23, y+
+    ld  r22, y+
+    ld  r21, y+
+    ld  r20, y+
+    ld  r19, y+
+    ld  r18, y+
+    ld  r17, y+
+    ld  r16, y+
+    ld  r15, y+
+    ld  r14, y+
+    ld  r13, y+
+    ld  r12, y+
+    ld  r11, y+
+    ld  r10, y+
+    ld  r9, y+
+    ld  r8, y+
+    ld  r7, y+
+    ld  r6, y+
+    ld  r5, y+
+    ld  r4, y+
+    ld  r3, y+
+    ld  r2, y+
+    ld  r1, y+
+
+    ld  r0, y+                      ; The next thing on the stack is the ...
+    out SPH, r0                     ; ... hardware stack pointer.
+    ld  r0, y+
+    out SPL, r0
+
+    ld  r0, y+                      ; Next there is the SREG register.
+    out SREG, r0
+
+    ld  r0, y+                      ; Finally we have finished with r0, so restore r0.
+
+    ENDM
+
+
+
+; vPortYield(), vPortYieldFromTick() and vPortYieldFromISR()
+; -------------------------------------
+;
+; Manual and preemptive context switch functions respectively.
+; The IAR compiler does not fully support inline assembler,
+; so these are implemented here rather than the more usually
+; place of within port.c.
+
+vPortYield:
+    portSAVE_CONTEXT                ; Save the context of the current task.
+    call vTaskSwitchContext         ; Call the scheduler.
+    portRESTORE_CONTEXT             ; Restore the context of whichever task the ...
+    ret                             ; ... scheduler decided should run.
+
+vPortYieldFromTick:
+    CLR_INT INT_FLAGS, INT_MASK     ; Clear tick interrupt flag
+ 
+    portSAVE_CONTEXT                ; Save the context of the current task.
+    call xTaskIncrementTick         ; Call the timer tick function.
+    tst r16
+    breq SkipTaskSwitch
+    call vTaskSwitchContext         ; Call the scheduler.
+
+SkipTaskSwitch:
+    portRESTORE_CONTEXT             ; Restore the context of whichever task the ...
+    reti                            ; ... scheduler decided should run.
+
+vPortYieldFromISR:
+    portSAVE_CONTEXT                ; Save the context of the current task.
+    call vTaskSwitchContext         ; Call the scheduler.
+    portRESTORE_CONTEXT             ; Restore the context of whichever task the ...
+    reti                            ; ... scheduler decided should run.
+
+; vPortStart()
+; ------------
+;
+; Again due to the lack of inline assembler, this is required
+; to get access to the portRESTORE_CONTEXT macro.
+
+vPortStart:
+        portRESTORE_CONTEXT
+        ret
+
+; Just a filler for unused interrupt vectors.
+vNoISR:
+    reti
+
+END


### PR DESCRIPTION
Update to AVR_Mega0 and AVR_Dx GCC ports + addition of their IAR equivalents

Description
-----------
Update to AVR_Mega0 and AVR_Dx GCC ports: indentation and removal of TICK_stop() macro (not used anywhere)
Addition of their IAR equivalents



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
