### PR TITLE
Fix code example in timers.h

### DIFF
--- a/include/timers.h
+++ b/include/timers.h
@@ -192,11 +192,11 @@ typedef void (* PendedFunction_t)( void *,
  *     // the scheduler starts.
  *     for( x = 0; x < NUM_TIMERS; x++ )
  *     {
- *         xTimers[ x ] = xTimerCreate(    "Timer",       // Just a text name, not used by the kernel.
- *                                         ( 100 * x ),   // The timer period in ticks.
- *                                         pdTRUE,        // The timers will auto-reload themselves when they expire.
- *                                         ( void * ) x,  // Assign each timer a unique id equal to its array index.
- *                                         vTimerCallback // Each timer calls the same callback when it expires.
+ *         xTimers[ x ] = xTimerCreate(    "Timer",             // Just a text name, not used by the kernel.
+ *                                         ( 100 * ( x + 1 ) ), // The timer period in ticks.
+ *                                         pdTRUE,              // The timers will auto-reload themselves when they expire.
+ *                                         ( void * ) x,        // Assign each timer a unique id equal to its array index.
+ *                                         vTimerCallback       // Each timer calls the same callback when it expires.
  *                                     );
  *
  *         if( xTimers[ x ] == NULL )


### PR DESCRIPTION
Description
-----------
The example was trying to create a timer with period 0 which is not a valid period.

This was reported here - https://forums.freertos.org/t/multiple-timers/13884

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
