### PR TITLE
Build the posix port on pushes and PRs to the Kernel repository

### DIFF
--- a/.github/workflows/kernel-checks.yml
+++ b/.github/workflows/kernel-checks.yml
@@ -1,6 +1,6 @@
 name: Kernel-Checker
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   kernel-checker:
@@ -45,3 +45,28 @@ jobs:
           cd inspect
           .github/scripts/kernel_checker.py --json ${HOME}/files_modified.json ${HOME}/files_added.json ${HOME}/files_renamed.json
           exit $?
+  build-checker:
+    name: FreeRTOS Posix Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the parent repository
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          repository: FreeRTOS/FreeRTOS
+          submodules: 'recursive'
+          fetch-depth: 1
+          path: ./workspace
+      - name: Checkout the current repository
+        uses: actions/checkout@v2
+        with:
+          path: ./workspace/FreeRTOS/Source
+      - name: Posix Build Checker
+        run: |
+              bash workspace/.github/scripts/posix_build_checker.sh workspace
+      - name: Install lib pcap dev
+        run: |
+          sudo apt-get install libpcap-dev
+      - name: Posix Network Build Checker
+        run: |
+          bash workspace/.github/scripts/posix_network_build_checker.sh workspace

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,11 +1,11 @@
 name: CMock Unit Tests
-on: [push]
+on: [push, pull_request]
 
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Parent Repo
+    - name: Checkout Parent Repository
       uses: actions/checkout@v2
       with:
         ref: master


### PR DESCRIPTION
Build the posix port on pushes and PRs to the Kernel repository

Description
-----------
Build the posix port on pushes and PRs to the Kernel repository.
Also, run the kernel unit tests on a "push" and "pull_request".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
