### PR TITLE
Remove support for tmrCOMMAND_START_DONT_TRACE

### DIFF
--- a/timers.c
+++ b/timers.c
@@ -589,8 +589,8 @@
              * then process received commands. */
             if ( prvProcessTimerOrBlockTask( xNextExpireTime, xListWasEmpty ) != pdTRUE )
             {
-               /* Empty the command queue. */
-               prvProcessReceivedCommands();
+                /* Empty the command queue. */
+                prvProcessReceivedCommands();
             }
         }
     }

--- a/timers.c
+++ b/timers.c
@@ -212,8 +212,8 @@
  * If a timer has expired, process it.  Otherwise, block the timer service task
  * until either a timer does expire or a command is received.
  */
-    static BaseType_t prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime,
-                                                  BaseType_t xListWasEmpty ) PRIVILEGED_FUNCTION;
+    static void prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime,
+                                            BaseType_t xListWasEmpty ) PRIVILEGED_FUNCTION;
 
 /*
  * Called after a Timer_t structure has been allocated either statically or
@@ -582,22 +582,17 @@
             xNextExpireTime = prvGetNextExpireTime( &xListWasEmpty );
 
             /* If a timer has expired, process it.  Otherwise, block this task
-             * until either a timer does expire, or a command is received.  If
-             * this processing causes the lists to switch, delay processing
-             * received commands until the next iteration of the loop.  The next
-             * iteration will finish processing the expired timer if needed and
-             * then process received commands. */
-            if ( prvProcessTimerOrBlockTask( xNextExpireTime, xListWasEmpty ) != pdTRUE )
-            {
-                /* Empty the command queue. */
-                prvProcessReceivedCommands();
-            }
+             * until either a timer does expire, or a command is received. */
+            prvProcessTimerOrBlockTask( xNextExpireTime, xListWasEmpty );
+
+            /* Empty the command queue. */
+            prvProcessReceivedCommands();
         }
     }
 /*-----------------------------------------------------------*/
 
-    static BaseType_t prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime,
-                                                  BaseType_t xListWasEmpty )
+    static void prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime,
+                                            BaseType_t xListWasEmpty )
     {
         TickType_t xTimeNow;
         BaseType_t xTimerListsWereSwitched;
@@ -655,8 +650,6 @@
                 ( void ) xTaskResumeAll();
             }
         }
-
-        return xTimerListsWereSwitched;
     }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
#### Remove support for tmrCOMMAND_START_DONT_TRACE

Description
-----------
This PR is a potential replacement for #303 and fixes the same issues but using a more direct approach.

>Prior to this PR, if an application attempts to stop or delete an auto-reload timer while it is backlogged, the timer unexpectedly restarts. A timer is "backlogged" when at the time of the auto-reload, the new timer period has already elapsed. In the case of a deleted timer, the timer continues running using freed memory which may eventually lead to a crash or failure of other unrelated timers when the memory is reallocated.

This PR also fixes one-shot timers that were not being marked as inactive:
- when they expired before the start command could be processed
- when the expiration was processed during the timer list switch

and also improves consistency:
- Always reload auto-reload timers *before* calling the callback.
- Always call traceTIMER_EXPIRED() just prior to the callback.

Test Steps
-----------
See https://github.com/FreeRTOS/FreeRTOS/pull/553.

Related Issue
-----------
https://forums.freertos.org/t/freertos-time-correction/11856
https://forums.freertos.org/t/timer-start-dont-trace-race-condition/12168

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
