### PR TITLE
Comment: xTaskResumeAll: comment: doesn't match the code

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2238,8 +2238,8 @@ BaseType_t xTaskResumeAll( void )
                     ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
                     prvAddTaskToReadyList( pxTCB );
 
-                    /* If the moved task has a priority higher than the current
-                     * task then a yield must be performed. */
+                    /* If the moved task has a priority higher than or equal to
+                     * the current task then a yield must be performed. */
                     if( pxTCB->uxPriority >= pxCurrentTCB->uxPriority )
                     {
                         xYieldPending = pdTRUE;


### PR DESCRIPTION
xTaskResumeAll: comment: doesn't match the code

Description
-----------
xTaskResumeAll: comment: doesn't match the code
comment says greater than
while code says greater than or equal


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
