### PR TITLE
Support for optionally allocating stacks separate from the heap.

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -896,6 +896,11 @@
     #define configSUPPORT_DYNAMIC_ALLOCATION    1
 #endif
 
+#ifndef configSUPPORT_SEPARATE_STACK_ALLOCATION
+    /* Defaults to 0 for backward compatibility. */
+    #define configSUPPORT_SEPARATE_STACK_ALLOCATION 0
+#endif
+
 #ifndef configSTACK_DEPTH_TYPE
 
 /* Defaults to uint16_t for backward compatibility, but can be overridden

--- a/include/portable.h
+++ b/include/portable.h
@@ -179,6 +179,14 @@ void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetMinimumEverFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 
+#if( configSUPPORT_SEPARATE_STACK_ALLOCATION == 1 )
+    void *pvPortMallocStack( size_t xSize ) PRIVILEGED_FUNCTION;
+    void vPortFreeStack( void *pv ) PRIVILEGED_FUNCTION;
+#else
+    #define pvPortMallocStack pvPortMalloc
+    #define vPortFreeStack vPortFree
+#endif
+
 /*
  * Setup the hardware ready for the scheduler to take control.  This generally
  * sets up a tick interrupt and sets timers for the correct tick frequency.

--- a/tasks.c
+++ b/tasks.c
@@ -748,7 +748,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                     /* Allocate space for the stack used by the task being created.
                      * The base of the stack memory stored in the TCB so the task can
                      * be deleted later if required. */
-                    pxNewTCB->pxStack = ( StackType_t * ) pvPortMalloc( ( ( ( size_t ) usStackDepth ) * sizeof( StackType_t ) ) ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
+                    pxNewTCB->pxStack = ( StackType_t * ) pvPortMallocStack( ( ( ( size_t ) usStackDepth ) * sizeof( StackType_t ) ) ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
                     if( pxNewTCB->pxStack == NULL )
                     {
@@ -763,7 +763,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                 StackType_t * pxStack;
 
                 /* Allocate space for the stack used by the task being created. */
-                pxStack = pvPortMalloc( ( ( ( size_t ) usStackDepth ) * sizeof( StackType_t ) ) ); /*lint !e9079 All values returned by pvPortMalloc() have at least the alignment required by the MCU's stack and this allocation is the stack. */
+                pxStack = pvPortMallocStack( ( ( ( size_t ) usStackDepth ) * sizeof( StackType_t ) ) ); /*lint !e9079 All values returned by pvPortMalloc() have at least the alignment required by the MCU's stack and this allocation is the stack. */
 
                 if( pxStack != NULL )
                 {
@@ -779,7 +779,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                     {
                         /* The stack cannot be used as the TCB was not created.  Free
                          * it again. */
-                        vPortFree( pxStack );
+                        vPortFreeStack( pxStack );
                     }
                 }
                 else
@@ -3950,7 +3950,7 @@ static void prvCheckTasksWaitingTermination( void )
             {
                 /* The task can only have been allocated dynamically - free both
                  * the stack and TCB. */
-                vPortFree( pxTCB->pxStack );
+                vPortFreeStack( pxTCB->pxStack );
                 vPortFree( pxTCB );
             }
         #elif ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE != 0 ) /*lint !e731 !e9029 Macro has been consolidated for readability reasons. */
@@ -3962,7 +3962,7 @@ static void prvCheckTasksWaitingTermination( void )
                 {
                     /* Both the stack and TCB were allocated dynamically, so both
                      * must be freed. */
-                    vPortFree( pxTCB->pxStack );
+                    vPortFreeStack( pxTCB->pxStack );
                     vPortFree( pxTCB );
                 }
                 else if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_ONLY )


### PR DESCRIPTION
Optional Separate Stack Allocation

Description
-----------
This change adds support for a new configuration parameter (configSUPPORT_SEPARATE_STACK_ALLOCATION), defaulted to 0, which when set will cause dynamic stack allocation to use new portable layer functions pvPortMallocStack and vPortFreeStack instead of pvPortMalloc and vPortFree.  This allows a client the option of providing separate allocators for stacks and the heap.

The changes are limited to the kernel, proper.  Sample allocators are not provided.

Test Steps
-----------
Compile tasks.c with the new configuration parameter set to 0 and 1, and observe the changes of calls to pvPortMalloc/vPortFree to pvPortMallocStack/vPortFreeStack.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
