### PR TITLE
Make FreeRTOSConfig.h and MPU port changes for xTaskCreateUntil updates.

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -126,8 +126,28 @@
     #define INCLUDE_vTaskSuspend    0
 #endif
 
-#ifndef INCLUDE_vTaskDelayUntil
-    #define INCLUDE_vTaskDelayUntil    0
+#ifdef INCLUDE_xTaskDelayUntil
+    #ifdef INCLUDE_vTaskDelayUntil
+        /* INCLUDE_vTaskDelayUntil was replaced by INCLUDE_xTaskDelayUntil.  Backward
+         * compatibility is maintained if only one or the other is defined, but
+         * there is a conflict if both are defined. */
+        #error INCLUDE_vTaskDelayUntil and INCLUDE_xTaskDelayUntil are both defined.  INCLUDE_vTaskDelayUntil is no longer required and should be removed
+    #endif
+#endif
+
+#ifndef INCLUDE_xTaskDelayUntil
+    #ifdef INCLUDE_vTaskDelayUntil
+        /* If INCLUDE_vTaskDelayUntil is set but INCLUDE_xTaskDelayUntil is not then
+         * the project's FreeRTOSConfig.h probably pre-dates the introduction of
+         * xTaskDelayUntil and setting INCLUDE_xTaskDelayUntil to whatever
+         * INCLUDE_vTaskDelayUntil is set to will ensure backward compatibility.
+         */
+        #define INCLUDE_xTaskDelayUntil INCLUDE_vTaskDelayUntil
+    #endif
+#endif
+
+#ifndef INCLUDE_xTaskDelayUntil
+    #define INCLUDE_xTaskDelayUntil    0
 #endif
 
 #ifndef INCLUDE_vTaskDelay

