### PR TITLE
Update xSTATIC_TCB layout in line with tskTCB

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1201,6 +1201,9 @@ typedef struct xSTATIC_TCB
     #if ( portUSING_MPU_WRAPPERS == 1 )
         xMPU_SETTINGS xDummy2;
     #endif
+    #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
+        UBaseType_t uxDummy25;
+    #endif
     StaticListItem_t xDummy3[ 2 ];
     UBaseType_t uxDummy5;
     void * pxDummy6;
@@ -1208,9 +1211,6 @@ typedef struct xSTATIC_TCB
     uint8_t ucDummy7[ configMAX_TASK_NAME_LEN ];
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         BaseType_t xDummy24;
-    #endif
-    #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
-        UBaseType_t uxDummy25;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;


### PR DESCRIPTION
Also updates the layout of `xSTATIC_TCB` in `FreeRTOS.h` to have the same layout as `tskTCB`, which I previously missed ([comment](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/372#issuecomment-894236193)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
