### PR TITLE
Style: Make Renesas RXv3 DPFPU port layer consistent with uncrustify.

### DIFF
--- a/portable/GCC/RX700v3_DPFPU/port.c
+++ b/portable/GCC/RX700v3_DPFPU/port.c
@@ -22,14 +22,13 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 /*-----------------------------------------------------------
 * Implementation of functions defined in portable.h for the RXv3 DPFPU port.
 *----------------------------------------------------------*/
 
-#warning Testing for DFPU support in this port is not yet complete
+#warning Testing for DPFPU support in this port is not yet complete
 
 /* Scheduler includes. */
 #include "FreeRTOS.h"
@@ -40,43 +39,39 @@
 
 /* Hardware specifics. */
 #if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
-
     #include "platform.h"
-
-#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
-
+#else
     #include "iodefine.h"
-
-#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Tasks should start with interrupts enabled and in Supervisor mode, therefore
  * PSW is set with U and I set, and PM and IPL clear. */
-#define portINITIAL_PSW     ( ( StackType_t ) 0x00030000 )
-#define portINITIAL_FPSW    ( ( StackType_t ) 0x00000100 )
-#define portINITIAL_DPSW    ( ( StackType_t ) 0x00000100 )
-#define portINITIAL_DCMR    ( ( StackType_t ) 0x00000000 )
-#define portINITIAL_DECNT   ( ( StackType_t ) 0x00000001 )
+#define portINITIAL_PSW                  ( ( StackType_t ) 0x00030000 )
+#define portINITIAL_FPSW                 ( ( StackType_t ) 0x00000100 )
+#define portINITIAL_DPSW                 ( ( StackType_t ) 0x00000100 )
+#define portINITIAL_DCMR                 ( ( StackType_t ) 0x00000000 )
+#define portINITIAL_DECNT                ( ( StackType_t ) 0x00000001 )
 
 /* Tasks are not created with a DPFPU context, but can be given a DPFPU context
  * after they have been created.  A variable is stored as part of the tasks context
  * that holds portNO_DPFPU_CONTEXT if the task does not have a DPFPU context, or
  * any other value if the task does have a DPFPU context. */
-#define portNO_DPFPU_CONTEXT    ( ( StackType_t ) 0 )
-#define portHAS_DPFPU_CONTEXT   ( ( StackType_t ) 1 )
+#define portNO_DPFPU_CONTEXT             ( ( StackType_t ) 0 )
+#define portHAS_DPFPU_CONTEXT            ( ( StackType_t ) 1 )
 
 /* The space on the stack required to hold the DPFPU data registers.  This is 16
  * 64-bit registers. */
-#define portDPFPU_DATA_REGISTER_WORDS   ( 16 * 2 )
+#define portDPFPU_DATA_REGISTER_WORDS    ( 16 * 2 )
 
 /* These macros allow a critical section to be added around the call to
  * xTaskIncrementTick(), which is only ever called from interrupts at the kernel
  * priority - ie a known priority.  Therefore these local macros are a slight
  * optimisation compared to calling the global SET/CLEAR_INTERRUPT_MASK macros,
  * which would require the old IPL to be read first and stored in a local variable. */
-#define portMASK_INTERRUPTS_FROM_KERNEL_ISR()      __asm volatile ( "MVTIPL	%0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
-#define portUNMASK_INTERRUPTS_FROM_KERNEL_ISR()    __asm volatile ( "MVTIPL	%0" ::"i" ( configKERNEL_INTERRUPT_PRIORITY ) )
+#define portMASK_INTERRUPTS_FROM_KERNEL_ISR()      __asm volatile ( "MVTIPL %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
+#define portUNMASK_INTERRUPTS_FROM_KERNEL_ISR()    __asm volatile ( "MVTIPL %0" ::"i" ( configKERNEL_INTERRUPT_PRIORITY ) )
 
 /*-----------------------------------------------------------*/
 
@@ -96,11 +91,11 @@ static void prvStartFirstTask( void ) __attribute__( ( naked ) );
     R_BSP_PRAGMA_INTERRUPT( vSoftwareInterruptISR, VECT( ICU, SWINT ) )
     R_BSP_ATTRIB_INTERRUPT void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
 
-#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+#else
 
     void vSoftwareInterruptISR( void ) __attribute__( ( naked ) );
 
-#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H  */
+#endif
 
 /*
  * The tick ISR handler.  The peripheral used is configured by the application
@@ -111,11 +106,11 @@ static void prvStartFirstTask( void ) __attribute__( ( naked ) );
     R_BSP_PRAGMA_INTERRUPT( vTickISR, _VECT( configTICK_VECTOR ) )
     R_BSP_ATTRIB_INTERRUPT void vTickISR( void ); /* Do not add __attribute__( ( interrupt ) ). */
 
-#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+#else
 
     void vTickISR( void ) __attribute__( ( interrupt ) );
 
-#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+#endif
 
 /*-----------------------------------------------------------*/
 
@@ -125,7 +120,7 @@ static void prvStartFirstTask( void ) __attribute__( ( naked ) );
 
     StackType_t ulPortTaskHasDPFPUContext = portNO_DPFPU_CONTEXT;
 
-#endif /* configUSE_TASK_DPFPU_SUPPORT */
+#endif
 
 /* This is accessed by the inline assembler functions so is file scope for
  * convenience. */
@@ -221,37 +216,37 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
             #ifdef USE_FULL_REGISTER_INITIALISATION
                 {
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1515.1515; /* DR15. */
+                    *( double * ) pxTopOfStack = 1515.1515;  /* DR15. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1414.1414; /* DR14. */
+                    *( double * ) pxTopOfStack = 1414.1414;  /* DR14. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1313.1313; /* DR13. */
+                    *( double * ) pxTopOfStack = 1313.1313;  /* DR13. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1212.1212; /* DR12. */
+                    *( double * ) pxTopOfStack = 1212.1212;  /* DR12. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1111.1111; /* DR11. */
+                    *( double * ) pxTopOfStack = 1111.1111;  /* DR11. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1010.1010; /* DR10. */
+                    *( double * ) pxTopOfStack = 1010.1010;  /* DR10. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  909.0909; /* DR9. */
+                    *( double * ) pxTopOfStack = 909.0909;   /* DR9. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  808.0808; /* DR8. */
+                    *( double * ) pxTopOfStack = 808.0808;   /* DR8. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  707.0707; /* DR7. */
+                    *( double * ) pxTopOfStack = 707.0707;   /* DR7. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  606.0606; /* DR6. */
+                    *( double * ) pxTopOfStack = 606.0606;   /* DR6. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  505.0505; /* DR5. */
+                    *( double * ) pxTopOfStack = 505.0505;   /* DR5. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  404.0404; /* DR4. */
+                    *( double * ) pxTopOfStack = 404.0404;   /* DR4. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  303.0303; /* DR3. */
+                    *( double * ) pxTopOfStack = 303.0303;   /* DR3. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  202.0202; /* DR2. */
+                    *( double * ) pxTopOfStack = 202.0202;   /* DR2. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  101.0101; /* DR1. */
+                    *( double * ) pxTopOfStack = 101.0101;   /* DR1. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 9876.54321;/* DR0. */
+                    *( double * ) pxTopOfStack = 9876.54321; /* DR0. */
                 }
             #else /* ifdef USE_FULL_REGISTER_INITIALISATION */
                 {
@@ -270,11 +265,11 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         {
             /* Omit DPFPU support. */
         }
-    #else /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+    #else /* configUSE_TASK_DPFPU_SUPPORT */
         {
             #error Invalid configUSE_TASK_DPFPU_SUPPORT setting - configUSE_TASK_DPFPU_SUPPORT must be set to 0, 1, 2, or left undefined.
         }
-    #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+    #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
     return pxTopOfStack;
 }
@@ -334,18 +329,19 @@ static void prvStartFirstTask( void )
 {
     __asm volatile
     (
+/* *INDENT-OFF* */
 
         /* When starting the scheduler there is nothing that needs moving to the
          * interrupt stack because the function is not called from an interrupt.
          * Just ensure the current stack is the user stack. */
-        "SETPSW		U						\n"\
+        "SETPSW     U                       \n"\
 
 
         /* Obtain the location of the stack associated with which ever task
          * pxCurrentTCB is currently pointing to. */
-        "MOV.L		#_pxCurrentTCB, R15		\n"\
-        "MOV.L		[R15], R15				\n"\
-        "MOV.L		[R15], R0				\n"\
+        "MOV.L      #_pxCurrentTCB, R15     \n"\
+        "MOV.L      [ R15 ], R15            \n"\
+        "MOV.L      [ R15 ], R0             \n"\
 
 
         /* Restore the registers from the stack of the task pointed to by
@@ -355,54 +351,56 @@ static void prvStartFirstTask( void )
 
             /* The restored ulPortTaskHasDPFPUContext is to be zero here.
              * So, it is never necessary to restore the DPFPU context here. */
-            "POP		R15									\n"\
-            "MOV.L		#_ulPortTaskHasDPFPUContext, R14	\n"\
-            "MOV.L		R15, [R14]							\n"\
+            "POP        R15                                 \n"\
+            "MOV.L      #_ulPortTaskHasDPFPUContext, R14    \n"\
+            "MOV.L      R15, [ R14 ]                        \n"\
 
         #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
             /* Restore the DPFPU context. */
-            "DPOPM.L	DPSW-DECNT				\n"\
-            "DPOPM.D	DR0-DR15				\n"\
+            "DPOPM.L    DPSW-DECNT              \n"\
+            "DPOPM.D    DR0-DR15                \n"\
 
-        #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
-        "POP		R15						\n"\
-
-        /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A0					\n"\
-        "POP		R15						\n"\
-
-        /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A0					\n"\
-        "POP		R15						\n"\
-
-        /* Accumulator guard. */
-        "MVTACGU	R15, A0					\n"\
-        "POP		R15						\n"\
+        "POP        R15                     \n"\
 
         /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A1					\n"\
-        "POP		R15						\n"\
+        "MVTACLO    R15, A0                 \n"\
+        "POP        R15                     \n"\
 
         /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A1					\n"\
-        "POP		R15						\n"\
+        "MVTACHI    R15, A0                 \n"\
+        "POP        R15                     \n"\
 
         /* Accumulator guard. */
-        "MVTACGU	R15, A1					\n"\
-        "POP		R15						\n"\
+        "MVTACGU    R15, A0                 \n"\
+        "POP        R15                     \n"\
+
+        /* Accumulator low 32 bits. */
+        "MVTACLO    R15, A1                 \n"\
+        "POP        R15                     \n"\
+
+        /* Accumulator high 32 bits. */
+        "MVTACHI    R15, A1                 \n"\
+        "POP        R15                     \n"\
+
+        /* Accumulator guard. */
+        "MVTACGU    R15, A1                 \n"\
+        "POP        R15                     \n"\
 
         /* Floating point status word. */
-        "MVTC		R15, FPSW 				\n"\
+        "MVTC       R15, FPSW               \n"\
 
         /* R1 to R15 - R0 is not included as it is the SP. */
-        "POPM		R1-R15 					\n"\
+        "POPM       R1-R15                  \n"\
 
         /* This pops the remaining registers. */
-        "RTE								\n"\
-        "NOP								\n"\
-        "NOP								\n"
+        "RTE                                \n"\
+        "NOP                                \n"\
+        "NOP                                  "
+
+/* *INDENT-ON* */
     );
 }
 /*-----------------------------------------------------------*/
