### PR TITLE
Remove .func and .endfunc keywords from the RISCV assembly

### DIFF
--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -117,7 +117,6 @@ at the top of this file. */
 /*-----------------------------------------------------------*/
 
 .align 8
-.func
 freertos_risc_v_trap_handler:
 	addi sp, sp, -portCONTEXT_SIZE
 	store_x x1, 1 * portWORD_SIZE( sp )
@@ -291,11 +290,9 @@ processed_source:
 	addi sp, sp, portCONTEXT_SIZE
 
 	mret
-	.endfunc
 /*-----------------------------------------------------------*/
 
 .align 8
-.func
 xPortStartFirstTask:
 
 #if( portasmHAS_SIFIVE_CLINT != 0 )
@@ -347,7 +344,6 @@ xPortStartFirstTask:
 
 	addi	sp, sp, portCONTEXT_SIZE
 	ret
-	.endfunc
 /*-----------------------------------------------------------*/
 
 /*
@@ -413,7 +409,6 @@ xPortStartFirstTask:
  * pxCode
  */
 .align 8
-.func
 pxPortInitialiseStack:
 
 	csrr t0, mstatus					/* Obtain current mstatus value. */
@@ -439,5 +434,4 @@ chip_specific_stack_frame:				/* First add any chip specific registers to the st
 	addi a0, a0, -portWORD_SIZE
 	store_x a1, 0(a0)					/* mret value (pxCode parameter) onto the stack. */
 	ret
-	.endfunc
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Clang doesn't understand `.func` and `.endfunc` keywords. Remove them, so RISCV port can be compiled. 

Related Issue
-----------
The whole file is changed, because of #245 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
