### PR TITLE
Add url link for Linux Port documentation

### DIFF
--- a/portable/ThirdParty/GCC/Posix/FreeRTOS-simulator-for-Linux.url
+++ b/portable/ThirdParty/GCC/Posix/FreeRTOS-simulator-for-Linux.url
@@ -1,0 +1,5 @@
+[{000214A0-0000-0000-C000-000000000046}]
+Prop3=19,11
+[InternetShortcut]
+IDList=
+URL=https://www.freertos.org/FreeRTOS-simulator-for-Linux.html


### PR DESCRIPTION
Adding a URL link to the Linux Port documentation