@@ -411,101 +409,103 @@ void vSoftwareInterruptISR( void )
 {
     __asm volatile
     (
+/* *INDENT-OFF* */
+
         /* Re-enable interrupts. */
-        "SETPSW		I							\n"\
+        "SETPSW     I                           \n"\
 
 
         /* Move the data that was automatically pushed onto the interrupt stack when
          * the interrupt occurred from the interrupt stack to the user stack.
          *
          * R15 is saved before it is clobbered. */
-        "PUSH.L		R15							\n"\
+        "PUSH.L     R15                         \n"\
 
         /* Read the user stack pointer. */
-        "MVFC		USP, R15					\n"\
+        "MVFC       USP, R15                    \n"\
 
         /* Move the address down to the data being moved. */
-        "SUB		#12, R15					\n"\
-        "MVTC		R15, USP					\n"\
+        "SUB        #12, R15                    \n"\
+        "MVTC       R15, USP                    \n"\
 
         /* Copy the data across, R15, then PC, then PSW. */
-        "MOV.L		[ R0 ], [ R15 ]				\n"\
-        "MOV.L 		4[ R0 ], 4[ R15 ]			\n"\
-        "MOV.L		8[ R0 ], 8[ R15 ]			\n"\
+        "MOV.L      [ R0 ], [ R15 ]             \n"\
+        "MOV.L      4[ R0 ], 4[ R15 ]           \n"\
+        "MOV.L      8[ R0 ], 8[ R15 ]           \n"\
 
         /* Move the interrupt stack pointer to its new correct position. */
-        "ADD		#12, R0						\n"\
+        "ADD        #12, R0                     \n"\
 
         /* All the rest of the registers are saved directly to the user stack. */
-        "SETPSW		U							\n"\
+        "SETPSW     U                           \n"\
 
         /* Save the rest of the general registers (R15 has been saved already). */
-        "PUSHM		R1-R14						\n"\
+        "PUSHM      R1-R14                      \n"\
 
         /* Save the FPSW and accumulators. */
-        "MVFC		FPSW, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACGU	#0, A1, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACHI	#0, A1, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACLO	#0, A1, R15					\n" /* Low order word. */ \
-        "PUSH.L		R15							\n"\
-        "MVFACGU	#0, A0, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACHI	#0, A0, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACLO	#0, A0, R15					\n" /* Low order word. */ \
-        "PUSH.L		R15							\n"\
+        "MVFC       FPSW, R15                   \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACGU    #0, A1, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACHI    #0, A1, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACLO    #0, A1, R15                 \n" /* Low order word. */ \
+        "PUSH.L     R15                         \n"\
+        "MVFACGU    #0, A0, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACHI    #0, A0, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACLO    #0, A0, R15                 \n" /* Low order word. */ \
+        "PUSH.L     R15                         \n"\
 
         #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
 
             /* Does the task have a DPFPU context that needs saving?  If
              * ulPortTaskHasDPFPUContext is 0 then no. */
-            "MOV.L		#_ulPortTaskHasDPFPUContext, R15	\n"\
-            "MOV.L		[R15], R15							\n"\
-            "CMP		#0, R15								\n"\
+            "MOV.L      #_ulPortTaskHasDPFPUContext, R15    \n"\
+            "MOV.L      [ R15 ], R15                        \n"\
+            "CMP        #0, R15                             \n"\
 
             /* Save the DPFPU context, if any. */
-            "BEQ.B		?+							\n"\
-            "DPUSHM.D	DR0-DR15					\n"\
-            "DPUSHM.L	DPSW-DECNT					\n"\
-            "?:										\n"\
+            "BEQ.B      ?+                          \n"\
+            "DPUSHM.D   DR0-DR15                    \n"\
+            "DPUSHM.L   DPSW-DECNT                  \n"\
+            "?:                                     \n"\
 
             /* Save ulPortTaskHasDPFPUContext itself. */
-            "PUSH.L		R15							\n"\
+            "PUSH.L     R15                         \n"\
 
         #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
             /* Save the DPFPU context, always. */
-            "DPUSHM.D	DR0-DR15					\n"\
-            "DPUSHM.L	DPSW-DECNT					\n"\
+            "DPUSHM.D   DR0-DR15                    \n"\
+            "DPUSHM.L   DPSW-DECNT                  \n"\
 
-        #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
 
         /* Save the stack pointer to the TCB. */
-        "MOV.L		#_pxCurrentTCB, R15			\n"\
-        "MOV.L		[ R15 ], R15				\n"\
-        "MOV.L		R0, [ R15 ]					\n"\
+        "MOV.L      #_pxCurrentTCB, R15         \n"\
+        "MOV.L      [ R15 ], R15                \n"\
+        "MOV.L      R0, [ R15 ]                 \n"\
 
 
         /* Ensure the interrupt mask is set to the syscall priority while the kernel
          * structures are being accessed. */
-        "MVTIPL		%0 							\n"\
+        "MVTIPL     %0                          \n"\
 
         /* Select the next task to run. */
-        "BSR.A		_vTaskSwitchContext			\n"\
+        "BSR.A      _vTaskSwitchContext         \n"\
 
         /* Reset the interrupt mask as no more data structure access is required. */
-        "MVTIPL		%1							\n"\
+        "MVTIPL     %1                          \n"\
 
 
         /* Load the stack pointer of the task that is now selected as the Running
          * state task from its TCB. */
-        "MOV.L		#_pxCurrentTCB,R15			\n"\
-        "MOV.L		[ R15 ], R15				\n"\
-        "MOV.L		[ R15 ], R0					\n"\
+        "MOV.L      #_pxCurrentTCB, R15         \n"\
+        "MOV.L      [ R15 ], R15                \n"\
+        "MOV.L      [ R15 ], R0                 \n"\
 
 
         /* Restore the context of the new task.  The PSW (Program Status Word) and
@@ -515,56 +515,58 @@ void vSoftwareInterruptISR( void )
 
             /* Is there a DPFPU context to restore?  If the restored
              * ulPortTaskHasDPFPUContext is zero then no. */
-            "POP		R15									\n"\
-            "MOV.L		#_ulPortTaskHasDPFPUContext, R14	\n"\
-            "MOV.L		R15, [R14]							\n"\
-            "CMP		#0, R15								\n"\
+            "POP        R15                                 \n"\
+            "MOV.L      #_ulPortTaskHasDPFPUContext, R14    \n"\
+            "MOV.L      R15, [ R14 ]                        \n"\
+            "CMP        #0, R15                             \n"\
 
             /* Restore the DPFPU context, if any. */
-            "BEQ.B		?+							\n"\
-            "DPOPM.L	DPSW-DECNT					\n"\
-            "DPOPM.D	DR0-DR15					\n"\
-            "?:										\n"\
+            "BEQ.B      ?+                          \n"\
+            "DPOPM.L    DPSW-DECNT                  \n"\
+            "DPOPM.D    DR0-DR15                    \n"\
+            "?:                                     \n"\
 
         #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
             /* Restore the DPFPU context, always. */
-            "DPOPM.L	DPSW-DECNT					\n"\
-            "DPOPM.D	DR0-DR15					\n"\
+            "DPOPM.L    DPSW-DECNT                  \n"\
+            "DPOPM.D    DR0-DR15                    \n"\
 
-        #endif /* if( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
-        "POP		R15							\n"\
-
-        /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A0						\n"\
-        "POP		R15							\n"\
-
-        /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A0						\n"\
-        "POP		R15							\n"\
-
-        /* Accumulator guard. */
-        "MVTACGU	R15, A0						\n"\
-        "POP		R15							\n"\
+        "POP        R15                         \n"\
 
         /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A1						\n"\
-        "POP		R15							\n"\
+        "MVTACLO    R15, A0                     \n"\
+        "POP        R15                         \n"\
 
         /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A1						\n"\
-        "POP		R15							\n"\
+        "MVTACHI    R15, A0                     \n"\
+        "POP        R15                         \n"\
 
         /* Accumulator guard. */
-        "MVTACGU	R15, A1						\n"\
-        "POP		R15							\n"\
-        "MVTC		R15, FPSW					\n"\
-        "POPM		R1-R15						\n"\
-        "RTE									\n"\
-        "NOP									\n"\
-        "NOP									  "
+        "MVTACGU    R15, A0                     \n"\
+        "POP        R15                         \n"\
+
+        /* Accumulator low 32 bits. */
+        "MVTACLO    R15, A1                     \n"\
+        "POP        R15                         \n"\
+
+        /* Accumulator high 32 bits. */
+        "MVTACHI    R15, A1                     \n"\
+        "POP        R15                         \n"\
+
+        /* Accumulator guard. */
+        "MVTACGU    R15, A1                     \n"\
+        "POP        R15                         \n"\
+        "MVTC       R15, FPSW                   \n"\
+        "POPM       R1-R15                      \n"\
+        "RTE                                    \n"\
+        "NOP                                    \n"\
+        "NOP                                      "
         ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ), "i" ( configKERNEL_INTERRUPT_PRIORITY )
+
+/* *INDENT-ON* */
     );
 }
 /*-----------------------------------------------------------*/
