### PR TITLE
Define default values of macros before first use

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -896,11 +896,6 @@
     #define configSUPPORT_DYNAMIC_ALLOCATION    1
 #endif
 
-#ifndef configSTACK_ALLOCATION_FROM_SEPARATE_HEAP
-    /* Defaults to 0 for backward compatibility. */
-    #define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP   0
-#endif
-
 #ifndef configSTACK_DEPTH_TYPE
 
 /* Defaults to uint16_t for backward compatibility, but can be overridden

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -177,7 +177,6 @@
     #define PRIVILEGED_FUNCTION
     #define PRIVILEGED_DATA
     #define FREERTOS_SYSTEM_CALL
-    #define portUSING_MPU_WRAPPERS    0
 
 #endif /* portUSING_MPU_WRAPPERS */
 

--- a/include/portable.h
+++ b/include/portable.h
@@ -79,6 +79,10 @@
     #error "Invalid portBYTE_ALIGNMENT definition"
 #endif
 
+#ifndef portUSING_MPU_WRAPPERS
+    #define portUSING_MPU_WRAPPERS 0
+#endif
+
 #ifndef portNUM_CONFIGURABLE_REGIONS
     #define portNUM_CONFIGURABLE_REGIONS    1
 #endif
@@ -89,6 +93,11 @@
 
 #ifndef portARCH_NAME
     #define portARCH_NAME    NULL
+#endif
+
+#ifndef configSTACK_ALLOCATION_FROM_SEPARATE_HEAP
+    /* Defaults to 0 for backward compatibility. */
+    #define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP 0
 #endif
 
 /* *INDENT-OFF* */


### PR DESCRIPTION
Description
-----------

`configSTACK_ALLOCATION_FROM_SEPARATE_HEAP` was added recently in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/267. This macro was used in `portable.h` before its default value was defined in `FreeRTOS.h`, resulting in a warning when built with `-Wundef`. This change moves the default value definition for `configSTACK_ALLOCATION_FROM_SEPARATE_HEAP` to `portable.h` to ensure that it is defined before first use.

`portUSING_MPU_WRAPPERS` check in `mpu_wrappers.h` was updated in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/285. The new check results in a warning when built with `-Wundef` because `portUSING_MPU_WRAPPERS` is not defined yet. This change adds the default value definition for `portUSING_MPU_WRAPPERS` to `portable.h` to ensure that it is defined before first use.

Test Steps
-----------
Built the code with the following flags: `-Wunused -Wuninitialized -Wall -Wextra -Wmissing-declarations -Wpointer-arith -Wbad-function-cast -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wundef`

Related Issue
-----------
https://forums.freertos.org/t/freertos-kernel-repos-pr-267-is-insufficient-for-high-warning-level-compile-option/12155

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
