### PR TITLE
Posix: Free the allocated memory after deleting a task or ending the scheduler

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -178,12 +178,15 @@ portBASE_TYPE xPortStartScheduler( void )
 {
 int iSignal;
 sigset_t xSignals;
+TaskHandle_t pxIdleThread;
 
 	hMainThread = pthread_self();
 
 	/* Start the timer that generates the tick ISR(SIGALRM).
 	   Interrupts are disabled here already. */
 	prvSetupTimerInterrupt();
+
+	pxIdleThread = xTaskGetIdleTaskHandle();
 
 	/* Start the first task. */
 	vPortStartFirstTask();
@@ -196,6 +199,9 @@ sigset_t xSignals;
 	{
 		sigwait( &xSignals, &iSignal );
 	}
+
+	/* Cancel the Idle task and free its resources */
+	vPortCancelThread(pxIdleThread);
 
 	/* Restore original signal mask. */
 	(void)pthread_sigmask( SIG_SETMASK, &xSchedulerOriginalSignalMask,  NULL );

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -411,6 +411,7 @@ Thread_t *pxThreadToCancel = prvGetThreadFromTask( pxTaskToDelete );
 	 */
 	pthread_cancel( pxThreadToCancel->pthread );
 	pthread_join( pxThreadToCancel->pthread, NULL );
+	event_delete( pxThreadToCancel->ev );
 }
 /*-----------------------------------------------------------*/
 
@@ -450,7 +451,6 @@ BaseType_t uxSavedCriticalNesting;
 		prvResumeThread( pxThreadToResume );
 		if ( pxThreadToSuspend->xDying )
 		{
-			event_delete(pxThreadToSuspend->ev);
 			pthread_exit( NULL );
 		}
 		prvSuspendSelf( pxThreadToSuspend );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
In Posix Simulator on Linux, the memory allocated by idle and first task is not freed properly after ending the scheduler. Also the memory allocated for the condition variable is not freed in case of deleting a task from another task. This is needed to avoid memory leaks errors when memory checkers (Valgrind, address sanitizer, ..) are used. This pull request is solving this issue.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Use the FreeRTOS Posix Simulator on Linux and run it under Valgrind or use address sanitizer. Make sure no memory leaks errors after deleting a task from another task (not just a task deletes itself) and after ending the scheduler.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
