### PR TITLE
Mention portMAX_DELAY in xEventGroupWaitBits docs

### DIFF
--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -243,7 +243,8 @@ typedef TickType_t               EventBits_t;
  *
  * @param xTicksToWait The maximum amount of time (specified in 'ticks') to wait
  * for one/all (depending on the xWaitForAllBits value) of the bits specified by
- * uxBitsToWaitFor to become set.
+ * uxBitsToWaitFor to become set. A value of portMAX_DELAY can be used to block
+ * indefinitely (provided INCLUDE_vTaskSuspend is set to 1 in FreeRTOSConfig.h).
  *
  * @return The value of the event group at the time either the bits being waited
  * for became set, or the block time expired.  Test the return value to know


### PR DESCRIPTION
Description
-----------

The public function `xEventGroupWaitBits` passes `xTicksToWait` to the function `vTaskPlaceOnUnorderedEventList`, which passes the number of ticks to `prvAddCurrentTaskToDelayedList` and sets `xCanBlockIndefinitely` to `pdTRUE`, causing the latter to block indefinitely if `xTicksToWait == portMAX_DELAY` and `INCLUDE_vTaskSuspend == 1`.

Test Steps
-----------

This documents existing behavior only.

Related Issue
-----------

None.

---

<sub>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.</sub>