### PR TITLE
Doxygen touch-ups

### DIFF
--- a/include/croutine.h
+++ b/include/croutine.h
@@ -60,12 +60,13 @@ typedef struct corCoRoutineControlBlock
 
 /**
  * croutine. h
- *<pre>
+ * <pre>
  * BaseType_t xCoRoutineCreate(
  *                               crCOROUTINE_CODE pxCoRoutineCode,
  *                               UBaseType_t uxPriority,
  *                               UBaseType_t uxIndex
- *                             );</pre>
+ *                             ); 
+ * </pre>
  *
  * Create a new co-routine and add it to the list of co-routines that are
  * ready to run.
@@ -137,8 +138,9 @@ BaseType_t xCoRoutineCreate( crCOROUTINE_CODE pxCoRoutineCode,
 
 /**
  * croutine. h
- *<pre>
- * void vCoRoutineSchedule( void );</pre>
+ * <pre>
+ * void vCoRoutineSchedule( void );
+ * </pre>
  *
  * Run a co-routine.
  *
@@ -179,7 +181,8 @@ void vCoRoutineSchedule( void );
 /**
  * croutine. h
  * <pre>
- * crSTART( CoRoutineHandle_t xHandle );</pre>
+ * crSTART( CoRoutineHandle_t xHandle );
+ * </pre>
  *
  * This macro MUST always be called at the start of a co-routine function.
  *
@@ -201,7 +204,8 @@ void vCoRoutineSchedule( void );
  *
  *   // Must end every co-routine with a call to crEND();
  *   crEND();
- * }</pre>
+ * }
+ * </pre>
  * \defgroup crSTART crSTART
  * \ingroup Tasks
  */
@@ -212,7 +216,8 @@ void vCoRoutineSchedule( void );
 /**
  * croutine. h
  * <pre>
- * crEND();</pre>
+ * crEND();
+ * </pre>
  *
  * This macro MUST always be called at the end of a co-routine function.
  *
@@ -234,7 +239,8 @@ void vCoRoutineSchedule( void );
  *
  *   // Must end every co-routine with a call to crEND();
  *   crEND();
- * }</pre>
+ * }
+ * </pre>
  * \defgroup crSTART crSTART
  * \ingroup Tasks
  */
@@ -253,8 +259,9 @@ void vCoRoutineSchedule( void );
 
 /**
  * croutine. h
- *<pre>
- * crDELAY( CoRoutineHandle_t xHandle, TickType_t xTicksToDelay );</pre>
+ * <pre>
+ * crDELAY( CoRoutineHandle_t xHandle, TickType_t xTicksToDelay );
+ * </pre>
  *
  * Delay a co-routine for a fixed period of time.
  *
@@ -293,7 +300,8 @@ void vCoRoutineSchedule( void );
  *
  *   // Must end every co-routine with a call to crEND();
  *   crEND();
- * }</pre>
+ * }
+ * </pre>
  * \defgroup crDELAY crDELAY
  * \ingroup Tasks
  */
@@ -312,7 +320,8 @@ void vCoRoutineSchedule( void );
  *                void *pvItemToQueue,
  *                TickType_t xTicksToWait,
  *                BaseType_t *pxResult
- *           )</pre>
+ *           )
+ * </pre>
  *
  * The macro's crQUEUE_SEND() and crQUEUE_RECEIVE() are the co-routine
  * equivalent to the xQueueSend() and xQueueReceive() functions used by tasks.
@@ -383,7 +392,8 @@ void vCoRoutineSchedule( void );
  *
  *  // Co-routines must end with a call to crEND().
  *  crEND();
- * }</pre>
+ * }
+ * </pre>
  * \defgroup crQUEUE_SEND crQUEUE_SEND
  * \ingroup Tasks
  */
@@ -411,7 +421,8 @@ void vCoRoutineSchedule( void );
  *                   void *pvBuffer,
  *                   TickType_t xTicksToWait,
  *                   BaseType_t *pxResult
- *               )</pre>
+ *               )
+ * </pre>
  *
  * The macro's crQUEUE_SEND() and crQUEUE_RECEIVE() are the co-routine
  * equivalent to the xQueueSend() and xQueueReceive() functions used by tasks.
@@ -475,7 +486,8 @@ void vCoRoutineSchedule( void );
  *  }
  *
  *  crEND();
- * }</pre>
+ * }
+ * </pre>
  * \defgroup crQUEUE_RECEIVE crQUEUE_RECEIVE
  * \ingroup Tasks
  */
