### PR TITLE
fix example usage of xMessageBufferCreateStatic and xStreamBufferCrea…

### DIFF
--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -194,7 +194,7 @@ typedef void * MessageBufferHandle_t;
  * {
  * MessageBufferHandle_t xMessageBuffer;
  *
- *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
+ *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucStorageBuffer ),
  *                                               ucStorageBuffer,
  *                                               &xMessageBufferStruct );
  *

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -165,7 +165,7 @@ typedef void * MessageBufferHandle_t;
  * stored in the message buffer is actually (xBufferSizeBytes - 1).
  *
  * @param pucMessageBufferStorageArea Must point to a uint8_t array that is at
- * least xBufferSizeBytes + 1 big.  This is the array to which messages are
+ * least xBufferSizeBytes big.  This is the array to which messages are
  * copied when they are written to the message buffer.
  *
  * @param pxStaticMessageBuffer Must point to a variable of type
@@ -194,7 +194,7 @@ typedef void * MessageBufferHandle_t;
  * {
  * MessageBufferHandle_t xMessageBuffer;
  *
- *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
+ *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucStorageBuffer ),
  *                                               ucStorageBuffer,
  *                                               &xMessageBufferStruct );
  *

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -194,8 +194,8 @@ typedef void * MessageBufferHandle_t;
  * {
  * MessageBufferHandle_t xMessageBuffer;
  *
- *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucBufferStorage ),
- *                                               ucBufferStorage,
+ *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
+ *                                               ucStorageBuffer,
  *                                               &xMessageBufferStruct );
  *
  *  // As neither the pucMessageBufferStorageArea or pxStaticMessageBuffer

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -194,7 +194,7 @@ typedef void * MessageBufferHandle_t;
  * {
  * MessageBufferHandle_t xMessageBuffer;
  *
- *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucStorageBuffer ),
+ *  xMessageBuffer = xMessageBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
  *                                               ucStorageBuffer,
  *                                               &xMessageBufferStruct );
  *

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -202,7 +202,7 @@ typedef struct StreamBufferDef_t * StreamBufferHandle_t;
  * StreamBufferHandle_t xStreamBuffer;
  * const size_t xTriggerLevel = 1;
  *
- *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ),
+ *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
  *                                             xTriggerLevel,
  *                                             ucStorageBuffer,
  *                                             &xStreamBufferStruct );

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -172,7 +172,7 @@ typedef struct StreamBufferDef_t * StreamBufferHandle_t;
  * that is greater than the buffer size.
  *
  * @param pucStreamBufferStorageArea Must point to a uint8_t array that is at
- * least xBufferSizeBytes + 1 big.  This is the array to which streams are
+ * least xBufferSizeBytes big.  This is the array to which streams are
  * copied when they are written to the stream buffer.
  *
  * @param pxStaticStreamBuffer Must point to a variable of type
@@ -202,7 +202,7 @@ typedef struct StreamBufferDef_t * StreamBufferHandle_t;
  * StreamBufferHandle_t xStreamBuffer;
  * const size_t xTriggerLevel = 1;
  *
- *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
+ *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ),
  *                                             xTriggerLevel,
  *                                             ucStorageBuffer,
  *                                             &xStreamBufferStruct );

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -202,9 +202,9 @@ typedef struct StreamBufferDef_t * StreamBufferHandle_t;
  * StreamBufferHandle_t xStreamBuffer;
  * const size_t xTriggerLevel = 1;
  *
- *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucBufferStorage ),
+ *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
  *                                             xTriggerLevel,
- *                                             ucBufferStorage,
+ *                                             ucStorageBuffer,
  *                                             &xStreamBufferStruct );
  *
  *  // As neither the pucStreamBufferStorageArea or pxStaticStreamBuffer

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -202,7 +202,7 @@ typedef struct StreamBufferDef_t * StreamBufferHandle_t;
  * StreamBufferHandle_t xStreamBuffer;
  * const size_t xTriggerLevel = 1;
  *
- *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ) - 1,
+ *  xStreamBuffer = xStreamBufferCreateStatic( sizeof( ucStorageBuffer ),
  *                                             xTriggerLevel,
  *                                             ucStorageBuffer,
  *                                             &xStreamBufferStruct );


### PR DESCRIPTION
…teStatic

<!--- Title -->

Description
-----------
Fix the code examples to pass a size of 1 less than the actual buffer size, as mentioned in the function header.

Test Steps
-----------
No additional test needed. Comments only.

Related Issue
-----------
379


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
