### PR TITLE
Fix Github checks after move from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 jobs:
   spell-check:

--- a/.github/workflows/kernel-checks.yml
+++ b/.github/workflows/kernel-checks.yml
@@ -36,7 +36,7 @@ jobs:
         uses: lots0logs/gh-action-get-changed-files@2.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       # Run checks
       - name: Check File Headers
         run: |


### PR DESCRIPTION
Fix Github checks after move from master to main

Description
-----------
Fix Github checks after move from master to main

Test Steps
-----------
github checks should run and pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
