### PR TITLE
Let each stream/message can use its own sbSEND_COMPLETED

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -47,7 +47,7 @@
  *     contains the typedefs required to build FreeRTOS.  Read the instructions
  *     in FreeRTOS/source/stdint.readme for more information.
  */
-#include <stdint.h>     /* READ COMMENT ABOVE. */
+#include <stdint.h> /* READ COMMENT ABOVE. */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -130,21 +130,23 @@
 
 #ifdef INCLUDE_xTaskDelayUntil
     #ifdef INCLUDE_vTaskDelayUntil
-        /* INCLUDE_vTaskDelayUntil was replaced by INCLUDE_xTaskDelayUntil.  Backward
-         * compatibility is maintained if only one or the other is defined, but
-         * there is a conflict if both are defined. */
+
+/* INCLUDE_vTaskDelayUntil was replaced by INCLUDE_xTaskDelayUntil.  Backward
+ * compatibility is maintained if only one or the other is defined, but
+ * there is a conflict if both are defined. */
         #error INCLUDE_vTaskDelayUntil and INCLUDE_xTaskDelayUntil are both defined.  INCLUDE_vTaskDelayUntil is no longer required and should be removed
     #endif
 #endif
 
 #ifndef INCLUDE_xTaskDelayUntil
     #ifdef INCLUDE_vTaskDelayUntil
-        /* If INCLUDE_vTaskDelayUntil is set but INCLUDE_xTaskDelayUntil is not then
-         * the project's FreeRTOSConfig.h probably pre-dates the introduction of
-         * xTaskDelayUntil and setting INCLUDE_xTaskDelayUntil to whatever
-         * INCLUDE_vTaskDelayUntil is set to will ensure backward compatibility.
-         */
-        #define INCLUDE_xTaskDelayUntil INCLUDE_vTaskDelayUntil
+
+/* If INCLUDE_vTaskDelayUntil is set but INCLUDE_xTaskDelayUntil is not then
+ * the project's FreeRTOSConfig.h probably pre-dates the introduction of
+ * xTaskDelayUntil and setting INCLUDE_xTaskDelayUntil to whatever
+ * INCLUDE_vTaskDelayUntil is set to will ensure backward compatibility.
+ */
+        #define INCLUDE_xTaskDelayUntil    INCLUDE_vTaskDelayUntil
     #endif
 #endif
 
@@ -906,6 +908,7 @@
 #endif
 
 #ifndef configRUN_TIME_COUNTER_TYPE
+
 /* Defaults to uint32_t for backward compatibility, but can be overridden in
  * FreeRTOSConfig.h if uint32_t is too restrictive. */
 
@@ -1065,6 +1068,11 @@
 
 #ifndef configRUN_ADDITIONAL_TESTS
     #define configRUN_ADDITIONAL_TESTS    0
+#endif
+
+/* Set configUSE_SB_COMPLETED_CALLBACK to 1 to enable each stream buffer to define its own sbSEND_COMPLETED*/
+#ifndef configUSE_SB_COMPLETED_CALLBACK
+    #define configUSE_SB_COMPLETED_CALLBACK    0
 #endif
 
 
