### PR TITLE
OpenOCD Support: Re-introduce uxTopUsedPriority

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -378,6 +378,7 @@ PRIVILEGED_DATA static volatile BaseType_t xNumOfOverflows = ( BaseType_t ) 0;
 PRIVILEGED_DATA static UBaseType_t uxTaskNumber = ( UBaseType_t ) 0U;
 PRIVILEGED_DATA static volatile TickType_t xNextTaskUnblockTime = ( TickType_t ) 0U; /* Initialised to portMAX_DELAY before the scheduler starts. */
 PRIVILEGED_DATA static TaskHandle_t xIdleTaskHandle = NULL;                          /*< Holds the handle of the idle task.  The idle task is created automatically when the scheduler is started. */
+const UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
 
 /* Context switches are held pending while the scheduler is suspended.  Also,
  * interrupts must not manipulate the xStateListItem of a TCB, or any of the
@@ -2093,6 +2094,10 @@ void vTaskStartScheduler( void )
     /* Prevent compiler warnings if INCLUDE_xTaskGetIdleTaskHandle is set to 0,
      * meaning xIdleTaskHandle is not used anywhere else. */
     ( void ) xIdleTaskHandle;
+    
+    /* OpenOCD makes use of uxTopUsedPriority for thread debugging. Prevent uxTopUsedPriority 
+     * from getting optimized out as it is no longer used by the kernel. */
+    ( void ) uxTopUsedPriority;
 }
 /*-----------------------------------------------------------*/
 

--- a/tasks.c
+++ b/tasks.c
@@ -378,7 +378,11 @@ PRIVILEGED_DATA static volatile BaseType_t xNumOfOverflows = ( BaseType_t ) 0;
 PRIVILEGED_DATA static UBaseType_t uxTaskNumber = ( UBaseType_t ) 0U;
 PRIVILEGED_DATA static volatile TickType_t xNextTaskUnblockTime = ( TickType_t ) 0U; /* Initialised to portMAX_DELAY before the scheduler starts. */
 PRIVILEGED_DATA static TaskHandle_t xIdleTaskHandle = NULL;                          /*< Holds the handle of the idle task.  The idle task is created automatically when the scheduler is started. */
-const UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
+
+/* Improve support for OpenOCD. The kernel tracks Ready tasks via priority lists.
+ * For tracking the state of remote threads, OpenOCD uses uxTopUsedPriority
+ * to determine the number of priority lists to read back from the remote target. */
+const volatile UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
 
 /* Context switches are held pending while the scheduler is suspended.  Also,
  * interrupts must not manipulate the xStateListItem of a TCB, or any of the


### PR DESCRIPTION
Description
-----------
Re-introduce `uxTopUsedPriority` for use by OpenOCD. 

The kernel tracks _Ready_ tasks via priority lists. For tracking the state of remote threads, OpenOCD uses `uxTopUsedPriority` to determine the number of priority lists to read back from the remote target. 

See OpenOCD's [FreeRTOS.c](https://sourceforge.net/p/openocd/code/ci/master/tree/src/rtos/FreeRTOS.c)

Test Steps
-----------
Build any project and verify the presence of `uxTopUsedPriority` in the executable's symbol table. 

To exercise OpenOCD awareness of FreeRTOS threads, add `-rtos FreeRTOS` in your call to `configure` within your `openocd.cfg` config file. 

**example-openocd.cfg** (snippet):
```cfg
$_TARGETNAME.0 configure -rtos FreeRTOS -work-area-phys 0x80000000 -work-area-size 0x4000 -work-area-backup 0
```

Note, OpenOCD does not support `-rtos FreeRTOS` for all its architectures. See [FreeRTOS.c::FreeRTOS_params_list](https://sourceforge.net/p/openocd/code/ci/master/tree/src/rtos/FreeRTOS.c#l55)

Related Issue
-----------

- Issue #33 


-----------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
