### PR TITLE
Fix: Pass lexicon.txt as a parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           PATH=$PATH:main/tools/spell
           # Make sure that the portable directory is not included in the spellcheck.
           sed -i 's/find $DIRNAME/find $DIRNAME -not -path '*portable*'/g' main/tools/spell/find-unknown-comment-words
-          find-unknown-comment-words --directory kernel/ --lexicon ./github/lexicon.txt
+          find-unknown-comment-words --directory kernel/ --lexicon ./kernel/.github/lexicon.txt
           if [ "$?" = "0" ]; then
             exit 0
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           PATH=$PATH:main/tools/spell
           # Make sure that the portable directory is not included in the spellcheck.
           sed -i 's/find $DIRNAME/find $DIRNAME -not -path '*portable*'/g' main/tools/spell/find-unknown-comment-words
-          find-unknown-comment-words --directory kernel/
+          find-unknown-comment-words --directory kernel/ --lexicon ./github/lexicon.txt
           if [ "$?" = "0" ]; then
             exit 0
           else


### PR DESCRIPTION
Pass lexicon.txt as a parameter

Description
-----------
Pass lexicon as a parameter so that when it is not in its default optional location, it would fail the ci spell-check job, instead of just printing a list of words

Test Steps
-----------
Ci fails when a bad path is passed: 
```
Error: Process completed with exit code 1.
```
When passed the correct location
```
  shell: /bin/bash -e {0}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
