### PR TITLE
Fix: C++ compiler warning

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -129,7 +129,7 @@ typedef struct xMEMORY_REGION
 typedef struct xTASK_PARAMETERS
 {
     TaskFunction_t pvTaskCode;
-    const char * const pcName;     /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+    const char * pcName;     /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
     configSTACK_DEPTH_TYPE usStackDepth;
     void * pvParameters;
     UBaseType_t uxPriority;


### PR DESCRIPTION
Fix C++ compiler warning when compiling task.h

Description
-----------
The Keil C166 EC++ compiler throws an error for each compilation unit that includes the task.h header file

Related Issue
-----------
#35 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
