### PR TITLE
Fix Stack alignment for Microchip PIC32MX port

### DIFF
--- a/portable/MPLAB/PIC32MX/port.c
+++ b/portable/MPLAB/PIC32MX/port.c
@@ -159,7 +159,8 @@ const StackType_t * const xISRStackTop = &( xISRStack[ ( configISR_STACK_SIZE & 
  */
 StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
 {
-	/* Ensure 8 byte alignment is maintained when leaving this function. */
+	/* Ensure 8 byte alignment is maintained when the context is popped from
+	 * stack. The size of the context is 33 words (132 bytes). */
 	pxTopOfStack--;
 	pxTopOfStack--;
 

--- a/portable/MPLAB/PIC32MX/port.c
+++ b/portable/MPLAB/PIC32MX/port.c
@@ -159,7 +159,8 @@ const StackType_t * const xISRStackTop = &( xISRStack[ ( configISR_STACK_SIZE & 
  */
 StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
 {
-	/* Ensure byte alignment is maintained when leaving this function. */
+	/* Ensure 8 byte alignment is maintained when leaving this function. */
+	pxTopOfStack--;
 	pxTopOfStack--;
 
 	*pxTopOfStack = (StackType_t) 0xDEADBEEF;


### PR DESCRIPTION
Description
-----------

The stack of a task was not 8 byte aligned. Adding one more unused space at the beginning of task stack (before simulated context) ensures that the stack is 8 byte aligned. The stack (with simulated context) of a newly created task looks like the following:

```
                    +------------+
                    | UNUSED     |
                    +------------+
                    | UNUSED     |
                    +------------+
                    | 0xDEADBEEF |
                    +------------+
                    | 0x12345678 |
                    +------------+
                    | CAUSE      | <-- SP After Context Restore
                    +------------+
                ^   | STATUS     |
                |   +------------+
                |   | EPC        |
                |   +------------+
                |   | ra         |
                |   +------------+
                |   | s8         |
                |   +------------+
                |   | t9         |
                |   +------------+
                |   | t8         |
                |   +------------+
                |   | t7         |
                |   +------------+
                |   | t6         |
                |   +------------+
                |   | t5         |
                |   +------------+
                |   | t4         |
                |   +------------+
                |   | t3         |
                |   +------------+
                |   | t2         |
                |   +------------+
                |   | t1         |
                |   +------------+
    Context     |   | t0         |
  (132 bytes)   |   +------------+
                |   | a3         |
                |   +------------+
                |   | a2         |
                |   +------------+
                |   | a1         |
                |   +------------+
                |   | a0         |
                |   +------------+
                |   | v1         |
                |   +------------+
                |   | v0         |
                |   +------------+
                |   | s7         |
                |   +------------+
                |   | s6         |
                |   +------------+
                |   | s5         |
                |   +------------+
                |   | s4         |
                |   +------------+
                |   | s3         |
                |   +------------+
                |   | s2         |
                |   +------------+
                |   | s1         |
                |   +------------+
                |   | s0         |
                |   +------------+
                |   | at         |
                |   +------------+
                |   | HI         |
                |   +------------+
                |   | LO         |
                |   +------------+
                |   |            |
                |   +------------+
                V   |            | <-- SP After Context Save
                    +------------+
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
