### PR TITLE
Update parent repository primary branch name from "master" to "main".

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When creating a new topic on the forums or filing an issue, please include as ma
 ## Contributing via pull request
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -63,7 +63,7 @@ Looking at the existing issues is a great way to find something to contribute on
 
 
 ## Licensing
-The FreeRTOS kernel is released under the MIT open source license, the text of which can be found [here](https://github.com/FreeRTOS/FreeRTOS/blob/master/FreeRTOS/License/license.txt)
+The FreeRTOS kernel is released under the MIT open source license, the text of which can be found [here](https://github.com/FreeRTOS/FreeRTOS/blob/main/FreeRTOS/License/license.txt)
 
 Additional license files can be found in the folders containing any supplementary libraries licensed by their respective copyright owners where applicable.
 

--- a/.github/workflows/kernel-checks.yml
+++ b/.github/workflows/kernel-checks.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: FreeRTOS/FreeRTOS
-          ref:  master
+          ref:  main
           path: tools
 
       # Checkout user pull request changes
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout the parent repository
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
           repository: FreeRTOS/FreeRTOS
           submodules: 'recursive'
           fetch-depth: 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Checkout Parent Repository
       uses: actions/checkout@v2
       with:
-        ref: master
+        ref: main
         repository: FreeRTOS/FreeRTOS
         submodules: 'recursive'
         fetch-depth: 1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the readme file in the ```./portable``` directory for more information.
 - The ```./include``` directory contains the real time kernel header files.
 
 ### Code Formatting
-FreeRTOS files are formatted using the "uncrustify" tool. The configuration file used by uncrustify can be found in the [FreeRTOS/FreeRTOS repository](https://github.com/FreeRTOS/FreeRTOS/blob/master/tools/uncrustify.cfg). 
+FreeRTOS files are formatted using the "uncrustify" tool. The configuration file used by uncrustify can be found in the [FreeRTOS/FreeRTOS repository](https://github.com/FreeRTOS/FreeRTOS/blob/main/tools/uncrustify.cfg). 
 
 ### Spelling
 *lexicon.txt* contains words that are not traditionally found in an English dictionary. It is used by the spellchecker to verify the various jargon, variable names, and other odd words used in the FreeRTOS code base. If your pull request fails to pass the spelling and you believe this is a mistake, then add the word to *lexicon.txt*. 


### PR DESCRIPTION
Update parent repository primary branch name from "master" to "main".

Description
-----------
The FreeRTOS/FreeRTOS repository changed its primary branch name from "master" to "main". This repository is needed for running Kernel Unit Tests on each PR. Update the reference to this branch name in the kernel unit tests github action configuration so that these tests can run successfully again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
