### PR TITLE
Adds SemphrGetCountFromISR with QMsgWaitingFromISR

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -2440,6 +2440,7 @@ uxsavedmaskvalue
 uxsavedtaskstackpointer
 uxschedulersuspended
 uxsemaphoregetcount
+uxsemaphoregetcountfromisr
 uxstate
 uxstreambuffernumber
 uxtaskgetnumberoftasks

--- a/include/semphr.h
+++ b/include/semphr.h
@@ -1172,4 +1172,18 @@ typedef QueueHandle_t SemaphoreHandle_t;
  */
 #define uxSemaphoreGetCount( xSemaphore )                uxQueueMessagesWaiting( ( QueueHandle_t ) ( xSemaphore ) )
 
+/**
+ * semphr.h
+ * <pre>
+ * UBaseType_t uxSemaphoreGetCountFromISR( SemaphoreHandle_t xSemaphore );
+ * </pre>
+ *
+ * If the semaphore is a counting semaphore then uxSemaphoreGetCountFromISR() returns
+ * its current count value.  If the semaphore is a binary semaphore then
+ * uxSemaphoreGetCountFromISR() returns 1 if the semaphore is available, and 0 if the
+ * semaphore is not available.
+ *
+ */
+#define uxSemaphoreGetCountFromISR( xSemaphore )                uxQueueMessagesWaitingFromISR( ( QueueHandle_t ) ( xSemaphore ) )
+
 #endif /* SEMAPHORE_H */


### PR DESCRIPTION
<!--- Title -->
Adds `uxSemaphoreGetCountFromISR` using `uxQueueMessagesWaitingFromISR`

Description
-----------
<!--- Describe your changes in detail. -->
Noticed this ISR function was missing but the function it wraps (non-ISR ..GetCount function) does contain an ISR friendly prototype. 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
NA

Related Issue
-----------
<!-- If any, please provide issue ID. -->
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
