### PR TITLE
Ensure interrupts are enabled at first task start

### DIFF
--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
@@ -84,6 +84,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r4											\n"/* Finally, branch to EXC_RETURN. */
         #else /* configENABLE_MPU */
             "	ldm  r0!, {r1-r3}								\n"/* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
@@ -95,6 +97,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r3											\n"/* Finally, branch to EXC_RETURN. */
         #endif /* configENABLE_MPU */
         "													\n"

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
@@ -82,6 +82,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r3											\n"/* Finally, branch to EXC_RETURN. */
         #else /* configENABLE_MPU */
             "	ldm  r0!, {r1-r2}								\n"/* Read from stack - r1 = PSPLIM and r2 = EXC_RETURN. */
@@ -91,6 +93,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r2											\n"/* Finally, branch to EXC_RETURN. */
         #endif /* configENABLE_MPU */
         "													\n"

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
@@ -128,6 +128,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r4									/* Finally, branch to EXC_RETURN. */
 #else /* configENABLE_MPU */
 	ldm  r0!, {r1-r3}						/* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
@@ -139,6 +141,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r3									/* Finally, branch to EXC_RETURN. */
 #endif /* configENABLE_MPU */
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
@@ -116,6 +116,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r3									/* Finally, branch to EXC_RETURN. */
 #else /* configENABLE_MPU */
 	ldm  r0!, {r1-r2}						/* Read from stack - r1 = PSPLIM and r2 = EXC_RETURN. */
@@ -125,6 +127,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r2									/* Finally, branch to EXC_RETURN. */
 #endif /* configENABLE_MPU */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *		configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
+/* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                          StackType_t * pxEndOfStack,
@@ -888,6 +888,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                                          TaskFunction_t pxCode,
                                          void * pvParameters ) /* PRIVILEGED_FUNCTION */
 #endif /* configENABLE_MPU */
+/* *INDENT-ON* */
 {
     /* Simulate the stack frame as it would be created by a context switch
      * interrupt. */

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *      configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *      configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *      configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,6 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
 /* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *		configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,6 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
 /* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,

--- a/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -84,6 +84,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r4											\n"/* Finally, branch to EXC_RETURN. */
         #else /* configENABLE_MPU */
             "	ldm  r0!, {r1-r3}								\n"/* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
@@ -95,6 +97,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r3											\n"/* Finally, branch to EXC_RETURN. */
         #endif /* configENABLE_MPU */
         "													\n"

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *		configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,6 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
 /* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
@@ -887,7 +886,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                          StackType_t * pxEndOfStack,
                                          TaskFunction_t pxCode,
-                                         void * pvParameters )       /* PRIVILEGED_FUNCTION */
+                                         void * pvParameters ) /* PRIVILEGED_FUNCTION */
 #endif /* configENABLE_MPU */
 /* *INDENT-ON* */
 {

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -82,6 +82,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r3											\n"/* Finally, branch to EXC_RETURN. */
         #else /* configENABLE_MPU */
             "	ldm  r0!, {r1-r2}								\n"/* Read from stack - r1 = PSPLIM and r2 = EXC_RETURN. */
@@ -91,6 +93,8 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	adds r0, #32									\n"/* Discard everything up to r0. */
             "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
             "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
             "	bx   r2											\n"/* Finally, branch to EXC_RETURN. */
         #endif /* configENABLE_MPU */
         "													\n"

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *		configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,6 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
 /* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *		configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,6 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
 /* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *		configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,6 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
 /* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,

--- a/portable/IAR/ARM_CM33/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM33/non_secure/portasm.s
@@ -128,6 +128,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r4									/* Finally, branch to EXC_RETURN. */
 #else /* configENABLE_MPU */
 	ldm  r0!, {r1-r3}						/* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
@@ -139,6 +141,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r3									/* Finally, branch to EXC_RETURN. */
 #endif /* configENABLE_MPU */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -54,13 +54,13 @@
  * on the secure side. The following are the valid configuration seetings:
  *
  * 1. Run FreeRTOS on the Secure Side:
- *		configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
  *
  * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
  *
  * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
- *		configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
  */
 #if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
     #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
@@ -875,7 +875,6 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
     }
 }
 /*-----------------------------------------------------------*/
-
 /* *INDENT-OFF* */
 #if ( configENABLE_MPU == 1 )
     StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
@@ -116,6 +116,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r3									/* Finally, branch to EXC_RETURN. */
 #else /* configENABLE_MPU */
 	ldm  r0!, {r1-r2}						/* Read from stack - r1 = PSPLIM and r2 = EXC_RETURN. */
@@ -125,6 +127,8 @@ vRestoreContextOfFirstTask:
 	adds r0, #32							/* Discard everything up to r0. */
 	msr  psp, r0							/* This is now the new top of stack to use in the task. */
 	isb
+	mov  r0, #0
+	msr  basepri, r0						/* Ensure that interrupts are enabled when the first task starts. */
 	bx   r2									/* Finally, branch to EXC_RETURN. */
 #endif /* configENABLE_MPU */
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------

Critical sections in FreeRTOS are implemented using the following two functions:

```c
void vPortEnterCritical( void )
{
    portDISABLE_INTERRUPTS();
    uxCriticalNesting++;
}

void vPortExitCritical( void )
{
    uxCriticalNesting--;

    if( uxCriticalNesting == 0 )
    {
        portENABLE_INTERRUPTS();
    }
}
```

`uxCriticalNesting` is initialized to a large value at the start and set to zero when the scheduler is started (`xPortStartScheduler`). As a result, before the scheduler is started, a pair of enter/exit critical section will leave the interrupts disabled because `uxCriticalNesting` will not reach zero in the `vPortExitCritical` function. This is done to ensure that the interrupts remain disabled from the time first FreeRTOS API is called to the time when the scheduler is started. The scheduler starting code is expected to enure that interrupts are enabled before the first task starts executing.

Cortex-M33 ports were not enabling interrupts before starting the first task and as a result, the first task was started with interrupts disabled. This PR fixes the issue by ensuring that interrupts are enabled before the first task is started.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