@@ -572,7 +574,7 @@ void vSoftwareInterruptISR( void )
 void vTickISR( void )
 {
     /* Re-enabled interrupts. */
-    __asm volatile ( "SETPSW	I");
+    __asm volatile ( "SETPSW    I" );
 
     /* Increment the tick, and perform any processing the new tick value
      * necessitates.  Ensure IPL is at the max syscall value first. */
@@ -591,9 +593,11 @@ uint32_t ulPortGetIPL( void )
 {
     __asm volatile
     (
-        "MVFC	PSW, R1			\n"\
-        "SHLR	#24, R1			\n"\
-        "RTS					  "
+/* *INDENT-OFF* */
+        "MVFC   PSW, R1         \n"\
+        "SHLR   #24, R1         \n"\
+        "RTS                      "
+/* *INDENT-ON* */
     );
 
     /* This will never get executed, but keeps the compiler from complaining. */
@@ -608,14 +612,16 @@ void vPortSetIPL( uint32_t ulNewIPL )
 
     __asm volatile
     (
-        "PUSH	R5				\n"\
-        "MVFC	PSW, R5			\n"\
-        "SHLL	#24, R1			\n"\
-        "AND	#-0F000001H, R5 \n"\
-        "OR		R1, R5			\n"\
-        "MVTC	R5, PSW			\n"\
-        "POP	R5				\n"\
-        "RTS					  "
+/* *INDENT-OFF* */
+        "PUSH   R5              \n"\
+        "MVFC   PSW, R5         \n"\
+        "SHLL   #24, R1         \n"\
+        "AND    #-0F000001H, R5 \n"\
+        "OR     R1, R5          \n"\
+        "MVTC   R5, PSW         \n"\
+        "POP    R5              \n"\
+        "RTS                      "
+/* *INDENT-ON* */
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/RX700v3_DPFPU/portmacro.h
+++ b/portable/GCC/RX700v3_DPFPU/portmacro.h
@@ -22,16 +22,16 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
-
 #ifndef PORTMACRO_H
-    #define PORTMACRO_H
+#define PORTMACRO_H
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /*-----------------------------------------------------------
  * Port specific definitions.
@@ -43,11 +43,11 @@
  *-----------------------------------------------------------
  */
 
-/* When the FIT configurator or the Smart Configurator is used, platform.h has to be 
+/* When the FIT configurator or the Smart Configurator is used, platform.h has to be
  * used. */
-    #ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
-        #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H 0
-    #endif
+#ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
+    #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H    0
+#endif
 
 /* If configUSE_TASK_DPFPU_SUPPORT is set to 1 (or undefined) then each task will
  * be created without a DPFPU context, and a task must call vTaskUsesDPFPU() before
@@ -55,110 +55,112 @@
  * tasks are created with a DPFPU context by default, and calling vTaskUsesDPFPU() has
  * no effect.  If configUSE_TASK_DPFPU_SUPPORT is set to 0 then tasks never take care
  * of any DPFPU context (even if DPFPU registers are used). */
-    #ifndef configUSE_TASK_DPFPU_SUPPORT
-        #define configUSE_TASK_DPFPU_SUPPORT 1
-    #endif
+#ifndef configUSE_TASK_DPFPU_SUPPORT
+    #define configUSE_TASK_DPFPU_SUPPORT    1
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Type definitions - these are a bit legacy and not really used now, other than
  * portSTACK_TYPE and portBASE_TYPE. */
-    #define portCHAR          char
-    #define portFLOAT         float
-    #define portDOUBLE        double
-    #define portLONG          long
-    #define portSHORT         short
-    #define portSTACK_TYPE    uint32_t
-    #define portBASE_TYPE     long
+#define portCHAR          char
+#define portFLOAT         float
+#define portDOUBLE        double
+#define portLONG          long
+#define portSHORT         short
+#define portSTACK_TYPE    uint32_t
+#define portBASE_TYPE     long
 
-    typedef portSTACK_TYPE   StackType_t;
-    typedef long             BaseType_t;
-    typedef unsigned long    UBaseType_t;
+typedef portSTACK_TYPE   StackType_t;
+typedef long             BaseType_t;
+typedef unsigned long    UBaseType_t;
 
-    #if ( configUSE_16_BIT_TICKS == 1 )
-        typedef uint16_t     TickType_t;
-        #define portMAX_DELAY              ( TickType_t ) 0xffff
-    #else
-        typedef uint32_t     TickType_t;
-        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+#if ( configUSE_16_BIT_TICKS == 1 )
+    typedef uint16_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffff
+#else
+    typedef uint32_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
 
-/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
- * not need to be guarded with a critical section. */
-        #define portTICK_TYPE_IS_ATOMIC    1
-    #endif
+    /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+     * not need to be guarded with a critical section. */
+    #define portTICK_TYPE_IS_ATOMIC    1
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Hardware specifics. */
-    #define portBYTE_ALIGNMENT    8     /* Could make four, according to manual. */
-    #define portSTACK_GROWTH      -1
-    #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-    #define portNOP()    __asm volatile ( "NOP" )
+#define portBYTE_ALIGNMENT    8     /* Could make four, according to manual. */
+#define portSTACK_GROWTH      -1
+#define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portNOP()    __asm volatile ( "NOP" )
 
 /* Yield equivalent to "*portITU_SWINTR = 0x01; ( void ) *portITU_SWINTR;"
  * where portITU_SWINTR is the location of the software interrupt register
  * (0x000872E0).  Don't rely on the assembler to select a register, so instead
  * save and restore clobbered registers manually. */
-    #define portYIELD()           \
-    __asm volatile                \
-    (                             \
-        "PUSH.L	R10					\n"\
-        "MOV.L	#0x872E0, R10		\n"\
-        "MOV.B	#0x1, [R10]			\n"\
-        "CMP	[R10].UB, R10		\n"\
-        "POP    R10					\n"\
-        :::"cc"						\
-    )
+/* *INDENT-OFF* */
+#define portYIELD()             \
+__asm volatile                  \
+(                               \
+    "PUSH.L R10              \n"\
+    "MOV.L  #0x872E0, R10    \n"\
+    "MOV.B  #0x1, [ R10 ]    \n"\
+    "CMP    [ R10 ].UB, R10  \n"\
+    "POP    R10                "\
+    :::"cc"                     \
+)
+/* *INDENT-ON* */
 
-    #define portYIELD_FROM_ISR( x )                           if( ( x ) != pdFALSE ) portYIELD()
+#define portYIELD_FROM_ISR( x )    if( ( x ) != pdFALSE ) portYIELD()
 
 /* Workaround to reduce errors/warnings caused by e2 studio CDT's INDEXER and CODAN. */
-    #ifdef __CDT_PARSER__
+#ifdef __CDT_PARSER__
     #ifndef __asm
-    #define __asm asm
+        #define __asm    asm
     #endif
     #ifndef __attribute__
-    #define __attribute__( ... )
+        #define __attribute__( ... )
     #endif
-    #endif
+#endif
 
 /* These macros should not be called directly, but through the
  * taskENTER_CRITICAL() and taskEXIT_CRITICAL() macros.  An extra check is
  * performed if configASSERT() is defined to ensure an assertion handler does not
  * inadvertently attempt to lower the IPL when the call to assert was triggered
- * because the IPL value was found to be above	configMAX_SYSCALL_INTERRUPT_PRIORITY
+ * because the IPL value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY
  * when an ISR safe FreeRTOS API function was executed.  ISR safe FreeRTOS API
  * functions are those that end in FromISR.  FreeRTOS maintains a separate
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
-    #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL	#0")
-    #ifdef configASSERT
-        #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
-        #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile ( "MVTIPL	%0"::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
-    #else
-        #define portDISABLE_INTERRUPTS()                      __asm volatile ( "MVTIPL	%0"::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
-    #endif
+#define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL  #0" )
+#ifdef configASSERT
+    #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
+    #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile ( "MVTIPL  %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
+#else
+    #define portDISABLE_INTERRUPTS()                      __asm volatile ( "MVTIPL  %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
+#endif
 
 /* Critical nesting counts are stored in the TCB. */
-    #define portCRITICAL_NESTING_IN_TCB    ( 1 )
+#define portCRITICAL_NESTING_IN_TCB    ( 1 )
 
 /* The critical nesting functions defined within tasks.c. */
-    extern void vTaskEnterCritical( void );
-    extern void vTaskExitCritical( void );
-    #define portENTER_CRITICAL()    vTaskEnterCritical()
-    #define portEXIT_CRITICAL()     vTaskExitCritical()
+extern void vTaskEnterCritical( void );
+extern void vTaskExitCritical( void );
+#define portENTER_CRITICAL()    vTaskEnterCritical()
+#define portEXIT_CRITICAL()     vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-    uint32_t ulPortGetIPL( void ) __attribute__( ( naked ) );
-    void vPortSetIPL( uint32_t ulNewIPL ) __attribute__( ( naked ) );
-    #define portSET_INTERRUPT_MASK_FROM_ISR()                              ulPortGetIPL(); portDISABLE_INTERRUPTS()
-    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( uxSavedInterruptStatus )
+uint32_t ulPortGetIPL( void ) __attribute__( ( naked ) );
+void vPortSetIPL( uint32_t ulNewIPL ) __attribute__( ( naked ) );
+#define portSET_INTERRUPT_MASK_FROM_ISR()                              ulPortGetIPL(); portDISABLE_INTERRUPTS()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    vPortSetIPL( uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
 /*-----------------------------------------------------------*/
 
@@ -167,20 +169,23 @@
  * themselves a DPFPU context before using any DPFPU instructions.  If
  * configUSE_TASK_DPFPU_SUPPORT is set to 2 then all tasks will have a DPFPU context
  * by default. */
-    #if( configUSE_TASK_DPFPU_SUPPORT == 1 )
-        void vPortTaskUsesDPFPU( void );
-    #else
-/* Each task has a DPFPU context already, so define this function away to
- * nothing to prevent it being called accidentally. */
-        #define vPortTaskUsesDPFPU()
-    #endif
-    #define portTASK_USES_DPFPU() vPortTaskUsesDPFPU()
+#if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
+    void vPortTaskUsesDPFPU( void );
+#else
+
+    /* Each task has a DPFPU context already, so define this function away to
+     * nothing to prevent it being called accidentally. */
+    #define vPortTaskUsesDPFPU()
+#endif
+#define portTASK_USES_DPFPU()             vPortTaskUsesDPFPU()
 
 /* Definition to allow compatibility with existing FreeRTOS Demo using flop.c. */
-    #define portTASK_USES_FLOATING_POINT() vPortTaskUsesDPFPU()
+#define portTASK_USES_FLOATING_POINT()    vPortTaskUsesDPFPU()
 
-    #ifdef __cplusplus
-        }
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* PORTMACRO_H */

--- a/portable/IAR/RX700v3_DPFPU/port.c
+++ b/portable/IAR/RX700v3_DPFPU/port.c
@@ -22,14 +22,13 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 /*-----------------------------------------------------------
 * Implementation of functions defined in portable.h for the RXv3 DPFPU port.
 *----------------------------------------------------------*/
 
-#warning Testing for DFPU support in this port is not yet complete
+#warning Testing for DPFPU support in this port is not yet complete
 
 /* Scheduler includes. */
 #include "FreeRTOS.h"
@@ -40,35 +39,31 @@
 
 /* Hardware specifics. */
 #if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
-
     #include "platform.h"
-
-#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
-
+#else
     #include "iodefine.h"
-
-#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Tasks should start with interrupts enabled and in Supervisor mode, therefore
  * PSW is set with U and I set, and PM and IPL clear. */
-#define portINITIAL_PSW     ( ( StackType_t ) 0x00030000 )
-#define portINITIAL_FPSW    ( ( StackType_t ) 0x00000100 )
-#define portINITIAL_DPSW    ( ( StackType_t ) 0x00000100 )
-#define portINITIAL_DCMR    ( ( StackType_t ) 0x00000000 )
-#define portINITIAL_DECNT   ( ( StackType_t ) 0x00000001 )
+#define portINITIAL_PSW                  ( ( StackType_t ) 0x00030000 )
+#define portINITIAL_FPSW                 ( ( StackType_t ) 0x00000100 )
+#define portINITIAL_DPSW                 ( ( StackType_t ) 0x00000100 )
+#define portINITIAL_DCMR                 ( ( StackType_t ) 0x00000000 )
+#define portINITIAL_DECNT                ( ( StackType_t ) 0x00000001 )
 
 /* Tasks are not created with a DPFPU context, but can be given a DPFPU context
  * after they have been created.  A variable is stored as part of the tasks context
  * that holds portNO_DPFPU_CONTEXT if the task does not have a DPFPU context, or
  * any other value if the task does have a DPFPU context. */
-#define portNO_DPFPU_CONTEXT    ( ( StackType_t ) 0 )
-#define portHAS_DPFPU_CONTEXT   ( ( StackType_t ) 1 )
+#define portNO_DPFPU_CONTEXT             ( ( StackType_t ) 0 )
+#define portHAS_DPFPU_CONTEXT            ( ( StackType_t ) 1 )
 
 /* The space on the stack required to hold the DPFPU data registers.  This is 16
  * 64-bit registers. */
-#define portDPFPU_DATA_REGISTER_WORDS   ( 16 * 2 )
+#define portDPFPU_DATA_REGISTER_WORDS    ( 16 * 2 )
 
 /*-----------------------------------------------------------*/
 
@@ -99,7 +94,7 @@ __interrupt void vTickISR( void );
 
     StackType_t ulPortTaskHasDPFPUContext = portNO_DPFPU_CONTEXT;
 
-#endif /* configUSE_TASK_DPFPU_SUPPORT */
+#endif
 
 /* This is accessed by the inline assembler functions so is file scope for
  * convenience. */
@@ -195,37 +190,37 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
             #ifdef USE_FULL_REGISTER_INITIALISATION
                 {
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1515.1515; /* DR15. */
+                    *( double * ) pxTopOfStack = 1515.1515;  /* DR15. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1414.1414; /* DR14. */
+                    *( double * ) pxTopOfStack = 1414.1414;  /* DR14. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1313.1313; /* DR13. */
+                    *( double * ) pxTopOfStack = 1313.1313;  /* DR13. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1212.1212; /* DR12. */
+                    *( double * ) pxTopOfStack = 1212.1212;  /* DR12. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1111.1111; /* DR11. */
+                    *( double * ) pxTopOfStack = 1111.1111;  /* DR11. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1010.1010; /* DR10. */
+                    *( double * ) pxTopOfStack = 1010.1010;  /* DR10. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  909.0909; /* DR9. */
+                    *( double * ) pxTopOfStack = 909.0909;   /* DR9. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  808.0808; /* DR8. */
+                    *( double * ) pxTopOfStack = 808.0808;   /* DR8. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  707.0707; /* DR7. */
+                    *( double * ) pxTopOfStack = 707.0707;   /* DR7. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  606.0606; /* DR6. */
+                    *( double * ) pxTopOfStack = 606.0606;   /* DR6. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  505.0505; /* DR5. */
+                    *( double * ) pxTopOfStack = 505.0505;   /* DR5. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  404.0404; /* DR4. */
+                    *( double * ) pxTopOfStack = 404.0404;   /* DR4. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  303.0303; /* DR3. */
+                    *( double * ) pxTopOfStack = 303.0303;   /* DR3. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  202.0202; /* DR2. */
+                    *( double * ) pxTopOfStack = 202.0202;   /* DR2. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  101.0101; /* DR1. */
+                    *( double * ) pxTopOfStack = 101.0101;   /* DR1. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 9876.54321;/* DR0. */
+                    *( double * ) pxTopOfStack = 9876.54321; /* DR0. */
                 }
             #else /* ifdef USE_FULL_REGISTER_INITIALISATION */
                 {
@@ -244,11 +239,11 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         {
             /* Omit DPFPU support. */
         }
-    #else /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+    #else /* configUSE_TASK_DPFPU_SUPPORT */
         {
             #error Invalid configUSE_TASK_DPFPU_SUPPORT setting - configUSE_TASK_DPFPU_SUPPORT must be set to 0, 1, 2, or left undefined.
         }
-    #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+    #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
     return pxTopOfStack;
 }
@@ -311,18 +306,19 @@ static void prvStartFirstTask( void )
 {
     __asm volatile
     (
+/* *INDENT-OFF* */
 
         /* When starting the scheduler there is nothing that needs moving to the
          * interrupt stack because the function is not called from an interrupt.
          * Just ensure the current stack is the user stack. */
-        "SETPSW		U						\n"\
+        "SETPSW     U                       \n"\
 
 
         /* Obtain the location of the stack associated with which ever task
          * pxCurrentTCB is currently pointing to. */
-        "MOV.L		#_pxCurrentTCB, R15		\n"\
-        "MOV.L		[R15], R15				\n"\
-        "MOV.L		[R15], R0				\n"\
+        "MOV.L      #_pxCurrentTCB, R15     \n"\
+        "MOV.L      [ R15 ], R15            \n"\
+        "MOV.L      [ R15 ], R0             \n"\
 
 
         /* Restore the registers from the stack of the task pointed to by
@@ -332,54 +328,56 @@ static void prvStartFirstTask( void )
 
             /* The restored ulPortTaskHasDPFPUContext is to be zero here.
              * So, it is never necessary to restore the DPFPU context here. */
-            "POP		R15									\n"\
-            "MOV.L		#_ulPortTaskHasDPFPUContext, R14	\n"\
-            "MOV.L		R15, [R14]							\n"\
+            "POP        R15                                 \n"\
+            "MOV.L      #_ulPortTaskHasDPFPUContext, R14    \n"\
+            "MOV.L      R15, [ R14 ]                        \n"\
 
         #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
             /* Restore the DPFPU context. */
-            "DPOPM.L	DPSW-DECNT				\n"\
-            "DPOPM.D	DR0-DR15				\n"\
+            "DPOPM.L    DPSW-DECNT              \n"\
+            "DPOPM.D    DR0-DR15                \n"\
 
-        #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
-        "POP		R15						\n"\
-
-        /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A0					\n"\
-        "POP		R15						\n"\
-
-        /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A0					\n"\
-        "POP		R15						\n"\
-
-        /* Accumulator guard. */
-        "MVTACGU	R15, A0					\n"\
-        "POP		R15						\n"\
+        "POP        R15                     \n"\
 
         /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A1					\n"\
-        "POP		R15						\n"\
+        "MVTACLO    R15, A0                 \n"\
+        "POP        R15                     \n"\
 
         /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A1					\n"\
-        "POP		R15						\n"\
+        "MVTACHI    R15, A0                 \n"\
+        "POP        R15                     \n"\
 
         /* Accumulator guard. */
-        "MVTACGU	R15, A1					\n"\
-        "POP		R15						\n"\
+        "MVTACGU    R15, A0                 \n"\
+        "POP        R15                     \n"\
+
+        /* Accumulator low 32 bits. */
+        "MVTACLO    R15, A1                 \n"\
+        "POP        R15                     \n"\
+
+        /* Accumulator high 32 bits. */
+        "MVTACHI    R15, A1                 \n"\
+        "POP        R15                     \n"\
+
+        /* Accumulator guard. */
+        "MVTACGU    R15, A1                 \n"\
+        "POP        R15                     \n"\
 
         /* Floating point status word. */
-        "MVTC		R15, FPSW 				\n"\
+        "MVTC       R15, FPSW               \n"\
 
         /* R1 to R15 - R0 is not included as it is the SP. */
-        "POPM		R1-R15 					\n"\
+        "POPM       R1-R15                  \n"\
 
         /* This pops the remaining registers. */
-        "RTE								\n"\
-        "NOP								\n"\
-        "NOP								\n"
+        "RTE                                \n"\
+        "NOP                                \n"\
+        "NOP                                  "
+
+/* *INDENT-ON* */
     );
 }
 /*-----------------------------------------------------------*/
@@ -389,101 +387,103 @@ __interrupt void vSoftwareInterruptISR( void )
 {
     __asm volatile
     (
+/* *INDENT-OFF* */
+
         /* Re-enable interrupts. */
-        "SETPSW		I							\n"\
+        "SETPSW     I                           \n"\
 
 
         /* Move the data that was automatically pushed onto the interrupt stack when
          * the interrupt occurred from the interrupt stack to the user stack.
          *
          * R15 is saved before it is clobbered. */
-        "PUSH.L		R15							\n"\
+        "PUSH.L     R15                         \n"\
 
         /* Read the user stack pointer. */
-        "MVFC		USP, R15					\n"\
+        "MVFC       USP, R15                    \n"\
 
         /* Move the address down to the data being moved. */
-        "SUB		#12, R15					\n"\
-        "MVTC		R15, USP					\n"\
+        "SUB        #12, R15                    \n"\
+        "MVTC       R15, USP                    \n"\
 
         /* Copy the data across, R15, then PC, then PSW. */
-        "MOV.L		[ R0 ], [ R15 ]				\n"\
-        "MOV.L 		4[ R0 ], 4[ R15 ]			\n"\
-        "MOV.L		8[ R0 ], 8[ R15 ]			\n"\
+        "MOV.L      [ R0 ], [ R15 ]             \n"\
+        "MOV.L      4[ R0 ], 4[ R15 ]           \n"\
+        "MOV.L      8[ R0 ], 8[ R15 ]           \n"\
 
         /* Move the interrupt stack pointer to its new correct position. */
-        "ADD		#12, R0						\n"\
+        "ADD        #12, R0                     \n"\
 
         /* All the rest of the registers are saved directly to the user stack. */
-        "SETPSW		U							\n"\
+        "SETPSW     U                           \n"\
 
         /* Save the rest of the general registers (R15 has been saved already). */
-        "PUSHM		R1-R14						\n"\
+        "PUSHM      R1-R14                      \n"\
 
         /* Save the FPSW and accumulators. */
-        "MVFC		FPSW, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACGU	#0, A1, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACHI	#0, A1, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACLO	#0, A1, R15					\n" /* Low order word. */ \
-        "PUSH.L		R15							\n"\
-        "MVFACGU	#0, A0, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACHI	#0, A0, R15					\n"\
-        "PUSH.L		R15							\n"\
-        "MVFACLO	#0, A0, R15					\n" /* Low order word. */ \
-        "PUSH.L		R15							\n"\
+        "MVFC       FPSW, R15                   \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACGU    #0, A1, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACHI    #0, A1, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACLO    #0, A1, R15                 \n" /* Low order word. */ \
+        "PUSH.L     R15                         \n"\
+        "MVFACGU    #0, A0, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACHI    #0, A0, R15                 \n"\
+        "PUSH.L     R15                         \n"\
+        "MVFACLO    #0, A0, R15                 \n" /* Low order word. */ \
+        "PUSH.L     R15                         \n"\
 
         #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
 
             /* Does the task have a DPFPU context that needs saving?  If
              * ulPortTaskHasDPFPUContext is 0 then no. */
-            "MOV.L		#_ulPortTaskHasDPFPUContext, R15	\n"\
-            "MOV.L		[R15], R15							\n"\
-            "CMP		#0, R15								\n"\
+            "MOV.L      #_ulPortTaskHasDPFPUContext, R15    \n"\
+            "MOV.L      [ R15 ], R15                        \n"\
+            "CMP        #0, R15                             \n"\
 
             /* Save the DPFPU context, if any. */
-            "BEQ.B		__lab1						\n"\
-            "DPUSHM.D	DR0-DR15					\n"\
-            "DPUSHM.L	DPSW-DECNT					\n"\
-            "__lab1:								\n"\
+            "BEQ.B      __lab1                      \n"\
+            "DPUSHM.D   DR0-DR15                    \n"\
+            "DPUSHM.L   DPSW-DECNT                  \n"\
+            "__lab1:                                \n"\
 
             /* Save ulPortTaskHasDPFPUContext itself. */
-            "PUSH.L		R15							\n"\
+            "PUSH.L     R15                         \n"\
 
         #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
             /* Save the DPFPU context, always. */
-            "DPUSHM.D	DR0-DR15					\n"\
-            "DPUSHM.L	DPSW-DECNT					\n"\
+            "DPUSHM.D   DR0-DR15                    \n"\
+            "DPUSHM.L   DPSW-DECNT                  \n"\
 
-        #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
 
         /* Save the stack pointer to the TCB. */
-        "MOV.L		#_pxCurrentTCB, R15			\n"\
-        "MOV.L		[ R15 ], R15				\n"\
-        "MOV.L		R0, [ R15 ]					\n"\
+        "MOV.L      #_pxCurrentTCB, R15         \n"\
+        "MOV.L      [ R15 ], R15                \n"\
+        "MOV.L      R0, [ R15 ]                 \n"\
 
 
         /* Ensure the interrupt mask is set to the syscall priority while the kernel
          * structures are being accessed. */
-        "MVTIPL		%0 							\n"\
+        "MVTIPL     %0                          \n"\
 
         /* Select the next task to run. */
-        "BSR.A		_vTaskSwitchContext			\n"\
+        "BSR.A      _vTaskSwitchContext         \n"\
 
         /* Reset the interrupt mask as no more data structure access is required. */
-        "MVTIPL		%1							\n"\
+        "MVTIPL     %1                          \n"\
 
 
         /* Load the stack pointer of the task that is now selected as the Running
          * state task from its TCB. */
-        "MOV.L		#_pxCurrentTCB,R15			\n"\
-        "MOV.L		[ R15 ], R15				\n"\
-        "MOV.L		[ R15 ], R0					\n"\
+        "MOV.L      #_pxCurrentTCB, R15         \n"\
+        "MOV.L      [ R15 ], R15                \n"\
+        "MOV.L      [ R15 ], R0                 \n"\
 
 
         /* Restore the context of the new task.  The PSW (Program Status Word) and
@@ -493,56 +493,58 @@ __interrupt void vSoftwareInterruptISR( void )
 
             /* Is there a DPFPU context to restore?  If the restored
              * ulPortTaskHasDPFPUContext is zero then no. */
-            "POP		R15									\n"\
-            "MOV.L		#_ulPortTaskHasDPFPUContext, R14	\n"\
-            "MOV.L		R15, [R14]							\n"\
-            "CMP		#0, R15								\n"\
+            "POP        R15                                 \n"\
+            "MOV.L      #_ulPortTaskHasDPFPUContext, R14    \n"\
+            "MOV.L      R15, [ R14 ]                        \n"\
+            "CMP        #0, R15                             \n"\
 
             /* Restore the DPFPU context, if any. */
-            "BEQ.B		__lab2						\n"\
-            "DPOPM.L	DPSW-DECNT					\n"\
-            "DPOPM.D	DR0-DR15					\n"\
-            "__lab2:								\n"\
+            "BEQ.B      __lab2                      \n"\
+            "DPOPM.L    DPSW-DECNT                  \n"\
+            "DPOPM.D    DR0-DR15                    \n"\
+            "__lab2:                                \n"\
 
         #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
             /* Restore the DPFPU context, always. */
-            "DPOPM.L	DPSW-DECNT					\n"\
-            "DPOPM.D	DR0-DR15					\n"\
+            "DPOPM.L    DPSW-DECNT                  \n"\
+            "DPOPM.D    DR0-DR15                    \n"\
 
-        #endif /* if( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
-        "POP		R15							\n"\
-
-        /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A0						\n"\
-        "POP		R15							\n"\
-
-        /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A0						\n"\
-        "POP		R15							\n"\
-
-        /* Accumulator guard. */
-        "MVTACGU	R15, A0						\n"\
-        "POP		R15							\n"\
+        "POP        R15                         \n"\
 
         /* Accumulator low 32 bits. */
-        "MVTACLO	R15, A1						\n"\
-        "POP		R15							\n"\
+        "MVTACLO    R15, A0                     \n"\
+        "POP        R15                         \n"\
 
         /* Accumulator high 32 bits. */
-        "MVTACHI	R15, A1						\n"\
-        "POP		R15							\n"\
+        "MVTACHI    R15, A0                     \n"\
+        "POP        R15                         \n"\
 
         /* Accumulator guard. */
-        "MVTACGU	R15, A1						\n"\
-        "POP		R15							\n"\
-        "MVTC		R15, FPSW					\n"\
-        "POPM		R1-R15						\n"\
-        "RTE									\n"\
-        "NOP									\n"\
-        "NOP									  "
+        "MVTACGU    R15, A0                     \n"\
+        "POP        R15                         \n"\
+
+        /* Accumulator low 32 bits. */
+        "MVTACLO    R15, A1                     \n"\
+        "POP        R15                         \n"\
+
+        /* Accumulator high 32 bits. */
+        "MVTACHI    R15, A1                     \n"\
+        "POP        R15                         \n"\
+
+        /* Accumulator guard. */
+        "MVTACGU    R15, A1                     \n"\
+        "POP        R15                         \n"\
+        "MVTC       R15, FPSW                   \n"\
+        "POPM       R1-R15                      \n"\
+        "RTE                                    \n"\
+        "NOP                                    \n"\
+        "NOP                                      "
         portCDT_NO_PARSE( :: ) "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ), "i" ( configKERNEL_INTERRUPT_PRIORITY )
+
+/* *INDENT-ON* */
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/RX700v3_DPFPU/portmacro.h
+++ b/portable/IAR/RX700v3_DPFPU/portmacro.h
@@ -22,19 +22,19 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
-
 #ifndef PORTMACRO_H
-    #define PORTMACRO_H
+#define PORTMACRO_H
 
 /* Hardware specifics. */
-    #include <intrinsics.h>
+#include <intrinsics.h>
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /*-----------------------------------------------------------
  * Port specific definitions.
@@ -46,11 +46,11 @@
  *-----------------------------------------------------------
  */
 
-/* When the FIT configurator or the Smart Configurator is used, platform.h has to be 
+/* When the FIT configurator or the Smart Configurator is used, platform.h has to be
  * used. */
-    #ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
-        #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H 0
-    #endif
+#ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
+    #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H    0
+#endif
 
 /* If configUSE_TASK_DPFPU_SUPPORT is set to 1 (or undefined) then each task will
  * be created without a DPFPU context, and a task must call vTaskUsesDPFPU() before
@@ -58,111 +58,113 @@
  * tasks are created with a DPFPU context by default, and calling vTaskUsesDPFPU() has
  * no effect.  If configUSE_TASK_DPFPU_SUPPORT is set to 0 then tasks never take care
  * of any DPFPU context (even if DPFPU registers are used). */
-    #ifndef configUSE_TASK_DPFPU_SUPPORT
-        #define configUSE_TASK_DPFPU_SUPPORT 1
-    #endif
+#ifndef configUSE_TASK_DPFPU_SUPPORT
+    #define configUSE_TASK_DPFPU_SUPPORT    1
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Type definitions - these are a bit legacy and not really used now, other than
  * portSTACK_TYPE and portBASE_TYPE. */
-    #define portCHAR          char
-    #define portFLOAT         float
-    #define portDOUBLE        double
-    #define portLONG          long
-    #define portSHORT         short
-    #define portSTACK_TYPE    uint32_t
-    #define portBASE_TYPE     long
+#define portCHAR          char
+#define portFLOAT         float
+#define portDOUBLE        double
+#define portLONG          long
+#define portSHORT         short
+#define portSTACK_TYPE    uint32_t
+#define portBASE_TYPE     long
 
-    typedef portSTACK_TYPE   StackType_t;
-    typedef long             BaseType_t;
-    typedef unsigned long    UBaseType_t;
+typedef portSTACK_TYPE   StackType_t;
+typedef long             BaseType_t;
+typedef unsigned long    UBaseType_t;
 
-    #if ( configUSE_16_BIT_TICKS == 1 )
-        typedef uint16_t     TickType_t;
-        #define portMAX_DELAY              ( TickType_t ) 0xffff
-    #else
-        typedef uint32_t     TickType_t;
-        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+#if ( configUSE_16_BIT_TICKS == 1 )
+    typedef uint16_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffff
+#else
+    typedef uint32_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
 
-/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
- * not need to be guarded with a critical section. */
-        #define portTICK_TYPE_IS_ATOMIC    1
-    #endif
+    /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+     * not need to be guarded with a critical section. */
+    #define portTICK_TYPE_IS_ATOMIC    1
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Hardware specifics. */
-    #define portBYTE_ALIGNMENT    8     /* Could make four, according to manual. */
-    #define portSTACK_GROWTH      -1
-    #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-    #define portNOP()    __no_operation()
+#define portBYTE_ALIGNMENT    8     /* Could make four, according to manual. */
+#define portSTACK_GROWTH      -1
+#define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portNOP()    __no_operation()
 
 /* Yield equivalent to "*portITU_SWINTR = 0x01; ( void ) *portITU_SWINTR;"
  * where portITU_SWINTR is the location of the software interrupt register
  * (0x000872E0).  Don't rely on the assembler to select a register, so instead
  * save and restore clobbered registers manually. */
-    #define portYIELD()           \
-    __asm volatile                \
-    (                             \
-        "PUSH.L	R10					\n"\
-        "MOV.L	#0x872E0, R10		\n"\
-        "MOV.B	#0x1, [R10]			\n"\
-        "CMP	[R10].UB, R10		\n"\
-        "POP    R10					\n"\
-        portCDT_NO_PARSE( ::: ) "cc"\
-    )
+/* *INDENT-OFF* */
+#define portYIELD()             \
+__asm volatile                  \
+(                               \
+    "PUSH.L R10              \n"\
+    "MOV.L  #0x872E0, R10    \n"\
+    "MOV.B  #0x1, [ R10 ]    \n"\
+    "CMP    [ R10 ].UB, R10  \n"\
+    "POP    R10                "\
+    portCDT_NO_PARSE( ::: ) "cc"\
+)
+/* *INDENT-ON* */
 
-    #define portYIELD_FROM_ISR( x )                           if( ( x ) != pdFALSE ) portYIELD()
+#define portYIELD_FROM_ISR( x )    if( ( x ) != pdFALSE ) portYIELD()
 
 /* Workaround to reduce errors/warnings caused by e2 studio CDT's INDEXER and CODAN. */
-    #ifdef __CDT_PARSER__
+#ifdef __CDT_PARSER__
     #ifndef __asm
-    #define __asm asm
+        #define __asm    asm
     #endif
     #ifndef __attribute__
-    #define __attribute__( ... )
+        #define __attribute__( ... )
     #endif
     #define portCDT_NO_PARSE( token )
-    #else
-    #define portCDT_NO_PARSE( token ) token
-    #endif
+#else
+    #define portCDT_NO_PARSE( token )    token
+#endif
 
 /* These macros should not be called directly, but through the
  * taskENTER_CRITICAL() and taskEXIT_CRITICAL() macros.  An extra check is
  * performed if configASSERT() is defined to ensure an assertion handler does not
  * inadvertently attempt to lower the IPL when the call to assert was triggered
- * because the IPL value was found to be above	configMAX_SYSCALL_INTERRUPT_PRIORITY
+ * because the IPL value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY
  * when an ISR safe FreeRTOS API function was executed.  ISR safe FreeRTOS API
  * functions are those that end in FromISR.  FreeRTOS maintains a separate
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
-    #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-    #ifdef configASSERT
-        #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
-        #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-    #else
-        #define portDISABLE_INTERRUPTS()                      __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-    #endif
+#define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
+#ifdef configASSERT
+    #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
+    #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
+#else
+    #define portDISABLE_INTERRUPTS()                      __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
+#endif
 
 /* Critical nesting counts are stored in the TCB. */
-    #define portCRITICAL_NESTING_IN_TCB    ( 1 )
+#define portCRITICAL_NESTING_IN_TCB    ( 1 )
 
 /* The critical nesting functions defined within tasks.c. */
-    extern void vTaskEnterCritical( void );
-    extern void vTaskExitCritical( void );
-    #define portENTER_CRITICAL()    vTaskEnterCritical()
-    #define portEXIT_CRITICAL()     vTaskExitCritical()
+extern void vTaskEnterCritical( void );
+extern void vTaskExitCritical( void );
+#define portENTER_CRITICAL()                                           vTaskEnterCritical()
+#define portEXIT_CRITICAL()                                            vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-    #define portSET_INTERRUPT_MASK_FROM_ISR()                              __get_interrupt_level(); portDISABLE_INTERRUPTS()
-    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    __set_interrupt_level( ( uint8_t ) ( uxSavedInterruptStatus ) )
+#define portSET_INTERRUPT_MASK_FROM_ISR()                              __get_interrupt_level(); portDISABLE_INTERRUPTS()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    __set_interrupt_level( ( uint8_t ) ( uxSavedInterruptStatus ) )
 
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
 /*-----------------------------------------------------------*/
 
@@ -171,25 +173,28 @@
  * themselves a DPFPU context before using any DPFPU instructions.  If
  * configUSE_TASK_DPFPU_SUPPORT is set to 2 then all tasks will have a DPFPU context
  * by default. */
-    #if( configUSE_TASK_DPFPU_SUPPORT == 1 )
-        void vPortTaskUsesDPFPU( void );
-    #else
-/* Each task has a DPFPU context already, so define this function away to
- * nothing to prevent it being called accidentally. */
-        #define vPortTaskUsesDPFPU()
-    #endif
-    #define portTASK_USES_DPFPU() vPortTaskUsesDPFPU()
+#if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
+    void vPortTaskUsesDPFPU( void );
+#else
+
+    /* Each task has a DPFPU context already, so define this function away to
+     * nothing to prevent it being called accidentally. */
+    #define vPortTaskUsesDPFPU()
+#endif
+#define portTASK_USES_DPFPU()             vPortTaskUsesDPFPU()
 
 /* Definition to allow compatibility with existing FreeRTOS Demo using flop.c. */
-    #define portTASK_USES_FLOATING_POINT() vPortTaskUsesDPFPU()
+#define portTASK_USES_FLOATING_POINT()    vPortTaskUsesDPFPU()
 
 /* Prevent warnings of undefined behaviour: the order of volatile accesses is
  * undefined - all warnings have been manually checked and are not an issue, and
  * the warnings cannot be prevent by code changes without undesirable effects. */
-    #pragma diag_suppress=Pa082
+#pragma diag_suppress=Pa082
 
-    #ifdef __cplusplus
-        }
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* PORTMACRO_H */

--- a/portable/Renesas/RX700v3_DPFPU/port.c
+++ b/portable/Renesas/RX700v3_DPFPU/port.c
@@ -22,14 +22,13 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 /*-----------------------------------------------------------
 * Implementation of functions defined in portable.h for the RXv3 DPFPU port.
 *----------------------------------------------------------*/
 
-#warning Testing for DFPU support in this port is not yet complete
+#warning Testing for DPFPU support in this port is not yet complete
 
 /* Scheduler includes. */
 #include "FreeRTOS.h"
@@ -40,35 +39,31 @@
 
 /* Hardware specifics. */
 #if ( configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H == 1 )
-
     #include "platform.h"
-
-#else /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
-
+#else
     #include "iodefine.h"
-
-#endif /* configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H */
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Tasks should start with interrupts enabled and in Supervisor mode, therefore
  * PSW is set with U and I set, and PM and IPL clear. */
-#define portINITIAL_PSW     ( ( StackType_t ) 0x00030000 )
-#define portINITIAL_FPSW    ( ( StackType_t ) 0x00000100 )
-#define portINITIAL_DPSW    ( ( StackType_t ) 0x00000100 )
-#define portINITIAL_DCMR    ( ( StackType_t ) 0x00000000 )
-#define portINITIAL_DECNT   ( ( StackType_t ) 0x00000001 )
+#define portINITIAL_PSW                  ( ( StackType_t ) 0x00030000 )
+#define portINITIAL_FPSW                 ( ( StackType_t ) 0x00000100 )
+#define portINITIAL_DPSW                 ( ( StackType_t ) 0x00000100 )
+#define portINITIAL_DCMR                 ( ( StackType_t ) 0x00000000 )
+#define portINITIAL_DECNT                ( ( StackType_t ) 0x00000001 )
 
 /* Tasks are not created with a DPFPU context, but can be given a DPFPU context
  * after they have been created.  A variable is stored as part of the tasks context
  * that holds portNO_DPFPU_CONTEXT if the task does not have a DPFPU context, or
  * any other value if the task does have a DPFPU context. */
-#define portNO_DPFPU_CONTEXT    ( ( StackType_t ) 0 )
-#define portHAS_DPFPU_CONTEXT   ( ( StackType_t ) 1 )
+#define portNO_DPFPU_CONTEXT             ( ( StackType_t ) 0 )
+#define portHAS_DPFPU_CONTEXT            ( ( StackType_t ) 1 )
 
 /* The space on the stack required to hold the DPFPU data registers.  This is 16
  * 64-bit registers. */
-#define portDPFPU_DATA_REGISTER_WORDS   ( 16 * 2 )
+#define portDPFPU_DATA_REGISTER_WORDS    ( 16 * 2 )
 
 /*-----------------------------------------------------------*/
 
@@ -115,7 +110,7 @@ void vTickISR( void );
 
     StackType_t ulPortTaskHasDPFPUContext = portNO_DPFPU_CONTEXT;
 
-#endif /* configUSE_TASK_DPFPU_SUPPORT */
+#endif
 
 /* This is accessed by the inline assembler functions so is file scope for
  * convenience. */
@@ -211,37 +206,37 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
             #ifdef USE_FULL_REGISTER_INITIALISATION
                 {
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1515.1515; /* DR15. */
+                    *( double * ) pxTopOfStack = 1515.1515;  /* DR15. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1414.1414; /* DR14. */
+                    *( double * ) pxTopOfStack = 1414.1414;  /* DR14. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1313.1313; /* DR13. */
+                    *( double * ) pxTopOfStack = 1313.1313;  /* DR13. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1212.1212; /* DR12. */
+                    *( double * ) pxTopOfStack = 1212.1212;  /* DR12. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1111.1111; /* DR11. */
+                    *( double * ) pxTopOfStack = 1111.1111;  /* DR11. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 1010.1010; /* DR10. */
+                    *( double * ) pxTopOfStack = 1010.1010;  /* DR10. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  909.0909; /* DR9. */
+                    *( double * ) pxTopOfStack = 909.0909;   /* DR9. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  808.0808; /* DR8. */
+                    *( double * ) pxTopOfStack = 808.0808;   /* DR8. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  707.0707; /* DR7. */
+                    *( double * ) pxTopOfStack = 707.0707;   /* DR7. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  606.0606; /* DR6. */
+                    *( double * ) pxTopOfStack = 606.0606;   /* DR6. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  505.0505; /* DR5. */
+                    *( double * ) pxTopOfStack = 505.0505;   /* DR5. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  404.0404; /* DR4. */
+                    *( double * ) pxTopOfStack = 404.0404;   /* DR4. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  303.0303; /* DR3. */
+                    *( double * ) pxTopOfStack = 303.0303;   /* DR3. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  202.0202; /* DR2. */
+                    *( double * ) pxTopOfStack = 202.0202;   /* DR2. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack =  101.0101; /* DR1. */
+                    *( double * ) pxTopOfStack = 101.0101;   /* DR1. */
                     pxTopOfStack -= 2;
-                    *(double *)pxTopOfStack = 9876.54321;/* DR0. */
+                    *( double * ) pxTopOfStack = 9876.54321; /* DR0. */
                 }
             #else /* ifdef USE_FULL_REGISTER_INITIALISATION */
                 {
@@ -260,11 +255,11 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         {
             /* Omit DPFPU support. */
         }
-    #else /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+    #else /* configUSE_TASK_DPFPU_SUPPORT */
         {
             #error Invalid configUSE_TASK_DPFPU_SUPPORT setting - configUSE_TASK_DPFPU_SUPPORT must be set to 0, 1, 2, or left undefined.
         }
-    #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+    #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
     return pxTopOfStack;
 }
@@ -329,78 +324,80 @@ void vPortEndScheduler( void )
 #pragma inline_asm prvStartFirstTask
 static void prvStartFirstTask( void )
 {
-#ifndef __CDT_PARSER__
+    #ifndef __CDT_PARSER__
+/* *INDENT-OFF* */
 
-    /* When starting the scheduler there is nothing that needs moving to the
-     * interrupt stack because the function is not called from an interrupt.
-     * Just ensure the current stack is the user stack. */
-    SETPSW U
-
-
-    /* Obtain the location of the stack associated with which ever task
-     * pxCurrentTCB is currently pointing to. */
-    MOV.L # _pxCurrentTCB, R15
-    MOV.L [ R15 ], R15
-    MOV.L [ R15 ], R0
+        /* When starting the scheduler there is nothing that needs moving to the
+         * interrupt stack because the function is not called from an interrupt.
+         * Just ensure the current stack is the user stack. */
+        SETPSW     U
 
 
-    /* Restore the registers from the stack of the task pointed to by
-     * pxCurrentTCB. */
+        /* Obtain the location of the stack associated with which ever task
+         * pxCurrentTCB is currently pointing to. */
+        MOV.L      #_pxCurrentTCB, R15
+        MOV.L      [ R15 ], R15
+        MOV.L      [ R15 ], R0
 
-    #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
 
-        /* The restored ulPortTaskHasDPFPUContext is to be zero here.
-         * So, it is never necessary to restore the DPFPU context here. */
-        POP R15
-        MOV.L # _ulPortTaskHasDPFPUContext, R14
-        MOV.L R15, [ R14 ]
+        /* Restore the registers from the stack of the task pointed to by
+         * pxCurrentTCB. */
 
-    #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
+        #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
 
-        /* Restore the DPFPU context. */
-        DPOPM.L DPSW-DECNT
-        DPOPM.D DR0-DR15
+            /* The restored ulPortTaskHasDPFPUContext is to be zero here.
+             * So, it is never necessary to restore the DPFPU context here. */
+            POP        R15
+            MOV.L      #_ulPortTaskHasDPFPUContext, R14
+            MOV.L      R15, [ R14 ]
 
-    #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
-    POP R15
+            /* Restore the DPFPU context. */
+            DPOPM.L    DPSW-DECNT
+            DPOPM.D    DR0-DR15
 
-    /* Accumulator low 32 bits. */
-    MVTACLO R15, A0
-    POP R15
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
-    /* Accumulator high 32 bits. */
-    MVTACHI R15, A0
-    POP R15
+        POP        R15
 
-    /* Accumulator guard. */
-    MVTACGU R15, A0
-    POP R15
+        /* Accumulator low 32 bits. */
+        MVTACLO    R15, A0
+        POP        R15
 
-    /* Accumulator low 32 bits. */
-    MVTACLO R15, A1
-    POP R15
+        /* Accumulator high 32 bits. */
+        MVTACHI    R15, A0
+        POP        R15
 
-    /* Accumulator high 32 bits. */
-    MVTACHI R15, A1
-    POP R15
+        /* Accumulator guard. */
+        MVTACGU    R15, A0
+        POP        R15
 
-    /* Accumulator guard. */
-    MVTACGU R15, A1
-    POP R15
+        /* Accumulator low 32 bits. */
+        MVTACLO    R15, A1
+        POP        R15
 
-    /* Floating point status word. */
-    MVTC R15, FPSW
+        /* Accumulator high 32 bits. */
+        MVTACHI    R15, A1
+        POP        R15
 
-    /* R1 to R15 - R0 is not included as it is the SP. */
-    POPM R1-R15
+        /* Accumulator guard. */
+        MVTACGU    R15, A1
+        POP        R15
 
-    /* This pops the remaining registers. */
-    RTE
-    NOP
-    NOP
+        /* Floating point status word. */
+        MVTC       R15, FPSW
 
-#endif /* ifndef __CDT_PARSER__ */
+        /* R1 to R15 - R0 is not included as it is the SP. */
+        POPM       R1-R15
+
+        /* This pops the remaining registers. */
+        RTE
+        NOP
+        NOP
+
+/* *INDENT-ON* */
+    #endif /* ifndef __CDT_PARSER__ */
 }
 /*-----------------------------------------------------------*/
 
@@ -413,163 +410,165 @@ void vSoftwareInterruptISR( void )
 #pragma inline_asm prvYieldHandler
 static void prvYieldHandler( void )
 {
-#ifndef __CDT_PARSER__
+    #ifndef __CDT_PARSER__
+/* *INDENT-OFF* */
 
-    /* Re-enable interrupts. */
-    SETPSW I
-
-
-    /* Move the data that was automatically pushed onto the interrupt stack when
-     * the interrupt occurred from the interrupt stack to the user stack.
-     *
-     * R15 is saved before it is clobbered. */
-    PUSH.L R15
-
-    /* Read the user stack pointer. */
-    MVFC USP, R15
-
-    /* Move the address down to the data being moved. */
-    SUB # 12, R15
-    MVTC R15, USP
-
-    /* Copy the data across, R15, then PC, then PSW. */
-    MOV.L [ R0 ], [ R15 ]
-    MOV.L 4[ R0 ], 4[ R15 ]
-    MOV.L 8[ R0 ], 8[ R15 ]
-
-    /* Move the interrupt stack pointer to its new correct position. */
-    ADD # 12, R0
-
-    /* All the rest of the registers are saved directly to the user stack. */
-    SETPSW U
-
-    /* Save the rest of the general registers (R15 has been saved already). */
-    PUSHM R1-R14
-
-    /* Save the FPSW and accumulators. */
-    MVFC FPSW, R15
-    PUSH.L R15
-    MVFACGU # 0, A1, R15
-    PUSH.L R15
-    MVFACHI # 0, A1, R15
-    PUSH.L R15
-    MVFACLO # 0, A1, R15 /* Low order word. */
-    PUSH.L R15
-    MVFACGU # 0, A0, R15
-    PUSH.L R15
-    MVFACHI # 0, A0, R15
-    PUSH.L R15
-    MVFACLO # 0, A0, R15 /* Low order word. */
-    PUSH.L R15
-
-    #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
-
-        /* Does the task have a DPFPU context that needs saving?  If
-         * ulPortTaskHasDPFPUContext is 0 then no. */
-        MOV.L # _ulPortTaskHasDPFPUContext, R15
-        MOV.L [ R15 ], R15
-        CMP # 0, R15
-
-        /* Save the DPFPU context, if any. */
-        BEQ.B ?+
-        DPUSHM.D DR0-DR15
-        DPUSHM.L DPSW-DECNT
-        ?:
-
-        /* Save ulPortTaskHasDPFPUContext itself. */
-        PUSH.L R15
-
-    #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
-
-        /* Save the DPFPU context, always. */
-        DPUSHM.D DR0-DR15
-        DPUSHM.L DPSW-DECNT
-
-    #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        /* Re-enable interrupts. */
+        SETPSW     I
 
 
-    /* Save the stack pointer to the TCB. */
-    MOV.L # _pxCurrentTCB, R15
-    MOV.L [ R15 ], R15
-    MOV.L R0, [ R15 ]
+        /* Move the data that was automatically pushed onto the interrupt stack when
+         * the interrupt occurred from the interrupt stack to the user stack.
+         *
+         * R15 is saved before it is clobbered. */
+        PUSH.L     R15
+
+        /* Read the user stack pointer. */
+        MVFC       USP, R15
+
+        /* Move the address down to the data being moved. */
+        SUB        #12, R15
+        MVTC       R15, USP
+
+        /* Copy the data across, R15, then PC, then PSW. */
+        MOV.L      [ R0 ], [ R15 ]
+        MOV.L      4[ R0 ], 4[ R15 ]
+        MOV.L      8[ R0 ], 8[ R15 ]
+
+        /* Move the interrupt stack pointer to its new correct position. */
+        ADD        #12, R0
+
+        /* All the rest of the registers are saved directly to the user stack. */
+        SETPSW     U
+
+        /* Save the rest of the general registers (R15 has been saved already). */
+        PUSHM      R1-R14
+
+        /* Save the FPSW and accumulators. */
+        MVFC       FPSW, R15
+        PUSH.L     R15
+        MVFACGU    #0, A1, R15
+        PUSH.L     R15
+        MVFACHI    #0, A1, R15
+        PUSH.L     R15
+        MVFACLO    #0, A1, R15 /* Low order word. */
+        PUSH.L     R15
+        MVFACGU    #0, A0, R15
+        PUSH.L     R15
+        MVFACHI    #0, A0, R15
+        PUSH.L     R15
+        MVFACLO    #0, A0, R15 /* Low order word. */
+        PUSH.L     R15
+
+        #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
+
+            /* Does the task have a DPFPU context that needs saving?  If
+             * ulPortTaskHasDPFPUContext is 0 then no. */
+            MOV.L      #_ulPortTaskHasDPFPUContext, R15
+            MOV.L      [ R15 ], R15
+            CMP        #0, R15
+
+            /* Save the DPFPU context, if any. */
+            BEQ.B      ?+
+            DPUSHM.D   DR0-DR15
+            DPUSHM.L   DPSW-DECNT
+            ?:
+
+            /* Save ulPortTaskHasDPFPUContext itself. */
+            PUSH.L     R15
+
+        #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
+
+            /* Save the DPFPU context, always. */
+            DPUSHM.D   DR0-DR15
+            DPUSHM.L   DPSW-DECNT
+
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
 
-    /* Ensure the interrupt mask is set to the syscall priority while the kernel
-     * structures are being accessed. */
-    MVTIPL # configMAX_SYSCALL_INTERRUPT_PRIORITY
-
-    /* Select the next task to run. */
-    BSR.A _vTaskSwitchContext
-
-    /* Reset the interrupt mask as no more data structure access is required. */
-    MVTIPL # configKERNEL_INTERRUPT_PRIORITY
+        /* Save the stack pointer to the TCB. */
+        MOV.L      #_pxCurrentTCB, R15
+        MOV.L      [ R15 ], R15
+        MOV.L      R0, [ R15 ]
 
 
-    /* Load the stack pointer of the task that is now selected as the Running
-     * state task from its TCB. */
-    MOV.L # _pxCurrentTCB, R15
-    MOV.L [ R15 ], R15
-    MOV.L [ R15 ], R0
+        /* Ensure the interrupt mask is set to the syscall priority while the kernel
+         * structures are being accessed. */
+        MVTIPL     #configMAX_SYSCALL_INTERRUPT_PRIORITY
+
+        /* Select the next task to run. */
+        BSR.A      _vTaskSwitchContext
+
+        /* Reset the interrupt mask as no more data structure access is required. */
+        MVTIPL     #configKERNEL_INTERRUPT_PRIORITY
 
 
-    /* Restore the context of the new task.  The PSW (Program Status Word) and
-     * PC will be popped by the RTE instruction. */
+        /* Load the stack pointer of the task that is now selected as the Running
+         * state task from its TCB. */
+        MOV.L      #_pxCurrentTCB, R15
+        MOV.L      [ R15 ], R15
+        MOV.L      [ R15 ], R0
 
-    #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
 
-        /* Is there a DPFPU context to restore?  If the restored
-         * ulPortTaskHasDPFPUContext is zero then no. */
-        POP R15
-        MOV.L # _ulPortTaskHasDPFPUContext, R14
-        MOV.L R15, [ R14 ]
-        CMP # 0, R15
+        /* Restore the context of the new task.  The PSW (Program Status Word) and
+         * PC will be popped by the RTE instruction. */
 
-        /* Restore the DPFPU context, if any. */
-        BEQ.B ?+
-        DPOPM.L DPSW-DECNT
-        DPOPM.D DR0-DR15
-        ?:
+        #if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
 
-    #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
+            /* Is there a DPFPU context to restore?  If the restored
+             * ulPortTaskHasDPFPUContext is zero then no. */
+            POP        R15
+            MOV.L      #_ulPortTaskHasDPFPUContext, R14
+            MOV.L      R15, [ R14 ]
+            CMP        #0, R15
 
-        /* Restore the DPFPU context, always. */
-        DPOPM.L DPSW-DECNT
-        DPOPM.D DR0-DR15
+            /* Restore the DPFPU context, if any. */
+            BEQ.B      ?+
+            DPOPM.L    DPSW-DECNT
+            DPOPM.D    DR0-DR15
+            ?:
 
-    #endif /* if ( configUSE_TASK_DPFPU_SUPPORT == 1 ) */
+        #elif ( configUSE_TASK_DPFPU_SUPPORT == 2 )
 
-    POP R15
+            /* Restore the DPFPU context, always. */
+            DPOPM.L    DPSW-DECNT
+            DPOPM.D    DR0-DR15
 
-    /* Accumulator low 32 bits. */
-    MVTACLO R15, A0
-    POP R15
+        #endif /* configUSE_TASK_DPFPU_SUPPORT */
 
-    /* Accumulator high 32 bits. */
-    MVTACHI R15, A0
-    POP R15
+        POP        R15
 
-    /* Accumulator guard. */
-    MVTACGU R15, A0
-    POP R15
+        /* Accumulator low 32 bits. */
+        MVTACLO    R15, A0
+        POP        R15
 
-    /* Accumulator low 32 bits. */
-    MVTACLO R15, A1
-    POP R15
+        /* Accumulator high 32 bits. */
+        MVTACHI    R15, A0
+        POP        R15
 
-    /* Accumulator high 32 bits. */
-    MVTACHI R15, A1
-    POP R15
+        /* Accumulator guard. */
+        MVTACGU    R15, A0
+        POP        R15
 
-    /* Accumulator guard. */
-    MVTACGU R15, A1
-    POP R15
-    MVTC R15, FPSW
-    POPM R1-R15
-    RTE
-    NOP
-    NOP
+        /* Accumulator low 32 bits. */
+        MVTACLO    R15, A1
+        POP        R15
 
-#endif /* ifndef __CDT_PARSER__ */
+        /* Accumulator high 32 bits. */
+        MVTACHI    R15, A1
+        POP        R15
+
+        /* Accumulator guard. */
+        MVTACGU    R15, A1
+        POP        R15
+        MVTC       R15, FPSW
+        POPM       R1-R15
+        RTE
+        NOP
+        NOP
+
+/* *INDENT-ON* */
+    #endif /* ifndef __CDT_PARSER__ */
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/Renesas/RX700v3_DPFPU/port_asm.src
+++ b/portable/Renesas/RX700v3_DPFPU/port_asm.src
@@ -1,41 +1,39 @@
-;/*
-; * FreeRTOS Kernel V10.3.1
-; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-; *
-; * Permission is hereby granted, free of charge, to any person obtaining a copy of
-; * this software and associated documentation files (the "Software"), to deal in
-; * the Software without restriction, including without limitation the rights to
-; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-; * the Software, and to permit persons to whom the Software is furnished to do so,
-; * subject to the following conditions:
-; *
-; * The above copyright notice and this permission notice shall be included in all
-; * copies or substantial portions of the Software.
-; *
-; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-; *
-; * https://www.FreeRTOS.org
-; * https://github.com/FreeRTOS
-; *
-; * 1 tab == 4 spaces!
-; */
-		.GLB	_vSoftwareInterruptISR
-		.GLB    _vSoftwareInterruptEntry
+; /* *INDENT-OFF* */
+; /*
+;  * FreeRTOS Kernel V10.3.1
+;  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+;  *
+;  * Permission is hereby granted, free of charge, to any person obtaining a copy of
+;  * this software and associated documentation files (the "Software"), to deal in
+;  * the Software without restriction, including without limitation the rights to
+;  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+;  * the Software, and to permit persons to whom the Software is furnished to do so,
+;  * subject to the following conditions:
+;  *
+;  * The above copyright notice and this permission notice shall be included in all
+;  * copies or substantial portions of the Software.
+;  *
+;  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+;  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+;  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+;  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+;  *
+;  * https://www.FreeRTOS.org
+;  * https://github.com/FreeRTOS
+;  *
+;  */
 
-		.SECTION   P,CODE
+        .GLB    _vSoftwareInterruptISR
+        .GLB    _vSoftwareInterruptEntry
+
+        .SECTION   P,CODE
 
 _vSoftwareInterruptEntry:
 
-	BRA	_vSoftwareInterruptISR
+    BRA _vSoftwareInterruptISR
 
-		.RVECTOR	27, _vSoftwareInterruptEntry
+        .RVECTOR    27, _vSoftwareInterruptEntry
 
-		.END
-
-
-
+        .END

--- a/portable/Renesas/RX700v3_DPFPU/portmacro.h
+++ b/portable/Renesas/RX700v3_DPFPU/portmacro.h
@@ -22,19 +22,19 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
-
 #ifndef PORTMACRO_H
-    #define PORTMACRO_H
+#define PORTMACRO_H
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* Hardware specifics. */
-    #include <machine.h>
+#include <machine.h>
 
 /*-----------------------------------------------------------
  * Port specific definitions.
@@ -46,11 +46,11 @@
  *-----------------------------------------------------------
  */
 
-/* When the FIT configurator or the Smart Configurator is used, platform.h has to be 
+/* When the FIT configurator or the Smart Configurator is used, platform.h has to be
  * used. */
-    #ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
-        #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H 0
-    #endif
+#ifndef configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H
+    #define configINCLUDE_PLATFORM_H_INSTEAD_OF_IODEFINE_H    0
+#endif
 
 /* If configUSE_TASK_DPFPU_SUPPORT is set to 1 (or undefined) then each task will
  * be created without a DPFPU context, and a task must call vTaskUsesDPFPU() before
@@ -58,106 +58,108 @@
  * tasks are created with a DPFPU context by default, and calling vTaskUsesDPFPU() has
  * no effect.  If configUSE_TASK_DPFPU_SUPPORT is set to 0 then tasks never take care
  * of any DPFPU context (even if DPFPU registers are used). */
-    #ifndef configUSE_TASK_DPFPU_SUPPORT
-        #define configUSE_TASK_DPFPU_SUPPORT 1
-    #endif
+#ifndef configUSE_TASK_DPFPU_SUPPORT
+    #define configUSE_TASK_DPFPU_SUPPORT    1
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Type definitions - these are a bit legacy and not really used now, other than
  * portSTACK_TYPE and portBASE_TYPE. */
-    #define portCHAR          char
-    #define portFLOAT         float
-    #define portDOUBLE        double
-    #define portLONG          long
-    #define portSHORT         short
-    #define portSTACK_TYPE    uint32_t
-    #define portBASE_TYPE     long
+#define portCHAR          char
+#define portFLOAT         float
+#define portDOUBLE        double
+#define portLONG          long
+#define portSHORT         short
+#define portSTACK_TYPE    uint32_t
+#define portBASE_TYPE     long
 
-    typedef portSTACK_TYPE   StackType_t;
-    typedef long             BaseType_t;
-    typedef unsigned long    UBaseType_t;
+typedef portSTACK_TYPE   StackType_t;
+typedef long             BaseType_t;
+typedef unsigned long    UBaseType_t;
 
-    #if ( configUSE_16_BIT_TICKS == 1 )
-        typedef uint16_t     TickType_t;
-        #define portMAX_DELAY              ( TickType_t ) 0xffff
-    #else
-        typedef uint32_t     TickType_t;
-        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+#if ( configUSE_16_BIT_TICKS == 1 )
+    typedef uint16_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffff
+#else
+    typedef uint32_t     TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
 
-/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
- * not need to be guarded with a critical section. */
-        #define portTICK_TYPE_IS_ATOMIC    1
-    #endif
+    /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+     * not need to be guarded with a critical section. */
+    #define portTICK_TYPE_IS_ATOMIC    1
+#endif
 
 /*-----------------------------------------------------------*/
 
 /* Hardware specifics. */
-    #define portBYTE_ALIGNMENT    8     /* Could make four, according to manual. */
-    #define portSTACK_GROWTH      -1
-    #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-    #define portNOP()    nop()
+#define portBYTE_ALIGNMENT    8     /* Could make four, according to manual. */
+#define portSTACK_GROWTH      -1
+#define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portNOP()    nop()
 
 /* Yield equivalent to "*portITU_SWINTR = 0x01; ( void ) *portITU_SWINTR;"
  * where portITU_SWINTR is the location of the software interrupt register
  * (0x000872E0).  Don't rely on the assembler to select a register, so instead
  * save and restore clobbered registers manually. */
-    #pragma inline_asm vPortYield
-    static void vPortYield( void )
-    {
-    #ifndef __CDT_PARSER__
-        /* Save clobbered register - may not actually be necessary if inline asm
-         * functions are considered to use the same rules as function calls by the
-         * compiler. */
-        PUSH.L R5
-        /* Set ITU SWINTR. */
-        MOV.L # 000872E0H, R5
-        MOV.B # 1, [ R5 ]
-        /* Read back to ensure the value is taken before proceeding. */
-        CMP [ R5 ].UB, R5
-        /* Restore clobbered register to its previous value. */
-        POP R5
-    #endif
-    }
+/* *INDENT-OFF* */
+#pragma inline_asm vPortYield
+static void vPortYield( void )
+{
+#ifndef __CDT_PARSER__
+    /* Save clobbered register - may not actually be necessary if inline asm
+     * functions are considered to use the same rules as function calls by the
+     * compiler. */
+    PUSH.L R5
+    /* Set ITU SWINTR. */
+    MOV.L  #000872E0H, R5
+    MOV.B  #1, [ R5 ]
+    /* Read back to ensure the value is taken before proceeding. */
+    CMP    [ R5 ].UB, R5
+    /* Restore clobbered register to its previous value. */
+    POP    R5
+#endif
+}
+/* *INDENT-ON* */
 
-    #define portYIELD()                                       vPortYield()
-    #define portYIELD_FROM_ISR( x )                           if( ( x ) != pdFALSE ) portYIELD()
+#define portYIELD()                                       vPortYield()
+#define portYIELD_FROM_ISR( x )                           if( ( x ) != pdFALSE ) portYIELD()
 
 /* These macros should not be called directly, but through the
  * taskENTER_CRITICAL() and taskEXIT_CRITICAL() macros.  An extra check is
  * performed if configASSERT() is defined to ensure an assertion handler does not
  * inadvertently attempt to lower the IPL when the call to assert was triggered
- * because the IPL value was found to be above	configMAX_SYSCALL_INTERRUPT_PRIORITY
+ * because the IPL value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY
  * when an ISR safe FreeRTOS API function was executed.  ISR safe FreeRTOS API
  * functions are those that end in FromISR.  FreeRTOS maintains a separate
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
-    #define portENABLE_INTERRUPTS()                           set_ipl( ( long ) 0 )
-    #ifdef configASSERT
-        #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
-        #define portDISABLE_INTERRUPTS()                      if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-    #else
-        #define portDISABLE_INTERRUPTS()                      set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-    #endif
+#define portENABLE_INTERRUPTS()                           set_ipl( ( long ) 0 )
+#ifdef configASSERT
+    #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
+    #define portDISABLE_INTERRUPTS()                      if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
+#else
+    #define portDISABLE_INTERRUPTS()                      set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
+#endif
 
 /* Critical nesting counts are stored in the TCB. */
-    #define portCRITICAL_NESTING_IN_TCB    ( 1 )
+#define portCRITICAL_NESTING_IN_TCB    ( 1 )
 
 /* The critical nesting functions defined within tasks.c. */
-    extern void vTaskEnterCritical( void );
-    extern void vTaskExitCritical( void );
-    #define portENTER_CRITICAL()    vTaskEnterCritical()
-    #define portEXIT_CRITICAL()     vTaskExitCritical()
+extern void vTaskEnterCritical( void );
+extern void vTaskExitCritical( void );
+#define portENTER_CRITICAL()                                           vTaskEnterCritical()
+#define portEXIT_CRITICAL()                                            vTaskExitCritical()
 
 /* As this port allows interrupt nesting... */
-    #define portSET_INTERRUPT_MASK_FROM_ISR()                              ( UBaseType_t ) get_ipl(); set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
-    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    set_ipl( ( long ) uxSavedInterruptStatus )
+#define portSET_INTERRUPT_MASK_FROM_ISR()                              ( UBaseType_t ) get_ipl(); set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus )    set_ipl( ( long ) uxSavedInterruptStatus )
 
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
 /*-----------------------------------------------------------*/
 
@@ -166,20 +168,23 @@
  * themselves a DPFPU context before using any DPFPU instructions.  If
  * configUSE_TASK_DPFPU_SUPPORT is set to 2 then all tasks will have a DPFPU context
  * by default. */
-    #if( configUSE_TASK_DPFPU_SUPPORT == 1 )
-        void vPortTaskUsesDPFPU( void );
-    #else
-/* Each task has a DPFPU context already, so define this function away to
- * nothing to prevent it being called accidentally. */
-        #define vPortTaskUsesDPFPU()
-    #endif
-    #define portTASK_USES_DPFPU() vPortTaskUsesDPFPU()
+#if ( configUSE_TASK_DPFPU_SUPPORT == 1 )
+    void vPortTaskUsesDPFPU( void );
+#else
+
+    /* Each task has a DPFPU context already, so define this function away to
+     * nothing to prevent it being called accidentally. */
+    #define vPortTaskUsesDPFPU()
+#endif
+#define portTASK_USES_DPFPU()             vPortTaskUsesDPFPU()
 
 /* Definition to allow compatibility with existing FreeRTOS Demo using flop.c. */
-    #define portTASK_USES_FLOATING_POINT() vPortTaskUsesDPFPU()
+#define portTASK_USES_FLOATING_POINT()    vPortTaskUsesDPFPU()
 
-    #ifdef __cplusplus
-        }
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
 
 #endif /* PORTMACRO_H */


### PR DESCRIPTION
Description

The following changes are made.

Add '/\* \*INDENT-OFF\* \*/' and '/\* \*INDENT-ON\* \*/' around inline assembly code in C source files.
Add above comments around '#ifdef __cplusplus extern "C" #endif' in portmacro.h.
Add above comments around '#ifdef __cplusplus } #endif' in portmacro.h.
Add '\; /\* \*INDENT-OFF\* \*/' at the top of assembly source file.
Remove '1 tab == 4 spaces!'.
Change tab to spaces.
Beautification by uncrustify.
Beautification by hand (no conflict with uncrustify).
Fix inconsistency which I didn't notice at the commit 386d854: DFPU --> DPFPU.

The following uncrustify and config file are used.

uncrustify: [uncrustify-0.71.0_f-win32](https://sourceforge.net/projects/uncrustify/) 
config: [FreeRTOS/tools/uncrustify.cfg](https://github.com/FreeRTOS/FreeRTOS/commit/4a7a48790d64127f85cc763721b575c51c452833)

Test Steps

There are no changes in the MOT and SREC files (the following total 2 * 3 * 3 = 18 cases) which are built for Renesas RX72N Envision Kit RTOS Demo between before and after.

Total 2 * 3 * 3 = 18 cases:

(1) Define/not define USE_FULL_REGISTER_INITIALISATION in FreeRTOSConfig.h
(2) Define configUSE_TASK_DPFPU_SUPPORT = 1, 2, 0 in FreeRTOSConfig.h
(3) GNURX, CC-RX, ICCRX

Related Issue

Style: Revert uncrustify for portable directories #115
[https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/115#issuecomment-673935703](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/115#issuecomment-673935703)

In addition to a small tip in the above conversation for embedding /\* \*INDENT-OFF\* \*/ into Renesas CC-RX's assembly source file (*.src), I notice that there is another tip to do it. The following source file is fortunately consistent with uncrustify. But I'm not sure whether it may cause some other problems or not.

Especially there are two spaces between ';' and '*', for example:
```
;  * FreeRTOS Kernel V10.3.1
```
instead of one space between ';' and '*', for example:
```
; * FreeRTOS Kernel V10.3.1
```
It may happen that two spaces will be re-formatted to one space by other tool or script.

FreeRTOS/Source/portable/Renesas/RX700v3_DPFPU/port_asm.src

```
; /* *INDENT-OFF* */     <---- HERE
; /*
;  * FreeRTOS Kernel V10.3.1
;  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
;  *
;  * Permission is hereby granted, free of charge, to any person obtaining a copy of
;  * this software and associated documentation files (the "Software"), to deal in
;  * the Software without restriction, including without limitation the rights to
;  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
;  * the Software, and to permit persons to whom the Software is furnished to do so,
;  * subject to the following conditions:
;  *
;  * The above copyright notice and this permission notice shall be included in all
;  * copies or substantial portions of the Software.
;  *
;  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
;  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
;  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
;  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
;  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
;  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
;  *
;  * https://www.FreeRTOS.org
;  * https://github.com/FreeRTOS
;  *
;  */

        .GLB    _vSoftwareInterruptISR
        .GLB    _vSoftwareInterruptEntry

        .SECTION   P,CODE

_vSoftwareInterruptEntry:

    BRA _vSoftwareInterruptISR

        .RVECTOR    27, _vSoftwareInterruptEntry

        .END
```
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