@@ -1340,7 +1348,11 @@ typedef struct xSTATIC_TIMER
 typedef struct xSTATIC_STREAM_BUFFER
 {
     size_t uxDummy1[ 4 ];
-    void * pvDummy2[ 3 ];
+    #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+        void * pvDummy2[ 4 ];
+    #else
+        void * pvDummy2[ 3 ];
+    #endif
     uint8_t ucDummy3;
     #if ( configUSE_TRACE_FACILITY == 1 )
         UBaseType_t uxDummy4;

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -142,8 +142,13 @@ typedef void * MessageBufferHandle_t;
  * \defgroup xMessageBufferCreate xMessageBufferCreate
  * \ingroup MessageBufferManagement
  */
-#define xMessageBufferCreate( xBufferSizeBytes ) \
+#if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+    #define xMessageBufferCreate( xBufferSizeBytes, pxStreamBufferCallbackFunction ) \
+    ( MessageBufferHandle_t ) xStreamBufferGenericCreate( xBufferSizeBytes, ( size_t ) 0, pdTRUE, pxStreamBufferCallbackFunction )
+#else
+    #define xMessageBufferCreate( xBufferSizeBytes ) \
     ( MessageBufferHandle_t ) xStreamBufferGenericCreate( xBufferSizeBytes, ( size_t ) 0, pdTRUE )
+#endif
 
 /**
  * message_buffer.h
@@ -209,8 +214,13 @@ typedef void * MessageBufferHandle_t;
  * \defgroup xMessageBufferCreateStatic xMessageBufferCreateStatic
  * \ingroup MessageBufferManagement
  */
-#define xMessageBufferCreateStatic( xBufferSizeBytes, pucMessageBufferStorageArea, pxStaticMessageBuffer ) \
+#if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+    #define xMessageBufferCreateStatic( xBufferSizeBytes, pucMessageBufferStorageArea, pxStaticMessageBuffer, pxStreamBufferCallbackFunction ) \
+    ( MessageBufferHandle_t ) xStreamBufferGenericCreateStatic( xBufferSizeBytes, 0, pdTRUE, pucMessageBufferStorageArea, pxStaticMessageBuffer, pxStreamBufferCallbackFunction )
+#else
+    #define xMessageBufferCreateStatic( xBufferSizeBytes, pucMessageBufferStorageArea, pxStaticMessageBuffer ) \
     ( MessageBufferHandle_t ) xStreamBufferGenericCreateStatic( xBufferSizeBytes, 0, pdTRUE, pucMessageBufferStorageArea, pxStaticMessageBuffer )
+#endif
 
 /**
  * message_buffer.h

--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -36,225 +36,234 @@
 
 
 #ifndef MPU_PROTOTYPES_H
-#define MPU_PROTOTYPES_H
+    #define MPU_PROTOTYPES_H
 
 /* MPU versions of tasks.h API functions. */
-BaseType_t MPU_xTaskCreate( TaskFunction_t pxTaskCode,
-                            const char * const pcName,
-                            const uint16_t usStackDepth,
-                            void * const pvParameters,
-                            UBaseType_t uxPriority,
-                            TaskHandle_t * const pxCreatedTask ) FREERTOS_SYSTEM_CALL;
-TaskHandle_t MPU_xTaskCreateStatic( TaskFunction_t pxTaskCode,
-                                    const char * const pcName,
-                                    const uint32_t ulStackDepth,
-                                    void * const pvParameters,
-                                    UBaseType_t uxPriority,
-                                    StackType_t * const puxStackBuffer,
-                                    StaticTask_t * const pxTaskBuffer ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskDelete( TaskHandle_t xTaskToDelete ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskDelay( const TickType_t xTicksToDelay ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
-                          const TickType_t xTimeIncrement ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskAbortDelay( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxTaskPriorityGet( const TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
-eTaskState MPU_eTaskGetState( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskGetInfo( TaskHandle_t xTask,
-                       TaskStatus_t * pxTaskStatus,
-                       BaseType_t xGetFreeStackSpace,
-                       eTaskState eState ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskPrioritySet( TaskHandle_t xTask,
-                           UBaseType_t uxNewPriority ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskSuspend( TaskHandle_t xTaskToSuspend ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskResume( TaskHandle_t xTaskToResume ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskStartScheduler( void ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskSuspendAll( void ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskResumeAll( void ) FREERTOS_SYSTEM_CALL;
-TickType_t MPU_xTaskGetTickCount( void ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxTaskGetNumberOfTasks( void ) FREERTOS_SYSTEM_CALL;
-char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) FREERTOS_SYSTEM_CALL;
-TaskHandle_t MPU_xTaskGetHandle( const char * pcNameToQuery ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
-configSTACK_DEPTH_TYPE MPU_uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskSetApplicationTaskTag( TaskHandle_t xTask,
-                                     TaskHookFunction_t pxHookFunction ) FREERTOS_SYSTEM_CALL;
-TaskHookFunction_t MPU_xTaskGetApplicationTaskTag( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskSetThreadLocalStoragePointer( TaskHandle_t xTaskToSet,
-                                            BaseType_t xIndex,
-                                            void * pvValue ) FREERTOS_SYSTEM_CALL;
-void * MPU_pvTaskGetThreadLocalStoragePointer( TaskHandle_t xTaskToQuery,
-                                               BaseType_t xIndex ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskCallApplicationTaskHook( TaskHandle_t xTask,
-                                             void * pvParameter ) FREERTOS_SYSTEM_CALL;
-TaskHandle_t MPU_xTaskGetIdleTaskHandle( void ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
-                                      const UBaseType_t uxArraySize,
-                                      configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) FREERTOS_SYSTEM_CALL;
-configRUN_TIME_COUNTER_TYPE MPU_ulTaskGetIdleRunTimeCounter( void ) FREERTOS_SYSTEM_CALL;
-configRUN_TIME_COUNTER_TYPE MPU_ulTaskGetIdleRunTimePercent( void ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskList( char * pcWriteBuffer ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskGetRunTimeStats( char * pcWriteBuffer ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskGenericNotify( TaskHandle_t xTaskToNotify,
-                                   UBaseType_t uxIndexToNotify,
-                                   uint32_t ulValue,
-                                   eNotifyAction eAction,
-                                   uint32_t * pulPreviousNotificationValue ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskGenericNotifyWait( UBaseType_t uxIndexToWaitOn,
-                                       uint32_t ulBitsToClearOnEntry,
-                                       uint32_t ulBitsToClearOnExit,
-                                       uint32_t * pulNotificationValue,
-                                       TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-uint32_t MPU_ulTaskGenericNotifyTake( UBaseType_t uxIndexToWaitOn,
-                                      BaseType_t xClearCountOnExit,
-                                      TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskGenericNotifyStateClear( TaskHandle_t xTask,
-                                             UBaseType_t uxIndexToClear ) FREERTOS_SYSTEM_CALL;
-uint32_t MPU_ulTaskGenericNotifyValueClear( TaskHandle_t xTask,
-                                            UBaseType_t uxIndexToClear,
-                                            uint32_t ulBitsToClear ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskIncrementTick( void ) FREERTOS_SYSTEM_CALL;
-TaskHandle_t MPU_xTaskGetCurrentTaskHandle( void ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
-                                     TickType_t * const pxTicksToWait ) FREERTOS_SYSTEM_CALL;
-void MPU_vTaskMissedYield( void ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskGetSchedulerState( void ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskCreate( TaskFunction_t pxTaskCode,
+                                const char * const pcName,
+                                const uint16_t usStackDepth,
+                                void * const pvParameters,
+                                UBaseType_t uxPriority,
+                                TaskHandle_t * const pxCreatedTask ) FREERTOS_SYSTEM_CALL;
+    TaskHandle_t MPU_xTaskCreateStatic( TaskFunction_t pxTaskCode,
+                                        const char * const pcName,
+                                        const uint32_t ulStackDepth,
+                                        void * const pvParameters,
+                                        UBaseType_t uxPriority,
+                                        StackType_t * const puxStackBuffer,
+                                        StaticTask_t * const pxTaskBuffer ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskDelete( TaskHandle_t xTaskToDelete ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskDelay( const TickType_t xTicksToDelay ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
+                                    const TickType_t xTimeIncrement ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskAbortDelay( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxTaskPriorityGet( const TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
+    eTaskState MPU_eTaskGetState( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskGetInfo( TaskHandle_t xTask,
+                           TaskStatus_t * pxTaskStatus,
+                           BaseType_t xGetFreeStackSpace,
+                           eTaskState eState ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskPrioritySet( TaskHandle_t xTask,
+                               UBaseType_t uxNewPriority ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskSuspend( TaskHandle_t xTaskToSuspend ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskResume( TaskHandle_t xTaskToResume ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskStartScheduler( void ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskSuspendAll( void ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskResumeAll( void ) FREERTOS_SYSTEM_CALL;
+    TickType_t MPU_xTaskGetTickCount( void ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxTaskGetNumberOfTasks( void ) FREERTOS_SYSTEM_CALL;
+    char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) FREERTOS_SYSTEM_CALL;
+    TaskHandle_t MPU_xTaskGetHandle( const char * pcNameToQuery ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
+    configSTACK_DEPTH_TYPE MPU_uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskSetApplicationTaskTag( TaskHandle_t xTask,
+                                         TaskHookFunction_t pxHookFunction ) FREERTOS_SYSTEM_CALL;
+    TaskHookFunction_t MPU_xTaskGetApplicationTaskTag( TaskHandle_t xTask ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskSetThreadLocalStoragePointer( TaskHandle_t xTaskToSet,
+                                                BaseType_t xIndex,
+                                                void * pvValue ) FREERTOS_SYSTEM_CALL;
+    void * MPU_pvTaskGetThreadLocalStoragePointer( TaskHandle_t xTaskToQuery,
+                                                   BaseType_t xIndex ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskCallApplicationTaskHook( TaskHandle_t xTask,
+                                                 void * pvParameter ) FREERTOS_SYSTEM_CALL;
+    TaskHandle_t MPU_xTaskGetIdleTaskHandle( void ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
+                                          const UBaseType_t uxArraySize,
+                                          configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) FREERTOS_SYSTEM_CALL;
+    configRUN_TIME_COUNTER_TYPE MPU_ulTaskGetIdleRunTimeCounter( void ) FREERTOS_SYSTEM_CALL;
+    configRUN_TIME_COUNTER_TYPE MPU_ulTaskGetIdleRunTimePercent( void ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskList( char * pcWriteBuffer ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskGetRunTimeStats( char * pcWriteBuffer ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskGenericNotify( TaskHandle_t xTaskToNotify,
+                                       UBaseType_t uxIndexToNotify,
+                                       uint32_t ulValue,
+                                       eNotifyAction eAction,
+                                       uint32_t * pulPreviousNotificationValue ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskGenericNotifyWait( UBaseType_t uxIndexToWaitOn,
+                                           uint32_t ulBitsToClearOnEntry,
+                                           uint32_t ulBitsToClearOnExit,
+                                           uint32_t * pulNotificationValue,
+                                           TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    uint32_t MPU_ulTaskGenericNotifyTake( UBaseType_t uxIndexToWaitOn,
+                                          BaseType_t xClearCountOnExit,
+                                          TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskGenericNotifyStateClear( TaskHandle_t xTask,
+                                                 UBaseType_t uxIndexToClear ) FREERTOS_SYSTEM_CALL;
+    uint32_t MPU_ulTaskGenericNotifyValueClear( TaskHandle_t xTask,
+                                                UBaseType_t uxIndexToClear,
+                                                uint32_t ulBitsToClear ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskIncrementTick( void ) FREERTOS_SYSTEM_CALL;
+    TaskHandle_t MPU_xTaskGetCurrentTaskHandle( void ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
+                                         TickType_t * const pxTicksToWait ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTaskMissedYield( void ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskGetSchedulerState( void ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) FREERTOS_SYSTEM_CALL;
 
 /* MPU versions of queue.h API functions. */
-BaseType_t MPU_xQueueGenericSend( QueueHandle_t xQueue,
-                                  const void * const pvItemToQueue,
-                                  TickType_t xTicksToWait,
-                                  const BaseType_t xCopyPosition ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueueReceive( QueueHandle_t xQueue,
-                              void * const pvBuffer,
-                              TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueuePeek( QueueHandle_t xQueue,
-                           void * const pvBuffer,
-                           TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
-                                    TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxQueueMessagesWaiting( const QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxQueueSpacesAvailable( const QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
-void MPU_vQueueDelete( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
-QueueHandle_t MPU_xQueueCreateMutex( const uint8_t ucQueueType ) FREERTOS_SYSTEM_CALL;
-QueueHandle_t MPU_xQueueCreateMutexStatic( const uint8_t ucQueueType,
-                                           StaticQueue_t * pxStaticQueue ) FREERTOS_SYSTEM_CALL;
-QueueHandle_t MPU_xQueueCreateCountingSemaphore( const UBaseType_t uxMaxCount,
-                                                 const UBaseType_t uxInitialCount ) FREERTOS_SYSTEM_CALL;
-QueueHandle_t MPU_xQueueCreateCountingSemaphoreStatic( const UBaseType_t uxMaxCount,
-                                                       const UBaseType_t uxInitialCount,
-                                                       StaticQueue_t * pxStaticQueue ) FREERTOS_SYSTEM_CALL;
-TaskHandle_t MPU_xQueueGetMutexHolder( QueueHandle_t xSemaphore ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueueTakeMutexRecursive( QueueHandle_t xMutex,
-                                         TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueueGiveMutexRecursive( QueueHandle_t pxMutex ) FREERTOS_SYSTEM_CALL;
-void MPU_vQueueAddToRegistry( QueueHandle_t xQueue,
-                              const char * pcName ) FREERTOS_SYSTEM_CALL;
-void MPU_vQueueUnregisterQueue( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
-const char * MPU_pcQueueGetName( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
-QueueHandle_t MPU_xQueueGenericCreate( const UBaseType_t uxQueueLength,
-                                       const UBaseType_t uxItemSize,
-                                       const uint8_t ucQueueType ) FREERTOS_SYSTEM_CALL;
-QueueHandle_t MPU_xQueueGenericCreateStatic( const UBaseType_t uxQueueLength,
-                                             const UBaseType_t uxItemSize,
-                                             uint8_t * pucQueueStorage,
-                                             StaticQueue_t * pxStaticQueue,
-                                             const uint8_t ucQueueType ) FREERTOS_SYSTEM_CALL;
-QueueSetHandle_t MPU_xQueueCreateSet( const UBaseType_t uxEventQueueLength ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueueAddToSet( QueueSetMemberHandle_t xQueueOrSemaphore,
-                               QueueSetHandle_t xQueueSet ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueueRemoveFromSet( QueueSetMemberHandle_t xQueueOrSemaphore,
-                                    QueueSetHandle_t xQueueSet ) FREERTOS_SYSTEM_CALL;
-QueueSetMemberHandle_t MPU_xQueueSelectFromSet( QueueSetHandle_t xQueueSet,
-                                                const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xQueueGenericReset( QueueHandle_t xQueue,
-                                   BaseType_t xNewQueue ) FREERTOS_SYSTEM_CALL;
-void MPU_vQueueSetQueueNumber( QueueHandle_t xQueue,
-                               UBaseType_t uxQueueNumber ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxQueueGetQueueNumber( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
-uint8_t MPU_ucQueueGetQueueType( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueGenericSend( QueueHandle_t xQueue,
+                                      const void * const pvItemToQueue,
+                                      TickType_t xTicksToWait,
+                                      const BaseType_t xCopyPosition ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueReceive( QueueHandle_t xQueue,
+                                  void * const pvBuffer,
+                                  TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueuePeek( QueueHandle_t xQueue,
+                               void * const pvBuffer,
+                               TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
+                                        TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxQueueMessagesWaiting( const QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxQueueSpacesAvailable( const QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
+    void MPU_vQueueDelete( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
+    QueueHandle_t MPU_xQueueCreateMutex( const uint8_t ucQueueType ) FREERTOS_SYSTEM_CALL;
+    QueueHandle_t MPU_xQueueCreateMutexStatic( const uint8_t ucQueueType,
+                                               StaticQueue_t * pxStaticQueue ) FREERTOS_SYSTEM_CALL;
+    QueueHandle_t MPU_xQueueCreateCountingSemaphore( const UBaseType_t uxMaxCount,
+                                                     const UBaseType_t uxInitialCount ) FREERTOS_SYSTEM_CALL;
+    QueueHandle_t MPU_xQueueCreateCountingSemaphoreStatic( const UBaseType_t uxMaxCount,
+                                                           const UBaseType_t uxInitialCount,
+                                                           StaticQueue_t * pxStaticQueue ) FREERTOS_SYSTEM_CALL;
+    TaskHandle_t MPU_xQueueGetMutexHolder( QueueHandle_t xSemaphore ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueTakeMutexRecursive( QueueHandle_t xMutex,
+                                             TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueGiveMutexRecursive( QueueHandle_t pxMutex ) FREERTOS_SYSTEM_CALL;
+    void MPU_vQueueAddToRegistry( QueueHandle_t xQueue,
+                                  const char * pcName ) FREERTOS_SYSTEM_CALL;
+    void MPU_vQueueUnregisterQueue( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
+    const char * MPU_pcQueueGetName( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
+    QueueHandle_t MPU_xQueueGenericCreate( const UBaseType_t uxQueueLength,
+                                           const UBaseType_t uxItemSize,
+                                           const uint8_t ucQueueType ) FREERTOS_SYSTEM_CALL;
+    QueueHandle_t MPU_xQueueGenericCreateStatic( const UBaseType_t uxQueueLength,
+                                                 const UBaseType_t uxItemSize,
+                                                 uint8_t * pucQueueStorage,
+                                                 StaticQueue_t * pxStaticQueue,
+                                                 const uint8_t ucQueueType ) FREERTOS_SYSTEM_CALL;
+    QueueSetHandle_t MPU_xQueueCreateSet( const UBaseType_t uxEventQueueLength ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueAddToSet( QueueSetMemberHandle_t xQueueOrSemaphore,
+                                   QueueSetHandle_t xQueueSet ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueRemoveFromSet( QueueSetMemberHandle_t xQueueOrSemaphore,
+                                        QueueSetHandle_t xQueueSet ) FREERTOS_SYSTEM_CALL;
+    QueueSetMemberHandle_t MPU_xQueueSelectFromSet( QueueSetHandle_t xQueueSet,
+                                                    const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xQueueGenericReset( QueueHandle_t xQueue,
+                                       BaseType_t xNewQueue ) FREERTOS_SYSTEM_CALL;
+    void MPU_vQueueSetQueueNumber( QueueHandle_t xQueue,
+                                   UBaseType_t uxQueueNumber ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxQueueGetQueueNumber( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
+    uint8_t MPU_ucQueueGetQueueType( QueueHandle_t xQueue ) FREERTOS_SYSTEM_CALL;
 
 /* MPU versions of timers.h API functions. */
-TimerHandle_t MPU_xTimerCreate( const char * const pcTimerName,
-                                const TickType_t xTimerPeriodInTicks,
-                                const UBaseType_t uxAutoReload,
-                                void * const pvTimerID,
-                                TimerCallbackFunction_t pxCallbackFunction ) FREERTOS_SYSTEM_CALL;
-TimerHandle_t MPU_xTimerCreateStatic( const char * const pcTimerName,
-                                      const TickType_t xTimerPeriodInTicks,
-                                      const UBaseType_t uxAutoReload,
-                                      void * const pvTimerID,
-                                      TimerCallbackFunction_t pxCallbackFunction,
-                                      StaticTimer_t * pxTimerBuffer ) FREERTOS_SYSTEM_CALL;
-void * MPU_pvTimerGetTimerID( const TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
-void MPU_vTimerSetTimerID( TimerHandle_t xTimer,
-                           void * pvNewID ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTimerIsTimerActive( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
-TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTimerPendFunctionCall( PendedFunction_t xFunctionToPend,
-                                       void * pvParameter1,
-                                       uint32_t ulParameter2,
-                                       TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-const char * MPU_pcTimerGetName( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
-void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                              const UBaseType_t uxAutoReload ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxTimerGetReloadMode( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
-TickType_t MPU_xTimerGetPeriod( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
-TickType_t MPU_xTimerGetExpiryTime( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTimerCreateTimerTask( void ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    TimerHandle_t MPU_xTimerCreate( const char * const pcTimerName,
+                                    const TickType_t xTimerPeriodInTicks,
+                                    const UBaseType_t uxAutoReload,
+                                    void * const pvTimerID,
+                                    TimerCallbackFunction_t pxCallbackFunction ) FREERTOS_SYSTEM_CALL;
+    TimerHandle_t MPU_xTimerCreateStatic( const char * const pcTimerName,
+                                          const TickType_t xTimerPeriodInTicks,
+                                          const UBaseType_t uxAutoReload,
+                                          void * const pvTimerID,
+                                          TimerCallbackFunction_t pxCallbackFunction,
+                                          StaticTimer_t * pxTimerBuffer ) FREERTOS_SYSTEM_CALL;
+    void * MPU_pvTimerGetTimerID( const TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTimerSetTimerID( TimerHandle_t xTimer,
+                               void * pvNewID ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTimerIsTimerActive( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
+    TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTimerPendFunctionCall( PendedFunction_t xFunctionToPend,
+                                           void * pvParameter1,
+                                           uint32_t ulParameter2,
+                                           TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    const char * MPU_pcTimerGetName( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
+    void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
+                                  const UBaseType_t uxAutoReload ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxTimerGetReloadMode( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
+    TickType_t MPU_xTimerGetPeriod( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
+    TickType_t MPU_xTimerGetExpiryTime( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTimerCreateTimerTask( void ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
+                                         const BaseType_t xCommandID,
+                                         const TickType_t xOptionalValue,
+                                         BaseType_t * const pxHigherPriorityTaskWoken,
+                                         const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
 
 /* MPU versions of event_group.h API functions. */
-EventGroupHandle_t MPU_xEventGroupCreate( void ) FREERTOS_SYSTEM_CALL;
-EventGroupHandle_t MPU_xEventGroupCreateStatic( StaticEventGroup_t * pxEventGroupBuffer ) FREERTOS_SYSTEM_CALL;
-EventBits_t MPU_xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
+    EventGroupHandle_t MPU_xEventGroupCreate( void ) FREERTOS_SYSTEM_CALL;
+    EventGroupHandle_t MPU_xEventGroupCreateStatic( StaticEventGroup_t * pxEventGroupBuffer ) FREERTOS_SYSTEM_CALL;
+    EventBits_t MPU_xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
+                                         const EventBits_t uxBitsToWaitFor,
+                                         const BaseType_t xClearOnExit,
+                                         const BaseType_t xWaitForAllBits,
+                                         TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    EventBits_t MPU_xEventGroupClearBits( EventGroupHandle_t xEventGroup,
+                                          const EventBits_t uxBitsToClear ) FREERTOS_SYSTEM_CALL;
+    EventBits_t MPU_xEventGroupSetBits( EventGroupHandle_t xEventGroup,
+                                        const EventBits_t uxBitsToSet ) FREERTOS_SYSTEM_CALL;
+    EventBits_t MPU_xEventGroupSync( EventGroupHandle_t xEventGroup,
+                                     const EventBits_t uxBitsToSet,
                                      const EventBits_t uxBitsToWaitFor,
-                                     const BaseType_t xClearOnExit,
-                                     const BaseType_t xWaitForAllBits,
                                      TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-EventBits_t MPU_xEventGroupClearBits( EventGroupHandle_t xEventGroup,
-                                      const EventBits_t uxBitsToClear ) FREERTOS_SYSTEM_CALL;
-EventBits_t MPU_xEventGroupSetBits( EventGroupHandle_t xEventGroup,
-                                    const EventBits_t uxBitsToSet ) FREERTOS_SYSTEM_CALL;
-EventBits_t MPU_xEventGroupSync( EventGroupHandle_t xEventGroup,
-                                 const EventBits_t uxBitsToSet,
-                                 const EventBits_t uxBitsToWaitFor,
-                                 TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-void MPU_vEventGroupDelete( EventGroupHandle_t xEventGroup ) FREERTOS_SYSTEM_CALL;
-UBaseType_t MPU_uxEventGroupGetNumber( void * xEventGroup ) FREERTOS_SYSTEM_CALL;
+    void MPU_vEventGroupDelete( EventGroupHandle_t xEventGroup ) FREERTOS_SYSTEM_CALL;
+    UBaseType_t MPU_uxEventGroupGetNumber( void * xEventGroup ) FREERTOS_SYSTEM_CALL;
 
 /* MPU versions of message/stream_buffer.h API functions. */
-size_t MPU_xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
-                              const void * pvTxData,
-                              size_t xDataLengthBytes,
-                              TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-size_t MPU_xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
-                                 void * pvRxData,
-                                 size_t xBufferLengthBytes,
-                                 TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
-size_t MPU_xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
-void MPU_vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xStreamBufferReset( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
-size_t MPU_xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
-size_t MPU_xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
-                                             size_t xTriggerLevel ) FREERTOS_SYSTEM_CALL;
-StreamBufferHandle_t MPU_xStreamBufferGenericCreate( size_t xBufferSizeBytes,
-                                                     size_t xTriggerLevelBytes,
-                                                     BaseType_t xIsMessageBuffer ) FREERTOS_SYSTEM_CALL;
-StreamBufferHandle_t MPU_xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
-                                                           size_t xTriggerLevelBytes,
-                                                           BaseType_t xIsMessageBuffer,
-                                                           uint8_t * const pucStreamBufferStorageArea,
-                                                           StaticStreamBuffer_t * const pxStaticStreamBuffer ) FREERTOS_SYSTEM_CALL;
-
-
-
-#endif /* MPU_PROTOTYPES_H */
+    size_t MPU_xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
+                                  const void * pvTxData,
+                                  size_t xDataLengthBytes,
+                                  TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    size_t MPU_xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
+                                     void * pvRxData,
+                                     size_t xBufferLengthBytes,
+                                     TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+    size_t MPU_xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    void MPU_vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xStreamBufferReset( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    size_t MPU_xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    size_t MPU_xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
+                                                 size_t xTriggerLevel ) FREERTOS_SYSTEM_CALL;
+    #if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
+        StreamBufferHandle_t MPU_xStreamBufferGenericCreate( size_t xBufferSizeBytes,
+                                                             size_t xTriggerLevelBytes,
+                                                             BaseType_t xIsMessageBuffer,
+                                                             StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) FREERTOS_SYSTEM_CALL;
+        StreamBufferHandle_t MPU_xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
+                                                                   size_t xTriggerLevelBytes,
+                                                                   BaseType_t xIsMessageBuffer,
+                                                                   uint8_t * const pucStreamBufferStorageArea,
+                                                                   StaticStreamBuffer_t * const pxStaticStreamBuffer,
+                                                                   StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) FREERTOS_SYSTEM_CALL;
+    #else /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
+        StreamBufferHandle_t MPU_xStreamBufferGenericCreate( size_t xBufferSizeBytes,
+                                                             size_t xTriggerLevelBytes,
+                                                             BaseType_t xIsMessageBuffer ) FREERTOS_SYSTEM_CALL;
+        StreamBufferHandle_t MPU_xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
+                                                                   size_t xTriggerLevelBytes,
+                                                                   BaseType_t xIsMessageBuffer,
+                                                                   uint8_t * const pucStreamBufferStorageArea,
+                                                                   StaticStreamBuffer_t * const pxStaticStreamBuffer ) FREERTOS_SYSTEM_CALL;
+    #endif /* MPU_PROTOTYPES_H */

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -1375,15 +1375,25 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
-    StreamBufferHandle_t MPU_xStreamBufferGenericCreate( size_t xBufferSizeBytes,
-                                                         size_t xTriggerLevelBytes,
-                                                         BaseType_t xIsMessageBuffer ) /* FREERTOS_SYSTEM_CALL */
+    #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+        StreamBufferHandle_t MPU_xStreamBufferGenericCreate( size_t xBufferSizeBytes,
+                                                             size_t xTriggerLevelBytes,
+                                                             BaseType_t xIsMessageBuffer, 
+							     StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) /* FREERTOS_SYSTEM_CALL */
+    #else
+	StreamBufferHandle_t MPU_xStreamBufferGenericCreate( size_t xBufferSizeBytes,
+                                                             size_t xTriggerLevelBytes,
+                                                             BaseType_t xIsMessageBuffer ) /* FREERTOS_SYSTEM_CALL */
+    #endif
     {
         StreamBufferHandle_t xReturn;
         BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-
-        xReturn = xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+        #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+            xReturn = xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxStreamBufferCallbackFunction );
+        #else
+            xReturn = xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer );
+        #endif
+	vPortResetPrivilege( xRunningPrivileged );
 
         return xReturn;
     }
@@ -1391,17 +1401,29 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-    StreamBufferHandle_t MPU_xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
-                                                               size_t xTriggerLevelBytes,
-                                                               BaseType_t xIsMessageBuffer,
-                                                               uint8_t * const pucStreamBufferStorageArea,
-                                                               StaticStreamBuffer_t * const pxStaticStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
+    #if (configUSE_SB_COMPLETED_CALLBACK == 1 )
+        StreamBufferHandle_t MPU_xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
+                                                                   size_t xTriggerLevelBytes,
+                                                                   BaseType_t xIsMessageBuffer,
+                                                                   uint8_t * const pucStreamBufferStorageArea,
+                                                                   StaticStreamBuffer_t * const pxStaticStreamBuffer,
+								   StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) /* FREERTOS_SYSTEM_CALL */
+    #else
+        StreamBufferHandle_t MPU_xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
+                                                                   size_t xTriggerLevelBytes,
+                                                                   BaseType_t xIsMessageBuffer,
+                                                                   uint8_t * const pucStreamBufferStorageArea,
+                                                                   StaticStreamBuffer_t * const pxStaticStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
+    #endif
     {
         StreamBufferHandle_t xReturn;
         BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-
-        xReturn = xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+        #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+            xReturn = xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxStreamBufferCallbackFunction );
+        #else
+	    xReturn = xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer );
+        #endif    
+	vPortResetPrivilege( xRunningPrivileged );
 
         return xReturn;
     }

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -90,11 +90,39 @@
     }
 #endif /* sbRECEIVE_COMPLETED_FROM_ISR */
 
-/* If the user has not provided an application specific Tx notification macro,
- * or #defined the notification macro away, them provide a default implementation
- * that uses task notifications. */
-#ifndef sbSEND_COMPLETED
-    #define sbSEND_COMPLETED( pxStreamBuffer )                               \
+/* If the configUSE_SB_COMPLETED_CALLBACK is set to 1, sbSEND_COMPLETED will use the
+ * implementation that defined by each stream buffer. If the user passes NULL for the
+ * callback fucntion name, the default implementation will be used.*/
+
+/* If the user has not provided an application specific Tx notification macro, or #defined the notification macro away,
+ * then provide a default implementation that uses task notifications.
+ * */
+
+#if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+    #ifndef sbSEND_COMPLETED
+        #define sbSEND_COMPLETED( pxStreamBuffer )                               \
+    vTaskSuspendAll();                                                           \
+    {                                                                            \
+        if( ( pxStreamBuffer )->pxStreamBufferCallbackFunction != NULL )         \
+        {                                                                        \
+            ( pxStreamBuffer )->pxStreamBufferCallbackFunction();                \
+        }                                                                        \
+        else                                                                     \
+        {                                                                        \
+            if( ( pxStreamBuffer )->xTaskWaitingToReceive != NULL )              \
+            {                                                                    \
+                ( void ) xTaskNotify( ( pxStreamBuffer )->xTaskWaitingToReceive, \
+                                      ( uint32_t ) 0,                            \
+                                      eNoAction );                               \
+                ( pxStreamBuffer )->xTaskWaitingToReceive = NULL;                \
+            }                                                                    \
+        }                                                                        \
+    }                                                                            \
+    ( void ) xTaskResumeAll();
+    #endif /* sbSEND_COMPLETED */
+#else /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
+    #ifndef sbSEND_COMPLETED
+        #define sbSEND_COMPLETED( pxStreamBuffer )                           \
     vTaskSuspendAll();                                                       \
     {                                                                        \
         if( ( pxStreamBuffer )->xTaskWaitingToReceive != NULL )              \
@@ -106,7 +134,8 @@
         }                                                                    \
     }                                                                        \
     ( void ) xTaskResumeAll();
-#endif /* sbSEND_COMPLETED */
+    #endif /* sbSEND_COMPLETED */
+#endif /* configUSE_SB_COMPLETED_CALLBACK */
 
 #ifndef sbSEND_COMPLETE_FROM_ISR
     #define sbSEND_COMPLETE_FROM_ISR( pxStreamBuffer, pxHigherPriorityTaskWoken )       \
@@ -150,6 +179,9 @@ typedef struct StreamBufferDef_t                 /*lint !e9058 Style convention 
     uint8_t * pucBuffer;                         /* Points to the buffer itself - that is - the RAM that stores the data passed through the buffer. */
     uint8_t ucFlags;
 
+    #if  ( configUSE_SB_COMPLETED_CALLBACK == 1 )/* if configUSE_SB_COMPLETED_CALLBACK == 1, used for stroing the function pointer to the stream buffer's callback*/
+        volatile StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction;
+    #endif
     #if ( configUSE_TRACE_FACILITY == 1 )
         UBaseType_t uxStreamBufferNumber; /* Used for tracing purposes. */
     #endif
@@ -222,19 +254,33 @@ static size_t prvReadBytesFromBuffer( StreamBuffer_t * pxStreamBuffer,
  * Called by both pxStreamBufferCreate() and pxStreamBufferCreateStatic() to
  * initialise the members of the newly created stream buffer structure.
  */
-static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
-                                          uint8_t * const pucBuffer,
-                                          size_t xBufferSizeBytes,
-                                          size_t xTriggerLevelBytes,
-                                          uint8_t ucFlags ) PRIVILEGED_FUNCTION;
+#if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+    static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
+                                              uint8_t * const pucBuffer,
+                                              size_t xBufferSizeBytes,
+                                              size_t xTriggerLevelBytes,
+                                              uint8_t ucFlags,
+                                              StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) PRIVILEGED_FUNCTION;
+#else
+    static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
+                                              uint8_t * const pucBuffer,
+                                              size_t xBufferSizeBytes,
+                                              size_t xTriggerLevelBytes,
+                                              uint8_t ucFlags ) PRIVILEGED_FUNCTION;
+#endif /*configUSE_SB_COMPLETED_CALLBACK*/
 
 /*-----------------------------------------------------------*/
-
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
-
-    StreamBufferHandle_t xStreamBufferGenericCreate( size_t xBufferSizeBytes,
-                                                     size_t xTriggerLevelBytes,
-                                                     BaseType_t xIsMessageBuffer )
+    #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+        StreamBufferHandle_t xStreamBufferGenericCreate( size_t xBufferSizeBytes,
+                                                         size_t xTriggerLevelBytes,
+                                                         BaseType_t xIsMessageBuffer,
+                                                         StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) /* If configUSE_SB_COMPLETED_CALLBACK is set to 1 */
+    #else
+        StreamBufferHandle_t xStreamBufferGenericCreate( size_t xBufferSizeBytes,
+                                                         size_t xTriggerLevelBytes,
+                                                         BaseType_t xIsMessageBuffer )
+    #endif
     {
         uint8_t * pucAllocatedMemory;
         uint8_t ucFlags;
@@ -276,7 +322,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         if( xBufferSizeBytes < ( xBufferSizeBytes + 1 + sizeof( StreamBuffer_t ) ) )
         {
             xBufferSizeBytes++;
-            pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) ); /*lint !e9079 malloc() only returns void*. */
+            pucAllocatedMemory = ( uint8_t * ) pvPortMalloc( xBufferSizeBytes + sizeof( StreamBuffer_t ) );     /*lint !e9079 malloc() only returns void*. */
         }
         else
         {
@@ -285,12 +331,20 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
         if( pucAllocatedMemory != NULL )
         {
-            prvInitialiseNewStreamBuffer( ( StreamBuffer_t * ) pucAllocatedMemory,       /* Structure at the start of the allocated memory. */ /*lint !e9087 Safe cast as allocated memory is aligned. */ /*lint !e826 Area is not too small and alignment is guaranteed provided malloc() behaves as expected and returns aligned buffer. */
-                                          pucAllocatedMemory + sizeof( StreamBuffer_t ), /* Storage area follows. */ /*lint !e9016 Indexing past structure valid for uint8_t pointer, also storage area has no alignment requirement. */
-                                          xBufferSizeBytes,
-                                          xTriggerLevelBytes,
-                                          ucFlags );
-
+            #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+                prvInitialiseNewStreamBuffer( ( StreamBuffer_t * ) pucAllocatedMemory,       /* Structure at the start of the allocated memory. */ /*lint !e9087 Safe cast as allocated memory is aligned. */ /*lint !e826 Area is not too small and alignment is guaranteed provided malloc() behaves as expected and returns aligned buffer. */
+                                              pucAllocatedMemory + sizeof( StreamBuffer_t ), /* Storage area follows. */ /*lint !e9016 Indexing past structure valid for uint8_t pointer, also storage area has no alignment requirement. */
+                                              xBufferSizeBytes,
+                                              xTriggerLevelBytes,
+                                              ucFlags,
+                                              pxStreamBufferCallbackFunction );              /* If configUSE_SB_COMPLETED_CALLBACK is set to 1 */
+            #else
+                prvInitialiseNewStreamBuffer( ( StreamBuffer_t * ) pucAllocatedMemory,       /* Structure at the start of the allocated memory. */ /*lint !e9087 Safe cast as allocated memory is aligned. */ /*lint !e826 Area is not too small and alignment is guaranteed provided malloc() behaves as expected and returns aligned buffer. */
+                                              pucAllocatedMemory + sizeof( StreamBuffer_t ), /* Storage area follows. */ /*lint !e9016 Indexing past structure valid for uint8_t pointer, also storage area has no alignment requirement. */
+                                              xBufferSizeBytes,
+                                              xTriggerLevelBytes,
+                                              ucFlags );
+            #endif /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
             traceSTREAM_BUFFER_CREATE( ( ( StreamBuffer_t * ) pucAllocatedMemory ), xIsMessageBuffer );
         }
         else
@@ -298,21 +352,28 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             traceSTREAM_BUFFER_CREATE_FAILED( xIsMessageBuffer );
         }
 
-        return ( StreamBufferHandle_t ) pucAllocatedMemory; /*lint !e9087 !e826 Safe cast as allocated memory is aligned. */
+        return ( StreamBufferHandle_t ) pucAllocatedMemory;     /*lint !e9087 !e826 Safe cast as allocated memory is aligned. */
     }
-
 #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-
-    StreamBufferHandle_t xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
-                                                           size_t xTriggerLevelBytes,
-                                                           BaseType_t xIsMessageBuffer,
-                                                           uint8_t * const pucStreamBufferStorageArea,
-                                                           StaticStreamBuffer_t * const pxStaticStreamBuffer )
+    #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+        StreamBufferHandle_t xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
+                                                               size_t xTriggerLevelBytes,
+                                                               BaseType_t xIsMessageBuffer,
+                                                               uint8_t * const pucStreamBufferStorageArea,
+                                                               StaticStreamBuffer_t * const pxStaticStreamBuffer,
+                                                               StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) /* If configUSE_SB_COMPLETED_CALLBACK is set to 1 */
+    #else
+        StreamBufferHandle_t xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
+                                                               size_t xTriggerLevelBytes,
+                                                               BaseType_t xIsMessageBuffer,
+                                                               uint8_t * const pucStreamBufferStorageArea,
+                                                               StaticStreamBuffer_t * const pxStaticStreamBuffer )
+    #endif /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
     {
-        StreamBuffer_t * const pxStreamBuffer = ( StreamBuffer_t * ) pxStaticStreamBuffer; /*lint !e740 !e9087 Safe cast as StaticStreamBuffer_t is opaque Streambuffer_t. */
+        StreamBuffer_t * const pxStreamBuffer = ( StreamBuffer_t * ) pxStaticStreamBuffer;     /*lint !e740 !e9087 Safe cast as StaticStreamBuffer_t is opaque Streambuffer_t. */
         StreamBufferHandle_t xReturn;
         uint8_t ucFlags;
 
@@ -351,16 +412,25 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
                  * message buffer structure. */
                 volatile size_t xSize = sizeof( StaticStreamBuffer_t );
                 configASSERT( xSize == sizeof( StreamBuffer_t ) );
-            } /*lint !e529 xSize is referenced is configASSERT() is defined. */
+            }     /*lint !e529 xSize is referenced is configASSERT() is defined. */
         #endif /* configASSERT_DEFINED */
 
         if( ( pucStreamBufferStorageArea != NULL ) && ( pxStaticStreamBuffer != NULL ) )
         {
-            prvInitialiseNewStreamBuffer( pxStreamBuffer,
-                                          pucStreamBufferStorageArea,
-                                          xBufferSizeBytes,
-                                          xTriggerLevelBytes,
-                                          ucFlags );
+            #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+                prvInitialiseNewStreamBuffer( pxStreamBuffer,
+                                              pucStreamBufferStorageArea,
+                                              xBufferSizeBytes,
+                                              xTriggerLevelBytes,
+                                              ucFlags
+                                              StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ); /* If configUSE_SB_COMPLETED_CALLBACK is set to 1 */
+            #else
+                prvInitialiseNewStreamBuffer( pxStreamBuffer,
+                                              pucStreamBufferStorageArea,
+                                              xBufferSizeBytes,
+                                              xTriggerLevelBytes,
+                                              ucFlags );
+            #endif /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
 
             /* Remember this was statically allocated in case it is ever deleted
              * again. */
@@ -368,7 +438,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
             traceSTREAM_BUFFER_CREATE( pxStreamBuffer, xIsMessageBuffer );
 
-            xReturn = ( StreamBufferHandle_t ) pxStaticStreamBuffer; /*lint !e9087 Data hiding requires cast to opaque type. */
+            xReturn = ( StreamBufferHandle_t ) pxStaticStreamBuffer;     /*lint !e9087 Data hiding requires cast to opaque type. */
         }
         else
         {
@@ -378,7 +448,6 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
         return xReturn;
     }
-
 #endif /* ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 /*-----------------------------------------------------------*/
 
@@ -441,11 +510,24 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
         {
             if( pxStreamBuffer->xTaskWaitingToSend == NULL )
             {
-                prvInitialiseNewStreamBuffer( pxStreamBuffer,
-                                              pxStreamBuffer->pucBuffer,
-                                              pxStreamBuffer->xLength,
-                                              pxStreamBuffer->xTriggerLevelBytes,
-                                              pxStreamBuffer->ucFlags );
+                #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+                    {
+                        prvInitialiseNewStreamBuffer( pxStreamBuffer,
+                                                      pxStreamBuffer->pucBuffer,
+                                                      pxStreamBuffer->xLength,
+                                                      pxStreamBuffer->xTriggerLevelBytes,
+                                                      pxStreamBuffer->ucFlags,
+                                                      pxStreamBuffer->pxStreamBufferCallbackFunction );
+                    }
+                #else
+                    {
+                        prvInitialiseNewStreamBuffer( pxStreamBuffer,
+                                                      pxStreamBuffer->pucBuffer,
+                                                      pxStreamBuffer->xLength,
+                                                      pxStreamBuffer->xTriggerLevelBytes,
+                                                      pxStreamBuffer->ucFlags );
+                    }
+                #endif /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
                 xReturn = pdPASS;
 
                 #if ( configUSE_TRACE_FACILITY == 1 )
@@ -503,14 +585,15 @@ size_t xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer )
     configASSERT( pxStreamBuffer );
 
     /* The code below reads xTail and then xHead.  This is safe if the stream
-    buffer is updated once between the two reads - but not if the stream buffer
-    is updated more than once between the two reads - hence the loop. */
+     * buffer is updated once between the two reads - but not if the stream buffer
+     * is updated more than once between the two reads - hence the loop. */
     do
     {
         xOriginalTail = pxStreamBuffer->xTail;
         xSpace = pxStreamBuffer->xLength + pxStreamBuffer->xTail;
         xSpace -= pxStreamBuffer->xHead;
     } while( xOriginalTail != pxStreamBuffer->xTail );
+
     xSpace -= ( size_t ) 1;
 
     if( xSpace >= pxStreamBuffer->xLength )
@@ -885,8 +968,8 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
             /* The number of bytes available is greater than the number of bytes
              * required to hold the length of the next message, so another message
              * is available. */
-             ( void ) prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) &xTempReturn, sbBYTES_TO_STORE_MESSAGE_LENGTH, pxStreamBuffer->xTail );
-             xReturn = ( size_t ) xTempReturn;
+            ( void ) prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) &xTempReturn, sbBYTES_TO_STORE_MESSAGE_LENGTH, pxStreamBuffer->xTail );
+            xReturn = ( size_t ) xTempReturn;
         }
         else
         {
@@ -1009,7 +1092,7 @@ static size_t prvReadMessageFromBuffer( StreamBuffer_t * pxStreamBuffer,
     if( xCount != ( size_t ) 0 )
     {
         /* Read the actual data and update the tail to mark the data as officially consumed. */
-        pxStreamBuffer->xTail = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) pvRxData, xCount, xNextTail); /*lint !e9079 Data storage area is implemented as uint8_t array for ease of sizing, indexing and alignment. */
+        pxStreamBuffer->xTail = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) pvRxData, xCount, xNextTail ); /*lint !e9079 Data storage area is implemented as uint8_t array for ease of sizing, indexing and alignment. */
     }
 
     return xCount;
@@ -1247,12 +1330,20 @@ static size_t prvBytesInBuffer( const StreamBuffer_t * const pxStreamBuffer )
     return xCount;
 }
 /*-----------------------------------------------------------*/
-
-static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
-                                          uint8_t * const pucBuffer,
-                                          size_t xBufferSizeBytes,
-                                          size_t xTriggerLevelBytes,
-                                          uint8_t ucFlags )
+#if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+    static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
+                                              uint8_t * const pucBuffer,
+                                              size_t xBufferSizeBytes,
+                                              size_t xTriggerLevelBytes,
+                                              uint8_t ucFlags,
+                                              StreamBufferCallbackFunction_t pxStreamBufferCallbackFunction ) /* If configUSE_SB_COMPLETED_CALLBACK is set to 1 */
+#else
+    static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
+                                              uint8_t * const pucBuffer,
+                                              size_t xBufferSizeBytes,
+                                              size_t xTriggerLevelBytes,
+                                              uint8_t ucFlags )
+#endif /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
 {
     /* Assert here is deliberately writing to the entire buffer to ensure it can
      * be written to without generating exceptions, and is setting the buffer to a
@@ -1264,14 +1355,17 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
              * result in confusion as to what is actually being observed. */
             const BaseType_t xWriteValue = 0x55;
             configASSERT( memset( pucBuffer, ( int ) xWriteValue, xBufferSizeBytes ) == pucBuffer );
-        } /*lint !e529 !e438 xWriteValue is only used if configASSERT() is defined. */
+        }     /*lint !e529 !e438 xWriteValue is only used if configASSERT() is defined. */
     #endif
 
-    ( void ) memset( ( void * ) pxStreamBuffer, 0x00, sizeof( StreamBuffer_t ) ); /*lint !e9087 memset() requires void *. */
+    ( void ) memset( ( void * ) pxStreamBuffer, 0x00, sizeof( StreamBuffer_t ) );     /*lint !e9087 memset() requires void *. */
     pxStreamBuffer->pucBuffer = pucBuffer;
     pxStreamBuffer->xLength = xBufferSizeBytes;
     pxStreamBuffer->xTriggerLevelBytes = xTriggerLevelBytes;
     pxStreamBuffer->ucFlags = ucFlags;
+    #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )        /* If configUSE_SB_COMPLETED_CALLBACK is set to 1 */
+        pxStreamBuffer->pxStreamBufferCallbackFunction = pxStreamBufferCallbackFunction;
+    #endif
 }
 
 #if ( configUSE_TRACE_FACILITY == 1 )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
According to issue #312, this PR provides `configUSE_SB_COMPLETED_CALLBACK` that makes each stream/message buffer use its own `sbSEND_COMPLETED`

Test Steps
-----------
In `FreeRTOSconfig.h`,
If `configUSE_SB_COMPLETED_CALLBACK` is not set or set to 0, the single global definition of `sbSEND_COMPLETED` applies to every stream/message buffer.
If `configUSE_SB_COMPLETED_CALLBACK` is set to 1, each stream/mesasage buffer can define a callback function as its own `sbSEND_COMPLETED`, Users can pass the callback function as the argument(if pass NULL, it will use the default implementaion) when the buffer is (static)created:
```
void func1()
{
  /* User-defined sbSEND_SOMPLETED */
}
xStreamBuffer = xStreamBufferCreate( xBufferSizeBytes, xTriggerLevelBytes, func1)
```
The default type of the callback fucntion is "void function()", users can change the type of the callback function in `stream_buffer.h`:
```
#if (configUSE_SB_COMPLETED_CALLBACK == 1)
    typedef void (* StreamBufferCallbackFunction_t)();   //Declare a function pointer that points to the stream buffer's callback
#endif
```
* Validated with STM32F407VG

Related Issue
-----------
Issue #312


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
