### PR TITLE
Add default for the new constant configRUN_ADDITIONAL_TESTS into FreeRTOS.h

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1054,6 +1054,11 @@
     #define configRUN_FREERTOS_SECURE_ONLY    0
 #endif
 
+#ifndef configRUN_ADDITIONAL_TESTS
+    #define configRUN_ADDITIONAL_TESTS    0
+#endif
+
+
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using
  * dynamically allocated RAM, in which case when any task is deleted it is known
  * that both the task's stack and TCB need to be freed.  Sometimes the


### PR DESCRIPTION
The FreeRTOS/FreeRTOS hub repo, which submodules the kernel from this repo, got updated to include a new compile time constant configRUN_ADDITIONAL_TESTS.  The constant allows new tests to be optionally inserted into pre-existing tests.  The purpose is to ensure exist port specific test and demo projects do not include the new tests until they are next executed - at which time it can be validate that the additional resources required to run the tests can be allocated without resource exhaustion.  This PR defaults configRUN_ADDITIONAL_TESTS to 0 for all projects that do not yet use the constant.

Test Steps
-----------
Not applicable.

Related Issue
-----------
Not applicable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
