### PR TITLE
Code: Remove redundant check

### DIFF
--- a/timers.c
+++ b/timers.c
@@ -350,27 +350,24 @@
         /* 0 is not a valid value for xTimerPeriodInTicks. */
         configASSERT( ( xTimerPeriodInTicks > 0 ) );
 
-        if( pxNewTimer != NULL )
+        /* Ensure the infrastructure used by the timer service task has been
+            * created/initialised. */
+        prvCheckForValidListAndQueue();
+
+        /* Initialise the timer structure members using the function
+            * parameters. */
+        pxNewTimer->pcTimerName = pcTimerName;
+        pxNewTimer->xTimerPeriodInTicks = xTimerPeriodInTicks;
+        pxNewTimer->pvTimerID = pvTimerID;
+        pxNewTimer->pxCallbackFunction = pxCallbackFunction;
+        vListInitialiseItem( &( pxNewTimer->xTimerListItem ) );
+
+        if( uxAutoReload != pdFALSE )
         {
-            /* Ensure the infrastructure used by the timer service task has been
-             * created/initialised. */
-            prvCheckForValidListAndQueue();
-
-            /* Initialise the timer structure members using the function
-             * parameters. */
-            pxNewTimer->pcTimerName = pcTimerName;
-            pxNewTimer->xTimerPeriodInTicks = xTimerPeriodInTicks;
-            pxNewTimer->pvTimerID = pvTimerID;
-            pxNewTimer->pxCallbackFunction = pxCallbackFunction;
-            vListInitialiseItem( &( pxNewTimer->xTimerListItem ) );
-
-            if( uxAutoReload != pdFALSE )
-            {
-                pxNewTimer->ucStatus |= tmrSTATUS_IS_AUTORELOAD;
-            }
-
-            traceTIMER_CREATE( pxNewTimer );
+            pxNewTimer->ucStatus |= tmrSTATUS_IS_AUTORELOAD;
         }
+
+        traceTIMER_CREATE( pxNewTimer );
     }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
 Remove redundant check

Description
-----------
every caller of prvInitialiseNewTimer is already checking if the value of  pxNewTimer is NULL before calling
prvInitialiseNewTimer is doing the same check.. removing

Test Steps
-----------
UT Coverage, cannot cover both branches of  
```c
if( pxNewTimer != NULL )
{
}
```
as it always evaluates  to true


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
