### PR TITLE
Fix: interrupt enabling at the end of vTaskExitCritical

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -4367,7 +4367,7 @@ static void prvResetNextTaskUnblockTime( void )
         }
         else
         {
-            mtCOVERAGE_TEST_MARKER();
+            portENABLE_INTERRUPTS();
         }
     }
 


### PR DESCRIPTION
Fix: interrupt enabling at the end of vTaskExitCritical

Description
-----------
When xSchedulerRunning is false interrupts are always disabled in vTaskExitCritical. Adds portENABLE_INTERRUPTS() in vTaskExitCritical when scheduling is false.

Test Steps
-----------
Call malloc() before scheduling, the interrupt will be disabled.

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
