### PR TITLE
Run CMock unit tests on each pull request with a github action.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,56 @@
+name: CMock Unit Tests
+on: [push]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Parent Repo
+      uses: actions/checkout@v2
+      with:
+        ref: master
+        repository: FreeRTOS/FreeRTOS
+        submodules: 'recursive'
+        fetch-depth: 1
+    - name: Clone This Repo
+      uses: actions/checkout@v2
+      with:
+        path: ./FreeRTOS/Source
+
+    - name: Setup Python
+      uses: actions/setup-python@master
+      with:
+        python-version: 3.8
+
+    - name: Install packages
+      run: |
+          sudo apt-get install lcov cflow ruby doxygen build-essential
+    - name: Run Unit Tests with ENABLE_SANITIZER=1
+      run: |
+          make -C FreeRTOS/Test/CMock clean
+          make -C FreeRTOS/Test/CMock ENABLE_SANITIZER=1 run_col_formatted
+    - name: Run Unit Tests for coverage
+      run: |
+          make -C FreeRTOS/Test/CMock clean
+          make -C FreeRTOS/Test/CMock lcovhtml
+          lcov --config-file FreeRTOS/Test/CMock/lcovrc --summary FreeRTOS/Test/CMock/build/cmock_test.info > FreeRTOS/Test/CMock/build/cmock_test_summary.txt
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        files: FreeRTOS/Test/CMock/build/cmock_test.info
+        working-directory: .
+        root_dir: FreeRTOS/Source
+        flags: unittests
+        fail_ci_if_error: false
+        path_to_write_report: coverage/codecov_report.txt
+        verbose: false
+    - name: Archive code coverage data
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-data
+        path: FreeRTOS/Test/CMock/build/cmock_test*
+    - name: Archive code coverage html report
+      uses: actions/upload-artifact@v2
+      with:
+        name: overage-report
+        path: FreeRTOS/Test/CMock/build/coverage

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,5 +52,5 @@ jobs:
     - name: Archive code coverage html report
       uses: actions/upload-artifact@v2
       with:
-        name: overage-report
+        name: coverage-report
         path: FreeRTOS/Test/CMock/build/coverage


### PR DESCRIPTION
Run CMock unit tests on each pull request with a github action.

Description
-----------
This PR adds a github workflow that runs the kernel CMock unit tests located in the FreeRTOS/FreeRTOS repository on each push to FreeRTOS / FreeRTOS-Kernel.


This workflow also uploads test coverage data to codecov.io so that it can be easily reviewed. Optionally, codecov.io can add a comment to the PR outlining the changes in coverage before and after the changes in the PR.

Test Steps
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
