### PR TITLE
Change the Linux Port to use condition variables instead of Signals

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -114,77 +114,6 @@ static void vPortSystemTickHandler( int sig );
 static void vPortStartFirstTask( void );
 /*-----------------------------------------------------------*/
 
-/*
- * The standard glibc malloc(), free() etc. take an internal lock so
- * it is not safe to switch tasks while calling them.
- *
- * Requiring the application use the safe xPortMalloc() and
- * vPortFree() is not sufficient as malloc() is used internally by
- * glibc (e.g., by strdup() and the pthread library.)
- *
- * To further complicate things malloc() and free() may be called
- * outside of task context during pthread destruction so using
- * vTaskSuspend() and xTaskResumeAll() cannot be used.
- * vPortEnterCritical() and vPortExitCritical() cannot be used either
- * as they use global state for the critical section nesting (this
- * cannot be fixed by using TLS as pthread destruction needs to free
- * the TLS).
- *
- * Explicitly save/disable and restore the signal mask to block the
- * timer (SIGALRM) and other signals.
- */
-
-/*
-extern void *__libc_malloc(size_t);
-extern void __libc_free(void *);
-extern void *__libc_calloc(size_t, size_t);
-extern void *__libc_realloc(void *ptr, size_t);
-
-void *malloc(size_t size)
-{
-sigset_t xSavedSignals;
-void *ptr;
-
-	pthread_sigmask( SIG_BLOCK, &xAllSignals, &xSavedSignals );
-	ptr = __libc_malloc( size );
-	pthread_sigmask( SIG_SETMASK, &xSavedSignals, NULL );
-
-	return ptr;
-}
-
-void free(void *ptr)
-{
-sigset_t xSavedSignals;
-
-	pthread_sigmask( SIG_BLOCK, &xAllSignals, &xSavedSignals );
-	__libc_free( ptr );
-	pthread_sigmask( SIG_SETMASK, &xSavedSignals, NULL );
-}
-
-void *calloc(size_t nmemb, size_t size)
-{
-sigset_t xSavedSignals;
-void *ptr;
-
-	pthread_sigmask( SIG_BLOCK, &xAllSignals, &xSavedSignals );
-	ptr = __libc_calloc( nmemb, size );
-	pthread_sigmask( SIG_SETMASK, &xSavedSignals, NULL );
-
-	return ptr;
-}
-
-void *realloc(void *ptr, size_t size)
-{
-sigset_t xSavedSignals;
-
-	pthread_sigmask( SIG_BLOCK, &xAllSignals, &xSavedSignals );
-	ptr = __libc_realloc( ptr, size );
-	pthread_sigmask( SIG_SETMASK, &xSavedSignals, NULL );
-
-	return ptr;
-}
-*/
-
 static void prvFatalError( const char *pcCall, int iErrno )
 {
 	fprintf( stderr, "%s: %s\n", pcCall, strerror( iErrno ) );
@@ -244,7 +173,7 @@ Thread_t *pxFirstThread = prvGetThreadFromTask( xTaskGetCurrentTaskHandle() );
 	prvResumeThread( pxFirstThread );
 }
 /*-----------------------------------------------------------*/
-#include <unistd.h>
+
 /*
  * See header file for description.
  */

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -446,7 +446,6 @@ BaseType_t uxSavedCriticalNesting;
 		}
 		prvSuspendSelf( pxThreadToSuspend );
 
-
 		uxCriticalNesting = uxSavedCriticalNesting;
 	}
 }
@@ -457,7 +456,7 @@ static void prvSuspendSelf( Thread_t *thread )
 int iSig;
 
 	/*
-	 * Suspend this thread by waiting for a SIG_RESUME signal.
+	 * Suspend this thread by waiting for a pthread_cond_signal event.
 	 *
 	 * A suspended thread must not handle signals (interrupts) so
 	 * all signals must be blocked by calling this from:

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -211,6 +211,7 @@ void vPortEndScheduler( void )
 {
 struct itimerval itimer;
 struct sigaction sigtick;
+Thread_t *xCurrentThread;
 
 	/* Stop the timer and ignore any pending SIGALRMs that would end
 	 * up running on the main thread when it is resumed. */
