### PR TITLE
Fixed two crashes in portASM.s when MMU is disabled and secure FIQ is used for external interrupt

### DIFF
--- a/portable/GCC/ARM_CA53_64_BIT/portASM.S
+++ b/portable/GCC/ARM_CA53_64_BIT/portASM.S
@@ -415,7 +415,7 @@ ullPortTaskHasFPUContextConst: .dword ullPortTaskHasFPUContext
 
 ullICCPMRConst: .dword ullICCPMR
 ullMaxAPIPriorityMaskConst: .dword ullMaxAPIPriorityMask
-vApplicationIRQHandlerConst: .word vApplicationIRQHandler
+vApplicationIRQHandlerConst: .dword vApplicationIRQHandler
 ullPortInterruptNestingConst: .dword ullPortInterruptNesting
 ullPortYieldRequiredConst: .dword ullPortYieldRequired
 ullICCIARConst:	.dword ullICCIAR

--- a/portable/GCC/ARM_CA53_64_BIT/portASM.S
+++ b/portable/GCC/ARM_CA53_64_BIT/portASM.S
@@ -319,7 +319,7 @@ FreeRTOS_IRQ_Handler:
 	BL vApplicationIRQHandler
 
 	/* Disable interrupts. */
-	MSR 	DAIFSET, #2
+	MSR 	DAIFSET, #3
 	DSB		SY
 	ISB		SY
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- -->
I have two patches in this pull request,
    1. Add disabling FIQ to protect critical data after calling application IRQ handler. 
     2. Fixed a unaligned access when MMU is disabled. 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
For patch 1: 
   1) Set external interrupt to GROUP0 in secure state, then external interrupt will triggered as FIQ
   2) Trigger two or more external IRQ to nest, such as Timer, DMA, Uart interrupts in the test
   3) System will crash or hang in interrupt processing as critical data is corrupted.

For patch 2:
  1) Disable MMU.
  2) Trigger any interrupt.
  3) The system will go into exception and the ESR will be 0x96000021 (data abort, unaligned access)

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
