### PR TITLE
Fix compiler warning in configASSERT on 64 bit architecture

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,13 +1,51 @@
 Documentation and download available at https://www.FreeRTOS.org/
 
+Changes between FreeRTOS V10.4.0 and FreeRTOS V10.3.1 released September 1 2020
+
+	See https://www.FreeRTOS.org/FreeRTOS-V10.4.x.html
+
+	Major enhancements:
+
+	+ Task notifications:  Prior to FreeRTOS V10.4.0 each created task had a
+	  single direct to task notification.  From FreeRTOS V10.4.0 each task has
+	  an array of notifications.  The direct to task notification API has been
+	  extended with API functions postfixed with "Indexed" to enable the API to
+	  operate on a task notification at any array index.  See
+	  https://www.freertos.org/RTOS-task-notifications.html for more information.
+	+ Kernel ports that support memory protection units (MPUs): The ARMv7-M and
+	  ARMv8-M MPU ports now support a privilege access only heap. The ARMv7-M
+	  MPU ports now support devices that have 16 MPU regions, have the ability
+	  to override default memory attributes for privileged code and data
+	  regions, and have the ability to place the FreeRTOS kernel code outside of
+	  the Flash memory. The ARMv8-M MPU ports now support tickless idle mode.
+	  See https://www.freertos.org/FreeRTOS-MPU-memory-protection-unit.html
+	  for more information.
+
+	Additional noteworthy updates:
+
+	+ Code formatting is now automated to facilitate the increase in
+	  collaborative development in Git.  The auto-formated code is not identical
+	  to the original formatting conventions.  Most notably spaces are now used
+	  in place of tabs.
+	+ The prototypes for callback functions (those that start with "Application",
+	  such as vApplicationStackOverflowHook()) are now in the FreeRTOS header
+	  files, removing the need for application writers to add prototypes into
+	  the C files in which they define the functions.
+	+ New Renesas RXv3 port layer.
+	+ Updates to the Synopsys ARC code, including support for EM and HS cores,
+	  and updated BSP.
+	+ Added new POSIX port layer that allows FreeRTOS to run on Linux hosts in
+	  the same way the Windows port layer enables FreeRTOS to run on Windows
+	  hosts.
+	+ Many other minor optimisations and enhancements.
+
+
 Changes between FreeRTOS V10.3.0 and FreeRTOS V10.3.1 released February 18 2020
 
 	See https://www.FreeRTOS.org/FreeRTOS-V10.3.x.html
 
 	+ ./FreeRTOS-Labs directory was removed from this file. The libraries it
 	contained are now available as a separate download.
-	+ Replaced the single task notification per task with an array of
-	notificatinos per task.
 
 Changes between FreeRTOS V10.2.1 and FreeRTOS V10.3.0 released February 7 2020
 

--- a/tasks.c
+++ b/tasks.c
@@ -4887,7 +4887,7 @@ TickType_t uxTaskResetEventItemValue( void )
                     /* Should not get here if all enums are handled.
                      * Artificially force an assert by testing a value the
                      * compiler can't assume is const. */
-                    configASSERT( pxTCB->ulNotifiedValue[ uxIndexToNotify ] == ~0UL );
+                    configASSERT( xTickCount == ( TickType_t ) 0 );
 
                     break;
             }
@@ -5030,7 +5030,7 @@ TickType_t uxTaskResetEventItemValue( void )
                     /* Should not get here if all enums are handled.
                      * Artificially force an assert by testing a value the
                      * compiler can't assume is const. */
-                    configASSERT( pxTCB->ulNotifiedValue[ uxIndexToNotify ] == ~0UL );
+                    configASSERT( xTickCount == ( TickType_t ) 0 );
                     break;
             }
 


### PR DESCRIPTION
Description
-----------
The following line was used in a couple of placed to force …
82b2079
an assert, but caused warnings on 64-bit architectures because
it compares a uint32_t with a 64-bit number.
configASSERT( pxTCB->ulNotifiedValue[ uxIndexToNotify ] == ~0UL );

The changed to configASSERT( xTickCount == ( TickType_t ) 0 );
which has the same effect of forcing an assert, but without
the warning.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
