### PR TITLE
Posix: use thread local storage for critical section counter

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -366,8 +366,11 @@ int iRet;
 
 static void vPortSystemTickHandler( int sig )
 {
+#if ( configUSE_PREEMPTION == 1 )
 Thread_t *pxThreadToSuspend;
 Thread_t *pxThreadToResume;
+#endif
+
 /* uint64_t xExpectedTicks; */
 
     uxCriticalNesting++; /* Signals are blocked in this signal handler. */


### PR DESCRIPTION
This commit allows non-FreeRTOS pthreads to safely call
vPortEnterCritical()/vPortExitCritical(). ie. avoid lockups due to seemingly nonblocked signals creating deadlocks.

Non-FreeRTOS Task pthreads may need to enter a critical
section (for eg. printf()). In this case a single global
uxCriticalNesting is bogus since it is not copied and
restored on pthread scheduling.

GCC Thread-Local Storage to the rescue.

See https://gcc.gnu.org/onlinedocs/gcc/Thread-Local.html