### PR TITLE
Posix: Fix no task switching issue if a task ended its main function

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -66,6 +66,7 @@
 /*-----------------------------------------------------------*/
 
 #define SIG_RESUME SIGUSR1
+#define portTASK_ENDED_DELAY ( 500 )
 
 typedef struct THREAD
 {
@@ -420,6 +421,14 @@ Thread_t *pxThread = pvParams;
 
 	/* Call the task's entry point. */
 	pxThread->pxCode( pxThread->pvParams );
+
+	/* The task has finished, we need to trigger a task switch here
+	 * to avoid exiting while all tasks are waiting to be signaled.
+	 * So we will mark the task as Dying here then delay the task
+	 * with any value to trigger a task switch where the task will
+	 * be suspended and exited. */
+	pxThread->xDying = pdTRUE;
+	vTaskDelay( portTASK_ENDED_DELAY );
 
 	return NULL;
 }

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -67,7 +67,6 @@
 /*-----------------------------------------------------------*/
 
 #define SIG_RESUME SIGUSR1
-#define portTASK_ENDED_DELAY ( 500 )
 
 typedef struct THREAD
 {
@@ -418,6 +417,24 @@ Thread_t *pxThreadToCancel = prvGetThreadFromTask( pxTaskToDelete );
 }
 /*-----------------------------------------------------------*/
 
+static void prvTaskExitError( void )
+{
+	/* A function that implements a task must not exit or attempt to return to
+	* its caller as there is nothing to return to. If a task wants to exit it
+	* should instead call vTaskDelete( NULL ). Artificially force an assert()
+	* to be triggered if configASSERT() is defined, then stop here so
+	* application writers can catch the error. */
+	configASSERT( pdFALSE );
+
+	portDISABLE_INTERRUPTS();
+
+	while( 1 )
+	{
+		/* Do Nothing */
+	}
+}
+/*-----------------------------------------------------------*/
+
 static void *prvWaitForStart( void * pvParams )
 {
 Thread_t *pxThread = pvParams;
@@ -431,13 +448,8 @@ Thread_t *pxThread = pvParams;
 	/* Call the task's entry point. */
 	pxThread->pxCode( pxThread->pvParams );
 
-	/* The task has finished, we need to trigger a task switch here
-	 * to avoid exiting while all tasks are waiting to be signaled.
-	 * So we will mark the task as Dying here then delay the task
-	 * with any value to trigger a task switch where the task will
-	 * be suspended and exited. */
-	pxThread->xDying = pdTRUE;
-	vTaskDelay( portTASK_ENDED_DELAY );
+	/* Task function should not return */
+	prvTaskExitError();
 
 	return NULL;
 }

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -417,24 +417,6 @@ Thread_t *pxThreadToCancel = prvGetThreadFromTask( pxTaskToDelete );
 }
 /*-----------------------------------------------------------*/
 
-static void prvTaskExitError( void )
-{
-	/* A function that implements a task must not exit or attempt to return to
-	* its caller as there is nothing to return to. If a task wants to exit it
-	* should instead call vTaskDelete( NULL ). Artificially force an assert()
-	* to be triggered if configASSERT() is defined, then stop here so
-	* application writers can catch the error. */
-	configASSERT( pdFALSE );
-
-	portDISABLE_INTERRUPTS();
-
-	while( 1 )
-	{
-		/* Do Nothing */
-	}
-}
-/*-----------------------------------------------------------*/
-
 static void *prvWaitForStart( void * pvParams )
 {
 Thread_t *pxThread = pvParams;
@@ -448,8 +430,12 @@ Thread_t *pxThread = pvParams;
 	/* Call the task's entry point. */
 	pxThread->pxCode( pxThread->pvParams );
 
-	/* Task function should not return */
-	prvTaskExitError();
+	/* A function that implements a task must not exit or attempt to return to
+	* its caller as there is nothing to return to. If a task wants to exit it
+	* should instead call vTaskDelete( NULL ). Artificially force an assert()
+	* to be triggered if configASSERT() is defined, so application writers can
+        * catch the error. */
+	configASSERT( pdFALSE );
 
 	return NULL;
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
When the main function of a task exits, no task switching happened.
This is because all the remaining tasks are waiting on the condition
variable. The fix is to trigger a task switch and mark the exiting
task as "Dying" to be suspened and exited properly from the scheduler.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Create an application with multi tasks. Make one task to exit normally from its main function. Then no task switching will happen.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
