### PR TITLE
Add some assertions and coverage exceptions to queue.c

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1529,6 +1529,7 @@ prvinitialisenewstreambuffer
 prvinitialisenewtimer
 prvinsertblockintofreelist
 prvlockqueue
+prvnotifyqueuesetcontainer
 prvportmalloc
 prvportresetpic
 prvprocesssimulatedinterrupts
@@ -1631,7 +1632,6 @@ pvyieldevent
 pwdtc
 pwm
 pwmc
-pxtaskcode
 pxblock
 pxblocktoinsert
 pxcallbackfunction
@@ -1688,6 +1688,7 @@ pxprevious
 pxpreviouswaketime
 pxqueue
 pxqueuebuffer
+pxqueuesetcontainer
 pxramstack
 pxreadycoroutinelists
 pxreadytaskslists
@@ -1707,6 +1708,7 @@ pxstreambuffercreatestatic
 pxtagvalue
 pxtask
 pxtaskbuffer
+pxtaskcode
 pxtaskdefinition
 pxtaskstatus
 pxtaskstatusarray
@@ -2653,7 +2655,6 @@ wu
 www
 wwwfreertos
 wxr
-xtasktodelete
 xa
 xaa
 xaaaa
@@ -3020,6 +3021,7 @@ xtaskswaitingforbits
 xtaskswaitingtermination
 xtaskswaitingtoreceive
 xtaskswaitingtosend
+xtasktodelete
 xtasktonotify
 xtasktoquery
 xtasktoresume

--- a/queue.c
+++ b/queue.c
@@ -345,7 +345,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
                 /* This assertion cannot be branch covered in unit tests */
                 configASSERT( xSize == sizeof( Queue_t ) ); /* LCOV_EXCL_BR_LINE */
-                ( void ) xSize; /* Keeps lint quiet when configASSERT() is not defined. */
+                ( void ) xSize;                             /* Keeps lint quiet when configASSERT() is not defined. */
             }
         #endif /* configASSERT_DEFINED */
 
@@ -400,7 +400,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         configASSERT( ( uxItemSize == 0 ) || ( uxQueueLength == ( xQueueSizeInBytes / uxItemSize ) ) );
 
         /* Check for addition overflow. */
-        configASSERT( ( sizeof( Queue_t ) + xQueueSizeInBytes ) >  xQueueSizeInBytes );
+        configASSERT( ( sizeof( Queue_t ) + xQueueSizeInBytes ) > xQueueSizeInBytes );
 
         /* Allocate the queue and storage area.  Justification for MISRA
          * deviation as follows:  pvPortMalloc() always ensures returned memory
@@ -948,15 +948,15 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToSend ), xTicksToWait );
 
                 /* Unlocking the queue means queue events can effect the
-                 * event list.  It is possible that interrupts occurring now
+                 * event list. It is possible that interrupts occurring now
                  * remove this task from the event list again - but as the
                  * scheduler is suspended the task will go onto the pending
-                 * ready last instead of the actual ready list. */
+                 * ready list instead of the actual ready list. */
                 prvUnlockQueue( pxQueue );
 
                 /* Resuming the scheduler will move tasks from the pending
                  * ready list into the ready list - so it is feasible that this
-                 * task is already in a ready list before it yields - in which
+                 * task is already in the ready list before it yields - in which
                  * case the yield will not cause a context switch unless there
                  * is also a higher priority task in the pending ready list. */
                 if( xTaskResumeAll() == pdFALSE )
@@ -1778,7 +1778,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
         taskEXIT_CRITICAL();
 
         /* Interrupts and other tasks can send to and receive from the queue
-         * now the critical section has been exited. */
+         * now that the critical section has been exited. */
 
         vTaskSuspendAll();
         prvLockQueue( pxQueue );
@@ -2748,6 +2748,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
+
         /* Assert that the queue was added successfully */
         configASSERT( ( ux != configQUEUE_REGISTRY_SIZE ) );
     }

--- a/queue.c
+++ b/queue.c
@@ -2969,7 +2969,10 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
         /* This function must be called form a critical section. */
 
