### PR TITLE
Fix race condition bugs when reading and writing to message buffers

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -200,13 +200,21 @@ static size_t prvWriteMessageToBuffer( StreamBuffer_t * const pxStreamBuffer,
                                        size_t xRequiredSpace ) PRIVILEGED_FUNCTION;
 
 /*
- * Read xMaxCount bytes from the pxStreamBuffer message buffer and write them
- * to pucData.
+ * Copies xCount bytes from the pxStreamBuffer's data storage area to pucData.
+ * This function does not update the buffer's xTail pointer, so multiple reads
+ * may be chained together "atomically". This is useful for Message Buffers where
+ * the length and data bytes are read in two separate chunks, and we don't want
+ * the writer to see the buffer as having more free space until after all data is
+ * copied over, especially if we have to abort the read due to insufficient receiving space.
+ * This function takes a custom xTail value to indicate where to read from (necessary
+ * for chaining) and returns the the resulting xTail position.
+ * To mark the read as complete, manually set the buffer's xTail field with the
+ * returned xTail from this function.
  */
 static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
                                       uint8_t * pucData,
-                                      size_t xMaxCount,
-                                      size_t xBytesAvailable ) PRIVILEGED_FUNCTION;
+                                      size_t xCount,
+                                      size_t xTail ) PRIVILEGED_FUNCTION;
 
 /*
  * Called by both pxStreamBufferCreate() and pxStreamBufferCreateStatic() to
@@ -864,7 +872,7 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
 size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
 {
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
-    size_t xReturn, xBytesAvailable, xOriginalTail;
+    size_t xReturn, xBytesAvailable;
     configMESSAGE_BUFFER_LENGTH_TYPE xTempReturn;
 
     configASSERT( pxStreamBuffer );
@@ -878,14 +886,9 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
         {
             /* The number of bytes available is greater than the number of bytes
              * required to hold the length of the next message, so another message
-             * is available.  Return its length without removing the length bytes
-             * from the buffer.  A copy of the tail is stored so the buffer can be
-             * returned to its prior state as the message is not actually being
-             * removed from the buffer. */
-            xOriginalTail = pxStreamBuffer->xTail;
-            ( void ) prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) &xTempReturn, sbBYTES_TO_STORE_MESSAGE_LENGTH, xBytesAvailable );
-            xReturn = ( size_t ) xTempReturn;
-            pxStreamBuffer->xTail = xOriginalTail;
+             * is available. */
+             ( void ) prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) &xTempReturn, sbBYTES_TO_STORE_MESSAGE_LENGTH, pxStreamBuffer->xTail);
+             xReturn = ( size_t ) xTempReturn;
         }
         else
         {
@@ -968,17 +971,16 @@ static size_t prvReadMessageFromBuffer( StreamBuffer_t * pxStreamBuffer,
                                         size_t xBufferLengthBytes,
                                         size_t xBytesAvailable )
 {
-    size_t xOriginalTail, xReceivedLength, xNextMessageLength;
+    size_t xTail, xCount, xNextMessageLength;
     configMESSAGE_BUFFER_LENGTH_TYPE xTempNextMessageLength;
+
+    xTail = pxStreamBuffer->xTail;
 
     if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) != ( uint8_t ) 0 )
     {
         /* A discrete message is being received.  First receive the length
-         * of the message.  A copy of the tail is stored so the buffer can be
-         * returned to its prior state if the length of the message is too
-         * large for the provided buffer. */
-        xOriginalTail = pxStreamBuffer->xTail;
-        ( void ) prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) &xTempNextMessageLength, sbBYTES_TO_STORE_MESSAGE_LENGTH, xBytesAvailable );
+         * of the message. */
+        xTail = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) &xTempNextMessageLength, sbBYTES_TO_STORE_MESSAGE_LENGTH, xTail );
         xNextMessageLength = ( size_t ) xTempNextMessageLength;
 
         /* Reduce the number of bytes available by the number of bytes just
@@ -989,10 +991,7 @@ static size_t prvReadMessageFromBuffer( StreamBuffer_t * pxStreamBuffer,
          * user. */
         if( xNextMessageLength > xBufferLengthBytes )
         {
-            /* The user has provided insufficient space to read the message
-             * so return the buffer to its previous state (so the length of
-             * the message is in the buffer again). */
-            pxStreamBuffer->xTail = xOriginalTail;
+            /* The user has provided insufficient space to read the message. */
             xNextMessageLength = 0;
         }
         else
