### PR TITLE
porthardware.h file update for AVR Mega0 and Dx

### DIFF
--- a/portable/IAR/AVR_AVRDx/porthardware.h
+++ b/portable/IAR/AVR_AVRDx/porthardware.h
@@ -1,7 +1,9 @@
 #ifndef PORTHARDWARE_H
 #define PORTHARDWARE_H
 
-#include <ioavr.h>
+#ifndef __IAR_SYSTEMS_ASM__
+    #include <ioavr.h>
+#endif
 #include "FreeRTOSConfig.h"
 
 /*-----------------------------------------------------------*/

--- a/portable/IAR/AVR_Mega0/porthardware.h
+++ b/portable/IAR/AVR_Mega0/porthardware.h
@@ -1,7 +1,9 @@
 #ifndef PORTHARDWARE_H
 #define PORTHARDWARE_H
 
-#include <ioavr.h>
+#ifndef __IAR_SYSTEMS_ASM__
+    #include <ioavr.h>
+#endif
 #include "FreeRTOSConfig.h"
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
porthardware.h file update for AVR Mega0 and Dx

Description
-----------
Solved warnings caused by multiple ioavr.h includes.

Test Steps
-----------
When compiling there are no warnings related to double inclusion of ioavr.h file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
