### PR TITLE
Posix: fix copyright

### DIFF
--- a/.github/scripts/kernel_checker.py
+++ b/.github/scripts/kernel_checker.py
@@ -36,6 +36,7 @@ KERNEL_IGNORED_EXTENSIONS = [
 
 KERNEL_IGNORED_PATTERNS = [
     r'.*\.git.*',
+    r'.*portable/ThirdParty/GCC/Posix/port*',
     r'.*portable.*Xtensa_ESP32\/include\/portmacro\.h',
     r'.*portable.*Xtensa_ESP32.*port\.c',
     r'.*portable.*Xtensa_ESP32.*portasm\.S',

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS Kernel V10.4.3
- * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2020 Cambridge Consultants Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -22,7 +22,6 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 


### PR DESCRIPTION
This fixes compilation error when `configENABLE_BACKWARD_COMPATIBILITY` is 0.