### PR TITLE
Add kernel header check workflow

### DIFF
--- a/.github/workflows/header-checks.yml
+++ b/.github/workflows/header-checks.yml
@@ -1,0 +1,46 @@
+name: FreeRTOS-Header-Checker
+
+on: [pull_request]          
+
+jobs:
+  header-checker:
+    name: File Header Checks
+    runs-on: ubuntu-latest
+    steps:
+      # Install python 3
+      - name: Tool Setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8.5
+          architecture:   x64  
+        env:  
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      
+      # Get latest checks from master
+      - name: Checkout FreeRTOS Tools
+        uses: actions/checkout@v2
+        with:
+          repository: FreeRTOS/FreeRTOS 
+          ref:  master
+          path: tools
+
+      # Checkout user pull request changes
+      - name: Checkout Pull Request
+        uses: actions/checkout@v2
+        with:
+          ref:  ${{ github.event.pull_request.head.sha }}
+          path: inspect  
+          
+      # Collect all affected files
+      - name: Collecting changed files
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      # Run checks     
+      - name: Check File Headers
+        run: |
+          cd inspect
+          ../tools/.github/scripts/check-header.py --kernel --json ${HOME}/files.json
+          exit $?
+                  


### PR DESCRIPTION
Similar to https://github.com/FreeRTOS/FreeRTOS/pull/408.
Except no need to add script as it's sourced from `FreeRTOS/FreeRTOS`.
The workflow is only _slightly_ different in that it adds `--kernel` option to header checker (Different headers for kernel)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
