### PR TITLE
doc: fix function name typo

### DIFF
--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -104,10 +104,10 @@ typedef TickType_t               EventBits_t;
  *
  * Internally, within the FreeRTOS implementation, event groups use a [small]
  * block of memory, in which the event group's structure is stored.  If an event
- * groups is created using xEventGropuCreate() then the required memory is
+ * groups is created using xEventGroupCreate() then the required memory is
  * automatically dynamically allocated inside the xEventGroupCreate() function.
  * (see https://www.FreeRTOS.org/a00111.html).  If an event group is created
- * using xEventGropuCreateStatic() then the application writer must instead
+ * using xEventGroupCreateStatic() then the application writer must instead
  * provide the memory that will get used by the event group.
  * xEventGroupCreateStatic() therefore allows an event group to be created
  * without using any dynamic memory allocation.
@@ -160,10 +160,10 @@ typedef TickType_t               EventBits_t;
  *
  * Internally, within the FreeRTOS implementation, event groups use a [small]
  * block of memory, in which the event group's structure is stored.  If an event
- * groups is created using xEventGropuCreate() then the required memory is
+ * groups is created using xEventGroupCreate() then the required memory is
  * automatically dynamically allocated inside the xEventGroupCreate() function.
  * (see https://www.FreeRTOS.org/a00111.html).  If an event group is created
- * using xEventGropuCreateStatic() then the application writer must instead
+ * using xEventGroupCreateStatic() then the application writer must instead
  * provide the memory that will get used by the event group.
  * xEventGroupCreateStatic() therefore allows an event group to be created
  * without using any dynamic memory allocation.


### PR DESCRIPTION
doc: fix function name typo

Description
-----------
Corrected spelling mistake xEventGropuCreate -> xEventGroupCreate

Noticed typo in the ESP IDF docs: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos.html

esp-idf PR:
https://github.com/espressif/esp-idf/pull/7265

Test Steps
-----------
Not tested (very minor change to docs)

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
