### PR TITLE
Fix: Add Parenthesis around if-statement in macro

### DIFF
--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -90,7 +90,12 @@
 
     #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
     #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-    #define portEND_SWITCHING_ISR( xSwitchRequired )    if( xSwitchRequired != pdFALSE ) portYIELD()
+
+    #define portEND_SWITCHING_ISR( xSwitchRequired )        \
+        do {                                                \
+            if( (xSwitchRequired) != pdFALSE ) portYIELD(); \
+        } while (0)
+
     #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Add Parenthesis around if-statement in macro

Description
-----------
Add Parenthesis around if-statement in macro

Related Issue
-----------
#66 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
