### PR TITLE
Upstream stack masking fix to GCC ports.

### DIFF
--- a/portable/ThirdParty/GCC/Xtensa_ESP32/port.c
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/port.c
@@ -176,7 +176,7 @@ void _xt_user_exit( void );
     #endif
 
     /* Create interrupt stack frame aligned to 16 byte boundary */
-    sp = ( StackType_t * ) ( ( ( UBaseType_t ) ( pxTopOfStack + 1 ) - XT_CP_SIZE - XT_STK_FRMSZ ) & ~0xf );
+    sp = ( StackType_t * ) ( ( ( UBaseType_t ) pxTopOfStack - XT_CP_SIZE - XT_STK_FRMSZ ) & ~0xf );
 
     /* Clear the entire frame (do not use memset() because we don't depend on C library) */
     for( tp = sp; tp <= pxTopOfStack; ++tp )
@@ -229,6 +229,7 @@ void _xt_user_exit( void );
          * //p = (uint32_t *) xMPUSettings->coproc_area;
          */
         p = ( uint32_t * ) ( ( ( uint32_t ) pxTopOfStack - XT_CP_SIZE ) & ~0xf );
+        configASSERT( ( uint32_t ) p >= frame->a1 );
         p[ 0 ] = 0;
         p[ 1 ] = 0;
         p[ 2 ] = ( ( ( uint32_t ) p ) + 12 + XCHAL_TOTAL_SA_ALIGN - 1 ) & -XCHAL_TOTAL_SA_ALIGN;
@@ -319,7 +320,9 @@ void vPortYieldOtherCore( BaseType_t coreid )
                                     uint32_t usStackDepth )
     {
         #if XCHAL_CP_NUM > 0
-            xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( ( uint32_t ) ( pxBottomOfStack + usStackDepth - 1 ) ) - XT_CP_SIZE ) & ~0xf );
+            xMPUSettings->coproc_area = ( StackType_t * ) ( ( uint32_t ) ( pxBottomOfStack + usStackDepth - 1 ));
+            xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) xMPUSettings->coproc_area ) & ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
+            xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( uint32_t ) xMPUSettings->coproc_area - XT_CP_SIZE ) & ~0xf );
 
 
             /* NOTE: we cannot initialize the coprocessor save area here because FreeRTOS is going to

--- a/portable/ThirdParty/GCC/Xtensa_ESP32_IDF3/port.c
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32_IDF3/port.c
@@ -157,7 +157,7 @@ void _xt_user_exit( void );
     #endif
 
     /* Create interrupt stack frame aligned to 16 byte boundary */
-    sp = ( StackType_t * ) ( ( ( UBaseType_t ) ( pxTopOfStack + 1 ) - XT_CP_SIZE - XT_STK_FRMSZ ) & ~0xf );
+    sp = ( StackType_t * ) ( ( ( UBaseType_t ) pxTopOfStack - XT_CP_SIZE - XT_STK_FRMSZ ) & ~0xf );
 
     /* Clear the entire frame (do not use memset() because we don't depend on C library) */
     for( tp = sp; tp <= pxTopOfStack; ++tp )
@@ -196,6 +196,7 @@ void _xt_user_exit( void );
          * //p = (uint32_t *) xMPUSettings->coproc_area;
          */
         p = ( uint32_t * ) ( ( ( uint32_t ) pxTopOfStack - XT_CP_SIZE ) & ~0xf );
+        configASSERT( ( uint32_t ) p >= frame->a1 );
         p[ 0 ] = 0;
         p[ 1 ] = 0;
         p[ 2 ] = ( ( ( uint32_t ) p ) + 12 + XCHAL_TOTAL_SA_ALIGN - 1 ) & -XCHAL_TOTAL_SA_ALIGN;
@@ -286,9 +287,11 @@ void vPortYieldOtherCore( BaseType_t coreid )
                                     uint32_t usStackDepth )
     {
         #if XCHAL_CP_NUM > 0
-            xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( ( uint32_t ) ( pxBottomOfStack + usStackDepth - 1 ) ) - XT_CP_SIZE ) & ~0xf );
+            xMPUSettings->coproc_area = ( StackType_t * ) ( ( uint32_t ) ( pxBottomOfStack + usStackDepth - 1 ));
+            xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) xMPUSettings->coproc_area ) & ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
+            xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( uint32_t ) xMPUSettings->coproc_area - XT_CP_SIZE ) & ~0xf );
 
-
+                
             /* NOTE: we cannot initialize the coprocessor save area here because FreeRTOS is going to
              * clear the stack area after we return. This is done in pxPortInitialiseStack().
              */

--- a/portable/ThirdParty/XCC/Xtensa/port.c
+++ b/portable/ThirdParty/XCC/Xtensa/port.c
@@ -220,7 +220,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
     #if XCHAL_CP_NUM > 0
         xMPUSettings->coproc_area = ( StackType_t * ) ( ( uint32_t ) ( pxBottomOfStack + ulStackDepth - 1 ));
         xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) xMPUSettings->coproc_area ) & ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
-        xMPUSettings->coproc_area = ( Stacktype_t * ) ( ( ( uint32_t ) xMPUSettings->coproc_area - XT_CP_SIZE ) & ~0xf );
+        xMPUSettings->coproc_area = ( StackType_t * ) ( ( ( uint32_t ) xMPUSettings->coproc_area - XT_CP_SIZE ) & ~0xf );
 
         /* NOTE: we cannot initialize the coprocessor save area here because FreeRTOS is going to
          * clear the stack area after we return. This is done in pxPortInitialiseStack().


### PR DESCRIPTION
Upstream stack masking fix to GCC ports.

Description
-----------
Fixes a compiler error on XCC port and applies #117 and #118 to GCC ports.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
