### PR TITLE
Improve heap2 bounds checking

### DIFF
--- a/portable/MemMang/heap_1.c
+++ b/portable/MemMang/heap_1.c
@@ -22,7 +22,6 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 

--- a/portable/MemMang/heap_1.c
+++ b/portable/MemMang/heap_1.c
@@ -72,16 +72,18 @@ void * pvPortMalloc( size_t xWantedSize )
     void * pvReturn = NULL;
     static uint8_t * pucAlignedHeap = NULL;
 
-    /* Ensure that blocks are always aligned to the required number of bytes. */
+    /* Ensure that blocks are always aligned. */
     #if ( portBYTE_ALIGNMENT != 1 )
         {
             if( xWantedSize & portBYTE_ALIGNMENT_MASK )
             {
-                /* Byte alignment required, check for overflow first */
+                /* Byte alignment required. Check for overflow. */
                 if ( (xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) )) > xWantedSize )
                 {
                     xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
-                } else {
+                } 
+                else 
+                {
                     xWantedSize = 0;
                 }
             }

--- a/portable/MemMang/heap_1.c
+++ b/portable/MemMang/heap_1.c
@@ -77,8 +77,13 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             if( xWantedSize & portBYTE_ALIGNMENT_MASK )
             {
-                /* Byte alignment required. */
-                xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+                /* Byte alignment required, check for overflow first */
+                if ( (xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) )) > xWantedSize )
+                {
+                    xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+                } else {
+                    xWantedSize = 0;
+                }
             }
         }
     #endif
@@ -91,8 +96,9 @@ void * pvPortMalloc( size_t xWantedSize )
             pucAlignedHeap = ( uint8_t * ) ( ( ( portPOINTER_SIZE_TYPE ) & ucHeap[ portBYTE_ALIGNMENT ] ) & ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
         }
 
-        /* Check there is enough room left for the allocation. */
-        if( ( ( xNextFreeByte + xWantedSize ) < configADJUSTED_HEAP_SIZE ) &&
+        /* Check there is enough room left for the allocation and. */
+        if( ( xWantedSize > 0 ) && /* valid size */
+            ( ( xNextFreeByte + xWantedSize ) < configADJUSTED_HEAP_SIZE ) &&
             ( ( xNextFreeByte + xWantedSize ) > xNextFreeByte ) ) /* Check for overflow. */
         {
             /* Return the next free byte then increment the index past this

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -22,7 +22,6 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 /*

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -139,7 +139,7 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             xWantedSize += heapSTRUCT_SIZE;
 
-            /* Byte alignment required. (check for overflow again) */
+            /* Byte alignment required. Check for overflow. */
             if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
                     > xWantedSize )
             {
@@ -150,8 +150,9 @@ void * pvPortMalloc( size_t xWantedSize )
             {
                 xWantedSize = 0;
             }       
-        } else {
-            /* If the requested size is too large to handle we force an error */
+        }
+        else 
+        {
             xWantedSize = 0; 
         }
 

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -138,7 +138,7 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             /* Ensure xWantedSize will never wrap after adjustment, even if we need
              * an alignment adjustment */
-            if ( xWantedSize < ( SIZE_MAX - heapSTRUCT_SIZE - portBYTE_ALIGNMENT - 1) )
+            if( ( xWantedSize > 0 ) && ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) )
             {
                 xWantedSize += heapSTRUCT_SIZE;
 
@@ -154,7 +154,7 @@ void * pvPortMalloc( size_t xWantedSize )
             }
         }
 
-        if( xWantedSize > 0 )
+        if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
         {
             /* Blocks are stored in byte order - traverse the list from the start
              * (smallest) block until one of adequate size is found. */

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -134,7 +134,7 @@ void * pvPortMalloc( size_t xWantedSize )
         /* The wanted size must be increased so it can contain a BlockLink_t
          * structure in addition to the requested amount of bytes. */
         if( ( xWantedSize > 0 ) && 
-            ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) ) /* Overflow check */
+            ( ( xWantedSize + heapSTRUCT_SIZE ) >  xWantedSize ) ) /* Overflow check */
         {
             xWantedSize += heapSTRUCT_SIZE;
 

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -125,7 +125,7 @@ void * pvPortMalloc( size_t xWantedSize )
     vTaskSuspendAll();
     {
         /* If this is the first call to malloc then the heap will require
-         *  initialisation to setup the list of free blocks. */
+         * initialisation to setup the list of free blocks. */
         if( xHeapHasBeenInitialised == pdFALSE )
         {
             prvHeapInit();
@@ -133,7 +133,7 @@ void * pvPortMalloc( size_t xWantedSize )
         }
 
         /* The wanted size must be increased so it can contain a BlockLink_t
-         *  structure in addition to the requested amount of bytes. */
+         * structure in addition to the requested amount of bytes. */
         if( xWantedSize > 0 )
         {
             /* Ensure xWantedSize will never wrap after adjustment, even if we need

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -136,44 +136,36 @@ void * pvPortMalloc( size_t xWantedSize )
          * kernel, so it must be free. */
         if( ( xWantedSize & xBlockAllocatedBit ) == 0 )
         {
-            /* The wanted size is increased so it can contain a BlockLink_t
+            /* The wanted size must be increased so it can contain a BlockLink_t
              * structure in addition to the requested amount of bytes. */
-            if( xWantedSize > 0 )
+            if( ( xWantedSize > 0 ) && 
+                ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) ) /* Overflow check */
             {
-                /* Check for overflow */
-                if ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) 
-                {
-                    xWantedSize += xHeapStructSize;
+                xWantedSize += xHeapStructSize;
 
-                    /* Ensure that blocks are always aligned to the required number
-                     * of bytes. */
-                    if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
+                /* Ensure that blocks are always aligned */
+                if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
+                {
+                    /* Byte alignment required. (check for overflow again) */
+                    if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
+                            > xWantedSize )
                     {
-                        /* Byte alignment required. (check for overflow again) */
-                        if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
-                             > xWantedSize )
-                        {
-                            xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
-                            configASSERT( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) == 0 );
-                        }
-                        else
-                        {
-                            xWantedSize = 0;
-                        }  
+                        xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+                        configASSERT( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) == 0 );
                     }
                     else
                     {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
-                } 
-                else 
-                {
-                    xWantedSize = 0;
+                        xWantedSize = 0;
+                    }  
                 }
