### PR TITLE
Add Thread Local Storage (TLS) support using Picolibc functions

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1054,6 +1054,7 @@ mclk
 mconfigintcoresw
 mcr
 mcu
+md
 mddr
 mder
 mdh
@@ -1335,6 +1336,7 @@ phy
 phya
 pic
 picnt
+picolibc
 pien
 piir
 pimr

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -95,34 +95,8 @@
 /* Required if struct _reent is used. */
 #if ( configUSE_NEWLIB_REENTRANT == 1 )
 
-/* Note Newlib support has been included by popular demand, but is not
- * used by the FreeRTOS maintainers themselves.  FreeRTOS is not
- * responsible for resulting newlib operation.  User must be familiar with
- * newlib and must provide system-wide implementations of the necessary
- * stubs. Be warned that (at the time of writing) the current newlib design
- * implements a system-wide malloc() that must be provided with locks.
- *
- * See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
- * for additional information. */
-    #include <reent.h>
+    #include "newlib-freertos.h"
 
-    #define configUSE_C_RUNTIME_TLS_SUPPORT    1
-
-    #ifndef configTLS_BLOCK_TYPE
-        #define configTLS_BLOCK_TYPE           struct _reent
-    #endif
-
-    #ifndef configINIT_TLS_BLOCK
-        #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )    _REENT_INIT_PTR( &( xTLSBlock ) )
-    #endif
-
-    #ifndef configSET_TLS_BLOCK
-        #define configSET_TLS_BLOCK( xTLSBlock )    ( _impure_ptr = &( xTLSBlock ) )
-    #endif
-
-    #ifndef configDEINIT_TLS_BLOCK
-        #define configDEINIT_TLS_BLOCK( xTLSBlock )    _reclaim_reent( &( xTLSBlock ) )
-    #endif
 #endif /* if ( configUSE_NEWLIB_REENTRANT == 1 ) */
 
 #ifndef configUSE_C_RUNTIME_TLS_SUPPORT

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -113,7 +113,7 @@
     #endif
 
     #ifndef configINIT_TLS_BLOCK
-        #define configINIT_TLS_BLOCK( xTLSBlock )    _REENT_INIT_PTR( &( xTLSBlock ) )
+        #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )    _REENT_INIT_PTR( &( xTLSBlock ) )
     #endif
 
     #ifndef configSET_TLS_BLOCK

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -103,7 +103,7 @@
     #define configUSE_C_RUNTIME_TLS_SUPPORT    0
 #endif
 
-#if ( ( configUSE_NEWLIB_REENTRANT == 0 ) && ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+#if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
 
     #ifndef configTLS_BLOCK_TYPE
         #error Missing definition:  configTLS_BLOCK_TYPE must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
@@ -120,7 +120,7 @@
     #ifndef configDEINIT_TLS_BLOCK
         #error Missing definition:  configDEINIT_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
     #endif
-#endif /* if ( ( configUSE_NEWLIB_REENTRANT == 0 ) && ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) ) */
+#endif /* if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) */
 
 /*
  * Check all the required application specific macros have been defined.
@@ -1280,7 +1280,7 @@ typedef struct xSTATIC_TCB
     #if ( configGENERATE_RUN_TIME_STATS == 1 )
         configRUN_TIME_COUNTER_TYPE ulDummy16;
     #endif
-    #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+    #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
         configTLS_BLOCK_TYPE xDummy17;
     #endif
     #if ( configUSE_TASK_NOTIFICATIONS == 1 )

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -99,6 +99,17 @@
 
 #endif /* if ( configUSE_NEWLIB_REENTRANT == 1 ) */
 
+/* Must be defaulted before configUSE_PICOLIBC_TLS is used below. */
+#ifndef configUSE_PICOLIBC_TLS
+    #define configUSE_PICOLIBC_TLS    0
+#endif
+
+#if ( configUSE_PICOLIBC_TLS == 1 )
+
+    #include "picolibc-freertos.h"
+
+#endif /* if ( configUSE_PICOLIBC_TLS == 1 ) */
+
 #ifndef configUSE_C_RUNTIME_TLS_SUPPORT
     #define configUSE_C_RUNTIME_TLS_SUPPORT    0
 #endif