@@ -230,7 +231,8 @@ struct sigaction sigtick;
 	xSchedulerEnd = pdTRUE;
 	(void)pthread_kill( hMainThread, SIG_RESUME );
 
-	//prvSuspendSelf();
+	xCurrentThread = prvGetThreadFromTask( xTaskGetCurrentTaskHandle() );
+	prvSuspendSelf(xCurrentThread);
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
@@ -1,0 +1,75 @@
+#include <pthread.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "wait_for_event.h"
+
+struct event
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    bool event_triggered;
+};
+
+struct event * event_create()
+{
+    struct event * ev = malloc( sizeof( struct event ) );
+
+    ev->event_triggered = false;
+    pthread_mutex_init( &ev->mutex, NULL );
+    pthread_cond_init( &ev->cond, NULL );
+    return ev;
+}
+
+void event_delete( struct event * ev )
+{
+    pthread_mutex_destroy( &ev->mutex );
+    pthread_cond_destroy( &ev->cond );
+    free( ev );
+}
+
+bool event_wait( struct event * ev )
+{
+    pthread_mutex_lock( &ev->mutex );
+
+    while( ev->event_triggered == false )
+    {
+        pthread_cond_wait( &ev->cond, &ev->mutex );
+    }
+
+    pthread_mutex_unlock( &ev->mutex );
+    return true;
+}
+bool event_wait_timed( struct event * ev,
+                       time_t ms )
+{
+    struct timespec ts;
+    int ret = 0;
+
+    clock_gettime( CLOCK_REALTIME, &ts );
+    //ts.tv_sec += ms;
+    ts.tv_nsec += (ms * 1000000);
+    pthread_mutex_lock( &ev->mutex );
+
+    while( (ev->event_triggered == false) && (ret == 0) )
+    {
+        ret = pthread_cond_timedwait( &ev->cond, &ev->mutex, &ts );
+
+        if( ( ret == -1 ) && ( errno == ETIMEDOUT ) )
+        {
+            return false;
+        }
+    }
+
+    ev->event_triggered = false;
+    pthread_mutex_unlock( &ev->mutex );
+    return true;
+}
+
+void event_signal( struct event * ev )
+{
+    pthread_mutex_lock( &ev->mutex );
+    ev->event_triggered = true;
+    pthread_cond_signal( &ev->cond );
+    pthread_mutex_unlock( &ev->mutex );
+}

--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
@@ -37,6 +37,7 @@ bool event_wait( struct event * ev )
         pthread_cond_wait( &ev->cond, &ev->mutex );
     }
 
+    ev->event_triggered = false;
     pthread_mutex_unlock( &ev->mutex );
     return true;
 }

--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.h
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.h
@@ -1,0 +1,18 @@
+#ifndef _WAIT_FOR_EVENT_H_
+#define _WAIT_FOR_EVENT_H_
+
+#include <stdbool.h>
+#include <time.h>
+
+struct event;
+
+struct event * event_create();
+void event_delete( struct event * );
+bool event_wait( struct event * ev );
+bool event_wait_timed( struct event * ev,
+                       time_t ms );
+void event_signal( struct event * ev );
+
+
+
+#endif /* ifndef _WAIT_FOR_EVENT_H_ */


### PR DESCRIPTION
Change the Linux Port to use condition variables instead of Signals

Description
-----------
Change the Linux Port to use condition variables instead of Signals
For some reason signals were found not to work as expected on MacOS, so we have decided to use condition variables instead of signals to resume and pause threads to simulate FreeRTOS Tasks

Test Steps
-----------
Ran the Demos on Linux, Mac and Windows under WSL


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
