### PR TITLE
Fix: Rename parameter  uxIndexToNotify to uxIndexToWaitOn

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -2558,7 +2558,7 @@ uint32_t ulTaskGenericNotifyTake( UBaseType_t uxIndexToWaitOn,
 #define ulTaskNotifyTake( xClearCountOnExit, xTicksToWait ) \
     ulTaskGenericNotifyTake( ( tskDEFAULT_INDEX_TO_NOTIFY ), ( xClearCountOnExit ), ( xTicksToWait ) )
 #define ulTaskNotifyTakeIndexed( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait ) \
-    ulTaskGenericNotifyTake( ( uxIndexToNotify ), ( xClearCountOnExit ), ( xTicksToWait ) )
+    ulTaskGenericNotifyTake( ( uxIndexToWaitOn ), ( xClearCountOnExit ), ( xTicksToWait ) )
 
 /**
  * task. h


### PR DESCRIPTION
Rename parameter  `uxIndexToNotify` to `uxIndexToWaitOn`

Description
-----------

This fixes the bug that, the  parameter passed from the macro `ulTaskNotifyTakeIndexed` to `ulTaskGenericNotifyTake()` was incorrectly named as `uxIndexToNotify`.

Test Steps
-----------
Enable task notifications array feature in `FreeRTOSConfig.h` as follows:
```
#define configUSE_TASK_NOTIFICATIONS 1
#define configTASK_NOTIFICATION_ARRAY_ENTRIES 5
```
Calling the API `ulTaskNotifyTakeIndexed()` from the code, will  give a compilation error:
```
 error: ‘uxIndexToNotify’ undeclared (first use in this function)
```

Related Issue
-----------
Issue was referenced in this forum post: https://forums.freertos.org/t/task-h-error-uxindextonotify-undeclared/10689



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
