### PR TITLE
Static allocation and lightweight idle tasks

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2715,6 +2715,8 @@ void vTaskStartScheduler( void )
             }
         #else  /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
             {
+                if(xCoreID == 0)
+                {
                 /* The Idle task is being created using dynamically allocated RAM. */
                 xReturn = xTaskCreate( prvIdleTask,
                                        cIdleName,
@@ -2722,6 +2724,18 @@ void vTaskStartScheduler( void )
                                        ( void * ) NULL,
                                        portPRIVILEGE_BIT,             /* In effect ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), but tskIDLE_PRIORITY is zero. */
                                        &xIdleTaskHandle[ xCoreID ] ); /*lint !e961 MISRA exception, justified as it is not a redundant explicit cast to all supported compilers. */
+                }
+                #if( configNUM_CORES > 1 )
+                else
+                {
+                xReturn = xTaskCreate( prvMinimalIdleTask,
+                                       cIdleName,
+                                       configMINIMAL_STACK_SIZE,
+                                       ( void * ) NULL,
+                                       portPRIVILEGE_BIT,             /* In effect ( tskIDLE_PRIORITY | portPRIVILEGE_BIT ), but tskIDLE_PRIORITY is zero. */
+                                       &xIdleTaskHandle[ xCoreID ] ); /*lint !e961 MISRA exception, justified as it is not a redundant explicit cast to all supported compilers. */
+                }
+                #endif
             }
         #endif /* configSUPPORT_STATIC_ALLOCATION */
     }


### PR DESCRIPTION

Description
-----------
This change adds static allocation for all tasks.  It also creates an idle task for each core.  The first idle task is the same as the legacy idle task and performs housekeeping and calls the vApplicationIdleHook() function.  The remaining idle tasks are very light and only call taskYield if needed.

If static allocation is enabled, the first idle task will call the task allocator just like it has always done.  But each additional idle task will have the minimum stack memory (configMINIMAL_STACK_SIZE) statically allocated from within the start scheduler function.

Test Steps
-----------
This was tested with the XMOS port with 1, 3 and 7 cores active.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