-            }
-            else
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+            } 
+            else 
             {
-                mtCOVERAGE_TEST_MARKER();
+                xWantedSize = 0;
             }
 
             if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -176,7 +176,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 mtCOVERAGE_TEST_MARKER();
             }
 
-            if( ( xWantedSize > 0 ) && ( xWantedSize < xFreeBytesRemaining ) )
+            if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
             {
                 /* Traverse the list from the start	(lowest address) block until
                  * one of adequate size is found. */

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -143,10 +143,10 @@ void * pvPortMalloc( size_t xWantedSize )
             {
                 xWantedSize += xHeapStructSize;
 
-                /* Ensure that blocks are always aligned */
+                /* Ensure that blocks are always aligned. */
                 if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
                 {
-                    /* Byte alignment required. (check for overflow again) */
+                    /* Byte alignment required. Check for overflow. */
                     if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
                             > xWantedSize )
                     {

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -146,7 +146,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     xWantedSize += xHeapStructSize;
 
                     /* Ensure that blocks are always aligned to the required number
-                    * of bytes. */
+                     * of bytes. */
                     if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
                     {
                         /* Byte alignment required. (check for overflow again) */
@@ -179,7 +179,7 @@ void * pvPortMalloc( size_t xWantedSize )
             if( ( xWantedSize > 0 ) && ( xWantedSize < xFreeBytesRemaining ) )
             {
                 /* Traverse the list from the start	(lowest address) block until
-                 * one	of adequate size is found. */
+                 * one of adequate size is found. */
                 pxPreviousBlock = &xStart;
                 pxBlock = xStart.pxNextFreeBlock;
 
@@ -190,7 +190,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
 
                 /* If the end marker was reached then a block of adequate size
-                 * was	not found. */
+                 * was not found. */
                 if( pxBlock != pxEnd )
                 {
                     /* Return the memory space pointed to - jumping over the

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -22,7 +22,6 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 /*

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -150,7 +150,7 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             /* The wanted size is increased so it can contain a BlockLink_t
              * structure in addition to the requested amount of bytes. */
-            if( xWantedSize > 0 )
+            if( ( xWantedSize > 0 ) && ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) )
             {
                 xWantedSize += xHeapStructSize;
 
@@ -159,7 +159,15 @@ void * pvPortMalloc( size_t xWantedSize )
                 if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
                 {
                     /* Byte alignment required. */
-                    xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+                    if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) >
+                         xWantedSize )
+                    {
+                        xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+                    } 
+                    else 
+                    {
+                        xWantedSize = 0;
+                    }
                 }
                 else
                 {
@@ -168,10 +176,10 @@ void * pvPortMalloc( size_t xWantedSize )
             }
             else
             {
-                mtCOVERAGE_TEST_MARKER();
+                xWantedSize = 0;
             }
 
-            if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
+            if( ( xWantedSize > 0 ) && ( xWantedSize < xFreeBytesRemaining ) )
             {
                 /* Traverse the list from the start	(lowest address) block until
                  * one	of adequate size is found. */

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -179,7 +179,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 xWantedSize = 0;
             }
 
-            if( ( xWantedSize > 0 ) && ( xWantedSize < xFreeBytesRemaining ) )
+            if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
             {
                 /* Traverse the list from the start	(lowest address) block until
                  * one of adequate size is found. */

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -150,15 +150,15 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             /* The wanted size is increased so it can contain a BlockLink_t
              * structure in addition to the requested amount of bytes. */
-            if( ( xWantedSize > 0 ) && ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) )
+            if( ( xWantedSize > 0 ) && 
+                ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) ) /* Overflow check */
             {
                 xWantedSize += xHeapStructSize;
 
-                /* Ensure that blocks are always aligned to the required number
-                 * of bytes. */
+                /* Ensure that blocks are always aligned */
                 if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
                 {
-                    /* Byte alignment required. */
+                    /* Byte alignment required. Check for overflow */
                     if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) >
                          xWantedSize )
                     {

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -182,7 +182,7 @@ void * pvPortMalloc( size_t xWantedSize )
             if( ( xWantedSize > 0 ) && ( xWantedSize < xFreeBytesRemaining ) )
             {
                 /* Traverse the list from the start	(lowest address) block until
-                 * one	of adequate size is found. */
+                 * one of adequate size is found. */
                 pxPreviousBlock = &xStart;
                 pxBlock = xStart.pxNextFreeBlock;
 
@@ -193,7 +193,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
 
                 /* If the end marker was reached then a block of adequate size
-                 * was	not found. */
+                 * was not found. */
                 if( pxBlock != pxEnd )
                 {
                     /* Return the memory space pointed to - jumping over the


### PR DESCRIPTION
This PR improves the heap2 bounds checking. There was a mostly theoretical case where an overflow could occur if the size of the requested memory block is between 4,294,967,288 and 4,294,967,296 bytes.