### PR TITLE
bugfix: Initialize uxTaskNumber at task initialization

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -2452,6 +2452,7 @@ uxstreambuffernumber
 uxtaskgetnumberoftasks
 uxtaskgetstackhighwatermark
 uxtaskgetsystemstate
+uxtaskgettasknumber
 uxtasknumber
 uxtaskpriorityget
 uxtaskprioritygetfromisr
@@ -2601,6 +2602,7 @@ vtaskremovefromunorderedeventlist
 vtaskresume
 vtaskresumefromisr
 vtasksetapplicationtasktag
+vtasksettasknumber
 vtasksettimeout
 vtasksettimeoutstate
 vtaskstartscheduler

--- a/tasks.c
+++ b/tasks.c
@@ -851,6 +851,13 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
     #endif /* tskSET_NEW_STACKS_TO_KNOWN_VALUE */
 
+    #if ( configUSE_TRACE_FACILITY == 1 )
+        {
+            /* Zero the uxTaskNumber TCB member to avoid random value from dynamically allocated TCBs */
+            pxNewTCB->uxTaskNumber = 0;
+        }
+    #endif  /* configUSE_TRACE_FACILITY */
+
     /* Calculate the top of stack address.  This depends on whether the stack
      * grows from high memory to low (as per the 80x86) or vice versa.
      * portSTACK_GROWTH is used to make the result positive or negative as required

--- a/tasks.c
+++ b/tasks.c
@@ -851,13 +851,6 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
     #endif /* tskSET_NEW_STACKS_TO_KNOWN_VALUE */
 
-    #if ( configUSE_TRACE_FACILITY == 1 )
-        {
-            /* Zero the uxTaskNumber TCB member to avoid random value from dynamically allocated TCBs */
-            pxNewTCB->uxTaskNumber = 0;
-        }
-    #endif  /* configUSE_TRACE_FACILITY */
-
     /* Calculate the top of stack address.  This depends on whether the stack
      * grows from high memory to low (as per the 80x86) or vice versa.
      * portSTACK_GROWTH is used to make the result positive or negative as required
@@ -1129,6 +1122,9 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
             {
                 /* Add a counter into the TCB for tracing only. */
                 pxNewTCB->uxTCBNumber = uxTaskNumber;
+                /* Initialize the uxTaskNumber member to zero. It is utilized by the
+                 * application using vTaskSetTaskNumber and uxTaskGetTaskNumber APIs. */
+                pxNewTCB->uxTaskNumber = 0;
             }
         #endif /* configUSE_TRACE_FACILITY */
         traceTASK_CREATE( pxNewTCB );

--- a/tasks.c
+++ b/tasks.c
@@ -1122,6 +1122,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
             {
                 /* Add a counter into the TCB for tracing only. */
                 pxNewTCB->uxTCBNumber = uxTaskNumber;
+
                 /* Initialize the uxTaskNumber member to zero. It is utilized by the
                  * application using vTaskSetTaskNumber and uxTaskGetTaskNumber APIs. */
                 pxNewTCB->uxTaskNumber = 0;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
uxTaskNumber member of struct tskTaskControlBlock is not initialized at thread creation.
As the TCB can be dynamically allocated, uxTaskNumber might then get a value from the heap.
As a result, the user might get a seems-valid value when calling uxTaskGetTaskNumber() and then take wrong decisions.

This fix zeroes uxTaskNumber when the task is initialized.

**Related:** ESP-IDF (FreeRTOS) [#4025](https://github.com/espressif/esp-idf/pull/4025)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
