### PR TITLE
Fix: testing for mpu wrapers to be equal to 1

### DIFF
--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -29,7 +29,7 @@
 
 /* This file redefines API functions to be called through a wrapper macro, but
  * only for ports that are using the MPU. */
-#ifdef portUSING_MPU_WRAPPERS
+#if ( portUSING_MPU_WRAPPERS == 1 )
 
 /* MPU_WRAPPERS_INCLUDED_FROM_API_FILE will be defined when this file is
  * included from queue.c or task.c to prevent it from having an effect within


### PR DESCRIPTION
testing for mpu wrapers to be equal to 1

Description
-----------
Testing for mpu wrapers to be equal to 1 similar to how portable.h is testing for the definition
as it might cause some issues with CPPFLAGS including it if defined to be zero



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
