### PR TITLE
Prevent unprivileged task from altering MPU configuration

### DIFF
--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -50,12 +50,6 @@ TaskHandle_t MPU_xTaskCreateStatic( TaskFunction_t pxTaskCode,
                                     UBaseType_t uxPriority,
                                     StackType_t * const puxStackBuffer,
                                     StaticTask_t * const pxTaskBuffer ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskCreateRestricted( const TaskParameters_t * const pxTaskDefinition,
-                                      TaskHandle_t * pxCreatedTask ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskCreateRestrictedStatic( const TaskParameters_t * const pxTaskDefinition,
-                                            TaskHandle_t * pxCreatedTask ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskAllocateMPURegions( TaskHandle_t xTask,
-                                  const MemoryRegion_t * const pxRegions ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskDelete( TaskHandle_t xTaskToDelete ) FREERTOS_SYSTEM_CALL;
 void MPU_vTaskDelay( const TickType_t xTicksToDelay ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -47,8 +47,6 @@
 /* Map standard tasks.h API functions to the MPU equivalents. */
         #define xTaskCreate                            MPU_xTaskCreate
         #define xTaskCreateStatic                      MPU_xTaskCreateStatic
-        #define xTaskCreateRestricted                  MPU_xTaskCreateRestricted
-        #define vTaskAllocateMPURegions                MPU_vTaskAllocateMPURegions
         #define vTaskDelete                            MPU_vTaskDelete
         #define vTaskDelay                             MPU_vTaskDelay
         #define xTaskDelayUntil                        MPU_xTaskDelayUntil

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -86,34 +86,6 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
-    BaseType_t MPU_xTaskCreateRestricted( const TaskParameters_t * const pxTaskDefinition,
-                                          TaskHandle_t * pxCreatedTask ) /* FREERTOS_SYSTEM_CALL */
-    {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-
-        xReturn = xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask );
-        vPortResetPrivilege( xRunningPrivileged );
-        return xReturn;
-    }
-#endif /* conifgSUPPORT_DYNAMIC_ALLOCATION */
-/*-----------------------------------------------------------*/
-
-#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-    BaseType_t MPU_xTaskCreateRestrictedStatic( const TaskParameters_t * const pxTaskDefinition,
-                                                TaskHandle_t * pxCreatedTask ) /* FREERTOS_SYSTEM_CALL */
-    {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-
-        xReturn = xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask );
-        vPortResetPrivilege( xRunningPrivileged );
-        return xReturn;
-    }
-#endif /* conifgSUPPORT_DYNAMIC_ALLOCATION */
-/*-----------------------------------------------------------*/
-
-#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     BaseType_t MPU_xTaskCreate( TaskFunction_t pvTaskCode,
                                 const char * const pcName,
                                 uint16_t usStackDepth,
@@ -148,16 +120,6 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
         return xReturn;
     }
 #endif /* configSUPPORT_STATIC_ALLOCATION */
-/*-----------------------------------------------------------*/
-
-void MPU_vTaskAllocateMPURegions( TaskHandle_t xTask,
-                                  const MemoryRegion_t * const xRegions ) /* FREERTOS_SYSTEM_CALL */
-{
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-
-    vTaskAllocateMPURegions( xTask, xRegions );
-    vPortResetPrivilege( xRunningPrivileged );
-}
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskDelete == 1 )


### PR DESCRIPTION
Description
-----------
This change removes the FreeRTOS System Calls (aka MPU wrappers) for the following kernel APIs:
- xTaskCreateRestricted
- xTaskCreateRestrictedStatic
- vTaskAllocateMPURegions

A system call allows an unprivileged task to execute a kernel API which is otherwise accessible to privileged software only. The above 3 APIs can create a new task with a different MPU configuration or alter the MPU configuration of an existing task. This an be (mis)used by an unprivileged task to grant itself access to a region which it does not have access to.

Removing the system calls for these APIs ensures that an unprivileged task cannot execute this APIs. If an unprivileged task attempts to execute any of these API, it will result in a Memory Fault.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
