### PR TITLE
Add addition overflow check for stream buffer

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -258,8 +258,16 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
          * this is a quirk of the implementation that means otherwise the free
          * space would be reported as one byte smaller than would be logically
          * expected. */
-        xBufferSizeBytes++;
-        pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) ); /*lint !e9079 malloc() only returns void*. */
+        if( xBufferSizeBytes < ( xBufferSizeBytes + 1 + sizeof( StreamBuffer_t ) ) )
+        {
+            xBufferSizeBytes++;
+            pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) ); /*lint !e9079 malloc() only returns void*. */
+        }
+        else
+        {
+            pucAllocatedMemory = NULL;
+        }
+        
 
         if( pucAllocatedMemory != NULL )
         {


### PR DESCRIPTION
Add addition overflow check for stream buffer for the mostly theoretical case where you are allocating close to 4,294,967,296 bytes and the size_t rolls over.