### PR TITLE
Use lower case filename for MinGW port

### DIFF
--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -28,8 +28,8 @@
 #ifndef PORTMACRO_H
 #define PORTMACRO_H
 
-#include <Windows.h>
-#include <WinBase.h>
+#include <windows.h>
+#include <winbase.h>
 
 /******************************************************************************
 	Defines


### PR DESCRIPTION
Use lower case filename for MinGW port to make is compatiable with GNU/Linux.

The Windows.h file provided with Microsoft's tools have used a variety of cases.

old VC++ installations (VC++98 and earlier) use WINDOWS.H 

newer VC++ installations and Windows SDKs use Windows.h

some mobile device SDKs (PocketPC or Windows mobile) use windows.h

The MinGW windows.h header always seems to be lower case. Since windows.h will always work on both Windows and a Linux cross compile, so we make it with all lowercase.
 
REF:  https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/119

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
