### PR TITLE
Fix: Comment - xTaskIncrementTick loop - to adhere to demo requirement

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -366,12 +366,15 @@ uint64_t xExpectedTicks;
 
 	/* Tick Increment, accounting for any lost signals or drift in
 	 * the timer. */
-	xExpectedTicks = (prvGetTimeNs() - prvStartTimeNs)
-		/ (portTICK_RATE_MICROSECONDS * 1000);
-	do {
+/*
+ *      Comment code to adjust timing according to full demo requirements
+ *      xExpectedTicks = (prvGetTimeNs() - prvStartTimeNs)
+ *		/ (portTICK_RATE_MICROSECONDS * 1000);
+ * do { */
 		xTaskIncrementTick();
-		prvTickCount++;
-	} while (prvTickCount < xExpectedTicks);
+/*		prvTickCount++;
+ *	} while (prvTickCount < xExpectedTicks);
+*/
 
 #if ( configUSE_PREEMPTION == 1 )
 	/* Select Next Task. */


### PR DESCRIPTION
Comment - xTaskIncrementTick loop - to adhere to demo requirement

Description
-----------
Commenting xTaskIncrementTick loop to adhere to the demo requirement

Test Steps
-----------
full demo run
```
[Posix_GCC]$ ./build/posix_demo

Trace started.
The trace will be dumped to disk if a call to configASSERT() fails.

The trace will be dumped to disk if Enter is hit.
Starting full demo
OK: No errors - tick count 10000
OK: No errors - tick count 20000
OK: No errors - tick count 30000
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
