### PR TITLE
Code: Remove dead code

### DIFF
--- a/list.c
+++ b/list.c
@@ -192,16 +192,6 @@ UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
     /* Only used during decision coverage testing. */
     mtCOVERAGE_TEST_DELAY();
 
-    /* Make sure the index is left pointing to a valid item. */
-    if( pxList->pxIndex == pxItemToRemove )
-    {
-        pxList->pxIndex = pxItemToRemove->pxPrevious;
-    }
-    else
-    {
-        mtCOVERAGE_TEST_MARKER();
-    }
-
     pxItemToRemove->pxContainer = NULL;
     ( pxList->uxNumberOfItems )--;
 


### PR DESCRIPTION
Remove dead code in  list.c

Description
-----------
Cde in uxListRemove
```c
    if( pxList->pxIndex == pxItemToRemove )
    {
            pxList->pxIndex = pxItemToRemove->pxPrevious;
    }
```
Can never evaluate to true, as pxList->pxIndex points to ListEnd which is MiniListItem_t, and should always be present, and doesn't count towards the count of the list elements


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
