### PR TITLE
Change the xRunningPrivileged check from "!=true" to "==false"

### DIFF
--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -68,7 +68,7 @@ BaseType_t xPortRaisePrivilege( void ) /* FREERTOS_SYSTEM_CALL */
     xRunningPrivileged = portIS_PRIVILEGED();
 
     /* If the processor is not already privileged, raise privilege. */
-    if( xRunningPrivileged != pdTRUE )
+    if( xRunningPrivileged == pdFALSE )
     {
         portRAISE_PRIVILEGE();
     }
@@ -79,7 +79,7 @@ BaseType_t xPortRaisePrivilege( void ) /* FREERTOS_SYSTEM_CALL */
 
 void vPortResetPrivilege( BaseType_t xRunningPrivileged )
 {
-    if( xRunningPrivileged != pdTRUE )
+    if( xRunningPrivileged == pdFALSE )
     {
         portRESET_PRIVILEGE();
     }


### PR DESCRIPTION
Description
-----------

The expected behavior of `portIS_PRIVILEGED` is:
* return 0 if the processor is not running privileged.
* return 1 if the processor is running privileged.

Some TI ports do not return 1 when the processor is running privileged causing the following check to fail: `if( xRunningPrivileged != pdTRUE )`.

This commit change the check to: `if( xRunningPrivileged == pdFALSE )`. It ensures that the check is successful even on the ports which return incorrect value from `portIS_PRIVILEGED` when the processor is running privileged.

See https://forums.freertos.org/t/kernel-bug-nested-mpu-wrapper-calls-generate-an-exception/10391

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
