### PR TITLE
Fix regression in vQueueAddToRegistry

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -2755,7 +2755,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             }
         }
 
-        if( pxEntryToWrite == NULL )
+        if( pxEntryToWrite != NULL )
         {
             /* Store the information on this queue. */
             pxEntryToWrite->pcQueueName = pcQueueName;


### PR DESCRIPTION
Fix regression in vQueueAddToRegistry.

Description
-----------
This regression was introduced in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/313.

Test Steps
-----------
Cmock test will be updated in https://github.com/FreeRTOS/FreeRTOS/pull/552.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