@@ -501,7 +513,8 @@ void vCoRoutineSchedule( void );
  *                          QueueHandle_t pxQueue,
  *                          void *pvItemToQueue,
  *                          BaseType_t xCoRoutinePreviouslyWoken
- *                     )</pre>
+ *                     )
+ * </pre>
  *
  * The macro's crQUEUE_SEND_FROM_ISR() and crQUEUE_RECEIVE_FROM_ISR() are the
  * co-routine equivalent to the xQueueSendFromISR() and xQueueReceiveFromISR()
@@ -584,7 +597,8 @@ void vCoRoutineSchedule( void );
  *       // many characters are posted to the queue.
  *       xCRWokenByPost = crQUEUE_SEND_FROM_ISR( xCommsRxQueue, &cRxedChar, xCRWokenByPost );
  *   }
- * }</pre>
+ * }
+ * </pre>
  * \defgroup crQUEUE_SEND_FROM_ISR crQUEUE_SEND_FROM_ISR
  * \ingroup Tasks
  */
@@ -599,7 +613,8 @@ void vCoRoutineSchedule( void );
  *                          QueueHandle_t pxQueue,
  *                          void *pvBuffer,
  *                          BaseType_t * pxCoRoutineWoken
- *                     )</pre>
+ *                     )
+ * </pre>
  *
  * The macro's crQUEUE_SEND_FROM_ISR() and crQUEUE_RECEIVE_FROM_ISR() are the
  * co-routine equivalent to the xQueueSendFromISR() and xQueueReceiveFromISR()
@@ -698,7 +713,8 @@ void vCoRoutineSchedule( void );
  *           SEND_CHARACTER( cCharToTx );
  *       }
  *   }
- * }</pre>
+ * }
+ * </pre>
  * \defgroup crQUEUE_RECEIVE_FROM_ISR crQUEUE_RECEIVE_FROM_ISR
  * \ingroup Tasks
  */

--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -94,7 +94,7 @@ typedef TickType_t               EventBits_t;
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  * EventGroupHandle_t xEventGroupCreate( void );
  * </pre>
  *
@@ -150,7 +150,7 @@ typedef TickType_t               EventBits_t;
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  * EventGroupHandle_t xEventGroupCreateStatic( EventGroupHandle_t * pxEventGroupBuffer );
  * </pre>
  *
@@ -203,7 +203,7 @@ typedef TickType_t               EventBits_t;
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  EventBits_t xEventGroupWaitBits(    EventGroupHandle_t xEventGroup,
  *                                      const EventBits_t uxBitsToWaitFor,
  *                                      const BaseType_t xClearOnExit,
@@ -301,7 +301,7 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToClear );
  * </pre>
  *
@@ -359,7 +359,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  BaseType_t xEventGroupClearBitsFromISR( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet );
  * </pre>
  *
@@ -420,7 +420,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet );
  * </pre>
  *
@@ -495,7 +495,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  BaseType_t xEventGroupSetBitsFromISR( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet, BaseType_t *pxHigherPriorityTaskWoken );
  * </pre>
  *
@@ -576,7 +576,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  EventBits_t xEventGroupSync(    EventGroupHandle_t xEventGroup,
  *                                  const EventBits_t uxBitsToSet,
  *                                  const EventBits_t uxBitsToWaitFor,
@@ -706,7 +706,7 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  EventBits_t xEventGroupGetBits( EventGroupHandle_t xEventGroup );
  * </pre>
  *
@@ -724,7 +724,7 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup );
  * </pre>
  *
