### PR TITLE
Fix missed yield in xTaskResumeFromISR

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -1949,6 +1949,11 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
                     if( pxTCB->uxPriority >= pxCurrentTCB->uxPriority )
                     {
                         xYieldRequired = pdTRUE;
+
+                        /* Mark that a yield is pending in case the user is not
+                         * using the return value to initiate a context switch
+                         * from the ISR using portYIELD_FROM_ISR. */
+                        xYieldPending = pdTRUE;
                     }
                     else
                     {


### PR DESCRIPTION
Description
-----------

If a higher priority task than the currently running task was resumed using `xTaskResumeFromISR` and the user chose to ignore the return value of `xTaskResumeFromISR` to initiate a context switch using `portYIELD_FROM_ISR`, we were not doing the context switch on the next run of the scheduler. This change fixes this by marking a yield as pending to ensure that the context switch is performed on the next run of the scheduler.

Related Issue
-----------
https://forums.freertos.org/t/issue-resuming-and-sending-a-message-to-a-task-from-an-isr-cortex-m4/10957/14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
