### PR TITLE
Moved git-secrets check to a different workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,22 +45,3 @@ jobs:
         run: |
             bash kernel/.github/actions/url_verifier.sh kernel
 
-  git-secrets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Checkout awslabs/git-secrets
-        uses: actions/checkout@v2
-        with:
-          repository: awslabs/git-secrets
-          ref: master
-          path: git-secrets
-      - name: Install git-secrets
-        run: cd git-secrets && sudo make install && cd ..
-      - name: Run git-secrets
-        run: |
-          git-secrets --register-aws
-          git-secrets --scan
-

--- a/.github/workflows/git-secrets.yml
+++ b/.github/workflows/git-secrets.yml
@@ -1,0 +1,24 @@
+name: git-secrets Check
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  git-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Checkout awslabs/git-secrets
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/git-secrets
+          ref: master
+          path: git-secrets
+      - name: Install git-secrets
+        run: cd git-secrets && sudo make install && cd ..
+      - name: Run git-secrets
+        run: |
+          git-secrets --register-aws
+          git-secrets --scan


### PR DESCRIPTION
Moved git-secrets check to a different workflow

Description
-----------
Now git-secrets check will be performed on push and pull-request on all branches.

Test Steps
-----------
Check the latest Github Action for the latest results

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