@@ -741,7 +741,7 @@ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup ) PRIVILEG
 
 /**
  * event_groups.h
- *<pre>
+ * <pre>
  *  void xEventGroupDelete( EventGroupHandle_t xEventGroup );
  * </pre>
  *

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -218,7 +218,7 @@ typedef void * MessageBufferHandle_t;
  *                         const void *pvTxData,
  *                         size_t xDataLengthBytes,
  *                         TickType_t xTicksToWait );
- * <pre>
+ * </pre>
  *
  * Sends a discrete message to the message buffer.  The message can be any
  * length that fits within the buffer's free space, and is copied into the
@@ -318,7 +318,7 @@ typedef void * MessageBufferHandle_t;
  *                                const void *pvTxData,
  *                                size_t xDataLengthBytes,
  *                                BaseType_t *pxHigherPriorityTaskWoken );
- * <pre>
+ * </pre>
  *
  * Interrupt safe version of the API function that sends a discrete message to
  * the message buffer.  The message can be any length that fits within the

--- a/include/queue.h
+++ b/include/queue.h
@@ -664,7 +664,8 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
  *                           QueueHandle_t xQueue,
  *                           void * const pvBuffer,
  *                           TickType_t xTicksToWait
- *                       );</pre>
+ *                       );
+ * </pre>
  *
  * Receive an item from a queue without removing the item from the queue.
  * The item is received by copy so a buffer of adequate size must be
@@ -759,7 +760,8 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
  * BaseType_t xQueuePeekFromISR(
  *                                  QueueHandle_t xQueue,
  *                                  void *pvBuffer,
- *                              );</pre>
+ *                              );
+ * </pre>
  *
  * A version of xQueuePeek() that can be called from an interrupt service
  * routine (ISR).
@@ -794,7 +796,8 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
  *                               QueueHandle_t xQueue,
  *                               void *pvBuffer,
  *                               TickType_t xTicksToWait
- *                          );</pre>
+ *                          );
+ * </pre>
  *
  * Receive an item from a queue.  The item is received by copy so a buffer of
  * adequate size must be provided.  The number of bytes copied into the buffer
@@ -882,7 +885,9 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
 
 /**
  * queue. h
- * <pre>UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue );</pre>
+ * <pre>
+ * UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue );
+ * </pre>
  *
  * Return the number of messages stored in a queue.
  *
@@ -897,7 +902,9 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue ) PRIVILEGED_FUNC
 
 /**
  * queue. h
- * <pre>UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue );</pre>
+ * <pre>
+ * UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue );
+ * </pre>
  *
  * Return the number of free spaces available in a queue.  This is equal to the
  * number of items that can be sent to the queue before the queue becomes full
@@ -914,7 +921,9 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue ) PRIVILEGED_FUNC
 
 /**
  * queue. h
- * <pre>void vQueueDelete( QueueHandle_t xQueue );</pre>
+ * <pre>
+ * void vQueueDelete( QueueHandle_t xQueue );
+ * </pre>
  *
  * Delete a queue - freeing all the memory allocated for storing of items
  * placed on the queue.

--- a/include/semphr.h
+++ b/include/semphr.h
@@ -42,7 +42,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>vSemaphoreCreateBinary( SemaphoreHandle_t xSemaphore )</pre>
+ * <pre>
+ * vSemaphoreCreateBinary( SemaphoreHandle_t xSemaphore );
+ * </pre>
  *
  * In many usage scenarios it is faster and more memory efficient to use a
  * direct to task notification in place of a binary semaphore!
@@ -102,7 +104,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateBinary( void )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateBinary( void );
+ * </pre>
  *
  * Creates a new binary semaphore instance, and returns a handle by which the
  * new semaphore can be referenced.
@@ -163,7 +167,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateBinaryStatic( StaticSemaphore_t *pxSemaphoreBuffer )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateBinaryStatic( StaticSemaphore_t *pxSemaphoreBuffer );
+ * </pre>
  *
  * Creates a new binary semaphore instance, and returns a handle by which the
  * new semaphore can be referenced.
@@ -222,10 +228,12 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>xSemaphoreTake(
+ * <pre>
+ * xSemaphoreTake(
  *                   SemaphoreHandle_t xSemaphore,
  *                   TickType_t xBlockTime
- *               )</pre>
+ *               );
+ * </pre>
  *
  * <i>Macro</i> to obtain a semaphore.  The semaphore must have previously been
  * created with a call to xSemaphoreCreateBinary(), xSemaphoreCreateMutex() or
@@ -289,10 +297,12 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
+ * <pre>
  * xSemaphoreTakeRecursive(
  *                          SemaphoreHandle_t xMutex,
  *                          TickType_t xBlockTime
- *                        )
+ *                        );
+ * </pre>
  *
  * <i>Macro</i> to recursively obtain, or 'take', a mutex type semaphore.
  * The mutex must have previously been created using a call to
@@ -384,7 +394,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>xSemaphoreGive( SemaphoreHandle_t xSemaphore )</pre>
+ * <pre>
+ * xSemaphoreGive( SemaphoreHandle_t xSemaphore );
+ * </pre>
  *
  * <i>Macro</i> to release a semaphore.  The semaphore must have previously been
  * created with a call to xSemaphoreCreateBinary(), xSemaphoreCreateMutex() or
@@ -447,7 +459,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>xSemaphoreGiveRecursive( SemaphoreHandle_t xMutex )</pre>
+ * <pre>
+ * xSemaphoreGiveRecursive( SemaphoreHandle_t xMutex );
+ * </pre>
  *
  * <i>Macro</i> to recursively release, or 'give', a mutex type semaphore.
  * The mutex must have previously been created using a call to
@@ -537,7 +551,8 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * xSemaphoreGiveFromISR(
  *                        SemaphoreHandle_t xSemaphore,
  *                        BaseType_t *pxHigherPriorityTaskWoken
- *                    )</pre>
+ *                    );
+ * </pre>
  *
  * <i>Macro</i> to  release a semaphore.  The semaphore must have previously been
  * created with a call to xSemaphoreCreateBinary() or xSemaphoreCreateCounting().
@@ -628,7 +643,8 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * xSemaphoreTakeFromISR(
  *                        SemaphoreHandle_t xSemaphore,
  *                        BaseType_t *pxHigherPriorityTaskWoken
- *                    )</pre>
+ *                    );
+ * </pre>
  *
  * <i>Macro</i> to  take a semaphore from an ISR.  The semaphore must have
  * previously been created with a call to xSemaphoreCreateBinary() or
@@ -658,7 +674,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateMutex( void )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateMutex( void );
+ * </pre>
  *
  * Creates a new mutex type semaphore instance, and returns a handle by which
  * the new mutex can be referenced.
@@ -717,7 +735,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateMutexStatic( StaticSemaphore_t *pxMutexBuffer )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateMutexStatic( StaticSemaphore_t *pxMutexBuffer );
+ * </pre>
  *
  * Creates a new mutex type semaphore instance, and returns a handle by which
  * the new mutex can be referenced.
@@ -779,7 +799,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateRecursiveMutex( void )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateRecursiveMutex( void );
+ * </pre>
  *
  * Creates a new recursive mutex type semaphore instance, and returns a handle
  * by which the new recursive mutex can be referenced.
@@ -846,7 +868,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateRecursiveMutexStatic( StaticSemaphore_t *pxMutexBuffer )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateRecursiveMutexStatic( StaticSemaphore_t *pxMutexBuffer );
+ * </pre>
  *
  * Creates a new recursive mutex type semaphore instance, and returns a handle
  * by which the new recursive mutex can be referenced.
@@ -919,7 +943,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateCounting( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateCounting( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount );
+ * </pre>
  *
  * Creates a new counting semaphore instance, and returns a handle by which the
  * new counting semaphore can be referenced.
@@ -999,7 +1025,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>SemaphoreHandle_t xSemaphoreCreateCountingStatic( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount, StaticSemaphore_t *pxSemaphoreBuffer )</pre>
+ * <pre>
+ * SemaphoreHandle_t xSemaphoreCreateCountingStatic( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount, StaticSemaphore_t *pxSemaphoreBuffer );
+ * </pre>
  *
  * Creates a new counting semaphore instance, and returns a handle by which the
  * new counting semaphore can be referenced.
@@ -1084,7 +1112,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr. h
- * <pre>void vSemaphoreDelete( SemaphoreHandle_t xSemaphore );</pre>
+ * <pre>
+ * void vSemaphoreDelete( SemaphoreHandle_t xSemaphore );
+ * </pre>
  *
  * Delete a semaphore.  This function must be used with care.  For example,
  * do not delete a mutex type semaphore if the mutex is held by a task.
@@ -1098,7 +1128,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr.h
- * <pre>TaskHandle_t xSemaphoreGetMutexHolder( SemaphoreHandle_t xMutex );</pre>
+ * <pre>
+ * TaskHandle_t xSemaphoreGetMutexHolder( SemaphoreHandle_t xMutex );
+ * </pre>
  *
  * If xMutex is indeed a mutex type semaphore, return the current mutex holder.
  * If xMutex is not a mutex type semaphore, or the mutex is available (not held
@@ -1113,7 +1145,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr.h
- * <pre>TaskHandle_t xSemaphoreGetMutexHolderFromISR( SemaphoreHandle_t xMutex );</pre>
+ * <pre>
+ * TaskHandle_t xSemaphoreGetMutexHolderFromISR( SemaphoreHandle_t xMutex );
+ * </pre>
  *
  * If xMutex is indeed a mutex type semaphore, return the current mutex holder.
  * If xMutex is not a mutex type semaphore, or the mutex is available (not held
@@ -1124,7 +1158,9 @@ typedef QueueHandle_t SemaphoreHandle_t;
 
 /**
  * semphr.h
- * <pre>UBaseType_t uxSemaphoreGetCount( SemaphoreHandle_t xSemaphore );</pre>
+ * <pre>
+ * UBaseType_t uxSemaphoreGetCount( SemaphoreHandle_t xSemaphore );
+ * </pre>
  *
  * If the semaphore is a counting semaphore then uxSemaphoreGetCount() returns
  * its current count value.  If the semaphore is a binary semaphore then

--- a/include/task.h
+++ b/include/task.h
@@ -244,7 +244,7 @@ typedef enum
 
 /**
  * task. h
- *<pre>
+ * <pre>
  * BaseType_t xTaskCreate(
  *                            TaskFunction_t pvTaskCode,
  *                            const char * const pcName,
@@ -252,7 +252,8 @@ typedef enum
  *                            void *pvParameters,
  *                            UBaseType_t uxPriority,
  *                            TaskHandle_t *pvCreatedTask
- *                        );</pre>
+ *                        );
+ * </pre>
  *
  * Create a new task and add it to the list of tasks that are ready to run.
  *
@@ -346,14 +347,15 @@ typedef enum
 
 /**
  * task. h
- *<pre>
+ * <pre>
  * TaskHandle_t xTaskCreateStatic( TaskFunction_t pvTaskCode,
  *                               const char * const pcName,
  *                               uint32_t ulStackDepth,
  *                               void *pvParameters,
  *                               UBaseType_t uxPriority,
  *                               StackType_t *pxStackBuffer,
- *                               StaticTask_t *pxTaskBuffer );</pre>
+ *                               StaticTask_t *pxTaskBuffer );
+ * </pre>
  *
  * Create a new task and add it to the list of tasks that are ready to run.
  *
@@ -463,8 +465,9 @@ typedef enum
 
 /**
  * task. h
- *<pre>
- * BaseType_t xTaskCreateRestricted( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );</pre>
+ * <pre>
+ * BaseType_t xTaskCreateRestricted( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );
+ * </pre>
  *
  * Only available when configSUPPORT_DYNAMIC_ALLOCATION is set to 1.
  *
@@ -540,8 +543,9 @@ typedef enum
 
 /**
  * task. h
- *<pre>
- * BaseType_t xTaskCreateRestrictedStatic( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );</pre>
+ * <pre>
+ * BaseType_t xTaskCreateRestrictedStatic( TaskParameters_t *pxTaskDefinition, TaskHandle_t *pxCreatedTask );
+ * </pre>
  *
  * Only available when configSUPPORT_STATIC_ALLOCATION is set to 1.
  *
@@ -629,8 +633,9 @@ typedef enum
 
 /**
  * task. h
- *<pre>
- * void vTaskAllocateMPURegions( TaskHandle_t xTask, const MemoryRegion_t * const pxRegions );</pre>
+ * <pre>
+ * void vTaskAllocateMPURegions( TaskHandle_t xTask, const MemoryRegion_t * const pxRegions );
+ * </pre>
  *
  * Memory regions are assigned to a restricted task when the task is created by
  * a call to xTaskCreateRestricted().  These regions can be redefined using
@@ -678,7 +683,9 @@ void vTaskAllocateMPURegions( TaskHandle_t xTask,
 
 /**
  * task. h
- * <pre>void vTaskDelete( TaskHandle_t xTask );</pre>
+ * <pre>
+ * void vTaskDelete( TaskHandle_t xTask );
+ * </pre>
  *
  * INCLUDE_vTaskDelete must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -723,7 +730,9 @@ void vTaskDelete( TaskHandle_t xTaskToDelete ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskDelay( const TickType_t xTicksToDelay );</pre>
+ * <pre>
+ * void vTaskDelay( const TickType_t xTicksToDelay );
+ * </pre>
  *
  * Delay a task for a given number of ticks.  The actual time that the
  * task remains blocked depends on the tick rate.  The constant
@@ -771,7 +780,9 @@ void vTaskDelay( const TickType_t xTicksToDelay ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskDelayUntil( TickType_t *pxPreviousWakeTime, const TickType_t xTimeIncrement );</pre>
+ * <pre>
+ * void vTaskDelayUntil( TickType_t *pxPreviousWakeTime, const TickType_t xTimeIncrement );
+ * </pre>
  *
  * INCLUDE_vTaskDelayUntil must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -831,7 +842,9 @@ void vTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
 
 /**
  * task. h
- * <pre>BaseType_t xTaskAbortDelay( TaskHandle_t xTask );</pre>
+ * <pre>
+ * BaseType_t xTaskAbortDelay( TaskHandle_t xTask );
+ * </pre>
  *
  * INCLUDE_xTaskAbortDelay must be defined as 1 in FreeRTOSConfig.h for this
  * function to be available.
@@ -861,7 +874,9 @@ BaseType_t xTaskAbortDelay( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>UBaseType_t uxTaskPriorityGet( const TaskHandle_t xTask );</pre>
+ * <pre>
+ * UBaseType_t uxTaskPriorityGet( const TaskHandle_t xTask );
+ * </pre>
  *
  * INCLUDE_uxTaskPriorityGet must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -908,7 +923,9 @@ UBaseType_t uxTaskPriorityGet( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>UBaseType_t uxTaskPriorityGetFromISR( const TaskHandle_t xTask );</pre>
+ * <pre>
+ * UBaseType_t uxTaskPriorityGetFromISR( const TaskHandle_t xTask );
+ * </pre>
  *
  * A version of uxTaskPriorityGet() that can be used from an ISR.
  */
