### PR TITLE
Overwrite existing QueueRegistry entries when a handle is added multiple times.

### DIFF
--- a/include/queue.h
+++ b/include/queue.h
@@ -1491,6 +1491,10 @@ BaseType_t xQueueGiveMutexRecursive( QueueHandle_t xMutex ) PRIVILEGED_FUNCTION;
  * does not effect the number of queues, semaphores and mutexes that can be
  * created - just the number that the registry can hold.
  *
+ * If vQueueAddToRegistry is called more than once with the same xQueue
+ * parameter, the registry will store the pcQueueName parameter from the
+ * most recent call to vQueueAddToRegistry.
+ *
  * @param xQueue The handle of the queue being added to the registry.  This
  * is the handle returned by a call to xQueueCreate().  Semaphore and mutex
  * handles can also be passed in here.


### PR DESCRIPTION
Description
-----------
Overwrite an existing entry for a given xQueue handle when vQueueAddToRegistry is called with an xQueue handle of a queue that is already in the Queue Registry.

Test Steps
-----------
Test will be updated in https://github.com/FreeRTOS/FreeRTOS/pull/552.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
