### PR TITLE
Update comment in list.c

### DIFF
--- a/list.c
+++ b/list.c
@@ -158,6 +158,9 @@ void vListInsert( List_t * const pxList,
         *   4) Using a queue or semaphore before it has been initialised or
         *      before the scheduler has been started (are interrupts firing
         *      before vTaskStartScheduler() has been called?).
+        *   5) If the FreeRTOS port supports interrupt nesting then ensure that
+        *      the priority of the tick interrupt is at or below
+        *      configMAX_SYSCALL_INTERRUPT_PRIORITY.
         **********************************************************************/
 
         for( pxIterator = ( ListItem_t * ) &( pxList->xListEnd ); pxIterator->pxNext->xItemValue <= xValueOfInsertion; pxIterator = pxIterator->pxNext ) /*lint !e826 !e740 !e9087 The mini list structure is used as the list end to save RAM.  This is checked and valid. *//*lint !e440 The iterator moves to a different value, not xValueOfInsertion. */


### PR DESCRIPTION
Description
-----------
The tick interrupt priority must be configured to ensure that it cannot interrupt a critical section. This change updates the comment to help the application writer while debugging.

This change was originally contributed by @lagerholm in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/215.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
