### PR TITLE
Fix description of vTaskDelay

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -757,7 +757,7 @@ void vTaskDelete( TaskHandle_t xTaskToDelete ) PRIVILEGED_FUNCTION;
  * period of 100 ticks will cause the task to unblock 100 ticks after
  * vTaskDelay() is called.  vTaskDelay() does not therefore provide a good method
  * of controlling the frequency of a periodic task as the path taken through the
- * code, as well as other task and interrupt activity, will effect the frequency
+ * code, as well as other task and interrupt activity, will affect the frequency
  * at which vTaskDelay() gets called and therefore the time at which the task
  * next executes.  See xTaskDelayUntil() for an alternative API function designed
  * to facilitate fixed frequency execution.  It does this by specifying an


### PR DESCRIPTION
<!--- Title -->

Description
-----------

This merely fixes the spelling of `affect` in the API documentation for `vTaskDelay`.