### PR TITLE
Xtensa_ESP32: Add definition for portMEMORY_BARRIER

### DIFF
--- a/portable/ThirdParty/GCC/Xtensa_ESP32/include/portmacro.h
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/include/portmacro.h
@@ -554,6 +554,10 @@
         #define configASSERT( x )    if( !( x ) ) { porttracePrint( -1 ); printf( "\nAssertion failed in %s:%d\n", __FILE__, __LINE__ ); exit( -1 ); }
     #endif
 
+/* Barriers */
+    #define portMEMORY_BARRIER()    __asm volatile ( "" ::: "memory" )
+
+
 #endif // __ASSEMBLER__
 
 /* *INDENT-OFF* */


### PR DESCRIPTION
Description
-----------
Adding memory barrier fixes crash on Espressif SoC's when compiler optimisations are enabled.

This regression was introduced with https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/6bf3a75c6a46c1b6b38f5b55751ec4cfa6333fdd commit.

Due to optimisations, [assignment of pxTCB](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/1b86b39940c18f2bba6e577b007c430a65839e24/tasks.c#L2246) is moved outside while loop. Due to this, value of pxTCB is not loaded on each iteration of loop.

Related: https://github.com/aws/amazon-freertos/pull/3374

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
