### PR TITLE
Replace <pre> with @code{c}

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -561,6 +561,7 @@ enablerx
 enabletx
 enametoolong
 endbusres
+endcode
 endian
 endif
 endinit

--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -96,9 +96,9 @@ typedef TickType_t               EventBits_t;
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  * EventGroupHandle_t xEventGroupCreate( void );
- * </pre>
+ * @endcode
  *
  * Create a new event group.
  *
@@ -125,7 +125,7 @@ typedef TickType_t               EventBits_t;
  * event group then NULL is returned.  See https://www.FreeRTOS.org/a00111.html
  *
  * Example usage:
- * <pre>
+ * @code{c}
  *  // Declare a variable to hold the created event group.
  *  EventGroupHandle_t xCreatedEventGroup;
  *
@@ -142,7 +142,7 @@ typedef TickType_t               EventBits_t;
  *  {
  *      // The event group was created.
  *  }
- * </pre>
+ * @endcode
  * \defgroup xEventGroupCreate xEventGroupCreate
  * \ingroup EventGroup
  */
@@ -152,9 +152,9 @@ typedef TickType_t               EventBits_t;
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  * EventGroupHandle_t xEventGroupCreateStatic( EventGroupHandle_t * pxEventGroupBuffer );
- * </pre>
+ * @endcode
  *
  * Create a new event group.
  *
@@ -184,7 +184,7 @@ typedef TickType_t               EventBits_t;
  * returned.  If pxEventGroupBuffer was NULL then NULL is returned.
  *
  * Example usage:
- * <pre>
+ * @code{c}
  *  // StaticEventGroup_t is a publicly accessible structure that has the same
  *  // size and alignment requirements as the real event group structure.  It is
  *  // provided as a mechanism for applications to know the size of the event
@@ -197,7 +197,7 @@ typedef TickType_t               EventBits_t;
  *
  *  // Create the event group without dynamically allocating any memory.
  *  xEventGroup = xEventGroupCreateStatic( &xEventGroupBuffer );
- * </pre>
+ * @endcode
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     EventGroupHandle_t xEventGroupCreateStatic( StaticEventGroup_t * pxEventGroupBuffer ) PRIVILEGED_FUNCTION;
@@ -205,13 +205,13 @@ typedef TickType_t               EventBits_t;
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  EventBits_t xEventGroupWaitBits(    EventGroupHandle_t xEventGroup,
  *                                      const EventBits_t uxBitsToWaitFor,
  *                                      const BaseType_t xClearOnExit,
  *                                      const BaseType_t xWaitForAllBits,
  *                                      const TickType_t xTicksToWait );
- * </pre>
+ * @endcode
  *
  * [Potentially] block to wait for one or more bits to be set within a
  * previously created event group.
@@ -255,9 +255,9 @@ typedef TickType_t               EventBits_t;
  * pdTRUE.
  *
  * Example usage:
- * <pre>
- #define BIT_0 ( 1 << 0 )
- #define BIT_4 ( 1 << 4 )
+ * @code{c}
+ * #define BIT_0 ( 1 << 0 )
+ * #define BIT_4 ( 1 << 4 )
  *
  * void aFunction( EventGroupHandle_t xEventGroup )
  * {
@@ -291,7 +291,7 @@ typedef TickType_t               EventBits_t;
  *          // without either BIT_0 or BIT_4 becoming set.
  *      }
  * }
- * </pre>
+ * @endcode
  * \defgroup xEventGroupWaitBits xEventGroupWaitBits
  * \ingroup EventGroup
  */
@@ -303,9 +303,9 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToClear );
- * </pre>
+ * @endcode
  *
  * Clear bits within an event group.  This function cannot be called from an
  * interrupt.
@@ -319,9 +319,9 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
  * @return The value of the event group before the specified bits were cleared.
  *
  * Example usage:
- * <pre>
- #define BIT_0 ( 1 << 0 )
- #define BIT_4 ( 1 << 4 )
+ * @code{c}
+ * #define BIT_0 ( 1 << 0 )
+ * #define BIT_4 ( 1 << 4 )
  *
  * void aFunction( EventGroupHandle_t xEventGroup )
  * {
@@ -352,7 +352,7 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
  *          // Neither bit 0 nor bit 4 were set in the first place.
  *      }
  * }
- * </pre>
+ * @endcode
  * \defgroup xEventGroupClearBits xEventGroupClearBits
  * \ingroup EventGroup
  */
@@ -361,9 +361,9 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  BaseType_t xEventGroupClearBitsFromISR( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet );
- * </pre>
+ * @endcode
  *
  * A version of xEventGroupClearBits() that can be called from an interrupt.
  *
@@ -388,9 +388,9 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
  * if the timer service queue was full.
  *
  * Example usage:
- * <pre>
- #define BIT_0 ( 1 << 0 )
- #define BIT_4 ( 1 << 4 )
+ * @code{c}
+ * #define BIT_0 ( 1 << 0 )
+ * #define BIT_4 ( 1 << 4 )
  *
  * // An event group which it is assumed has already been created by a call to
  * // xEventGroupCreate().
