### PR TITLE
bugfix: Initialise stack correctly on dsPIC port

### DIFF
--- a/portable/MPLAB/PIC24_dsPIC/port.c
+++ b/portable/MPLAB/PIC24_dsPIC/port.c
@@ -69,7 +69,7 @@ UBaseType_t uxCriticalNesting = 0xef;
 
 #if defined( __PIC24E__ ) || defined ( __PIC24F__ ) || defined( __PIC24FK__ ) || defined( __PIC24H__ )
 
-    #ifdef __HAS_EDS__
+	#ifdef __HAS_EDS__
 		#define portRESTORE_CONTEXT()																						\
 					asm volatile(	"MOV	_pxCurrentTCB, W0		\n"	/* Restore the stack pointer for the task. */		\
 							"MOV	[W0], W15				\n"																\
@@ -109,7 +109,7 @@ UBaseType_t uxCriticalNesting = 0xef;
 							"POP.D	W0						\n"																\
 							"POP	SR						  " );
 		#endif /* __HAS_EDS__ */
-#endif /* MPLAB_PIC24_PORT */
+#endif /* defined( __PIC24E__ ) || defined ( __PIC24F__ ) || defined( __PIC24FK__ ) || defined( __PIC24H__ ) */
 
 #if defined( __dsPIC30F__ ) || defined( __dsPIC33F__ )
 
@@ -143,7 +143,7 @@ UBaseType_t uxCriticalNesting = 0xef;
 						"POP.D	W0						\n"																\
 						"POP	SR						  " );
 
-#endif /* MPLAB_DSPIC_PORT */
+#endif /* defined( __dsPIC30F__ ) || defined( __dsPIC33F__ ) */
 
 #ifndef portRESTORE_CONTEXT
 	#error Unrecognised device selected
@@ -331,4 +331,4 @@ void __attribute__((__interrupt__, auto_psv)) configTICK_INTERRUPT_HANDLER( void
 		portYIELD();
 	}
 }
-
+/*-----------------------------------------------------------*/

--- a/portable/MPLAB/PIC24_dsPIC/port.c
+++ b/portable/MPLAB/PIC24_dsPIC/port.c
@@ -185,7 +185,7 @@ const StackType_t xInitialStack[] =
 	0xabac, /* TBLPAG */
 
 	/* dsPIC specific registers. */
-	#ifdef MPLAB_DSPIC_PORT
+	#if defined( __dsPIC30F__ ) || defined( __dsPIC33F__ )
 		0x0202, /* ACCAL */
 		0x0303, /* ACCAH */
 		0x0404, /* ACCAU */


### PR DESCRIPTION
Description
-----------
Remove the use of MPLAB_DSPIC_PORT for determining correct stack initialisation, use the XC16 compiler device family macros instead.

Related Issue
-----------
[BUG] Stack initialisation incorrect on dsPIC. #404 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
