### PR TITLE
[kernel & MemMang] use space to replace tab and remove meaningless space in the end of each line

### DIFF
--- a/include/croutine.h
+++ b/include/croutine.h
@@ -65,7 +65,7 @@ typedef struct corCoRoutineControlBlock
  *                               crCOROUTINE_CODE pxCoRoutineCode,
  *                               UBaseType_t uxPriority,
  *                               UBaseType_t uxIndex
- *                             ); 
+ *                             );
  * </pre>
  *
  * Create a new co-routine and add it to the list of co-routines that are

--- a/include/timers.h
+++ b/include/timers.h
@@ -1329,10 +1329,10 @@ BaseType_t xTimerGenericCommand( TimerHandle_t xTimer,
     /**
      * task.h
      * <pre>void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer, StackType_t ** ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize ) </pre>
-     * 
-     * This function is used to provide a statically allocated block of memory to FreeRTOS to hold the Timer Task TCB.  This function is required when 
+     *
+     * This function is used to provide a statically allocated block of memory to FreeRTOS to hold the Timer Task TCB.  This function is required when
      * configSUPPORT_STATIC_ALLOCATION is set.  For more information see this URI: https://www.FreeRTOS.org/a00110.html#configSUPPORT_STATIC_ALLOCATION
-     * 
+     *
      * @param ppxTimerTaskTCBBuffer   A handle to a statically allocated TCB buffer
      * @param ppxTimerTaskStackBuffer A handle to a statically allocated Stack buffer for thie idle task
      * @param pulTimerTaskStackSize   A pointer to the number of elements that will fit in the allocated stack buffer

--- a/portable/MemMang/heap_1.c
+++ b/portable/MemMang/heap_1.c
@@ -80,8 +80,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 if ( (xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) )) > xWantedSize )
                 {
                     xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
-                } 
-                else 
+                }
+                else
                 {
                     xWantedSize = 0;
                 }

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -133,13 +133,13 @@ void * pvPortMalloc( size_t xWantedSize )
 
         /* The wanted size must be increased so it can contain a BlockLink_t
          * structure in addition to the requested amount of bytes. */
-        if( ( xWantedSize > 0 ) && 
+        if( ( xWantedSize > 0 ) &&
             ( ( xWantedSize + heapSTRUCT_SIZE ) >  xWantedSize ) ) /* Overflow check */
         {
             xWantedSize += heapSTRUCT_SIZE;
 
             /* Byte alignment required. Check for overflow. */
-            if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
+            if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) )
                     > xWantedSize )
             {
                 xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
@@ -148,11 +148,11 @@ void * pvPortMalloc( size_t xWantedSize )
             else
             {
                 xWantedSize = 0;
-            }       
+            }
         }
-        else 
+        else
         {
-            xWantedSize = 0; 
+            xWantedSize = 0;
         }
 
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -138,7 +138,7 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             /* The wanted size must be increased so it can contain a BlockLink_t
              * structure in addition to the requested amount of bytes. */
-            if( ( xWantedSize > 0 ) && 
+            if( ( xWantedSize > 0 ) &&
                 ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) ) /* Overflow check */
             {
                 xWantedSize += xHeapStructSize;
@@ -147,7 +147,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
                 {
                     /* Byte alignment required. Check for overflow. */
-                    if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
+                    if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) )
                             > xWantedSize )
                     {
                         xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
@@ -156,21 +156,21 @@ void * pvPortMalloc( size_t xWantedSize )
                     else
                     {
                         xWantedSize = 0;
-                    }  
+                    }
                 }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
-            } 
-            else 
+            }
+            else
             {
                 xWantedSize = 0;
             }
 
             if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
             {
-                /* Traverse the list from the start	(lowest address) block until
+                /* Traverse the list from the start (lowest address) block until
                  * one of adequate size is found. */
                 pxPreviousBlock = &xStart;
                 pxBlock = xStart.pxNextFreeBlock;

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -45,8 +45,8 @@
  *
  * typedef struct HeapRegion
  * {
- *	uint8_t *pucStartAddress; << Start address of a block of memory that will be part of the heap.
- *	size_t xSizeInBytes;	  << Size of the block of memory.
+ *  uint8_t *pucStartAddress; << Start address of a block of memory that will be part of the heap.
+ *  size_t xSizeInBytes;      << Size of the block of memory.
  * } HeapRegion_t;
  *
  * The array is terminated using a NULL zero sized region definition, and the
@@ -149,7 +149,7 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             /* The wanted size is increased so it can contain a BlockLink_t
              * structure in addition to the requested amount of bytes. */
-            if( ( xWantedSize > 0 ) && 
+            if( ( xWantedSize > 0 ) &&
                 ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) ) /* Overflow check */
             {
                 xWantedSize += xHeapStructSize;
@@ -162,8 +162,8 @@ void * pvPortMalloc( size_t xWantedSize )
                          xWantedSize )
                     {
                         xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
-                    } 
-                    else 
+                    }
+                    else
                     {
                         xWantedSize = 0;
                     }
@@ -180,7 +180,7 @@ void * pvPortMalloc( size_t xWantedSize )
 
             if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
             {
-                /* Traverse the list from the start	(lowest address) block until
+                /* Traverse the list from the start (lowest address) block until
                  * one of adequate size is found. */
                 pxPreviousBlock = &xStart;
                 pxBlock = xStart.pxNextFreeBlock;

--- a/timers.c
+++ b/timers.c
@@ -523,7 +523,7 @@
         {
             /* Advance the expiry time. */
             xExpiredTime += pxTimer->xTimerPeriodInTicks;
-            
+
             /* Call the timer callback. */
             traceTIMER_EXPIRED( pxTimer );
             pxTimer->pxCallbackFunction( ( TimerHandle_t ) pxTimer );


### PR DESCRIPTION
[kernel & MemMang] use space to replace tab and remove meaningless space in the end of each line
Signed-off-by: Meco Man <920369182@qq.com>

Description
-----------

be required to re-submit from #310

Related Issue
-----------
Negative


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
