### PR TITLE
Fix prototype issue for the Posix port.

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -111,6 +111,7 @@ static void prvSuspendSelf( Thread_t * thread);
 static void prvResumeThread( Thread_t * xThreadId );
 static void vPortSystemTickHandler( int sig );
 static void vPortStartFirstTask( void );
+static void prvPortYieldFromISR( void );
 /*-----------------------------------------------------------*/
 
 static void prvFatalError( const char *pcCall, int iErrno )
@@ -267,7 +268,7 @@ void vPortExitCritical( void )
 }
 /*-----------------------------------------------------------*/
 
-void vPortYieldFromISR( void )
+static void prvPortYieldFromISR( void )
 {
 Thread_t *xThreadToSuspend;
 Thread_t *xThreadToResume;
@@ -286,7 +287,7 @@ void vPortYield( void )
 {
     vPortEnterCritical();
 
-    vPortYieldFromISR();
+    prvPortYieldFromISR();
 
     vPortExitCritical();
 }

--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
@@ -39,7 +39,7 @@ struct event
     bool event_triggered;
 };
 
-struct event * event_create()
+struct event * event_create( void )
 {
     struct event * ev = malloc( sizeof( struct event ) );
 

--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.h
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.h
@@ -34,7 +34,7 @@
 
 struct event;
 
-struct event * event_create();
+struct event * event_create( void );
 void event_delete( struct event * );
 bool event_wait( struct event * ev );
 bool event_wait_timed( struct event * ev,


### PR DESCRIPTION
Build with -Wmissing-prototypes flags vPortYieldFromISR() in the Posix port.

<!--- Title -->

There's already a portYIELD_FROM_ISR() macro that calls vPortYield() which wraps the FromISR code.
It doesn't appear that vPortYieldFromISR() is intended to be publicly accessible in this port so
I've marked it as private to silence the warning.

-----------
<!--- Describe your changes in detail. -->

Flagged by -Wmissing-prototypes

-----------
<!-- Describe the steps to reproduce. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
