### PR TITLE
Add history.txt for the 10.4.4 release

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,6 @@
 Documentation and download available at https://www.FreeRTOS.org/
 
-Changes between FreeRTOS V10.4.3 and FreeRTOS V10.4.4 released May 2021
+Changes between FreeRTOS V10.4.3 and FreeRTOS V10.4.4 released May 28 2021
     + Minor performance improvements to xTaskIncrementTick() achieved by providing
       macro versions of uxListRemove() and vListInsertEnd().
     + Minor refactor of timers.c that obsoletes the need for the

--- a/History.txt
+++ b/History.txt
@@ -37,7 +37,7 @@ Changes between FreeRTOS V10.4.3 and FreeRTOS V10.4.4 released May 28 2021
     + Other minor updates include adding additional configASSERT() checks and
       correcting and improving code comments.
     + Go look at the smp branch to see the progress towards the Symetric
-      Multiprocessing Kernel
+      Multiprocessing Kernel. https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/smp
 	  
 Changes between FreeRTOS V10.4.2 and FreeRTOS V10.4.3 released December 14 2020
 

--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,44 @@
 Documentation and download available at https://www.FreeRTOS.org/
 
+Changes between FreeRTOS V10.4.3 and FreeRTOS V10.4.4 released May 2021
+    + Minor performance improvements to xTaskIncrementTick() achieved by providing
+      macro versions of uxListRemove() and vListInsertEnd().
+    + Minor refactor of timers.c that obsoletes the need for the
+      tmrCOMMAND_START_DONT_TRACE macro and removes the need for timers.c to
+      post to its own event queue.  A consequence of this change is that auto-
+      reload timers that miss their intended next execution time will execute
+      again immediately rather than executing again the next time the command
+      queue is processed.  (thanks Jeff Tenney).
+    + Fix a race condition in the message buffer implementation.  The
+      underlying cause was that length and data bytes are written and read as
+      two distinct operations, which both modify the size of the buffer. If a
+      context switch occurs after adding or removing the length bytes, but
+      before adding or removing the data bytes, then another task may observe
+      the message buffer in an invalid state.
+    + The xTaskCreate() and xTaskCreateStatic() functions accept a task priority
+      as an input parameter.  The priority has always been silently capped to
+      (configMAX_PRIORITIES - 1) should it be set to a value above that priority.
+      Now values above that priority will also trigger a configASSERT() failure.
+	+ Replace configASSERT( pcQueueName ) in vQueueAddToRegistry with a NULL
+      pointer check.
+    + Introduce the configSTACK_ALLOCATION_FROM_SEPARATE_HEAP configuration
+      constant that enables the stack allocated to tasks to come from a heap other
+      than the heap used by other memory allocations.  This enables stacks to be
+      placed within special regions, such as fast tightly coupled memory.
+    + If there is an attempt to add the same queue or semaphore handle to the
+      queue registry more than once then prior versions would create two separate
+      entries.  Now if this is done the first entry is overwritten rather than
+      duplicated.
+    + Update the ESP32 port and TF-M (Trusted Firmware M)code to the latest from
+      their respective repositories.
+    + Correct a build error in the POSIX port.
+    + Additional minor formatting updates, including replacing tabs with spaces
+      in more files.
+    + Other minor updates include adding additional configASSERT() checks and
+      correcting and improving code comments.
+    + Go look at the smp branch to see the progress towards the Symetric
+      Multiprocessing Kernel
+	  
 Changes between FreeRTOS V10.4.2 and FreeRTOS V10.4.3 released December 14 2020
 
 	V10.4.3 is included in the 202012.00 LTS release.  Learn more at https:/freertos.org/lts-libraries.html

--- a/include/task.h
+++ b/include/task.h
@@ -46,10 +46,17 @@
 * MACROS AND DEFINITIONS
 *----------------------------------------------------------*/
 
-#define tskKERNEL_VERSION_NUMBER       "V10.4.999"
+/*
+ * If tskKERNEL_VERSION_NUMBER ends with + it represents the version in development
+ * the numbered release.
+ *
+ * The tskKERNEL_VERSION_MAJOR, tskKERNEL_VERSION_MINOR, tskKERNEL_VERSION_BUILD
+ * values will reflect the last released version1 number.
+ */ 
+#define tskKERNEL_VERSION_NUMBER       "V10.4.3+"
 #define tskKERNEL_VERSION_MAJOR        10
 #define tskKERNEL_VERSION_MINOR        4
-#define tskKERNEL_VERSION_BUILD        999
+#define tskKERNEL_VERSION_BUILD        3
 
 /* MPU region parameters passed in ulParameters
  * of MemoryRegion_t struct. */

--- a/include/task.h
+++ b/include/task.h
@@ -48,10 +48,10 @@
 
 /*
  * If tskKERNEL_VERSION_NUMBER ends with + it represents the version in development
- * the numbered release.
+ * after the numbered release.
  *
  * The tskKERNEL_VERSION_MAJOR, tskKERNEL_VERSION_MINOR, tskKERNEL_VERSION_BUILD
- * values will reflect the last released version1 number.
+ * values will reflect the last released version number.
  */ 
 #define tskKERNEL_VERSION_NUMBER       "V10.4.3+"
 #define tskKERNEL_VERSION_MAJOR        10


### PR DESCRIPTION
Adding history.txt preparatory to releasing v10.4.4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
