### PR TITLE
Fix stop/delete of backlogged auto-reload timer

### DIFF
--- a/include/timers.h
+++ b/include/timers.h
@@ -51,10 +51,16 @@
  * be used solely through the macros that make up the public software timer API,
  * as defined below.  The commands that are sent from interrupts must use the
  * highest numbers as tmrFIRST_FROM_ISR_COMMAND is used to determine if the task
- * or interrupt version of the queue send function should be used. */
+ * or interrupt version of the queue send function should be used.  Priority
+ * commands, which are sent to the front of the command queue, must begin at
+ * zero as tmrLAST_PRIORITY_COMMAND is used to determine if a command is a
+ * priority command. */
 #define tmrCOMMAND_EXECUTE_CALLBACK_FROM_ISR    ( ( BaseType_t ) -2 )
 #define tmrCOMMAND_EXECUTE_CALLBACK             ( ( BaseType_t ) -1 )
+
 #define tmrCOMMAND_START_DONT_TRACE             ( ( BaseType_t ) 0 )
+#define tmrLAST_PRIORITY_COMMAND                ( ( BaseType_t ) 0 )
+
 #define tmrCOMMAND_START                        ( ( BaseType_t ) 1 )
 #define tmrCOMMAND_RESET                        ( ( BaseType_t ) 2 )
 #define tmrCOMMAND_STOP                         ( ( BaseType_t ) 3 )
@@ -1316,7 +1322,7 @@ BaseType_t xTimerGenericCommand( TimerHandle_t xTimer,
                                  const BaseType_t xCommandID,
                                  const TickType_t xOptionalValue,
                                  BaseType_t * const pxHigherPriorityTaskWoken,
-                                 const TickType_t xTicksToWait ) PRIVILEGED_FUNCTION;
+                                 TickType_t xTicksToWait ) PRIVILEGED_FUNCTION;
 
 #if ( configUSE_TRACE_FACILITY == 1 )
     void vTimerSetTimerNumber( TimerHandle_t xTimer,

--- a/timers.c
+++ b/timers.c
@@ -409,7 +409,7 @@
                 }
 
                 /* Priority commands must be executed before any standard commands
-                 * now in the queue for this timer, so them to the front of the
+                 * now in the queue for this timer, so send them to the front of the
                  * queue. */
                 if( xCommandID <= tmrLAST_PRIORITY_COMMAND )
                 {

--- a/timers.c
+++ b/timers.c
@@ -395,7 +395,18 @@
             {
                 if( xTaskGetSchedulerState() == taskSCHEDULER_RUNNING )
                 {
-                    xReturn = xQueueSendToBack( xTimerQueue, &xMessage, xTicksToWait );
+                    /* The "start don't trace" command comes only from the timer
+                     * task itself. This command must be executed before any other
+                     * commands now in the queue for this timer, in case one of
+                     * those commands is stop or delete. */
+                    if( xCommandID == tmrCOMMAND_START_DONT_TRACE )
+                    {
+                        xReturn = xQueueSendToFront( xTimerQueue, &xMessage, xTicksToWait );
+                    }
+                    else
+                    {
+                        xReturn = xQueueSendToBack( xTimerQueue, &xMessage, xTicksToWait );
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
#### Fix stop/delete backlogged auto-reload timer

Description
-----------
Prior to this PR, if an application attempts to stop or delete an auto-reload timer while it is backlogged, the timer unexpectedly restarts.  A timer is "backlogged" when at the time of the auto-reload, the new timer period has already elapsed.  In the case of a deleted timer, the timer continues running using freed memory which may eventually lead to a crash or failure of other unrelated timers when the memory is reallocated.

Test Steps
-----------
See https://github.com/FreeRTOS/FreeRTOS/pull/553.

Related Issue
-----------
https://forums.freertos.org/t/freertos-time-correction/11856
https://forums.freertos.org/t/timer-start-dont-trace-race-condition/12168


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