@@ -1007,10 +1006,16 @@ static size_t prvReadMessageFromBuffer( StreamBuffer_t * pxStreamBuffer,
         xNextMessageLength = xBufferLengthBytes;
     }
 
-    /* Read the actual data. */
-    xReceivedLength = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) pvRxData, xNextMessageLength, xBytesAvailable ); /*lint !e9079 Data storage area is implemented as uint8_t array for ease of sizing, indexing and alignment. */
+    /* Use the minimum of the wanted bytes and the available bytes. */
+    xCount = configMIN( xNextMessageLength, xBytesAvailable );
 
-    return xReceivedLength;
+    /* Read the actual data. */
+    xTail = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) pvRxData, xCount, xTail); /*lint !e9079 Data storage area is implemented as uint8_t array for ease of sizing, indexing and alignment. */
+
+    /* Update the tail to mark the data as officialy consumed. */
+    pxStreamBuffer->xTail = xTail;
+
+    return xCount;
 }
 /*-----------------------------------------------------------*/
 
@@ -1185,17 +1190,14 @@ static size_t prvWriteBytesToBuffer( StreamBuffer_t * const pxStreamBuffer,
 
 static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
                                       uint8_t * pucData,
-                                      size_t xMaxCount,
-                                      size_t xBytesAvailable )
+                                      size_t xCount,
+                                      size_t xTail )
 {
-    size_t xCount, xFirstLength, xNextTail;
-
-    /* Use the minimum of the wanted bytes and the available bytes. */
-    xCount = configMIN( xBytesAvailable, xMaxCount );
+    size_t xFirstLength, xNextTail;
 
     if( xCount > ( size_t ) 0 )
     {
-        xNextTail = pxStreamBuffer->xTail;
+        xNextTail = xTail;
 
         /* Calculate the number of bytes that can be read - which may be
          * less than the number wanted if the data wraps around to the start of
@@ -1204,7 +1206,7 @@ static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
 
         /* Obtain the number of bytes it is possible to obtain in the first
          * read.  Asserts check bounds of read and write. */
-        configASSERT( xFirstLength <= xMaxCount );
+        configASSERT( xFirstLength <= xCount );
         configASSERT( ( xNextTail + xFirstLength ) <= pxStreamBuffer->xLength );
         ( void ) memcpy( ( void * ) pucData, ( const void * ) &( pxStreamBuffer->pucBuffer[ xNextTail ] ), xFirstLength ); /*lint !e9087 memcpy() requires void *. */
 
@@ -1213,7 +1215,7 @@ static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
         if( xCount > xFirstLength )
         {
             /*...then read the remaining bytes from the start of the buffer. */
-            configASSERT( xCount <= xMaxCount );
+            configASSERT( xCount <= xCount );
             ( void ) memcpy( ( void * ) &( pucData[ xFirstLength ] ), ( void * ) ( pxStreamBuffer->pucBuffer ), xCount - xFirstLength ); /*lint !e9087 memcpy() requires void *. */
         }
         else
@@ -1229,15 +1231,13 @@ static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
         {
             xNextTail -= pxStreamBuffer->xLength;
         }
-
-        pxStreamBuffer->xTail = xNextTail;
     }
     else
     {
         mtCOVERAGE_TEST_MARKER();
     }
 
-    return xCount;
+    return xNextTail;
 }
 /*-----------------------------------------------------------*/
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -1191,21 +1191,21 @@ static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
     configASSERT( xCount != ( size_t ) 0 );
 
     /* Calculate the number of bytes that can be read - which may be
-    * less than the number wanted if the data wraps around to the start of
-    * the buffer. */
+     * less than the number wanted if the data wraps around to the start of
+     * the buffer. */
     xFirstLength = configMIN( pxStreamBuffer->xLength - xTail, xCount );
 
     /* Obtain the number of bytes it is possible to obtain in the first
-    * read.  Asserts check bounds of read and write. */
+     * read.  Asserts check bounds of read and write. */
     configASSERT( xFirstLength <= xCount );
     configASSERT( ( xTail + xFirstLength ) <= pxStreamBuffer->xLength );
     ( void ) memcpy( ( void * ) pucData, ( const void * ) &( pxStreamBuffer->pucBuffer[ xTail ] ), xFirstLength ); /*lint !e9087 memcpy() requires void *. */
 
     /* If the total number of wanted bytes is greater than the number
-    * that could be read in the first read... */
+     * that could be read in the first read... */
     if( xCount > xFirstLength )
     {
-        /*...then read the remaining bytes from the start of the buffer. */
+        /* ...then read the remaining bytes from the start of the buffer. */
         configASSERT( xCount <= xCount );
         ( void ) memcpy( ( void * ) &( pucData[ xFirstLength ] ), ( void * ) ( pxStreamBuffer->pucBuffer ), xCount - xFirstLength ); /*lint !e9087 memcpy() requires void *. */
     }

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -724,51 +724,40 @@ static size_t prvWriteMessageToBuffer( StreamBuffer_t * const pxStreamBuffer,
                                        size_t xSpace,
                                        size_t xRequiredSpace )
 {
-    BaseType_t xShouldWrite;
-    size_t xReturn;
     size_t xNextHead = pxStreamBuffer->xHead;
 
-    if( xSpace == ( size_t ) 0 )
+    if( xDataLengthBytes != xRequiredSpace )
     {
-        /* Doesn't matter if this is a stream buffer or a message buffer, there
-         * is no space to write. */
-        xShouldWrite = pdFALSE;
+        /* This is a message buffer, as opposed to a stream buffer. */
+
+        if( xSpace >= xRequiredSpace )
+        {
+            /* There is enough space to write both the message length and the message
+             * itself into the buffer.  Start by writing the length of the data, the data
+             * itself will be written later in this function. */
+            xNextHead = prvWriteBytesToBuffer( pxStreamBuffer, ( const uint8_t * ) &( xDataLengthBytes ), sbBYTES_TO_STORE_MESSAGE_LENGTH, xNextHead);
+        }
+        else
+        {
+            /* Not enough space, so do not write data to the buffer. */
+            xDataLengthBytes = 0;
+        }
     }
-    else if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) == ( uint8_t ) 0 )
+    else
     {
         /* This is a stream buffer, as opposed to a message buffer, so writing a
-         * stream of bytes rather than discrete messages.  Write as many bytes as
-         * possible. */
-        xShouldWrite = pdTRUE;
+         * stream of bytes rather than discrete messages.  Plan to write as many
+         * bytes as possible. */
         xDataLengthBytes = configMIN( xDataLengthBytes, xSpace );
     }