--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -58,7 +58,7 @@ void MPU_vTaskAllocateMPURegions( TaskHandle_t xTask,
                                   const MemoryRegion_t * const pxRegions ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskDelete( TaskHandle_t xTaskToDelete ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskDelay( const TickType_t xTicksToDelay ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
+BaseType_t MPU_xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
                           const TickType_t xTimeIncrement ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskAbortDelay( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
 UBaseType_t MPU_uxTaskPriorityGet( const TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -51,7 +51,7 @@
         #define vTaskAllocateMPURegions                MPU_vTaskAllocateMPURegions
         #define vTaskDelete                            MPU_vTaskDelete
         #define vTaskDelay                             MPU_vTaskDelay
-        #define vTaskDelayUntil                        MPU_vTaskDelayUntil
+        #define xTaskDelayUntil                        MPU_xTaskDelayUntil
         #define xTaskAbortDelay                        MPU_xTaskAbortDelay
         #define uxTaskPriorityGet                      MPU_uxTaskPriorityGet
         #define eTaskGetState                          MPU_eTaskGetState

--- a/include/task.h
+++ b/include/task.h
@@ -750,7 +750,7 @@ void vTaskDelete( TaskHandle_t xTaskToDelete ) PRIVILEGED_FUNCTION;
  * of controlling the frequency of a periodic task as the path taken through the
  * code, as well as other task and interrupt activity, will effect the frequency
  * at which vTaskDelay() gets called and therefore the time at which the task
- * next executes.  See vTaskDelayUntil() for an alternative API function designed
+ * next executes.  See xTaskDelayUntil() for an alternative API function designed
  * to facilitate fixed frequency execution.  It does this by specifying an
  * absolute time (rather than a relative time) at which the calling task should
  * unblock.
@@ -784,7 +784,7 @@ void vTaskDelay( const TickType_t xTicksToDelay ) PRIVILEGED_FUNCTION;
  * BaseType_t xTaskDelayUntil( TickType_t *pxPreviousWakeTime, const TickType_t xTimeIncrement );
  * </pre>
  *
- * INCLUDE_vTaskDelayUntil must be defined as 1 for this function to be available.
+ * INCLUDE_xTaskDelayUntil must be defined as 1 for this function to be available.
  * See the configuration section for more information.
  *
  * Delay a task until a specified time.  This function can be used by periodic
@@ -802,8 +802,8 @@ void vTaskDelay( const TickType_t xTicksToDelay ) PRIVILEGED_FUNCTION;
  * is called, xTaskDelayUntil () specifies the absolute (exact) time at which it wishes to
  * unblock.
  *
- * The constant portTICK_PERIOD_MS can be used to calculate real time from the tick
- * rate - with the resolution of one tick period.
+ * The macro pdMS_TO_TICKS() can be used to calculate the number of ticks from a
+ * time specified in milliseconds with a resolution of one tick period.
  *
  * @param pxPreviousWakeTime Pointer to a variable that holds the time at which the
  * task was last unblocked.  The variable must be initialised with the current time
@@ -846,6 +846,10 @@ void vTaskDelay( const TickType_t xTicksToDelay ) PRIVILEGED_FUNCTION;
 BaseType_t xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
                             const TickType_t xTimeIncrement ) PRIVILEGED_FUNCTION;
 
+/*
+ * vTaskDelayUntil() is the older version of xTaskDelayUntil() and does not
+ * return a value.
+ */
 #define vTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )       \
 {                                                                   \
     ( void ) xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement ); \
@@ -1311,7 +1315,7 @@ void vTaskEndScheduler( void ) PRIVILEGED_FUNCTION;
  * made.
  *
  * API functions that have the potential to cause a context switch (for example,
- * vTaskDelayUntil(), xQueueSend(), etc.) must not be called while the scheduler
+ * xTaskDelayUntil(), xQueueSend(), etc.) must not be called while the scheduler
  * is suspended.
  *
  * Example usage:

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -171,14 +171,16 @@ void MPU_vTaskAllocateMPURegions( TaskHandle_t xTask,
 #endif
 /*-----------------------------------------------------------*/
 
-#if ( INCLUDE_vTaskDelayUntil == 1 )
-    void MPU_vTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
-                              TickType_t xTimeIncrement ) /* FREERTOS_SYSTEM_CALL */
+#if ( INCLUDE_xTaskDelayUntil == 1 )
+    BaseType_t MPU_xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
+                                    TickType_t xTimeIncrement ) /* FREERTOS_SYSTEM_CALL */
     {
         BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn;
 
-        vTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
+        xReturn = xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
         vPortResetPrivilege( xRunningPrivileged );
+        return xReturn;
     }
 #endif
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -1244,10 +1244,10 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
 #endif /* INCLUDE_vTaskDelete */
 /*-----------------------------------------------------------*/
 
-#if ( INCLUDE_vTaskDelayUntil == 1 )
+#if ( INCLUDE_xTaskDelayUntil == 1 )
 
     BaseType_t xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
-                          const TickType_t xTimeIncrement )
+                                const TickType_t xTimeIncrement )
     {
         TickType_t xTimeToWake;
         BaseType_t xAlreadyYielded, xShouldDelay = pdFALSE;
@@ -1324,11 +1324,11 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
         {
             mtCOVERAGE_TEST_MARKER();
         }
-        
+
         return xShouldDelay;
     }
 
-#endif /* INCLUDE_vTaskDelayUntil */
+#endif /* INCLUDE_xTaskDelayUntil */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskDelay == 1 )
@@ -2100,8 +2100,8 @@ void vTaskStartScheduler( void )
     /* Prevent compiler warnings if INCLUDE_xTaskGetIdleTaskHandle is set to 0,
      * meaning xIdleTaskHandle is not used anywhere else. */
     ( void ) xIdleTaskHandle;
-    
-    /* OpenOCD makes use of uxTopUsedPriority for thread debugging. Prevent uxTopUsedPriority 
+
+    /* OpenOCD makes use of uxTopUsedPriority for thread debugging. Prevent uxTopUsedPriority
      * from getting optimized out as it is no longer used by the kernel. */
     ( void ) uxTopUsedPriority;
 }


### PR DESCRIPTION
Description
-----------
Recently vTaskDelayUntil() was updated to xTaskDelayUntil() because the function now returns a value.  The PR didn't make the same change in the MPU port, or update the constants required to include the xTaskDelayUntil() function in the build.

This PR:
Changes the INCLUDE_vTaskDelayUntil compile time constant to INCLUDE_xTaskDelayUntil.
Updates FreeRTOS.h to ensure backward compatibility for projects that already have INCLUDE_vTaskDelayUntil defined.
Updates the MPU prototypes, wrapper and implementation to use the updated xTaskDelayUntil() function.

Related Issues
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/198


Test Steps
-----------
Tests to be checked into the FreeRTOS/FreeRTOS repository after this PR and consist of updates to the standard tests/demos.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