--- a/include/newlib-freertos.h
+++ b/include/newlib-freertos.h
@@ -1,0 +1,62 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef INC_NEWLIB_FREERTOS_H
+#define INC_NEWLIB_FREERTOS_H
+
+/* Note Newlib support has been included by popular demand, but is not
+ * used by the FreeRTOS maintainers themselves.  FreeRTOS is not
+ * responsible for resulting newlib operation.  User must be familiar with
+ * newlib and must provide system-wide implementations of the necessary
+ * stubs. Be warned that (at the time of writing) the current newlib design
+ * implements a system-wide malloc() that must be provided with locks.
+ *
+ * See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+ * for additional information. */
+
+#include <reent.h>
+
+#define configUSE_C_RUNTIME_TLS_SUPPORT    1
+
+#ifndef configTLS_BLOCK_TYPE
+    #define configTLS_BLOCK_TYPE           struct _reent
+#endif
+
+#ifndef configINIT_TLS_BLOCK
+    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )    _REENT_INIT_PTR( &( xTLSBlock ) )
+#endif
+
+#ifndef configSET_TLS_BLOCK
+    #define configSET_TLS_BLOCK( xTLSBlock )    _impure_ptr = &( xTLSBlock )
+#endif
+
+#ifndef configDEINIT_TLS_BLOCK
+    #define configDEINIT_TLS_BLOCK( xTLSBlock )    _reclaim_reent( &( xTLSBlock ) )
+#endif
+
+#endif /* INC_NEWLIB_FREERTOS_H */

--- a/include/picolibc-freertos.h
+++ b/include/picolibc-freertos.h
@@ -1,0 +1,69 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef INC_PICOLIBC_FREERTOS_H
+#define INC_PICOLIBC_FREERTOS_H
+
+/* Use picolibc TLS support to allocate space for __thread variables,
+ * initialize them at thread creation and set the TLS context at
+ * thread switch time.
+ *
+ * See the picolibc TLS docs:
+ * https://github.com/picolibc/picolibc/blob/main/doc/tls.md
+ * for additional information. */
+
+#include <picotls.h>
+
+#define configUSE_C_RUNTIME_TLS_SUPPORT    1
+
+#define configTLS_BLOCK_TYPE               void *
+
+/* Allocate thread local storage block off the end of the
+* stack. The _tls_size() function returns the size (in
+* bytes) of the total TLS area used by the application */
+#if ( portSTACK_GROWTH < 0 )
+    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                                            \
+    do {                                                                                               \
+        pxTopOfStack = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack ) - _tls_size() ); \
+        xTLSBlock = pxTopOfStack;                                                                      \
+        _init_tls( xTLSBlock );                                                                        \
+    } while( 0 )
+#else /* portSTACK_GROWTH */
+    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                                            \
+    do {                                                                                               \
+        xTLSBlock = pxTopOfStack;                                                                      \
+        pxTopOfStack = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack ) + _tls_size() ); \
+        _init_tls( xTLSBlock );                                                                        \
+    } while( 0 )
+#endif /* portSTACK_GROWTH */
+
+#define configSET_TLS_BLOCK( xTLSBlock )    _set_tls( xTLSBlock )
+
+#define configDEINIT_TLS_BLOCK( xTLSBlock )
+
+#endif /* INC_PICOLIBC_FREERTOS_H */

--- a/portable/ThirdParty/GCC/ARC_EM_HS/port.c
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/port.c
@@ -251,16 +251,8 @@ void vPortEndTask( void )
             uint32_t ulRunTimeCounter; /*< Stores the amount of time the task has spent in the Running state. */
         #endif
 
-        #if ( configUSE_NEWLIB_REENTRANT == 1 )
-
-            /* Allocate a Newlib reent structure that is specific to this task.
-             * Note Newlib support has been included by popular demand, but is not
-             * used by the FreeRTOS maintainers themselves.  FreeRTOS is not
-             * responsible for resulting newlib operation.  User must be familiar with
-             * newlib and must provide system-wide implementations of the necessary
-             * stubs. Be warned that (at the time of writing) the current newlib design
-             * implements a system-wide malloc() that must be provided with locks. */
-            struct  _reent xNewLib_reent;
+        #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
+            configTLS_BLOCK_TYPE xTLSBlock; /*< Memory block used as Thread Local Storage (TLS) Block for the task. */
         #endif
 
         #if ( configUSE_TASK_NOTIFICATIONS == 1 )

