### PR TITLE
Xtensa_ESP32: Fix build issues when external SPIRAM is enabled

### DIFF
--- a/portable/ThirdParty/GCC/Xtensa_ESP32/include/portmacro.h
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/include/portmacro.h
@@ -89,6 +89,9 @@
 
     #include <esp_heap_caps.h>
     #include "soc/soc_memory_layout.h"
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0))
+    #include "soc/compare_set.h"
+#endif /* ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0) */
 
 /*#include "xtensa_context.h" */
 

--- a/portable/ThirdParty/GCC/Xtensa_ESP32/port.c
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/port.c
@@ -484,6 +484,8 @@ void vPortSetStackWatchpoint( void * pxStackStart )
     esp_set_watchpoint( 1, ( char * ) addr, 32, ESP_WATCHPOINT_STORE );
 }
 
+#if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 2, 0))
+
 #if defined( CONFIG_SPIRAM_SUPPORT )
 
 /*
@@ -522,6 +524,7 @@ void vPortSetStackWatchpoint( void * pxStackStart )
     }
 #endif //defined(CONFIG_SPIRAM_SUPPORT)
 
+#endif /* ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 2, 0) */
 
 
 uint32_t xPortGetTickRateHz( void )


### PR DESCRIPTION
Description
-----------
This change was not included when migrating to ESP-IDF v4.2

Test Steps
-----------
Enable SPIRAM on ESP32 in amazon-freertos

Related Issue
-----------
Fixes https://github.com/aws/amazon-freertos/issues/3353


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