-        configASSERT( pxQueueSetContainer );
+        /* The following line is not reachable in unit tests because every call
+         * to prvNotifyQueueSetContainer is preceded by a check that
+         * pxQueueSetContainer != NULL */
+        configASSERT( pxQueueSetContainer ); /* LCOV_EXCL_BR_LINE */
         configASSERT( pxQueueSetContainer->uxMessagesWaiting < pxQueueSetContainer->uxLength );
 
         if( pxQueueSetContainer->uxMessagesWaiting < pxQueueSetContainer->uxLength )

--- a/queue.c
+++ b/queue.c
@@ -563,6 +563,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         TaskHandle_t pxReturn;
         Queue_t * const pxSemaphore = ( Queue_t * ) xSemaphore;
 
+        configASSERT( xSemaphore );
+
         /* This function is called by xSemaphoreGetMutexHolder(), and should not
          * be called directly.  Note:  This is a good way of determining if the
          * calling task is the mutex holder, but not a good way of determining the

--- a/queue.c
+++ b/queue.c
@@ -2748,9 +2748,6 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-
-        /* Assert that the queue was added successfully */
-        configASSERT( ( ux != configQUEUE_REGISTRY_SIZE ) );
     }
 
 #endif /* configQUEUE_REGISTRY_SIZE */

--- a/queue.c
+++ b/queue.c
@@ -2725,6 +2725,9 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         UBaseType_t ux;
 
+        configASSERT( xQueue );
+        configASSERT( pcQueueName );
+
         /* See if there is an empty space in the registry.  A NULL name denotes
          * a free slot. */
         for( ux = ( UBaseType_t ) 0U; ux < ( UBaseType_t ) configQUEUE_REGISTRY_SIZE; ux++ )
@@ -2743,6 +2746,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
+        /* Assert that the queue was added successfully */
+        configASSERT( ( ux != configQUEUE_REGISTRY_SIZE ) );
     }
 
 #endif /* configQUEUE_REGISTRY_SIZE */
@@ -2754,6 +2759,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         UBaseType_t ux;
         const char * pcReturn = NULL; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+
+        configASSERT( xQueue );
 
         /* Note there is nothing here to protect against another task adding or
          * removing entries from the registry while it is being searched. */
@@ -2782,6 +2789,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     void vQueueUnregisterQueue( QueueHandle_t xQueue )
     {
         UBaseType_t ux;
+
+        configASSERT( xQueue );
 
         /* See if the handle of the queue being unregistered in actually in the
          * registry. */

--- a/queue.c
+++ b/queue.c
@@ -342,7 +342,9 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
                  * variable of type StaticQueue_t or StaticSemaphore_t equals the size of
                  * the real queue and semaphore structures. */
                 volatile size_t xSize = sizeof( StaticQueue_t );
-                configASSERT( xSize == sizeof( Queue_t ) );
+
+                /* This assertion cannot be branch covered in unit tests */
+                configASSERT( xSize == sizeof( Queue_t ) ); /* LCOV_EXCL_BR_LINE */
                 ( void ) xSize; /* Keeps lint quiet when configASSERT() is not defined. */
             }
         #endif /* configASSERT_DEFINED */

--- a/tasks.c
+++ b/tasks.c
@@ -2694,8 +2694,8 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
                 #if ( configUSE_PREEMPTION == 1 )
                     {
                         /* Preemption is on, but a context switch should only be
-                         *  performed if the unblocked task has a priority that is
-                         *  equal to or higher than the currently executing task. */
+                         * performed if the unblocked task has a priority that is
+                         * higher than the currently executing task. */
                         if( pxTCB->uxPriority > pxCurrentTCB->uxPriority )
                         {
                             /* Pend the yield to be performed when the scheduler


### PR DESCRIPTION
Add some assertions and coverage exceptions to queue.c

Description
-----------
* Correct some typos in queue.c
* Assert that the semaphore handle passed into xQueueGetMutexHolder is not NULL.
* Add assertions to check when invalid parameters are passed into Queue Registry related functions.
* Add a configASSERT when vQueueAddToRegistry is called but the queue registry is full.
* Add LCOV_BRANCH coverage exception for a configASSERT on pxQueueSetContainer with a condition that is unreachable.
* Add an LCOV_BRANCH exception for the check that sizeof( StaticQueue_t ) == sizeof( Queue_t )
* Run uncrustify

Test Steps
-----------
Only assertions and comments have been changed. This should be verified by inspection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
