### PR TITLE
Adjust portPOINTER_SIZE_TYPE to correct size

### DIFF
--- a/portable/GCC/ATMega323/portmacro.h
+++ b/portable/GCC/ATMega323/portmacro.h
@@ -22,7 +22,6 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  *
- * 1 tab == 4 spaces!
  */
 
 /*

--- a/portable/GCC/ATMega323/portmacro.h
+++ b/portable/GCC/ATMega323/portmacro.h
@@ -58,6 +58,8 @@ extern "C" {
 #define portSTACK_TYPE	uint8_t
 #define portBASE_TYPE	char
 
+#define portPOINTER_SIZE_TYPE    uint16_t
+
 typedef portSTACK_TYPE StackType_t;
 typedef signed char BaseType_t;
 typedef unsigned char UBaseType_t;


### PR DESCRIPTION
portPOINTER_SIZE_TYPE wasn't yet set correctly to be 16 bit

Description
Adjusted portmacro for ATMega323 port to contain the correct pointer size.

Test Steps
-----------
Build a demo for this port and observe that there are no warnings anymore regarding some casts in heap_1.c and tasks.c.

Related Issue
-----------
none found


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
