### PR TITLE
Move uxCoreAffinityMask after xMPUSettings

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -242,6 +242,10 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
         xMPU_SETTINGS xMPUSettings; /*< The MPU settings are defined as part of the port layer.  THIS MUST BE THE SECOND MEMBER OF THE TCB STRUCT. */
     #endif
 
+    #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
+        UBaseType_t uxCoreAffinityMask; /*< Used to link the task to certain cores.  UBaseType_t must have >= the same number of bits as SMP confNUM_CORES */
+    #endif
+
     ListItem_t xStateListItem;                  /*< The list that the state list item of a task is reference from denotes the state of that task (Ready, Blocked, Suspended ). */
     ListItem_t xEventListItem;                  /*< Used to reference a task from an event list. */
     UBaseType_t uxPriority;                     /*< The priority of the task.  0 is the lowest priority. */
@@ -252,10 +256,6 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
 
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         BaseType_t xPreemptionDisable; /*< Used to prevent the task from being preempted */
-    #endif
-
-    #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
-        UBaseType_t uxCoreAffinityMask; /*< Used to link the task to certain cores.  UBaseType_t must have >= the same number of bits as SMP confNUM_CORES */
     #endif
 
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
@@ -1009,7 +1009,7 @@ static void prvYieldForTask( TCB_t * pxTCB,
                     {
                         int uxCore = 31UL - ( uint32_t ) __builtin_clz( uxCoreMap );
 
-                        xassert( taskVALID_CORE_ID( uxCore ) );
+                        configASSERT( taskVALID_CORE_ID( uxCore ) );
 
                         uxCoreMap &= ~( 1 << uxCore );
 


### PR DESCRIPTION
Allows for much easier assembly access to the `uxCoreAffinityMask` field. This allows for the port implementation to pin the task to one or more cores much easier and without relying on hardcoded field offset constants.

One such occasion would be in the ESP32 port. The ESP32 port needs to pin the task to a single core when the FPU is used in a multi-core environment. This is because each core has its own FPU where its contents are lazily saved and restored only upon usage. When a task is switched to another core in the middle of a floating-point calculation, the state remains in the other core. To work around this without pinning the core, one would need to either save the FPU state for every task context switch or use some cross-core interrupt magic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
