### PR TITLE
Added git-secrets check to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,23 @@ jobs:
       - name: URL Checker
         run: |
             bash kernel/.github/actions/url_verifier.sh kernel
+
+  git-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Checkout awslabs/git-secrets
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/git-secrets
+          ref: master
+          path: git-secrets
+      - name: Install git-secrets
+        run: cd git-secrets && sudo make install && cd ..
+      - name: Run git-secrets
+        run: |
+          git-secrets --register-aws
+          git-secrets --scan
+


### PR DESCRIPTION
Added git-secrets check to Github Actions

Description
-----------
The added Github action will check and report PR check failure if a credential is committed into the repository.

Test Steps
-----------
Check the Github Actions to see the git-secrets check result

Related Issue
-----------



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
