### PR TITLE
Replace configASSERT( pcQueueName ) in vQueueAddToRegistry with a NULL pointer check.

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -2728,28 +2728,30 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         UBaseType_t ux;
 
         configASSERT( xQueue );
-        configASSERT( pcQueueName );
 
         QueueRegistryItem_t * pxEntryToWrite = NULL;
 
-        /* See if there is an empty space in the registry.  A NULL name denotes
-         * a free slot. */
-        for( ux = ( UBaseType_t ) 0U; ux < ( UBaseType_t ) configQUEUE_REGISTRY_SIZE; ux++ )
+        if( NULL != pcQueueName )
         {
-            /* Replace an existing entry if the queue is already in the registry. */
-            if( xQueueRegistry[ ux ].xHandle == xQueue )
+            /* See if there is an empty space in the registry.  A NULL name denotes
+             * a free slot. */
+            for( ux = ( UBaseType_t ) 0U; ux < ( UBaseType_t ) configQUEUE_REGISTRY_SIZE; ux++ )
             {
-                pxEntryToWrite = &( xQueueRegistry[ ux ] );
-                break;
-            }
-            /* Otherwise, store in the next empty location */
-            else if( ( NULL == pxEntryToWrite ) && ( xQueueRegistry[ ux ].pcQueueName == NULL ) )
-            {
-                pxEntryToWrite = &( xQueueRegistry[ ux ] );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
+                /* Replace an existing entry if the queue is already in the registry. */
+                if( xQueueRegistry[ ux ].xHandle == xQueue )
+                {
+                    pxEntryToWrite = &( xQueueRegistry[ ux ] );
+                    break;
+                }
+                /* Otherwise, store in the next empty location */
+                else if( ( NULL == pxEntryToWrite ) && ( xQueueRegistry[ ux ].pcQueueName == NULL ) )
+                {
+                    pxEntryToWrite = &( xQueueRegistry[ ux ] );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
             }
         }
 

--- a/queue.c
+++ b/queue.c
@@ -2731,20 +2731,20 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
         QueueRegistryItem_t * pxEntryToWrite = NULL;
 
-        if( NULL != pcQueueName )
+        if( pcQueueName != NULL )
         {
             /* See if there is an empty space in the registry.  A NULL name denotes
              * a free slot. */
             for( ux = ( UBaseType_t ) 0U; ux < ( UBaseType_t ) configQUEUE_REGISTRY_SIZE; ux++ )
             {
                 /* Replace an existing entry if the queue is already in the registry. */
-                if( xQueueRegistry[ ux ].xHandle == xQueue )
+                if( xQueue == xQueueRegistry[ ux ].xHandle )
                 {
                     pxEntryToWrite = &( xQueueRegistry[ ux ] );
                     break;
                 }
                 /* Otherwise, store in the next empty location */
-                else if( ( NULL == pxEntryToWrite ) && ( xQueueRegistry[ ux ].pcQueueName == NULL ) )
+                else if( ( pxEntryToWrite == NULL ) && ( xQueueRegistry[ ux ].pcQueueName == NULL ) )
                 {
                     pxEntryToWrite = &( xQueueRegistry[ ux ] );
                 }
@@ -2755,7 +2755,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             }
         }
 
-        if( NULL != pxEntryToWrite )
+        if( pxEntryToWrite == NULL )
         {
             /* Store the information on this queue. */
             pxEntryToWrite->pcQueueName = pcQueueName;


### PR DESCRIPTION
Replace configASSERT( pcQueueName ) in vQueueAddToRegistry with a NULL pointer check.

Description
-----------
Replace the configASSERT added to vQueueAddToRegistry with a NULL pointer check so that it does not break usage in https://github.com/ARM-software/CMSIS-FreeRTOS.

Test Steps
-----------
Unit test currently in a Pull Request will be updated.

Related Issue
-----------
Fixes #311


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
