### PR TITLE
Revert "Fix: Add Parenthesis around if-statement in macro"

### DIFF
--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -90,12 +90,7 @@
 
     #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
     #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-
-    #define portEND_SWITCHING_ISR( xSwitchRequired )        \
-        do {                                                \
-            if( (xSwitchRequired) != pdFALSE ) portYIELD(); \
-        } while (0)
-
+    #define portEND_SWITCHING_ISR( xSwitchRequired )    if( xSwitchRequired != pdFALSE ) portYIELD()
     #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Reverts FreeRTOS/FreeRTOS-Kernel#138