### PR TITLE
Posix: fix event_wait_timed()

### DIFF
--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
@@ -76,8 +76,8 @@ bool event_wait_timed( struct event * ev,
     int ret = 0;
 
     clock_gettime( CLOCK_REALTIME, &ts );
-    //ts.tv_sec += ms;
-    ts.tv_nsec += (ms * 1000000);
+    ts.tv_sec += ms / 1000;
+    ts.tv_nsec += ((ms % 1000) * 1000000);
     pthread_mutex_lock( &ev->mutex );
 
     while( (ev->event_triggered == false) && (ret == 0) )


### PR DESCRIPTION
event_wait_timed() was ignoring a timeout of 1000 ms.
Presumably this is because pthread_cond_timedwait() only
considers tv_nsec less than one second.

Convert the timeout in miliseconds to second and nanosecond
components to fix this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
