### PR TITLE
Correct version numbers in assembly files

### DIFF
--- a/portable/ARMv8M/copy_files.py
+++ b/portable/ARMv8M/copy_files.py
@@ -1,5 +1,5 @@
 #/*
-# * FreeRTOS Kernel V10.3.1
+# * FreeRTOS Kernel V10.4.0
 # * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ARMv8M/secure/context/portable/IAR/ARM_CM23/secure_context_port_asm.s
+++ b/portable/ARMv8M/secure/context/portable/IAR/ARM_CM23/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ARMv8M/secure/context/portable/IAR/ARM_CM33/secure_context_port_asm.s
+++ b/portable/ARMv8M/secure/context/portable/IAR/ARM_CM33/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/CCS/ARM_CM3/portasm.asm
+++ b/portable/CCS/ARM_CM3/portasm.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/CCS/ARM_CM4F/portasm.asm
+++ b/portable/CCS/ARM_CM4F/portasm.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/CCS/ARM_Cortex-R4/portASM.asm
+++ b/portable/CCS/ARM_Cortex-R4/portASM.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/CCS/MSP430X/portext.asm
+++ b/portable/CCS/MSP430X/portext.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/CodeWarrior/ColdFire_V1/portasm.S
+++ b/portable/CodeWarrior/ColdFire_V1/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/CodeWarrior/ColdFire_V2/portasm.S
+++ b/portable/CodeWarrior/ColdFire_V2/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/ARM_CA53_64_BIT/portASM.S
+++ b/portable/GCC/ARM_CA53_64_BIT/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/ARM_CA9/portASM.S
+++ b/portable/GCC/ARM_CA9/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/ARM_CR5/portASM.S
+++ b/portable/GCC/ARM_CR5/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/ColdFire_V2/portasm.S
+++ b/portable/GCC/ColdFire_V2/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/IA32_flat/portASM.S
+++ b/portable/GCC/IA32_flat/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/MicroBlaze/portasm.s
+++ b/portable/GCC/MicroBlaze/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/MicroBlazeV8/portasm.S
+++ b/portable/GCC/MicroBlazeV8/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/MicroBlazeV9/portasm.S
+++ b/portable/GCC/MicroBlazeV9/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/NiosII/port_asm.S
+++ b/portable/GCC/NiosII/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/PPC405_Xilinx/portasm.S
+++ b/portable/GCC/PPC405_Xilinx/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/PPC440_Xilinx/portasm.S
+++ b/portable/GCC/PPC440_Xilinx/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/GCC/RL78/portasm.S
+++ b/portable/GCC/RL78/portasm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/78K0R/portasm.s26
+++ b/portable/IAR/78K0R/portasm.s26
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CA5_No_GIC/portASM.s
+++ b/portable/IAR/ARM_CA5_No_GIC/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CA9/portASM.s
+++ b/portable/IAR/ARM_CA9/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM0/portasm.s
+++ b/portable/IAR/ARM_CM0/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM23/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM23/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM23/secure/secure_context_port_asm.s
+++ b/portable/IAR/ARM_CM23/secure/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM3/portasm.s
+++ b/portable/IAR/ARM_CM3/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM33/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM33/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM33/secure/secure_context_port_asm.s
+++ b/portable/IAR/ARM_CM33/secure/secure_context_port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM4F/portasm.s
+++ b/portable/IAR/ARM_CM4F/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM4F_MPU/portasm.s
+++ b/portable/IAR/ARM_CM4F_MPU/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CM7/r0p1/portasm.s
+++ b/portable/IAR/ARM_CM7/r0p1/portasm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ARM_CRx_No_GIC/portASM.s
+++ b/portable/IAR/ARM_CRx_No_GIC/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/ATMega323/portmacro.s90
+++ b/portable/IAR/ATMega323/portmacro.s90
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/AVR_AVRDx/portmacro.s90
+++ b/portable/IAR/AVR_AVRDx/portmacro.s90
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/AVR_Mega0/portmacro.s90
+++ b/portable/IAR/AVR_Mega0/portmacro.s90
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/AtmelSAM7S64/portasm.s79
+++ b/portable/IAR/AtmelSAM7S64/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/LPC2000/portasm.s79
+++ b/portable/IAR/LPC2000/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/MSP430/portext.s43
+++ b/portable/IAR/MSP430/portext.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/MSP430X/portext.s43
+++ b/portable/IAR/MSP430X/portext.s43
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/RISC-V/portASM.s
+++ b/portable/IAR/RISC-V/portASM.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/RL78/portasm.s87
+++ b/portable/IAR/RL78/portasm.s87
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/RX100/port_asm.s
+++ b/portable/IAR/RX100/port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/RX600/port_asm.s
+++ b/portable/IAR/RX600/port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/RXv2/port_asm.s
+++ b/portable/IAR/RXv2/port_asm.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/STR71x/portasm.s79
+++ b/portable/IAR/STR71x/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/STR75x/portasm.s79
+++ b/portable/IAR/STR75x/portasm.s79
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/STR91x/portasm.s79
+++ b/portable/IAR/STR91x/portasm.s79
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/V850ES/portasm.s85
+++ b/portable/IAR/V850ES/portasm.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/V850ES/portasm_Fx3.s85
+++ b/portable/IAR/V850ES/portasm_Fx3.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/IAR/V850ES/portasm_Hx2.s85
+++ b/portable/IAR/V850ES/portasm_Hx2.s85
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/MPLAB/PIC24_dsPIC/portasm_PIC24.S
+++ b/portable/MPLAB/PIC24_dsPIC/portasm_PIC24.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/MPLAB/PIC24_dsPIC/portasm_dsPIC.S
+++ b/portable/MPLAB/PIC24_dsPIC/portasm_dsPIC.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/MPLAB/PIC32MEC14xx/port_asm.S
+++ b/portable/MPLAB/PIC32MEC14xx/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/MPLAB/PIC32MX/port_asm.S
+++ b/portable/MPLAB/PIC32MX/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/MPLAB/PIC32MZ/port_asm.S
+++ b/portable/MPLAB/PIC32MZ/port_asm.S
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/RVDS/ARM7_LPC21xx/portASM.s
+++ b/portable/RVDS/ARM7_LPC21xx/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/RVDS/ARM7_LPC21xx/portmacro.inc
+++ b/portable/RVDS/ARM7_LPC21xx/portmacro.inc
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/RVDS/ARM_CA9/portASM.s
+++ b/portable/RVDS/ARM_CA9/portASM.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/RVDS/ARM_CA9/portmacro.inc
+++ b/portable/RVDS/ARM_CA9/portmacro.inc
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Renesas/RX100/port_asm.src
+++ b/portable/Renesas/RX100/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Renesas/RX200/port_asm.src
+++ b/portable/Renesas/RX200/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Renesas/RX600/port_asm.src
+++ b/portable/Renesas/RX600/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Renesas/RX600v2/port_asm.src
+++ b/portable/Renesas/RX600v2/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Renesas/RX700v3_DPFPU/port_asm.src
+++ b/portable/Renesas/RX700v3_DPFPU/port_asm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Renesas/SH2A_FPU/ISR_Support.inc
+++ b/portable/Renesas/SH2A_FPU/ISR_Support.inc
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Renesas/SH2A_FPU/portasm.src
+++ b/portable/Renesas/SH2A_FPU/portasm.src
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Rowley/MSP430F449/portext.asm
+++ b/portable/Rowley/MSP430F449/portext.asm
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.3.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/Tasking/ARM_CM4F/port_asm.asm
+++ b/portable/Tasking/ARM_CM4F/port_asm.asm
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V10.3.1
+; * FreeRTOS Kernel V10.4.0
 ; * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc_support.s
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc_support.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.2.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ThirdParty/GCC/ARC_v1/arc_freertos_exceptions.c
+++ b/portable/ThirdParty/GCC/ARC_v1/arc_freertos_exceptions.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.2.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ThirdParty/GCC/ARC_v1/arc_freertos_exceptions.h
+++ b/portable/ThirdParty/GCC/ARC_v1/arc_freertos_exceptions.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.2.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ThirdParty/GCC/ARC_v1/arc_support.s
+++ b/portable/ThirdParty/GCC/ARC_v1/arc_support.s
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.2.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ThirdParty/GCC/ARC_v1/port.c
+++ b/portable/ThirdParty/GCC/ARC_v1/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.2.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/portable/ThirdParty/GCC/ARC_v1/portmacro.h
+++ b/portable/ThirdParty/GCC/ARC_v1/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.2.1
+ * FreeRTOS Kernel V10.4.0
  * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Description
-----------
The FreeRTOS V10.4.0 set the version numbers correctly in .c and .h files, but missed assembly files.  This pull request sets the version number to V10.4.0 in the assembly files.


Test Steps
-----------
N/A as no code changes.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/165


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
