### PR TITLE
Fix documentation mistake

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -2338,7 +2338,6 @@ ultablebase
 ultaskgetidleruntimecounter
 ultaskgetidleruntimepercent
 ultaskhasfpucontext
-ultasknotificationtakeindexed
 ultasknotifystateclear
 ultasknotifytake
 ultasknotifytakeindexed

--- a/include/task.h
+++ b/include/task.h
@@ -2404,7 +2404,7 @@ BaseType_t xTaskGenericNotifyWait( UBaseType_t uxIndexToWaitOn,
  *
  * When task notifications are being used as a binary or counting semaphore
  * equivalent then the task being notified should wait for the notification
- * using the ulTaskNotificationTakeIndexed() API function rather than the
+ * using the ulTaskNotifyTakeIndexed() API function rather than the
  * xTaskNotifyWaitIndexed() API function.
  *
  * **NOTE** Each notification within the array operates independently - a task
@@ -2481,7 +2481,7 @@ BaseType_t xTaskGenericNotifyWait( UBaseType_t uxIndexToWaitOn,
  *
  * When task notifications are being used as a binary or counting semaphore
  * equivalent then the task being notified should wait for the notification
- * using the ulTaskNotificationTakeIndexed() API function rather than the
+ * using the ulTaskNotifyTakeIndexed() API function rather than the
  * xTaskNotifyWaitIndexed() API function.
  *
  * **NOTE** Each notification within the array operates independently - a task


### PR DESCRIPTION
Description
-----------
Fix a mistake in the docs where `ulTaskNotifyTakeIndexed` is referred to as `ulTaskNotificationTakeIndexed`

Test Steps
-----------
None - only comments changed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
