### PR TITLE
The Interupt need to be disabled over the restore of the FPU and rest…

### DIFF
--- a/portable/GCC/ARM_CA9/portASM.S
+++ b/portable/GCC/ARM_CA9/portASM.S
@@ -201,12 +201,13 @@ FreeRTOS_IRQ_Handler:
 	PUSH	{r0-r4, lr}
 	LDR		r1, vApplicationIRQHandlerConst
 	BLX		r1
-	POP		{r0-r4, lr}
-	ADD		sp, sp, r2
-
+	
 	CPSID	i
 	DSB
 	ISB
+	
+	POP		{r0-r4, lr}
+	ADD		sp, sp, r2
 
 	/* Write the value read from ICCIAR to ICCEOIR. */
 	LDR 	r4, ulICCEOIRConst
@@ -295,6 +296,10 @@ vApplicationIRQHandler:
 
 	LDR		r1, vApplicationFPUSafeIRQHandlerConst
 	BLX		r1
+	
+	CPSID	i
+	DSB
+	ISB
 
 	POP		{R0}
 	VPOP	{D16-D31}


### PR DESCRIPTION
…ore Stackaligment

ARM CORTEX A9 Port

Description
-----------
In the ISR should be the Interrupts locked over the Restore FPU and Restore Stackaligment. In other case, the interrupts can interrupts the Restore the FPU register / Restore Stackaligment

Please Integrate this change in the FreeRTOS LTS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
