### PR TITLE
Update Renesas GCC compiler ports

### DIFF
--- a/portable/GCC/RX100/port.c
+++ b/portable/GCC/RX100/port.c
@@ -40,12 +40,15 @@
 #include "string.h"
 
 /* Hardware specifics. */
-#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
-#include "platform.h"
-#else
-#include "iodefine.h"
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
 
+    #include "platform.h"
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    #include "iodefine.h"
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
 /*-----------------------------------------------------------*/
 
 /* Tasks should start with interrupts enabled and in Supervisor mode, therefore
@@ -93,21 +96,32 @@ static void prvStartFirstTask( void ) __attribute__((naked));
  * restoring of registers).  Written in asm code as direct register access is
  * required.
  */
-#if defined(configTICK_VECTOR)
-void vPortSoftwareInterruptISR( void ) __attribute__((naked, vector( R_BSP_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
-#else
-void vPortSoftwareInterruptISR( void ) __attribute__((naked));
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    R_BSP_PRAGMA_INTERRUPT( vSoftwareInterruptISR, VECT( ICU, SWINT ) )
+    R_BSP_ATTRIB_INTERRUPT void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H  */
 
 /*
- * The tick interrupt handler.
+ * The tick ISR handler.  The peripheral used is configured by the application
+ * via a hook/callback function.
  */
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
 
-#if defined(configTICK_VECTOR)
-void vPortTickISR( void ) __attribute__((interrupt( R_BSP_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
-#else
-void vPortTickISR( void ) __attribute__((interrupt));
-#endif
+    R_BSP_PRAGMA_INTERRUPT( vTickISR, _VECT( configTICK_VECTOR ) )
+    R_BSP_ATTRIB_INTERRUPT void vTickISR( void ); /* Do not add __attribute__( ( interrupt ) ). */
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    void vTickISR( void ) __attribute__( ( interrupt ) );
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
 /*
  * Sets up the periodic ISR used for the RTOS tick using the CMT.
  * The application writer can define configSETUP_TICK_INTERRUPT() (in

--- a/portable/GCC/RX100/port.c
+++ b/portable/GCC/RX100/port.c
@@ -40,7 +40,11 @@
 #include "string.h"
 
 /* Hardware specifics. */
+#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
+#include "platform.h"
+#else
 #include "iodefine.h"
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -89,13 +93,21 @@ static void prvStartFirstTask( void ) __attribute__((naked));
  * restoring of registers).  Written in asm code as direct register access is
  * required.
  */
+#if defined(configTICK_VECTOR)
+void vPortSoftwareInterruptISR( void ) __attribute__((naked, vector( R_BSP_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
+#else
 void vPortSoftwareInterruptISR( void ) __attribute__((naked));
+#endif
 
 /*
  * The tick interrupt handler.
  */
-void vPortTickISR( void ) __attribute__((interrupt));
 
+#if defined(configTICK_VECTOR)
+void vPortTickISR( void ) __attribute__((interrupt( R_BSP_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
+#else
+void vPortTickISR( void ) __attribute__((interrupt));
+#endif
 /*
  * Sets up the periodic ISR used for the RTOS tick using the CMT.
  * The application writer can define configSETUP_TICK_INTERRUPT() (in

--- a/portable/GCC/RX100/portmacro.h
+++ b/portable/GCC/RX100/portmacro.h
@@ -42,6 +42,11 @@ extern "C" {
  * These settings should not be altered.
  *-----------------------------------------------------------
  */
+/* When the FIT configurator or the Smart Configurator is used, platform.h has to be
+ * used. */
+#ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
+    #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H 0
+#endif
 
 /* Type definitions - these are a bit legacy and not really used now, other than
 portSTACK_TYPE and portBASE_TYPE. */

--- a/portable/GCC/RX200/port.c
+++ b/portable/GCC/RX200/port.c
@@ -1,0 +1,419 @@
+/*
+ * FreeRTOS Kernel V10.3.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/*-----------------------------------------------------------
+ * Implementation of functions defined in portable.h for the SH2A port.
+ *----------------------------------------------------------*/
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Library includes. */
+#include "string.h"
+
+/* Hardware specifics. */
+#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
+#include "platform.h"
+#else
+#include "iodefine.h"
+#endif
+
+/*-----------------------------------------------------------*/
+
+/* Tasks should start with interrupts enabled and in Supervisor mode, therefore
+PSW is set with U and I set, and PM and IPL clear. */
+#define portINITIAL_PSW     ( ( StackType_t ) 0x00030000 )
+#define portINITIAL_FPSW    ( ( StackType_t ) 0x00000100 )
+
+/* These macros allow a critical section to be added around the call to
+xTaskIncrementTick(), which is only ever called from interrupts at the kernel
+priority - ie a known priority.  Therefore these local macros are a slight
+optimisation compared to calling the global SET/CLEAR_INTERRUPT_MASK macros,
+which would require the old IPL to be read first and stored in a local variable. */
+#define portMASK_INTERRUPTS_FROM_KERNEL_ISR() 	__asm volatile ( "MVTIPL	%0" ::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY) )
+#define portUNMASK_INTERRUPTS_FROM_KERNEL_ISR() 	__asm volatile ( "MVTIPL	%0" ::"i"(configKERNEL_INTERRUPT_PRIORITY) )
+
+/*-----------------------------------------------------------*/
+
+/*
+ * Function to start the first task executing - written in asm code as direct
+ * access to registers is required.
+ */
+static void prvStartFirstTask( void ) __attribute__((naked));
+
+/*
+ * Software interrupt handler.  Performs the actual context switch (saving and
+ * restoring of registers).  Written in asm code as direct register access is
+ * required.
+ */
+#if defined(configTICK_VECTOR)
+void vSoftwareInterruptISR( void ) __attribute__((naked, vector( R_BSP_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
+#else
+void vSoftwareInterruptISR( void ) __attribute__((naked));
+#endif
+
+/*
+ * The tick interrupt handler.
+ */
+#if defined(configTICK_VECTOR)
+void vTickISR( void ) __attribute__((interrupt( R_BSP_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
+#else
+void vTickISR( void ) __attribute__((interrupt));
+#endif
+
+/*-----------------------------------------------------------*/
+
+extern void *pxCurrentTCB;
+
+/*-----------------------------------------------------------*/
+
+/*
+ * See header file for description.
+ */
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+{
+	/* R0 is not included as it is the stack pointer. */
+
+	*pxTopOfStack = 0x00;
+	pxTopOfStack--;
+ 	*pxTopOfStack = portINITIAL_PSW;
+	pxTopOfStack--;
+	*pxTopOfStack = ( StackType_t ) pxCode;
+
+	/* When debugging it can be useful if every register is set to a known
+	value.  Otherwise code space can be saved by just setting the registers
+	that need to be set. */
+	#ifdef USE_FULL_REGISTER_INITIALISATION
+	{
+		pxTopOfStack--;
+		*pxTopOfStack = 0xffffffff;	/* r15. */
+		pxTopOfStack--;
+		*pxTopOfStack = 0xeeeeeeee;
+		pxTopOfStack--;
+		*pxTopOfStack = 0xdddddddd;
+		pxTopOfStack--;
+		*pxTopOfStack = 0xcccccccc;
+		pxTopOfStack--;
+		*pxTopOfStack = 0xbbbbbbbb;
+		pxTopOfStack--;
+		*pxTopOfStack = 0xaaaaaaaa;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x99999999;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x88888888;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x77777777;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x66666666;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x55555555;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x44444444;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x33333333;
+		pxTopOfStack--;
+		*pxTopOfStack = 0x22222222;
+		pxTopOfStack--;
+	}
+	#else
+	{
+		pxTopOfStack -= 15;
+	}
+	#endif
+
+	*pxTopOfStack = ( StackType_t ) pvParameters; /* R1 */
+	pxTopOfStack--;
+	*pxTopOfStack = portINITIAL_FPSW;
+	pxTopOfStack--;
+	*pxTopOfStack = 0x11111111; /* Accumulator 0. */
+	pxTopOfStack--;
+	*pxTopOfStack = 0x22222222; /* Accumulator 0. */
+	pxTopOfStack--;
+	*pxTopOfStack = 0x33333333; /* Accumulator 0. */
+	pxTopOfStack--;
+	*pxTopOfStack = 0x44444444; /* Accumulator 1. */
+	pxTopOfStack--;
+	*pxTopOfStack = 0x55555555; /* Accumulator 1. */
+	pxTopOfStack--;
+	*pxTopOfStack = 0x66666666; /* Accumulator 1. */
+
+	return pxTopOfStack;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortStartScheduler( void )
+{
+extern void vApplicationSetupTimerInterrupt( void );
+
+	/* Use pxCurrentTCB just so it does not get optimised away. */
+	if( pxCurrentTCB != NULL )
+	{
+		/* Call an application function to set up the timer that will generate the
+		tick interrupt.  This way the application can decide which peripheral to
+		use.  A demo application is provided to show a suitable example. */
+		vApplicationSetupTimerInterrupt();
+
+		/* Enable the software interrupt. */
+		_IEN( _ICU_SWINT ) = 1;
+
+		/* Ensure the software interrupt is clear. */
+		_IR( _ICU_SWINT ) = 0;
+
+		/* Ensure the software interrupt is set to the kernel priority. */
+		_IPR( _ICU_SWINT ) = configKERNEL_INTERRUPT_PRIORITY;
+
+		/* Start the first task. */
+		prvStartFirstTask();
+	}
+
+	/* Should not get here. */
+	return pdFAIL;
+}
+/*-----------------------------------------------------------*/
+
+void vPortEndScheduler( void )
+{
+	/* Not implemented in ports where there is nothing to return to.
+	Artificially force an assert. */
+	configASSERT( pxCurrentTCB == NULL );
+}
+/*-----------------------------------------------------------*/
+
+static void prvStartFirstTask( void )
+{
+	__asm volatile
+	(
+		/* When starting the scheduler there is nothing that needs moving to the
+		interrupt stack because the function is not called from an interrupt.
+		Just ensure the current stack is the user stack. */
+		"SETPSW		U						\n" \
+
+		/* Obtain the location of the stack associated with which ever task
+		pxCurrentTCB is currently pointing to. */
+		"MOV.L		#_pxCurrentTCB, R15		\n" \
+		"MOV.L		[R15], R15				\n" \
+		"MOV.L		[R15], R0				\n" \
+
+		/* Restore the registers from the stack of the task pointed to by
+		pxCurrentTCB. */
+	    "POP		R15						\n" \
+
+		/* Accumulator low 32 bits. */
+	    "MVTACLO	R15, A0					\n" \
+	    "POP		R15						\n" \
+
+	    /* Accumulator high 32 bits. */
+	    "MVTACHI	R15, A0					\n" \
+	    "POP		R15						\n" \
+
+	    /* Accumulator guard. */
+	    "MVTACGU	R15, A0					\n" \
+	    "POP		R15						\n" \
+
+	    /* Accumulator low 32 bits. */
+	    "MVTACLO	R15, A1					\n" \
+	    "POP		R15						\n" \
+
+	    /* Accumulator high 32 bits. */
+	    "MVTACHI	R15, A1					\n" \
+	    "POP		R15						\n" \
+
+	    /* Accumulator guard. */
+	    "MVTACGU	R15, A1					\n" \
+	    "POP		R15						\n" \
+
+		/* Floating point status word. */
+	    "MVTC		R15, FPSW 				\n" \
+
+		/* R1 to R15 - R0 is not included as it is the SP. */
+	    "POPM		R1-R15 					\n" \
+
+		/* This pops the remaining registers. */
+	    "RTE								\n" \
+	    "NOP								\n" \
+	    "NOP								\n"
+	);
+}
+/*-----------------------------------------------------------*/
+
+void vSoftwareInterruptISR( void )
+{
+	__asm volatile
+	(
+		/* Re-enable interrupts. */
+		"SETPSW		I							\n" \
+
+		/* Move the data that was automatically pushed onto the interrupt stack when
+		the interrupt occurred from the interrupt stack to the user stack.
+
+		R15 is saved before it is clobbered. */
+		"PUSH.L		R15							\n" \
+
+		/* Read the user stack pointer. */
+		"MVFC		USP, R15					\n" \
+
+		/* Move the address down to the data being moved. */
+		"SUB		#12, R15					\n" \
+		"MVTC		R15, USP					\n" \
+
+		/* Copy the data across, R15, then PC, then PSW. */
+		"MOV.L		[ R0 ], [ R15 ]				\n" \
+		"MOV.L 		4[ R0 ], 4[ R15 ]			\n" \
+		"MOV.L		8[ R0 ], 8[ R15 ]			\n" \
+
+		/* Move the interrupt stack pointer to its new correct position. */
+		"ADD		#12, R0						\n" \
+
+		/* All the rest of the registers are saved directly to the user stack. */
+		"SETPSW		U							\n" \
+
+		/* Save the rest of the general registers (R15 has been saved already). */
+		"PUSHM		R1-R14						\n" \
+
+		/* Save the FPSW and accumulator. */
+		"MVFC		FPSW, R15					\n" \
+		"PUSH.L		R15							\n" \
+		"MVFACGU	#0, A1, R15					\n" \
+		"PUSH.L		R15							\n" \
+		"MVFACHI	#0, A1, R15					\n" \
+		"PUSH.L		R15							\n" \
+		/* Low order word. */
+		"MVFACLO	#0, A1, R15					\n" \
+		"PUSH.L		R15							\n" \
+		"MVFACGU	#0, A0, R15					\n" \
+		"PUSH.L		R15							\n" \
+		"MVFACHI	#0, A0, R15					\n" \
+		"PUSH.L		R15							\n" \
+		/* Low order word. */
+		"MVFACLO	#0, A0, R15					\n" \
+		"PUSH.L		R15							\n" \
+
+		/* Save the stack pointer to the TCB. */
+		"MOV.L		#_pxCurrentTCB, R15			\n" \
+		"MOV.L		[ R15 ], R15				\n" \
+		"MOV.L		R0, [ R15 ]					\n" \
+
+		/* Ensure the interrupt mask is set to the syscall priority while the kernel
+		structures are being accessed. */
+		"MVTIPL		%0 							\n" \
+
+		/* Select the next task to run. */
+		"BSR.A		_vTaskSwitchContext			\n" \
+
+		/* Reset the interrupt mask as no more data structure access is required. */
+		"MVTIPL		%1							\n" \
+
+		/* Load the stack pointer of the task that is now selected as the Running
+		state task from its TCB. */
+		"MOV.L		#_pxCurrentTCB,R15			\n" \
+		"MOV.L		[ R15 ], R15				\n" \
+		"MOV.L		[ R15 ], R0					\n" \
+
+		/* Restore the context of the new task.  The PSW (Program Status Word) and
+		PC will be popped by the RTE instruction. */
+	    "POP		R15							\n" \
+
+	    /* Accumulator low 32 bits. */
+	    "MVTACLO	R15, A0						\n" \
+	    "POP		R15							\n" \
+
+	    /* Accumulator high 32 bits. */
+	    "MVTACHI	R15, A0						\n" \
+	    "POP		R15							\n" \
+
+	    /* Accumulator guard. */
+	    "MVTACGU	R15, A0						\n" \
+	    "POP		R15							\n" \
+
+	    /* Accumulator low 32 bits. */
+	    "MVTACLO	R15, A1						\n" \
+	    "POP		R15							\n" \
+
+	    /* Accumulator high 32 bits. */
+	    "MVTACHI	R15, A1						\n" \
+	    "POP		R15							\n" \
+
+	    /* Accumulator guard. */
+	    "MVTACGU	R15, A1						\n" \
+		"POP		R15							\n" \
+		"MVTC		R15, FPSW					\n" \
+		"POPM		R1-R15						\n" \
+		"RTE									\n" \
+		"NOP									\n" \
+		"NOP									  "
+		:: "i"(configMAX_SYSCALL_INTERRUPT_PRIORITY), "i"(configKERNEL_INTERRUPT_PRIORITY)
+	);
+}
+/*-----------------------------------------------------------*/
+
+void vTickISR( void )
+{
+	/* Re-enabled interrupts. */
+	__asm volatile( "SETPSW	I" );
+
+	/* Increment the tick, and perform any processing the new tick value
+	necessitates.  Ensure IPL is at the max syscall value first. */
+	portMASK_INTERRUPTS_FROM_KERNEL_ISR();
+	{
+		if( xTaskIncrementTick() != pdFALSE )
+		{
+			taskYIELD();
+		}
+	}
+	portUNMASK_INTERRUPTS_FROM_KERNEL_ISR();
+}
+/*-----------------------------------------------------------*/
+
+uint32_t ulPortGetIPL( void )
+{
+	__asm volatile
+	(
+		"MVFC	PSW, R1			\n"	\
+		"SHLR	#24, R1			\n"	\
+		"RTS					  "
+	);
+
+	/* This will never get executed, but keeps the compiler from complaining. */
+	return 0;
+}
+/*-----------------------------------------------------------*/
+
+void vPortSetIPL( uint32_t ulNewIPL )
+{
+	__asm volatile
+	(
+		"PUSH	R5				\n" \
+		"MVFC	PSW, R5			\n"	\
+		"SHLL	#24, R1			\n" \
+		"AND	#-0F000001H, R5 \n" \
+		"OR		R1, R5			\n" \
+		"MVTC	R5, PSW			\n" \
+		"POP	R5				\n" \
+		"RTS					  "
+	 );
+}

--- a/portable/GCC/RX200/port.c
+++ b/portable/GCC/RX200/port.c
@@ -37,11 +37,15 @@
 #include "string.h"
 
 /* Hardware specifics. */
-#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
-#include "platform.h"
-#else
-#include "iodefine.h"
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    #include "platform.h"
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    #include "iodefine.h"
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
 
 /*-----------------------------------------------------------*/
 
@@ -66,25 +70,37 @@ which would require the old IPL to be read first and stored in a local variable.
  */
 static void prvStartFirstTask( void ) __attribute__((naked));
 
+
 /*
  * Software interrupt handler.  Performs the actual context switch (saving and
  * restoring of registers).  Written in asm code as direct register access is
  * required.
  */
-#if defined(configTICK_VECTOR)
-void vSoftwareInterruptISR( void ) __attribute__((naked, vector( R_BSP_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
-#else
-void vSoftwareInterruptISR( void ) __attribute__((naked));
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    R_BSP_PRAGMA_INTERRUPT( vSoftwareInterruptISR, VECT( ICU, SWINT ) )
+    R_BSP_ATTRIB_INTERRUPT void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H  */
 
 /*
- * The tick interrupt handler.
+ * The tick ISR handler.  The peripheral used is configured by the application
+ * via a hook/callback function.
  */
-#if defined(configTICK_VECTOR)
-void vTickISR( void ) __attribute__((interrupt( R_BSP_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
-#else
-void vTickISR( void ) __attribute__((interrupt));
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    R_BSP_PRAGMA_INTERRUPT( vTickISR, _VECT( configTICK_VECTOR ) )
+    R_BSP_ATTRIB_INTERRUPT void vTickISR( void ); /* Do not add __attribute__( ( interrupt ) ). */
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    void vTickISR( void ) __attribute__( ( interrupt ) );
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/RX200/portmacro.h
+++ b/portable/GCC/RX200/portmacro.h
@@ -1,0 +1,138 @@
+/*
+ * FreeRTOS Kernel V10.0.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*-----------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the
+ * given hardware and compiler.
+ *
+ * These settings should not be altered.
+ *-----------------------------------------------------------
+ */
+
+/* Type definitions - these are a bit legacy and not really used now, other than
+portSTACK_TYPE and portBASE_TYPE. */
+#define portCHAR		char
+#define portFLOAT		float
+#define portDOUBLE		double
+#define portLONG		long
+#define portSHORT		short
+#define portSTACK_TYPE	uint32_t
+#define portBASE_TYPE	long
+
+typedef portSTACK_TYPE StackType_t;
+typedef long BaseType_t;
+typedef unsigned long UBaseType_t;
+
+#if( configUSE_16_BIT_TICKS == 1 )
+	typedef uint16_t TickType_t;
+	#define portMAX_DELAY ( TickType_t ) 0xffff
+#else
+	typedef uint32_t TickType_t;
+	#define portMAX_DELAY ( TickType_t ) 0xffffffffUL
+
+	/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+	not need to be guarded with a critical section. */
+	#define portTICK_TYPE_IS_ATOMIC 1
+#endif
+/*-----------------------------------------------------------*/
+
+/* Hardware specifics. */
+#define portBYTE_ALIGNMENT			8	/* Could make four, according to manual. */
+#define portSTACK_GROWTH			-1
+#define portTICK_PERIOD_MS			( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portNOP()					__asm volatile( "NOP" )
+
+/* Yield equivalent to "*portITU_SWINTR = 0x01; ( void ) *portITU_SWINTR;"
+where portITU_SWINTR is the location of the software interrupt register
+(0x000872E0).  Don't rely on the assembler to select a register, so instead
+save and restore clobbered registers manually. */
+#define portYIELD()							\
+	__asm volatile 							\
+	(										\
+		"PUSH.L	R10					\n"		\
+		"MOV.L	#0x872E0, R10		\n"		\
+		"MOV.B	#0x1, [R10]			\n"		\
+		"MOV.L	[R10], R10			\n"		\
+		"POP	R10					\n"		\
+	)
+
+#define portYIELD_FROM_ISR( x )	if( x != pdFALSE ) portYIELD()
+
+/* These macros should not be called directly, but through the
+taskENTER_CRITICAL() and taskEXIT_CRITICAL() macros.  An extra check is
+performed if configASSERT() is defined to ensure an assertion handler does not
+inadvertently attempt to lower the IPL when the call to assert was triggered
+because the IPL value was found to be above	configMAX_SYSCALL_INTERRUPT_PRIORITY
+when an ISR safe FreeRTOS API function was executed.  ISR safe FreeRTOS API
+functions are those that end in FromISR.  FreeRTOS maintains a separate
+interrupt API to ensure API function and interrupt entry is as fast and as
+simple as possible. */
+#define portENABLE_INTERRUPTS() 	__asm volatile ( "MVTIPL	#0" )
+#ifdef configASSERT
+	#define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
+	#define portDISABLE_INTERRUPTS() 	if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile ( "MVTIPL	%0" ::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY) )
+#else
+	#define portDISABLE_INTERRUPTS() 	__asm volatile ( "MVTIPL	%0" ::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY) )
+#endif
+
+/* Critical nesting counts are stored in the TCB. */
+#define portCRITICAL_NESTING_IN_TCB ( 1 )
+
+/* The critical nesting functions defined within tasks.c. */
+extern void vTaskEnterCritical( void );
+extern void vTaskExitCritical( void );
+#define portENTER_CRITICAL()	vTaskEnterCritical()
+#define portEXIT_CRITICAL()		vTaskExitCritical()
+
+/* As this port allows interrupt nesting... */
+uint32_t ulPortGetIPL( void ) __attribute__((naked));
+void vPortSetIPL( uint32_t ulNewIPL ) __attribute__((naked));
+#define portSET_INTERRUPT_MASK_FROM_ISR() ulPortGetIPL(); portDISABLE_INTERRUPTS()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ) vPortSetIPL( uxSavedInterruptStatus )
+
+/*-----------------------------------------------------------*/
+
+/* Task function macros as described on the FreeRTOS.org WEB site. */
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTMACRO_H */
+

--- a/portable/GCC/RX200/portmacro.h
+++ b/portable/GCC/RX200/portmacro.h
@@ -43,6 +43,12 @@ extern "C" {
  *-----------------------------------------------------------
  */
 
+/* When the FIT configurator or the Smart Configurator is used, platform.h has to be
+ * used. */
+#ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
+    #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H 0
+#endif
+
 /* Type definitions - these are a bit legacy and not really used now, other than
 portSTACK_TYPE and portBASE_TYPE. */
 #define portCHAR		char

--- a/portable/GCC/RX600/port.c
+++ b/portable/GCC/RX600/port.c
@@ -37,11 +37,16 @@
 #include "string.h"
 
 /* Hardware specifics. */
-#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
-#include "platform.h"
-#else
-#include "iodefine.h"
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    #include "platform.h"
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    #include "iodefine.h"
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
 
 /*-----------------------------------------------------------*/
 
@@ -65,26 +70,36 @@ which would require the old IPL to be read first and stored in a local variable.
  * access to registers is required.
  */
 static void prvStartFirstTask( void ) __attribute__((naked));
-
 /*
  * Software interrupt handler.  Performs the actual context switch (saving and
  * restoring of registers).  Written in asm code as direct register access is
  * required.
  */
-#if defined(configTICK_VECTOR)
-void vSoftwareInterruptISR( void ) __attribute__((naked, vector( R_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
-#else
-void vSoftwareInterruptISR( void ) __attribute__((naked));
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    R_BSP_PRAGMA_INTERRUPT( vSoftwareInterruptISR, VECT( ICU, SWINT ) )
+    R_BSP_ATTRIB_INTERRUPT void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H  */
 
 /*
- * The tick interrupt handler.
+ * The tick ISR handler.  The peripheral used is configured by the application
+ * via a hook/callback function.
  */
-#if defined(configTICK_VECTOR)
-void vTickISR( void ) __attribute__((interrupt( R_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
-#else
-void vTickISR( void ) __attribute__((interrupt));
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    R_BSP_PRAGMA_INTERRUPT( vTickISR, _VECT( configTICK_VECTOR ) )
+    R_BSP_ATTRIB_INTERRUPT void vTickISR( void ); /* Do not add __attribute__( ( interrupt ) ). */
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    void vTickISR( void ) __attribute__( ( interrupt ) );
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/RX600/port.c
+++ b/portable/GCC/RX600/port.c
@@ -37,7 +37,11 @@
 #include "string.h"
 
 /* Hardware specifics. */
+#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
+#include "platform.h"
+#else
 #include "iodefine.h"
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -67,12 +71,20 @@ static void prvStartFirstTask( void ) __attribute__((naked));
  * restoring of registers).  Written in asm code as direct register access is
  * required.
  */
+#if defined(configTICK_VECTOR)
+void vSoftwareInterruptISR( void ) __attribute__((naked, vector( R_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
+#else
 void vSoftwareInterruptISR( void ) __attribute__((naked));
+#endif
 
 /*
  * The tick interrupt handler.
  */
+#if defined(configTICK_VECTOR)
+void vTickISR( void ) __attribute__((interrupt( R_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
+#else
 void vTickISR( void ) __attribute__((interrupt));
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -344,6 +356,9 @@ uint32_t ulPortGetIPL( void )
 
 void vPortSetIPL( uint32_t ulNewIPL )
 {
+	/* Avoid compiler warning about unreferenced parameter. */
+	( void ) ulNewIPL;
+
 	__asm volatile
 	(
 		"PUSH	R5				\n" \

--- a/portable/GCC/RX600/portmacro.h
+++ b/portable/GCC/RX600/portmacro.h
@@ -43,6 +43,12 @@ extern "C" {
  *-----------------------------------------------------------
  */
 
+/* When the FIT configurator or the Smart Configurator is used, platform.h has to be
+ * used. */
+#ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
+    #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H 0
+#endif
+
 /* Type definitions - these are a bit legacy and not really used now, other than
 portSTACK_TYPE and portBASE_TYPE. */
 #define portCHAR		char

--- a/portable/GCC/RX600v2/port.c
+++ b/portable/GCC/RX600v2/port.c
@@ -37,7 +37,11 @@
 #include "string.h"
 
 /* Hardware specifics. */
+#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
+#include "platform.h"
+#else
 #include "iodefine.h"
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -67,12 +71,20 @@ static void prvStartFirstTask( void ) __attribute__((naked));
  * restoring of registers).  Written in asm code as direct register access is
  * required.
  */
+#if defined(configTICK_VECTOR)
+void vSoftwareInterruptISR( void ) __attribute__((naked, vector( R_BSP_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
+#else
 void vSoftwareInterruptISR( void ) __attribute__((naked));
+#endif
 
 /*
  * The tick interrupt handler.
  */
+#if defined(configTICK_VECTOR)
+void vTickISR( void ) __attribute__((interrupt( R_BSP_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
+#else
 void vTickISR( void ) __attribute__((interrupt));
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -393,6 +405,9 @@ uint32_t ulPortGetIPL( void )
 
 void vPortSetIPL( uint32_t ulNewIPL )
 {
+	/* Avoid compiler warning about unreferenced parameter. */
+	( void ) ulNewIPL;
+
 	__asm volatile
 	(
 		"PUSH	R5				\n" \

--- a/portable/GCC/RX600v2/port.c
+++ b/portable/GCC/RX600v2/port.c
@@ -37,11 +37,15 @@
 #include "string.h"
 
 /* Hardware specifics. */
-#if defined(configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H) && (configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1)
-#include "platform.h"
-#else
-#include "iodefine.h"
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+
+    #include "platform.h"
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    #include "iodefine.h"
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
 
 /*-----------------------------------------------------------*/
 
@@ -71,21 +75,27 @@ static void prvStartFirstTask( void ) __attribute__((naked));
  * restoring of registers).  Written in asm code as direct register access is
  * required.
  */
-#if defined(configTICK_VECTOR)
-void vSoftwareInterruptISR( void ) __attribute__((naked, vector( R_BSP_SECNAME_INTVECTTBL, VECT_ICU_SWINT )));
-#else
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
+R_BSP_PRAGMA_INTERRUPT( vSoftwareInterruptISR, VECT( ICU, SWINT ) )
+R_BSP_ATTRIB_INTERRUPT void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
 void vSoftwareInterruptISR( void ) __attribute__((naked));
-#endif
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H  */
 
 /*
- * The tick interrupt handler.
+ * The tick ISR handler.  The peripheral used is configured by the application
+ * via a hook/callback function.
  */
-#if defined(configTICK_VECTOR)
-void vTickISR( void ) __attribute__((interrupt( R_BSP_SECNAME_INTVECTTBL, _VECT( configTICK_VECTOR ) )));
-#else
-void vTickISR( void ) __attribute__((interrupt));
-#endif
+#if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
 
+    R_BSP_PRAGMA_INTERRUPT( vTickISR, _VECT( configTICK_VECTOR ) )
+    R_BSP_ATTRIB_INTERRUPT void vTickISR( void ); /* Do not add __attribute__( ( interrupt ) ). */
+
+#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+
+    void vTickISR( void ) __attribute__( ( interrupt ) );
+
+#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
 /*-----------------------------------------------------------*/
 
 extern void *pxCurrentTCB;

--- a/portable/GCC/RX600v2/portmacro.h
+++ b/portable/GCC/RX600v2/portmacro.h
@@ -43,6 +43,12 @@ extern "C" {
  *-----------------------------------------------------------
  */
 
+/* When the FIT configurator or the Smart Configurator is used, platform.h has to be
+ * used. */
+#ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
+    #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H 0
+#endif
+
 /* Type definitions - these are a bit legacy and not really used now, other than
 portSTACK_TYPE and portBASE_TYPE. */
 #define portCHAR		char


### PR DESCRIPTION
Update Renesas GCC compiler ports

Description
-----------

This contains the changes for Renesas GCC compiler ports, authored in PR #89, rebased to latest master branch.  Also it fixes the ports as per the [proposal](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/89#issuecomment-660153971) in the PR

Test Steps
-----------

Demos for Renesas GCC compiler ports fails without the fix mentioned above.

https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Demo/RX200_RX231-RSK_GCC_e2studio_IAR
https://github.com/FreeRTOS/FreeRTOS/tree/master/FreeRTOS/Demo/RX600_RX64M_RSK_GCC_e2studio

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/89


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