@@ -408,7 +408,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
  *          // The message was posted successfully.
  *      }
  * }
- * </pre>
+ * @endcode
  * \defgroup xEventGroupClearBitsFromISR xEventGroupClearBitsFromISR
  * \ingroup EventGroup
  */
@@ -422,9 +422,9 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet );
- * </pre>
+ * @endcode
  *
  * Set bits within an event group.
  * This function cannot be called from an interrupt.  xEventGroupSetBitsFromISR()
@@ -450,9 +450,9 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
  * event group value before the call to xEventGroupSetBits() returns.
  *
  * Example usage:
- * <pre>
- #define BIT_0 ( 1 << 0 )
- #define BIT_4 ( 1 << 4 )
+ * @code{c}
+ * #define BIT_0 ( 1 << 0 )
+ * #define BIT_4 ( 1 << 4 )
  *
  * void aFunction( EventGroupHandle_t xEventGroup )
  * {
@@ -488,7 +488,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
  *          // cleared as the task left the Blocked state.
  *      }
  * }
- * </pre>
+ * @endcode
  * \defgroup xEventGroupSetBits xEventGroupSetBits
  * \ingroup EventGroup
  */
@@ -497,9 +497,9 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  BaseType_t xEventGroupSetBitsFromISR( EventGroupHandle_t xEventGroup, const EventBits_t uxBitsToSet, BaseType_t *pxHigherPriorityTaskWoken );
- * </pre>
+ * @endcode
  *
  * A version of xEventGroupSetBits() that can be called from an interrupt.
  *
@@ -532,9 +532,9 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
  * if the timer service queue was full.
  *
  * Example usage:
- * <pre>
- #define BIT_0 ( 1 << 0 )
- #define BIT_4 ( 1 << 4 )
+ * @code{c}
+ * #define BIT_0 ( 1 << 0 )
+ * #define BIT_4 ( 1 << 4 )
  *
  * // An event group which it is assumed has already been created by a call to
  * // xEventGroupCreate().
@@ -563,7 +563,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
  *          portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
  *      }
  * }
- * </pre>
+ * @endcode
  * \defgroup xEventGroupSetBitsFromISR xEventGroupSetBitsFromISR
  * \ingroup EventGroup
  */
@@ -578,12 +578,12 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  EventBits_t xEventGroupSync(    EventGroupHandle_t xEventGroup,
  *                                  const EventBits_t uxBitsToSet,
  *                                  const EventBits_t uxBitsToWaitFor,
  *                                  TickType_t xTicksToWait );
- * </pre>
+ * @endcode
  *
  * Atomically set bits within an event group, then wait for a combination of
  * bits to be set within the same event group.  This functionality is typically
@@ -622,13 +622,13 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
  * automatically cleared.
  *
  * Example usage:
- * <pre>
+ * @code{c}
  * // Bits used by the three tasks.
- #define TASK_0_BIT     ( 1 << 0 )
- #define TASK_1_BIT     ( 1 << 1 )
- #define TASK_2_BIT     ( 1 << 2 )
+ * #define TASK_0_BIT     ( 1 << 0 )
+ * #define TASK_1_BIT     ( 1 << 1 )
+ * #define TASK_2_BIT     ( 1 << 2 )
  *
- #define ALL_SYNC_BITS ( TASK_0_BIT | TASK_1_BIT | TASK_2_BIT )
+ * #define ALL_SYNC_BITS ( TASK_0_BIT | TASK_1_BIT | TASK_2_BIT )
  *
  * // Use an event group to synchronise three tasks.  It is assumed this event
  * // group has already been created elsewhere.
@@ -696,7 +696,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
  *  }
  * }
  *
- * </pre>
+ * @endcode
  * \defgroup xEventGroupSync xEventGroupSync
  * \ingroup EventGroup
  */
@@ -708,9 +708,9 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  EventBits_t xEventGroupGetBits( EventGroupHandle_t xEventGroup );
- * </pre>
+ * @endcode
  *
  * Returns the current value of the bits in an event group.  This function
  * cannot be used from an interrupt.
@@ -726,9 +726,9 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup );
- * </pre>
+ * @endcode
  *
  * A version of xEventGroupGetBits() that can be called from an ISR.
  *
@@ -743,9 +743,9 @@ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup ) PRIVILEG
 
 /**
  * event_groups.h
- * <pre>
+ * @code{c}
  *  void xEventGroupDelete( EventGroupHandle_t xEventGroup );
- * </pre>
+ * @endcode
  *
  * Delete an event group that was previously created by a call to
  * xEventGroupCreate().  Tasks that are blocked on the event group will be


### PR DESCRIPTION
Following discussion on the forum, this PR replaces \<pre> with @code{c}

Description
-----------

As discussed here:
https://forums.freertos.org/t/doxygen-tags-in-the-documentation/13244/2
This improves handling of code blocks in FreeRTOS documentation.

Test Steps
-----------
Check if internally generated FreeRTOS documentation is correct after this change.

Related Issue
-----------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