-    else if( xSpace >= xRequiredSpace )
-    {
-        /* This is a message buffer, as opposed to a stream buffer, and there
-         * is enough space to write both the message length and the message itself
-         * into the buffer.  Start by writing the length of the data, the data
-         * itself will be written later in this function. */
-        xShouldWrite = pdTRUE;
-        xNextHead = prvWriteBytesToBuffer( pxStreamBuffer, ( const uint8_t * ) &( xDataLengthBytes ), sbBYTES_TO_STORE_MESSAGE_LENGTH, xNextHead);
-    }
-    else
-    {
-        /* There is space available, but not enough space. */
-        xShouldWrite = pdFALSE;
-    }
 
-    if( xShouldWrite != pdFALSE )
+    if( xDataLengthBytes != ( size_t ) 0 )
     {
-        /* Write the actual data and update the head to mark the data as officially written. */
+        /* Write the data to the buffer. */
         pxStreamBuffer->xHead = prvWriteBytesToBuffer( pxStreamBuffer, ( const uint8_t * ) pvTxData, xDataLengthBytes, xNextHead ); /*lint !e9079 Storage buffer is implemented as uint8_t for ease of sizing, alignment and access. */
-        xReturn = xDataLengthBytes;
-    }
-    else
-    {
-        xReturn = 0;
     }
 