@@ -916,7 +933,9 @@ UBaseType_t uxTaskPriorityGetFromISR( const TaskHandle_t xTask ) PRIVILEGED_FUNC
 
 /**
  * task. h
- * <pre>eTaskState eTaskGetState( TaskHandle_t xTask );</pre>
+ * <pre>
+ * eTaskState eTaskGetState( TaskHandle_t xTask );
+ * </pre>
  *
  * INCLUDE_eTaskGetState must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -934,7 +953,9 @@ eTaskState eTaskGetState( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskGetInfo( TaskHandle_t xTask, TaskStatus_t *pxTaskStatus, BaseType_t xGetFreeStackSpace, eTaskState eState );</pre>
+ * <pre>
+ * void vTaskGetInfo( TaskHandle_t xTask, TaskStatus_t *pxTaskStatus, BaseType_t xGetFreeStackSpace, eTaskState eState );
+ * </pre>
  *
  * configUSE_TRACE_FACILITY must be defined as 1 for this function to be
  * available.  See the configuration section for more information.
@@ -993,7 +1014,9 @@ void vTaskGetInfo( TaskHandle_t xTask,
 
 /**
  * task. h
- * <pre>void vTaskPrioritySet( TaskHandle_t xTask, UBaseType_t uxNewPriority );</pre>
+ * <pre>
+ * void vTaskPrioritySet( TaskHandle_t xTask, UBaseType_t uxNewPriority );
+ * </pre>
  *
  * INCLUDE_vTaskPrioritySet must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -1036,7 +1059,9 @@ void vTaskPrioritySet( TaskHandle_t xTask,
 
 /**
  * task. h
- * <pre>void vTaskSuspend( TaskHandle_t xTaskToSuspend );</pre>
+ * <pre>
+ * void vTaskSuspend( TaskHandle_t xTaskToSuspend );
+ * </pre>
  *
  * INCLUDE_vTaskSuspend must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -1087,7 +1112,9 @@ void vTaskSuspend( TaskHandle_t xTaskToSuspend ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskResume( TaskHandle_t xTaskToResume );</pre>
+ * <pre>
+ * void vTaskResume( TaskHandle_t xTaskToResume );
+ * </pre>
  *
  * INCLUDE_vTaskSuspend must be defined as 1 for this function to be available.
  * See the configuration section for more information.
@@ -1136,7 +1163,9 @@ void vTaskResume( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void xTaskResumeFromISR( TaskHandle_t xTaskToResume );</pre>
+ * <pre>
+ * void xTaskResumeFromISR( TaskHandle_t xTaskToResume );
+ * </pre>
  *
  * INCLUDE_xTaskResumeFromISR must be defined as 1 for this function to be
  * available.  See the configuration section for more information.
@@ -1169,7 +1198,9 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskStartScheduler( void );</pre>
+ * <pre>
+ * void vTaskStartScheduler( void );
+ * </pre>
  *
  * Starts the real time kernel tick processing.  After calling the kernel
  * has control over which tasks are executed and when.
@@ -1198,7 +1229,9 @@ void vTaskStartScheduler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskEndScheduler( void );</pre>
+ * <pre>
+ * void vTaskEndScheduler( void );
+ * </pre>
  *
  * NOTE:  At the time of writing only the x86 real mode port, which runs on a PC
  * in place of DOS, implements this function.
@@ -1254,7 +1287,9 @@ void vTaskEndScheduler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>void vTaskSuspendAll( void );</pre>
+ * <pre>
+ * void vTaskSuspendAll( void );
+ * </pre>
  *
  * Suspends the scheduler without disabling interrupts.  Context switches will
  * not occur while the scheduler is suspended.
@@ -1305,7 +1340,9 @@ void vTaskSuspendAll( void ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
- * <pre>BaseType_t xTaskResumeAll( void );</pre>
+ * <pre>
+ * BaseType_t xTaskResumeAll( void );
+ * </pre>
  *
  * Resumes scheduler activity after it was suspended by a call to
  * vTaskSuspendAll().
@@ -1496,7 +1533,9 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
 
 /**
  * task.h
- * <pre>void vTaskSetApplicationTaskTag( TaskHandle_t xTask, TaskHookFunction_t pxHookFunction );</pre>
+ * <pre>
+ * void vTaskSetApplicationTaskTag( TaskHandle_t xTask, TaskHookFunction_t pxHookFunction );
+ * </pre>
  *
  * Sets pxHookFunction to be the task hook function used by the task xTask.
  * Passing xTask as NULL has the effect of setting the calling tasks hook
@@ -1507,7 +1546,9 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
 
 /**
  * task.h
- * <pre>void xTaskGetApplicationTaskTag( TaskHandle_t xTask );</pre>
+ * <pre>
+ * void xTaskGetApplicationTaskTag( TaskHandle_t xTask );
+ * </pre>
  *
  * Returns the pxHookFunction value assigned to the task xTask.  Do not
  * call from an interrupt service routine - call
@@ -1517,7 +1558,9 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
 
 /**
  * task.h
- * <pre>void xTaskGetApplicationTaskTagFromISR( TaskHandle_t xTask );</pre>
+ * <pre>
+ * void xTaskGetApplicationTaskTagFromISR( TaskHandle_t xTask );
+ * </pre>
  *
  * Returns the pxHookFunction value assigned to the task xTask.  Can
  * be called from an interrupt service routine.
@@ -1589,7 +1632,9 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
 
 /**
  * task.h
- * <pre>BaseType_t xTaskCallApplicationTaskHook( TaskHandle_t xTask, void *pvParameter );</pre>
+ * <pre>
+ * BaseType_t xTaskCallApplicationTaskHook( TaskHandle_t xTask, void *pvParameter );
+ * </pre>
  *
  * Calls the hook function associated with xTask.  Passing xTask as NULL has
  * the effect of calling the Running tasks (the calling task) hook function.
@@ -2137,8 +2182,11 @@ BaseType_t xTaskGenericNotifyFromISR( TaskHandle_t xTaskToNotify,
 
 /**
  * task. h
- * <PRE>BaseType_t xTaskNotifyWaitIndexed( UBaseType_t uxIndexToWaitOn, uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );</pre>
- * <PRE>BaseType_t xTaskNotifyWait( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );</pre>
+ * <pre>
+ * BaseType_t xTaskNotifyWaitIndexed( UBaseType_t uxIndexToWaitOn, uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );
+ *
+ * BaseType_t xTaskNotifyWait( uint32_t ulBitsToClearOnEntry, uint32_t ulBitsToClearOnExit, uint32_t *pulNotificationValue, TickType_t xTicksToWait );
+ * </pre>
  *
  * Waits for a direct to task notification to be pending at a given index within
  * an array of direct to task notifications.
@@ -2323,8 +2371,8 @@ BaseType_t xTaskGenericNotifyWait( UBaseType_t uxIndexToWaitOn,
 
 /**
  * task. h
- * <PRE>void vTaskNotifyGiveIndexedFromISR( TaskHandle_t xTaskHandle, UBaseType_t uxIndexToNotify, BaseType_t *pxHigherPriorityTaskWoken );
- * <PRE>void vTaskNotifyGiveFromISR( TaskHandle_t xTaskHandle, BaseType_t *pxHigherPriorityTaskWoken );
+ * <PRE>void vTaskNotifyGiveIndexedFromISR( TaskHandle_t xTaskHandle, UBaseType_t uxIndexToNotify, BaseType_t *pxHigherPriorityTaskWoken );</PRE>
+ * <PRE>void vTaskNotifyGiveFromISR( TaskHandle_t xTaskHandle, BaseType_t *pxHigherPriorityTaskWoken );</PRE>
  *
  * A version of xTaskNotifyGiveIndexed() that can be called from an interrupt
  * service routine (ISR).
@@ -2408,8 +2456,11 @@ void vTaskGenericNotifyGiveFromISR( TaskHandle_t xTaskToNotify,
 
 /**
  * task. h
- * <PRE>uint32_t ulTaskNotifyTakeIndexed( UBaseType_t uxIndexToWaitOn, BaseType_t xClearCountOnExit, TickType_t xTicksToWait );</pre>
- * <PRE>uint32_t ulTaskNotifyTake( BaseType_t xClearCountOnExit, TickType_t xTicksToWait );</pre>
+ * <pre>
+ * uint32_t ulTaskNotifyTakeIndexed( UBaseType_t uxIndexToWaitOn, BaseType_t xClearCountOnExit, TickType_t xTicksToWait );
+ * 
+ * uint32_t ulTaskNotifyTake( BaseType_t xClearCountOnExit, TickType_t xTicksToWait );
+ * </pre>
  *
  * Waits for a direct to task notification on a particular index in the calling
  * task's notification array in a manner similar to taking a counting semaphore.
@@ -2511,8 +2562,11 @@ uint32_t ulTaskGenericNotifyTake( UBaseType_t uxIndexToWaitOn,
 
 /**
  * task. h
- * <PRE>BaseType_t xTaskNotifyStateClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToCLear );</pre>
- * <PRE>BaseType_t xTaskNotifyStateClear( TaskHandle_t xTask );</pre>
+ * <pre>
+ * BaseType_t xTaskNotifyStateClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToCLear );
+ * 
+ * BaseType_t xTaskNotifyStateClear( TaskHandle_t xTask );
+ * </pre>
  *
  * See http://www.FreeRTOS.org/RTOS-task-notifications.html for details.
  *
@@ -2572,8 +2626,11 @@ BaseType_t xTaskGenericNotifyStateClear( TaskHandle_t xTask,
 
 /**
  * task. h
- * <PRE>uint32_t ulTaskNotifyValueClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToClear, uint32_t ulBitsToClear );</pre>
- * <PRE>uint32_t ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear );</pre>
+ * <pre>
+ * uint32_t ulTaskNotifyValueClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToClear, uint32_t ulBitsToClear );
+ * 
+ * uint32_t ulTaskNotifyValueClear( TaskHandle_t xTask, uint32_t ulBitsToClear );
+ * </pre>
  *
  * See http://www.FreeRTOS.org/RTOS-task-notifications.html for details.
  *
@@ -2635,7 +2692,9 @@ uint32_t ulTaskGenericNotifyValueClear( TaskHandle_t xTask,
 
 /**
  * task.h
- * <pre>void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )</pre>
+ * <pre>
+ * void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut );
+ * </pre>
  *
  * Capture the current time for future use with xTaskCheckForTimeOut().
  *
@@ -2649,7 +2708,9 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNCTION;
 
 /**
  * task.h
- * <pre>BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait );</pre>
+ * <pre>
+ * BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut, TickType_t * const pxTicksToWait );
+ * </pre>
  *
  * Determines if pxTicksToWait ticks has passed since a time was captured
  * using a call to vTaskSetTimeOutState().  The captured time includes the tick
@@ -2733,7 +2794,9 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
 
 /**
  * task.h
- * <pre>BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp );</pre>
+ * <pre>
+ * BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp );
+ * </pre>
  *
  * This function corrects the tick count value after the application code has held
  * interrupts disabled for an extended period resulting in tick interrupts having


### PR DESCRIPTION
No code changes. Only in-comment changes.

Cleanup of PR #67. Modified to retain leading asterisk in `<pre>` blocks. In that PR, it was reported leading asterisk affected generated html. I was unable to reproduce those issues, and the generated html appeared OK. This may be a doxygen versioning/settings issue. See `Test Steps` section below.

Description
-----------

- Some functions were missing `<pre><\pre>` wrappers. These wrappers were added
- `<pre>` blocks can be placed on separate lines, rather than inline. Improves doxygen code readability while retaining presentation
- Some functions were missing a `;` at the end of the doxygen function signature. The semicolons were added for consistency with other signatures  

**Note:** Neither PR #67 nor this PR contain changes to `<PRE>` tags. HTML tags are case-insensitive so it's the same as `<pre>`. I did not alter the uppercase `<PRE>`  in case uppercase vs. lowercase had some non-functional purpose intended, like organization or emphasis mechanism. Will need to follow up with Richard, but we may end up opting for either all lowercase or uppercase `<PRE>` for consistency.

Test Steps
-----------
Generate the HTML. Verify no warnings/errors regarding unclosed `<pre>` blocks and that all API functions have a doxygen function signature. Visually verify changes. You can use the [attached config file](https://github.com/FreeRTOS/FreeRTOS-Kernel/files/5093120/test-doxy-config.txt), or try out your own doxygen config.
Tested with doxygen v1.8.17




Related Issue
-----------
PR #67 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
