### PR TITLE
Fix typo in comment

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2140,7 +2140,7 @@ void vTaskSuspendAll( void )
      * post in the FreeRTOS support forum before reporting this as a bug! -
      * https://goo.gl/wu4acr */
 
-    /* portSOFRWARE_BARRIER() is only implemented for emulated/simulated ports that
+    /* portSOFTWARE_BARRIER() is only implemented for emulated/simulated ports that
      * do not otherwise exhibit real time behaviour. */
     portSOFTWARE_BARRIER();
 


### PR DESCRIPTION
Fix a typo in a comment in tasks.c

Description
-----------
Just fixed a typo.

Test Steps
-----------
None

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
