### PR TITLE
Handle interrupt acknowledge register in Cortex-A53 SRE port

### DIFF
--- a/portable/GCC/ARM_CA53_64_BIT_SRE/portASM.S
+++ b/portable/GCC/ARM_CA53_64_BIT_SRE/portASM.S
@@ -303,6 +303,13 @@ FreeRTOS_IRQ_Handler:
 	/* Maintain the interrupt nesting information across the function call. */
 	STP		X1, X5, [SP, #-0x10]!
 
+	/* Read value from the interrupt acknowledge register, which is stored in W0
+	for future parameter and interrupt clearing use. */
+	MRS		X0, S3_0_C12_C12_0 /* read ICC_IAR1_EL1 and store ICCIAR in X0 as parameter */
+
+	/* Maintain the ICCIAR value across the function call. */
+	STP		X0, X1, [SP, #-0x10]!
+
 	/* Call the C handler. */
 	BL vApplicationIRQHandler
 
@@ -310,6 +317,12 @@ FreeRTOS_IRQ_Handler:
 	MSR 	DAIFSET, #2
 	DSB		SY
 	ISB		SY
+
+	/* Restore the ICCIAR value. */
+	LDP		X0, X1, [SP], #0x10
+
+	/* End IRQ processing by writing ICCIAR to the EOI register. */
+	MSR		S3_0_C12_C12_1, X0	/* ICC_EOIR1_EL1 */
 
 	/* Restore the critical nesting count. */
 	LDP		X1, X5, [SP], #0x10


### PR DESCRIPTION
Description
-----------
Let the FreeRTOS IRQ handler properly store and restore the ICCIAR register value around the vApplicationIRQHandler() call.

This pull request is essentially created so that the "SRE" port matches the original ("MMIO") port [1] so that `vApplicationIRQHandler()` does not depend on the port being used.

[1] https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/portable/GCC/ARM_CA53_64_BIT/portASM.S#L310

Test Steps
-----------
Tested with an application - with the same implementation of `vApplicationIRQHandler()` - for both A53 ports.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