--- a/portable/ThirdParty/GCC/ARC_v1/port.c
+++ b/portable/ThirdParty/GCC/ARC_v1/port.c
@@ -251,16 +251,8 @@ void vPortEndTask( void )
             uint32_t ulRunTimeCounter;      /*< Stores the amount of time the task has spent in the Running state. */
         #endif
 
-        #if ( configUSE_NEWLIB_REENTRANT == 1 )
-
-            /* Allocate a Newlib reent structure that is specific to this task.
-             * Note Newlib support has been included by popular demand, but is not
-             * used by the FreeRTOS maintainers themselves.  FreeRTOS is not
-             * responsible for resulting newlib operation.  User must be familiar with
-             * newlib and must provide system-wide implementations of the necessary
-             * stubs. Be warned that (at the time of writing) the current newlib design
-             * implements a system-wide malloc() that must be provided with locks. */
-            struct  _reent xNewLib_reent;
+        #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
+            configTLS_BLOCK_TYPE xTLSBlock; /*< Memory block used as Thread Local Storage (TLS) Block for the task. */
         #endif
 
         #if ( configUSE_TASK_NOTIFICATIONS == 1 )

--- a/tasks.c
+++ b/tasks.c
@@ -958,7 +958,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
     {
         /* Allocate and initialize memory for the task's TLS Block. */
-        configINIT_TLS_BLOCK( pxNewTCB->xTLSBlock );
+        configINIT_TLS_BLOCK( pxNewTCB->xTLSBlock, pxTopOfStack );
     }
     #endif
 

--- a/tasks.c
+++ b/tasks.c
@@ -300,7 +300,7 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
         configRUN_TIME_COUNTER_TYPE ulRunTimeCounter; /**< Stores the amount of time the task has spent in the Running state. */
     #endif
 
-    #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+    #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
         configTLS_BLOCK_TYPE xTLSBlock; /**< Memory block used as Thread Local Storage (TLS) Block for the task. */
     #endif
 
@@ -955,7 +955,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     }
     #endif
 
-    #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+    #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
     {
         /* Allocate and initialize memory for the task's TLS Block. */
         configINIT_TLS_BLOCK( pxNewTCB->xTLSBlock, pxTopOfStack );
@@ -2030,7 +2030,7 @@ void vTaskStartScheduler( void )
          * starts to run. */
         portDISABLE_INTERRUPTS();
 
-        #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+        #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
         {
             /* Switch C-Runtime's TLS Block to point to the TLS
              * block specific to the task that will run first. */
@@ -3074,7 +3074,7 @@ void vTaskSwitchContext( void )
         }
         #endif
 
-        #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+        #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
         {
             /* Switch C-Runtime's TLS Block to point to the TLS
              * Block specific to this task. */
@@ -3950,7 +3950,7 @@ static void prvCheckTasksWaitingTermination( void )
          * want to allocate and clean RAM statically. */
         portCLEAN_UP_TCB( pxTCB );
 
-        #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+        #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
         {
             /* Free up the memory allocated for the task's TLS Block. */
             configDEINIT_TLS_BLOCK( pxCurrentTCB->xTLSBlock );


### PR DESCRIPTION
Thread Local Storage (TLS) offers a platform-native mechanism for
managing per-task variables that doesn't rely on custom support in
FreeRTOS for things like errno.

Picolibc uses TLS internally for all variables that are intended to be
task-local. Because of the TLS architecture, only variables which are
actually used end up getting allocate space in the TLS block. Contrast
this with the newlib 'struct _reent' block which holds all possible
task-local values, even for APIs not used by the application.

Picolibc also has TLS helper functions that provide the necessary
platform-specific code which makes the FreeRTOS changes platform
independent. This patch uses those hooks instead of providing the
platform specific code in FreeRTOS itself.

The picolibc helper functions rely on elements within the linker
script to arrange the TLS data in memory and define some symbols.
Applications wanting to use this mechanism will need changes in their
linker script when migrating to picolibc.

Signed-off-by: Keith Packard <keithp@keithp.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