-    return xReturn;
+    return xDataLengthBytes;
 }
 /*-----------------------------------------------------------*/
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -159,10 +159,9 @@ typedef struct StreamBufferDef_t                 /*lint !e9058 Style convention 
 static size_t prvBytesInBuffer( const StreamBuffer_t * const pxStreamBuffer ) PRIVILEGED_FUNCTION;
 
 /*
- * Add xCount bytes from pucData into the pxStreamBuffer message buffer.
- * Returns the number of bytes written, which will either equal xCount in the
- * success case, or 0 if there was not enough space in the buffer (in which case
- * no data is written into the buffer).
+ * Add xCount bytes from pucData into the pxStreamBuffer's data storage area.
+ * Assumes there is enough free space in the buffer.
+ * Always returns xCount, which is the number of bytes written.
  */
 static size_t prvWriteBytesToBuffer( StreamBuffer_t * const pxStreamBuffer,
                                      const uint8_t * pucData,

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -760,7 +760,7 @@ static size_t prvWriteMessageToBuffer( StreamBuffer_t * const pxStreamBuffer,
     if( xShouldWrite != pdFALSE )
     {
         /* Writes the data itself. */
-        xNextHead = prvWriteBytesToBuffer( pxStreamBuffer, ( const uint8_t * ) pvTxData, xDataLengthBytes, xNextHead ); /*lint !e9079 Storage buffer is implemented as uint8_t for ease of sizing, alighment and access. */
+        xNextHead = prvWriteBytesToBuffer( pxStreamBuffer, ( const uint8_t * ) pvTxData, xDataLengthBytes, xNextHead ); /*lint !e9079 Storage buffer is implemented as uint8_t for ease of sizing, alignment and access. */
         pxStreamBuffer->xHead = xNextHead;
         xReturn = xDataLengthBytes;
     }
@@ -1017,11 +1017,14 @@ static size_t prvReadMessageFromBuffer( StreamBuffer_t * pxStreamBuffer,
     /* Use the minimum of the wanted bytes and the available bytes. */
     xCount = configMIN( xNextMessageLength, xBytesAvailable );
 
-    /* Read the actual data. */
-    xTail = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) pvRxData, xCount, xTail); /*lint !e9079 Data storage area is implemented as uint8_t array for ease of sizing, indexing and alignment. */
+    if( xCount != ( size_t ) 0 )
+    {
+        /* Read the actual data. */
+        xTail = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) pvRxData, xCount, xTail); /*lint !e9079 Data storage area is implemented as uint8_t array for ease of sizing, indexing and alignment. */
 
-    /* Update the tail to mark the data as officialy consumed. */
-    pxStreamBuffer->xTail = xTail;
+        /* Update the tail to mark the data as officially consumed. */
+        pxStreamBuffer->xTail = xTail;
+    }
 
     return xCount;
 }
