### PR TITLE
Allow application to override TEX,S,C and B bits for Flash and RAM

### DIFF
--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -703,7 +703,7 @@ static void prvSetupMPU( void )
                                           ( portUNPRIVILEGED_FLASH_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_READ_ONLY ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_FLASH & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        ( prvGetMPURegionSizeSetting( ( uint32_t ) __FLASH_segment_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -714,7 +714,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_FLASH_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_ONLY ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_FLASH & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        ( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__ ) ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -725,7 +725,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_RAM_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -836,7 +836,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
-            ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
@@ -849,7 +849,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 1 ].ulRegionAttribute =
             ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-            ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
             ( portMPU_REGION_ENABLE );
 
@@ -877,7 +877,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
                 ( portMPU_REGION_READ_WRITE ) | /* Read and write. */
                 ( prvGetMPURegionSizeSetting( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) ) |
-                ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                 ( portMPU_REGION_ENABLE );
         }
 

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -80,11 +80,91 @@
     #define portMPU_REGION_PRIVILEGED_READ_WRITE_UNPRIV_READ_ONLY    ( 0x02UL << 24UL )
     #define portMPU_REGION_CACHEABLE_BUFFERABLE                      ( 0x07UL << 16UL )
     #define portMPU_REGION_EXECUTE_NEVER                             ( 0x01UL << 28UL )
+    /* Location of the TEX,S,C,B bits in the MPU Region Attribute and Size
+     * Register (RASR). */
+    #define portMPU_RASR_TEX_S_C_B_LOCATION                          ( 16UL )
+    #define portMPU_RASR_TEX_S_C_B_MASK                              ( 0x3FUL )
 
     /* MPU settings that can be overriden in FreeRTOSConfig.h. */
     #ifndef configTOTAL_MPU_REGIONS
         /* Define to 8 for backward compatibility. */
         #define configTOTAL_MPU_REGIONS                              ( 8UL )
+    #endif
+
+    /*
+     * The TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits define the
+     * memory type, and where necessary the cacheable and shareable properties
+     * of the memory region.
+     *
+     * The TEX, C, and B bits together indicate the memory type of the region,
+     * and:
+     * - For Normal memory, the cacheable properties of the region.
+     * - For Device memory, whether the region is shareable.
+     *
+     * For Normal memory regions, the S bit indicates whether the region is
+     * shareable. For Strongly-ordered and Device memory, the S bit is ignored.
+     *
+     * See the following two tables for setting TEX, S, C and B bits for
+     * unprivileged flash, privileged flash and privileged RAM regions.
+     *
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | TEX | C | B | Memory type            |  Description or Normal region cacheability             |  Shareable?             |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 0 | 0 | Strongly-ordered       |  Strongly ordered                                      |  Shareable              |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 0 | 1 | Device                 |  Shared device                                         |  Shareable              |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 1 | 0 | Normal                 |  Outer and inner   write-through; no write allocate    |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 1 | 1 | Normal                 |  Outer and inner   write-back; no write allocate       |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 0 | 0 | Normal                 |  Outer and inner   Non-cacheable                       |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 0 | 1 | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 1 | 0 | IMPLEMENTATION DEFINED |  IMPLEMENTATION DEFINED                                |  IMPLEMENTATION DEFINED |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 1 | 1 | Normal                 |  Outer and inner   write-back; write and read allocate |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 010 | 0 | 0 | Device                 |  Non-shared device                                     |  Not shareable          |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 010 | 0 | 1 | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 010 | 1 | X | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 011 | X | X | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 1BB | A | A | Normal                 | Cached memory, with AA and BB indicating the inner and |  Reserved               |
+    |     |   |   |                        | outer cacheability rules that must be exported on the  |                         |
+    |     |   |   |                        | bus. See the table below for the cacheability policy   |                         |
+    |     |   |   |                        | encoding. memory, BB=Outer policy, AA=Inner policy.    |                         |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+
+    +-----------------------------------------+----------------------------------------+
+    | AA or BB subfield of {TEX,C,B} encoding |  Cacheability policy                   |
+    +-----------------------------------------+----------------------------------------+
+    | 00                                      |  Non-cacheable                         |
+    +-----------------------------------------+----------------------------------------+
+    | 01                                      |  Write-back, write and   read allocate |
+    +-----------------------------------------+----------------------------------------+
+    | 10                                      |  Write-through, no write   allocate    |
+    +-----------------------------------------+----------------------------------------+
+    | 11                                      |  Write-back, no write   allocate       |
+    +-----------------------------------------+----------------------------------------+
+    */
+
+    /* TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for flash
+     * region. */
+    #ifndef configTEX_S_C_B_FLASH
+        /* Default to TEX=000, S=1, C=1, B=1 for backward compatibility. */
+        #define configTEX_S_C_B_FLASH                                ( 0x07UL )
+    #endif
+
+    /* TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for RAM
+     * region. */
+    #ifndef configTEX_S_C_B_SRAM
+        /* Default to TEX=000, S=1, C=1, B=1 for backward compatibility. */
+        #define configTEX_S_C_B_SRAM                                 ( 0x07UL )
     #endif
 
     #define portUNPRIVILEGED_FLASH_REGION                            ( 0UL )

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -542,7 +542,7 @@ static void prvSetupMPU( void )
                                           ( portUNPRIVILEGED_FLASH_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_READ_ONLY ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_FLASH & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        ( prvGetMPURegionSizeSetting( ( uint32_t ) __FLASH_segment_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -553,7 +553,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_FLASH_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_ONLY ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_FLASH & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        ( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__ ) ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -564,7 +564,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_RAM_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -633,7 +633,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
-            ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
@@ -646,7 +646,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 1 ].ulRegionAttribute =
             ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-            ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
             ( portMPU_REGION_ENABLE );
 
@@ -674,7 +674,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
                 ( portMPU_REGION_READ_WRITE ) | /* Read and write. */
                 ( prvGetMPURegionSizeSetting( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) ) |
-                ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                 ( portMPU_REGION_ENABLE );
         }
 

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -83,11 +83,91 @@
     #define portMPU_REGION_PRIVILEGED_READ_WRITE_UNPRIV_READ_ONLY    ( 0x02UL << 24UL )
     #define portMPU_REGION_CACHEABLE_BUFFERABLE                      ( 0x07UL << 16UL )
     #define portMPU_REGION_EXECUTE_NEVER                             ( 0x01UL << 28UL )
+    /* Location of the TEX,S,C,B bits in the MPU Region Attribute and Size
+     * Register (RASR). */
+    #define portMPU_RASR_TEX_S_C_B_LOCATION                          ( 16UL )
+    #define portMPU_RASR_TEX_S_C_B_MASK                              ( 0x3FUL )
 
     /* MPU settings that can be overriden in FreeRTOSConfig.h. */
     #ifndef configTOTAL_MPU_REGIONS
         /* Define to 8 for backward compatibility. */
         #define configTOTAL_MPU_REGIONS                              ( 8UL )
+    #endif
+
+    /*
+     * The TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits define the
+     * memory type, and where necessary the cacheable and shareable properties
+     * of the memory region.
+     *
+     * The TEX, C, and B bits together indicate the memory type of the region,
+     * and:
+     * - For Normal memory, the cacheable properties of the region.
+     * - For Device memory, whether the region is shareable.
+     *
+     * For Normal memory regions, the S bit indicates whether the region is
+     * shareable. For Strongly-ordered and Device memory, the S bit is ignored.
+     *
+     * See the following two tables for setting TEX, S, C and B bits for
+     * unprivileged flash, privileged flash and privileged RAM regions.
+     *
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | TEX | C | B | Memory type            |  Description or Normal region cacheability             |  Shareable?             |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 0 | 0 | Strongly-ordered       |  Strongly ordered                                      |  Shareable              |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 0 | 1 | Device                 |  Shared device                                         |  Shareable              |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 1 | 0 | Normal                 |  Outer and inner   write-through; no write allocate    |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 000 | 1 | 1 | Normal                 |  Outer and inner   write-back; no write allocate       |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 0 | 0 | Normal                 |  Outer and inner   Non-cacheable                       |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 0 | 1 | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 1 | 0 | IMPLEMENTATION DEFINED |  IMPLEMENTATION DEFINED                                |  IMPLEMENTATION DEFINED |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 001 | 1 | 1 | Normal                 |  Outer and inner   write-back; write and read allocate |  S bit                  |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 010 | 0 | 0 | Device                 |  Non-shared device                                     |  Not shareable          |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 010 | 0 | 1 | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 010 | 1 | X | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 011 | X | X | Reserved               |  Reserved                                              |  Reserved               |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+    | 1BB | A | A | Normal                 | Cached memory, with AA and BB indicating the inner and |  Reserved               |
+    |     |   |   |                        | outer cacheability rules that must be exported on the  |                         |
+    |     |   |   |                        | bus. See the table below for the cacheability policy   |                         |
+    |     |   |   |                        | encoding. memory, BB=Outer policy, AA=Inner policy.    |                         |
+    +-----+---+---+------------------------+--------------------------------------------------------+-------------------------+
+
+    +-----------------------------------------+----------------------------------------+
+    | AA or BB subfield of {TEX,C,B} encoding |  Cacheability policy                   |
+    +-----------------------------------------+----------------------------------------+
+    | 00                                      |  Non-cacheable                         |
+    +-----------------------------------------+----------------------------------------+
+    | 01                                      |  Write-back, write and   read allocate |
+    +-----------------------------------------+----------------------------------------+
+    | 10                                      |  Write-through, no write   allocate    |
+    +-----------------------------------------+----------------------------------------+
+    | 11                                      |  Write-back, no write   allocate       |
+    +-----------------------------------------+----------------------------------------+
+    */
+
+    /* TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for flash
+     * region. */
+    #ifndef configTEX_S_C_B_FLASH
+        /* Default to TEX=000, S=1, C=1, B=1 for backward compatibility. */
+        #define configTEX_S_C_B_FLASH                                ( 0x07UL )
+    #endif
+
+    /* TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for RAM
+     * region. */
+    #ifndef configTEX_S_C_B_SRAM
+        /* Default to TEX=000, S=1, C=1, B=1 for backward compatibility. */
+        #define configTEX_S_C_B_SRAM                                 ( 0x07UL )
     #endif
 
     #define portUNPRIVILEGED_FLASH_REGION                            ( 0UL )

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -690,7 +690,7 @@ static void prvSetupMPU( void )
                                           ( portUNPRIVILEGED_FLASH_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_READ_ONLY ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_FLASH & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        ( prvGetMPURegionSizeSetting( ( uint32_t ) __FLASH_segment_end__ - ( uint32_t ) __FLASH_segment_start__ ) ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -701,7 +701,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_FLASH_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_ONLY ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_FLASH & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        ( prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_functions_end__ - ( uint32_t ) __privileged_functions_start__ ) ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -712,7 +712,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_RAM_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-                                       ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -807,7 +807,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
-            ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
@@ -820,7 +820,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 1 ].ulRegionAttribute =
             ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-            ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
             ( portMPU_REGION_ENABLE );
 
@@ -848,7 +848,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
                 ( portMPU_REGION_READ_WRITE ) | /* Read and write. */
                 ( prvGetMPURegionSizeSetting( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) ) |
-                ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                 ( portMPU_REGION_ENABLE );
         }
 


### PR DESCRIPTION
Description
-----------

The TEX,  Shareable (S), Cacheable (C) and Bufferable (B) bits define the memory type, and where necessary the cacheable and shareable properties of the memory region.

The default values for these bits, as configured in our MPU ports, are sometimes not suitable for application. One such example is when the MCU has a cache, the application writer may not want to mark the memory as shareable to avoid disabling the cache. This change allows the application writer to override default vales for TEX, S C and B bits for Flash and RAM in their `FreeRTOSConfig.h`. The following two new configurations are introduced:

* `configTEX_S_C_B_FLASH`
* `configTEX_S_C_B_SRAM`

If undefined, the default values for the above configurations are TEX=000, S=1, C=1, B=1. This ensures backward compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