@@ -1203,9 +1206,9 @@ static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
 {
     size_t xFirstLength, xNextTail;
 
+    xNextTail = xTail;
     if( xCount > ( size_t ) 0 )
     {
-        xNextTail = xTail;
 
         /* Calculate the number of bytes that can be read - which may be
          * less than the number wanted if the data wraps around to the start of


### PR DESCRIPTION
Description of original issue
-----------

There are a few sections of message buffer code that are vulnerable to race conditions. The underlying cause is that length and data bytes are written and read as two distinct operations, which both modify the size of the buffer. If a context switch occurs after adding or removing the length bytes, but before adding or removing the data bytes, then another task may observe the message buffer in this invalid state, and could further corrupt the contents with another buffer-modifying operation.

Here are some specific examples of how things can go wrong:

**Corruption due to Send in the middle of a Receive:**
```c
// Initial condition:
// 50-byte buffer contains a 20-byte message, plus 4-byte length overhead

// Task 1:
xStreamBufferReceive // to 10-byte destination
  prvReadMessageFromBuffer
    prvReadBytesFromBuffer // get 4-byte length, shifts tail, buffer now appears to have 30 bytes free space
    // Check if 10-byte destination is large enough for 20-byte message. It is not.
    // Context switch

// Task 2:
xStreamBufferSend // 25-byte payload, plus 4-byte length overhead
  // Sees 30 bytes free, so writes 29-byte message.
  // There should only be 26 bytes of free space.
// Context switch

// Task 1:
    // Continue from context switch.
    // Restore original tail position because destination is too small.
    // 3 of 4 length field bytes at the original tail position now contain overwritten data from Task 2.
    // Buffer is corrupted.
```

**Corruption due to Send in the middle of a NextMessageLength:**
```c
// Initial condition:
// Buffer has 30 bytes free space

// Task 1:
xStreamBufferNextMessageLengthBytes
  prvReadBytesFromBuffer // consumes 4-byte length field and makes buffer appear to have 34 bytes free space
  // Not yet called // reset tail position so buffer has original 30 bytes free space

-- Context Switch --

// Task 2:
// Attempt to send a 32-byte (with overhead) packet
xStreamBufferSend
  // Sees 34 spaces available
  // Writes packet and clobbers 2-bytes of off-limits space

-- Context Switch --

// Task 1:
  // Continue from context switch.
  // Reset tail position
  // Now the next 'length' field contains 2-bytes of garbage data
```

**Crash due to NextMessageLength in the middle of a Send:**
```c
// Initial condition:
// Buffer is empty

// Task 1:
xStreamBufferSend
  prvWriteMessageToBuffer
    prvWriteBytesToBuffer // write 4-byte length field
    // Not yet called // prvWriteBytesToBuffer // write n-byte payload

-- Context Switch --

// Task 2:
xStreamBufferNextMessageLengthBytes
  prvBytesInBuffer // just returns 4
  // Crash because expecting 5 or more bytes (at least 1 payload byte)
```


Description of changes
-----------

The fix is to ensure that the buffer's `xHead` and `xTail` pointers are only modified after both length and payload are either written or read. This makes the read and write operations appear to be atomic, even if they are interrupted with a context switch.

This also simplifies some code, such as in `xStreamBufferReceive` and `xStreamBufferNextMessageLengthBytes`, where we don't have to roll-back to an original `xTail` if we're not ready to actually consume the data.

I also included some minor clean-up tasks, which I hope are clearly described in the individual commits of this PR, but I could alternatively break those out into separate PRs if you'd prefer.

This change does not modify any public APIs.

Test Steps
-----------

I'm able to consistently reproduce the third (crashing) issue after a few seconds of execution on an STM32 uC. I'm running at high USB data rates and using this snippet to create large data blocks to transmit. Here's a snippet of that code, which makes many calls to `xMessageBufferNextLengthBytes()`:
```cpp
    // Keep attempting to pack more messages into single USB transfer
    while (1) {
      // Check for additional messages to read
      next_msg_len = xMessageBufferNextLengthBytes(txMsgBuf.handle);
      // If there's another message to read and we have space for it
      if (next_msg_len && txLen + next_msg_len <= sizeof(txBuf)) {
        // Grab next message with no timeout
        size_t next_rec_len = xMessageBufferReceive(txMsgBuf.handle, txBuf + txLen, sizeof(txBuf) - txLen, 0);
        // Sanity check that we read the expected number of bytes
        if (next_rec_len != next_msg_len) {
          critical();
        }
        // Note consumed bytes
        txLen += next_rec_len;
      } else {
        // Either no more messages, or no more space
        break;
      }
    }

    // Setup transmit
    USBD_CDC_SetTxBuffer(&usbDeviceHandle, txBuf, txLen);
```

With the changes in this PR, I am not able to reproduce the issue, even after running for an hour+.

-----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
