### PR TITLE
Apply fixes released in 10.4.6

### DIFF
--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -168,10 +168,40 @@
 
     #else /* MPU_WRAPPERS_INCLUDED_FROM_API_FILE */
 
-/* Ensure API functions go in the privileged execution section. */
+        /* Ensure API functions go in the privileged execution section. */
         #define PRIVILEGED_FUNCTION     __attribute__( ( section( "privileged_functions" ) ) )
         #define PRIVILEGED_DATA         __attribute__( ( section( "privileged_data" ) ) )
         #define FREERTOS_SYSTEM_CALL    __attribute__( ( section( "freertos_system_calls" ) ) )
+
+        /**
+         * @brief Calls the port specific code to raise the privilege.
+         *
+         * Sets xRunningPrivileged to pdFALSE if privilege was raised, else sets
+         * it to pdTRUE.
+         */
+        #define xPortRaisePrivilege( xRunningPrivileged )                      \
+        {                                                                      \
+            /* Check whether the processor is already privileged. */           \
+            xRunningPrivileged = portIS_PRIVILEGED();                          \
+                                                                               \
+            /* If the processor is not already privileged, raise privilege. */ \
+            if( xRunningPrivileged == pdFALSE )                                \
+            {                                                                  \
+                portRAISE_PRIVILEGE();                                         \
+            }                                                                  \
+        }
+
+        /**
+         * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
+         * code to reset the privilege, otherwise does nothing.
+         */
+        #define vPortResetPrivilege( xRunningPrivileged )   \
+        {                                                   \
+            if( xRunningPrivileged == pdFALSE )             \
+            {                                               \
+                portRESET_PRIVILEGE();                      \
+            }                                               \
+        }
 
     #endif /* MPU_WRAPPERS_INCLUDED_FROM_API_FILE */
 

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -168,40 +168,40 @@
 
     #else /* MPU_WRAPPERS_INCLUDED_FROM_API_FILE */
 
-        /* Ensure API functions go in the privileged execution section. */
+/* Ensure API functions go in the privileged execution section. */
         #define PRIVILEGED_FUNCTION     __attribute__( ( section( "privileged_functions" ) ) )
         #define PRIVILEGED_DATA         __attribute__( ( section( "privileged_data" ) ) )
         #define FREERTOS_SYSTEM_CALL    __attribute__( ( section( "freertos_system_calls" ) ) )
 
-        /**
-         * @brief Calls the port specific code to raise the privilege.
-         *
-         * Sets xRunningPrivileged to pdFALSE if privilege was raised, else sets
-         * it to pdTRUE.
-         */
-        #define xPortRaisePrivilege( xRunningPrivileged )                      \
-        {                                                                      \
-            /* Check whether the processor is already privileged. */           \
-            xRunningPrivileged = portIS_PRIVILEGED();                          \
-                                                                               \
-            /* If the processor is not already privileged, raise privilege. */ \
-            if( xRunningPrivileged == pdFALSE )                                \
-            {                                                                  \
-                portRAISE_PRIVILEGE();                                         \
-            }                                                                  \
-        }
+/**
+ * @brief Calls the port specific code to raise the privilege.
+ *
+ * Sets xRunningPrivileged to pdFALSE if privilege was raised, else sets
+ * it to pdTRUE.
+ */
+        #define xPortRaisePrivilege( xRunningPrivileged )                  \
+    {                                                                      \
+        /* Check whether the processor is already privileged. */           \
+        xRunningPrivileged = portIS_PRIVILEGED();                          \
+                                                                           \
+        /* If the processor is not already privileged, raise privilege. */ \
+        if( xRunningPrivileged == pdFALSE )                                \
+        {                                                                  \
+            portRAISE_PRIVILEGE();                                         \
+        }                                                                  \
+    }
 
-        /**
-         * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
-         * code to reset the privilege, otherwise does nothing.
-         */
-        #define vPortResetPrivilege( xRunningPrivileged )   \
-        {                                                   \
-            if( xRunningPrivileged == pdFALSE )             \
-            {                                               \
-                portRESET_PRIVILEGE();                      \
-            }                                               \
-        }
+/**
+ * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
+ * code to reset the privilege, otherwise does nothing.
+ */
+        #define vPortResetPrivilege( xRunningPrivileged ) \
+    {                                                     \
+        if( xRunningPrivileged == pdFALSE )               \
+        {                                                 \
+            portRESET_PRIVILEGE();                        \
+        }                                                 \
+    }
 
     #endif /* MPU_WRAPPERS_INCLUDED_FROM_API_FILE */
 

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -46,45 +46,6 @@
 #include "mpu_prototypes.h"
 
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
-
-/**
- * @brief Calls the port specific code to raise the privilege.
- *
- * @return pdFALSE if privilege was raised, pdTRUE otherwise.
- */
-BaseType_t xPortRaisePrivilege( void ) FREERTOS_SYSTEM_CALL;
-
-/**
- * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
- * code to reset the privilege, otherwise does nothing.
- */
-void vPortResetPrivilege( BaseType_t xRunningPrivileged );
-/*-----------------------------------------------------------*/
-
-BaseType_t xPortRaisePrivilege( void ) /* FREERTOS_SYSTEM_CALL */
-{
-    BaseType_t xRunningPrivileged;
-
-    /* Check whether the processor is already privileged. */
-    xRunningPrivileged = portIS_PRIVILEGED();
-
-    /* If the processor is not already privileged, raise privilege. */
-    if( xRunningPrivileged == pdFALSE )
-    {
-        portRAISE_PRIVILEGE();
-    }
-
-    return xRunningPrivileged;
-}
-/*-----------------------------------------------------------*/
-
-void vPortResetPrivilege( BaseType_t xRunningPrivileged )
-{
-    if( xRunningPrivileged == pdFALSE )
-    {
-        portRESET_PRIVILEGE();
-    }
-}
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
@@ -95,11 +56,12 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
                                 UBaseType_t uxPriority,
                                 TaskHandle_t * pxCreatedTask ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskCreate( pvTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
@@ -115,10 +77,12 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
                                         StaticTask_t * const pxTaskBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* configSUPPORT_STATIC_ALLOCATION */
@@ -127,8 +91,9 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
 #if ( INCLUDE_vTaskDelete == 1 )
     void MPU_vTaskDelete( TaskHandle_t pxTaskToDelete ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskDelete( pxTaskToDelete );
         vPortResetPrivilege( xRunningPrivileged );
     }
@@ -139,34 +104,37 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
     BaseType_t MPU_xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
                                     TickType_t xTimeIncrement ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-        BaseType_t xReturn;
+        BaseType_t xRunningPrivileged, xReturn;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( INCLUDE_xTaskDelayUntil == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_xTaskAbortDelay == 1 )
     BaseType_t MPU_xTaskAbortDelay( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskAbortDelay( xTask );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( INCLUDE_xTaskAbortDelay == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskDelay == 1 )
     void MPU_vTaskDelay( TickType_t xTicksToDelay ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskDelay( xTicksToDelay );
         vPortResetPrivilege( xRunningPrivileged );
     }
@@ -177,38 +145,43 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
     UBaseType_t MPU_uxTaskPriorityGet( const TaskHandle_t pxTask ) /* FREERTOS_SYSTEM_CALL */
     {
         UBaseType_t uxReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         uxReturn = uxTaskPriorityGet( pxTask );
         vPortResetPrivilege( xRunningPrivileged );
+
         return uxReturn;
     }
-#endif
+#endif /* if ( INCLUDE_uxTaskPriorityGet == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskPrioritySet == 1 )
     void MPU_vTaskPrioritySet( TaskHandle_t pxTask,
                                UBaseType_t uxNewPriority ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskPrioritySet( pxTask, uxNewPriority );
         vPortResetPrivilege( xRunningPrivileged );
     }
-#endif
+#endif /* if ( INCLUDE_vTaskPrioritySet == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_eTaskGetState == 1 )
     eTaskState MPU_eTaskGetState( TaskHandle_t pxTask ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
         eTaskState eReturn;
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         eReturn = eTaskGetState( pxTask );
         vPortResetPrivilege( xRunningPrivileged );
+
         return eReturn;
     }
-#endif
+#endif /* if ( INCLUDE_eTaskGetState == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TRACE_FACILITY == 1 )
@@ -217,8 +190,9 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
                            BaseType_t xGetFreeStackSpace,
                            eTaskState eState ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState );
         vPortResetPrivilege( xRunningPrivileged );
     }
@@ -229,20 +203,23 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
     TaskHandle_t MPU_xTaskGetIdleTaskHandle( void ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGetIdleTaskHandle();
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskSuspend == 1 )
     void MPU_vTaskSuspend( TaskHandle_t pxTaskToSuspend ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskSuspend( pxTaskToSuspend );
         vPortResetPrivilege( xRunningPrivileged );
     }
@@ -252,8 +229,9 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
 #if ( INCLUDE_vTaskSuspend == 1 )
     void MPU_vTaskResume( TaskHandle_t pxTaskToResume ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskResume( pxTaskToResume );
         vPortResetPrivilege( xRunningPrivileged );
     }
@@ -262,8 +240,9 @@ void vPortResetPrivilege( BaseType_t xRunningPrivileged )
 
 void MPU_vTaskSuspendAll( void ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     vTaskSuspendAll();
     vPortResetPrivilege( xRunningPrivileged );
 }
@@ -271,11 +250,12 @@ void MPU_vTaskSuspendAll( void ) /* FREERTOS_SYSTEM_CALL */
 
 BaseType_t MPU_xTaskResumeAll( void ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xTaskResumeAll();
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -283,10 +263,12 @@ BaseType_t MPU_xTaskResumeAll( void ) /* FREERTOS_SYSTEM_CALL */
 TickType_t MPU_xTaskGetTickCount( void ) /* FREERTOS_SYSTEM_CALL */
 {
     TickType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xTaskGetTickCount();
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -294,10 +276,12 @@ TickType_t MPU_xTaskGetTickCount( void ) /* FREERTOS_SYSTEM_CALL */
 UBaseType_t MPU_uxTaskGetNumberOfTasks( void ) /* FREERTOS_SYSTEM_CALL */
 {
     UBaseType_t uxReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     uxReturn = uxTaskGetNumberOfTasks();
     vPortResetPrivilege( xRunningPrivileged );
+
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -305,10 +289,12 @@ UBaseType_t MPU_uxTaskGetNumberOfTasks( void ) /* FREERTOS_SYSTEM_CALL */
 char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
 {
     char * pcReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     pcReturn = pcTaskGetName( xTaskToQuery );
     vPortResetPrivilege( xRunningPrivileged );
+
     return pcReturn;
 }
 /*-----------------------------------------------------------*/
@@ -317,20 +303,23 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
     TaskHandle_t MPU_xTaskGetHandle( const char * pcNameToQuery ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGetHandle( pcNameToQuery );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( INCLUDE_xTaskGetHandle == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     void MPU_vTaskList( char * pcWriteBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskList( pcWriteBuffer );
         vPortResetPrivilege( xRunningPrivileged );
     }
@@ -340,8 +329,9 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
 #if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     void MPU_vTaskGetRunTimeStats( char * pcWriteBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskGetRunTimeStats( pcWriteBuffer );
         vPortResetPrivilege( xRunningPrivileged );
     }
@@ -352,51 +342,58 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
     configRUN_TIME_COUNTER_TYPE MPU_ulTaskGetIdleRunTimePercent( void ) /* FREERTOS_SYSTEM_CALL */
     {
         configRUN_TIME_COUNTER_TYPE xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = ulTaskGetIdleRunTimePercent();
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) )
     configRUN_TIME_COUNTER_TYPE MPU_ulTaskGetIdleRunTimeCounter( void ) /* FREERTOS_SYSTEM_CALL */
     {
         configRUN_TIME_COUNTER_TYPE xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = ulTaskGetIdleRunTimeCounter();
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_APPLICATION_TASK_TAG == 1 )
     void MPU_vTaskSetApplicationTaskTag( TaskHandle_t xTask,
                                          TaskHookFunction_t pxTagValue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskSetApplicationTaskTag( xTask, pxTagValue );
         vPortResetPrivilege( xRunningPrivileged );
     }
-#endif
+#endif /* if ( configUSE_APPLICATION_TASK_TAG == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_APPLICATION_TASK_TAG == 1 )
     TaskHookFunction_t MPU_xTaskGetApplicationTaskTag( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHookFunction_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGetApplicationTaskTag( xTask );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( configUSE_APPLICATION_TASK_TAG == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configNUM_THREAD_LOCAL_STORAGE_POINTERS != 0 )
@@ -404,12 +401,13 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
                                                 BaseType_t xIndex,
                                                 void * pvValue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue );
         vPortResetPrivilege( xRunningPrivileged );
     }
-#endif
+#endif /* if ( configNUM_THREAD_LOCAL_STORAGE_POINTERS != 0 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configNUM_THREAD_LOCAL_STORAGE_POINTERS != 0 )
@@ -417,10 +415,12 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
                                                    BaseType_t xIndex ) /* FREERTOS_SYSTEM_CALL */
     {
         void * pvReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         pvReturn = pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex );
         vPortResetPrivilege( xRunningPrivileged );
+
         return pvReturn;
     }
 #endif /* if ( configNUM_THREAD_LOCAL_STORAGE_POINTERS != 0 ) */
@@ -430,11 +430,12 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
     BaseType_t MPU_xTaskCallApplicationTaskHook( TaskHandle_t xTask,
                                                  void * pvParameter ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskCallApplicationTaskHook( xTask, pvParameter );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_APPLICATION_TASK_TAG == 1 ) */
@@ -446,10 +447,12 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
                                           configRUN_TIME_COUNTER_TYPE * pulTotalRunTime ) /* FREERTOS_SYSTEM_CALL */
     {
         UBaseType_t uxReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         uxReturn = uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
         vPortResetPrivilege( xRunningPrivileged );
+
         return uxReturn;
     }
 #endif /* if ( configUSE_TRACE_FACILITY == 1 ) */
@@ -457,11 +460,12 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
 
 BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xTaskCatchUpTicks( xTicksToCatchUp );
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -470,58 +474,66 @@ BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTE
     UBaseType_t MPU_uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
         UBaseType_t uxReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         uxReturn = uxTaskGetStackHighWaterMark( xTask );
         vPortResetPrivilege( xRunningPrivileged );
+
         return uxReturn;
     }
-#endif
+#endif /* if ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_uxTaskGetStackHighWaterMark2 == 1 )
     configSTACK_DEPTH_TYPE MPU_uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
         configSTACK_DEPTH_TYPE uxReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         uxReturn = uxTaskGetStackHighWaterMark2( xTask );
         vPortResetPrivilege( xRunningPrivileged );
+
         return uxReturn;
     }
-#endif
+#endif /* if ( INCLUDE_uxTaskGetStackHighWaterMark2 == 1 ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( INCLUDE_xTaskGetCurrentTaskHandle == 1 ) || ( configUSE_MUTEXES == 1 ))
+#if ( ( INCLUDE_xTaskGetCurrentTaskHandle == 1 ) || ( configUSE_MUTEXES == 1 ) )
     TaskHandle_t MPU_xTaskGetCurrentTaskHandle( void ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGetCurrentTaskHandle();
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( ( INCLUDE_xTaskGetCurrentTaskHandle == 1 ) || ( configUSE_MUTEXES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_xTaskGetSchedulerState == 1 )
     BaseType_t MPU_xTaskGetSchedulerState( void ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGetSchedulerState();
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( INCLUDE_xTaskGetSchedulerState == 1 ) */
 /*-----------------------------------------------------------*/
 
 void MPU_vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     vTaskSetTimeOutState( pxTimeOut );
     vPortResetPrivilege( xRunningPrivileged );
 }
@@ -530,11 +542,12 @@ void MPU_vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) /* FREERTOS_SYSTEM_
 BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                      TickType_t * const pxTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -546,11 +559,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                        eNotifyAction eAction,
                                        uint32_t * pulPreviousNotificationValue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
@@ -563,11 +577,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                            uint32_t * pulNotificationValue,
                                            TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
@@ -579,10 +594,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                           TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
         uint32_t ulReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         ulReturn = ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait );
         vPortResetPrivilege( xRunningPrivileged );
+
         return ulReturn;
     }
 #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
@@ -592,11 +609,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
     BaseType_t MPU_xTaskGenericNotifyStateClear( TaskHandle_t xTask,
                                                  UBaseType_t uxIndexToClear ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTaskGenericNotifyStateClear( xTask, uxIndexToClear );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
@@ -608,10 +626,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                                 uint32_t ulBitsToClear ) /* FREERTOS_SYSTEM_CALL */
     {
         uint32_t ulReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         ulReturn = ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear );
         vPortResetPrivilege( xRunningPrivileged );
+
         return ulReturn;
     }
 #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
@@ -623,10 +643,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                            uint8_t ucQueueType ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) */
@@ -640,10 +662,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                                  const uint8_t ucQueueType ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
@@ -652,11 +676,12 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
 BaseType_t MPU_xQueueGenericReset( QueueHandle_t pxQueue,
                                    BaseType_t xNewQueue ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xQueueGenericReset( pxQueue, xNewQueue );
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -666,33 +691,38 @@ BaseType_t MPU_xQueueGenericSend( QueueHandle_t xQueue,
                                   TickType_t xTicksToWait,
                                   BaseType_t xCopyPosition ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t MPU_uxQueueMessagesWaiting( const QueueHandle_t pxQueue ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
     UBaseType_t uxReturn;
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     uxReturn = uxQueueMessagesWaiting( pxQueue );
     vPortResetPrivilege( xRunningPrivileged );
+
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t MPU_uxQueueSpacesAvailable( const QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
     UBaseType_t uxReturn;
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     uxReturn = uxQueueSpacesAvailable( xQueue );
     vPortResetPrivilege( xRunningPrivileged );
+
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -701,11 +731,12 @@ BaseType_t MPU_xQueueReceive( QueueHandle_t pxQueue,
                               void * const pvBuffer,
                               TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-    BaseType_t xReturn;
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xQueueReceive( pxQueue, pvBuffer, xTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -714,11 +745,12 @@ BaseType_t MPU_xQueuePeek( QueueHandle_t xQueue,
                            void * const pvBuffer,
                            TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-    BaseType_t xReturn;
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xQueuePeek( xQueue, pvBuffer, xTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -726,11 +758,12 @@ BaseType_t MPU_xQueuePeek( QueueHandle_t xQueue,
 BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                     TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
-    BaseType_t xReturn;
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xQueueSemaphoreTake( xQueue, xTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -738,27 +771,31 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
 #if ( ( configUSE_MUTEXES == 1 ) && ( INCLUDE_xSemaphoreGetMutexHolder == 1 ) )
     TaskHandle_t MPU_xQueueGetMutexHolder( QueueHandle_t xSemaphore ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
         void * xReturn;
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueGetMutexHolder( xSemaphore );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( ( configUSE_MUTEXES == 1 ) && ( INCLUDE_xSemaphoreGetMutexHolder == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configUSE_MUTEXES == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     QueueHandle_t MPU_xQueueCreateMutex( const uint8_t ucQueueType ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueCreateMutex( ucQueueType );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( ( configUSE_MUTEXES == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configUSE_MUTEXES == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
@@ -766,10 +803,12 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                StaticQueue_t * pxStaticQueue ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueCreateMutexStatic( ucQueueType, pxStaticQueue );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( ( configUSE_MUTEXES == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
@@ -780,10 +819,12 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                      UBaseType_t uxInitialCount ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueCreateCountingSemaphore( uxCountValue, uxInitialCount );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( ( configUSE_COUNTING_SEMAPHORES == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
@@ -796,10 +837,12 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                            StaticQueue_t * pxStaticQueue ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( ( configUSE_COUNTING_SEMAPHORES == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
@@ -809,11 +852,12 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     BaseType_t MPU_xQueueTakeMutexRecursive( QueueHandle_t xMutex,
                                              TickType_t xBlockTime ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueTakeMutexRecursive( xMutex, xBlockTime );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_RECURSIVE_MUTEXES == 1 ) */
@@ -822,27 +866,30 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
 #if ( configUSE_RECURSIVE_MUTEXES == 1 )
     BaseType_t MPU_xQueueGiveMutexRecursive( QueueHandle_t xMutex ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueGiveMutexRecursive( xMutex );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( configUSE_RECURSIVE_MUTEXES == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configUSE_QUEUE_SETS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     QueueSetHandle_t MPU_xQueueCreateSet( UBaseType_t uxEventQueueLength ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueSetHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueCreateSet( uxEventQueueLength );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
-#endif
+#endif /* if ( ( configUSE_QUEUE_SETS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_QUEUE_SETS == 1 )
@@ -850,10 +897,12 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                     TickType_t xBlockTimeTicks ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueSetMemberHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueSelectFromSet( xQueueSet, xBlockTimeTicks );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_QUEUE_SETS == 1 ) */
@@ -863,11 +912,12 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     BaseType_t MPU_xQueueAddToSet( QueueSetMemberHandle_t xQueueOrSemaphore,
                                    QueueSetHandle_t xQueueSet ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_QUEUE_SETS == 1 ) */
@@ -877,11 +927,12 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     BaseType_t MPU_xQueueRemoveFromSet( QueueSetMemberHandle_t xQueueOrSemaphore,
                                         QueueSetHandle_t xQueueSet ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet );
         vPortResetPrivilege( xRunningPrivileged );
+
         return xReturn;
     }
 #endif /* if ( configUSE_QUEUE_SETS == 1 ) */
@@ -891,36 +942,37 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     void MPU_vQueueAddToRegistry( QueueHandle_t xQueue,
                                   const char * pcName ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vQueueAddToRegistry( xQueue, pcName );
-
         vPortResetPrivilege( xRunningPrivileged );
     }
-#endif
+#endif /* if configQUEUE_REGISTRY_SIZE > 0 */
 /*-----------------------------------------------------------*/
 
 #if configQUEUE_REGISTRY_SIZE > 0
     void MPU_vQueueUnregisterQueue( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vQueueUnregisterQueue( xQueue );
-
         vPortResetPrivilege( xRunningPrivileged );
     }
-#endif
+#endif /* if configQUEUE_REGISTRY_SIZE > 0 */
 /*-----------------------------------------------------------*/
 
 #if configQUEUE_REGISTRY_SIZE > 0
     const char * MPU_pcQueueGetName( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
         const char * pcReturn;
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         pcReturn = pcQueueGetName( xQueue );
-
         vPortResetPrivilege( xRunningPrivileged );
+
         return pcReturn;
     }
 #endif /* if configQUEUE_REGISTRY_SIZE > 0 */
@@ -928,10 +980,10 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
 
 void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     vQueueDelete( xQueue );
-
     vPortResetPrivilege( xRunningPrivileged );
 }
 /*-----------------------------------------------------------*/
@@ -944,8 +996,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                     TimerCallbackFunction_t pxCallbackFunction ) /* FREERTOS_SYSTEM_CALL */
     {
         TimerHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerCreate( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -963,8 +1016,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                           StaticTimer_t * pxTimerBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         TimerHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -977,8 +1031,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     void * MPU_pvTimerGetTimerID( const TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         void * pvReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         pvReturn = pvTimerGetTimerID( xTimer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -991,20 +1046,21 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     void MPU_vTimerSetTimerID( TimerHandle_t xTimer,
                                void * pvNewID ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTimerSetTimerID( xTimer, pvNewID );
         vPortResetPrivilege( xRunningPrivileged );
     }
-#endif
+#endif /* if ( configUSE_TIMERS == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TIMERS == 1 )
     BaseType_t MPU_xTimerIsTimerActive( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerIsTimerActive( xTimer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1017,8 +1073,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerGetTimerDaemonTaskHandle();
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1033,9 +1090,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                            uint32_t ulParameter2,
                                            TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xReturn, xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1048,33 +1105,37 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
                                   const UBaseType_t uxAutoReload ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         vTimerSetReloadMode( xTimer, uxAutoReload );
         vPortResetPrivilege( xRunningPrivileged );
     }
-#endif
+#endif /* if ( configUSE_TIMERS == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TIMERS == 1 )
     UBaseType_t MPU_uxTimerGetReloadMode( TimerHandle_t xTimer )
     {
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
         UBaseType_t uxReturn;
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         uxReturn = uxTimerGetReloadMode( xTimer );
         vPortResetPrivilege( xRunningPrivileged );
+
         return uxReturn;
     }
-#endif
+#endif /* if ( configUSE_TIMERS == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TIMERS == 1 )
     const char * MPU_pcTimerGetName( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         const char * pcReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         pcReturn = pcTimerGetName( xTimer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1087,8 +1148,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     TickType_t MPU_xTimerGetPeriod( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         TickType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerGetPeriod( xTimer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1101,8 +1163,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     TickType_t MPU_xTimerGetExpiryTime( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         TickType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerGetExpiryTime( xTimer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1119,8 +1182,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                          const TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
         BaseType_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xTimerGenericCommand( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1133,8 +1197,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     EventGroupHandle_t MPU_xEventGroupCreate( void ) /* FREERTOS_SYSTEM_CALL */
     {
         EventGroupHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xEventGroupCreate();
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1147,8 +1212,9 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     EventGroupHandle_t MPU_xEventGroupCreateStatic( StaticEventGroup_t * pxEventGroupBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         EventGroupHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xEventGroupCreateStatic( pxEventGroupBuffer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1164,8 +1230,9 @@ EventBits_t MPU_xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                      TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1177,8 +1244,9 @@ EventBits_t MPU_xEventGroupClearBits( EventGroupHandle_t xEventGroup,
                                       const EventBits_t uxBitsToClear ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xEventGroupClearBits( xEventGroup, uxBitsToClear );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1190,8 +1258,9 @@ EventBits_t MPU_xEventGroupSetBits( EventGroupHandle_t xEventGroup,
                                     const EventBits_t uxBitsToSet ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xEventGroupSetBits( xEventGroup, uxBitsToSet );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1205,8 +1274,9 @@ EventBits_t MPU_xEventGroupSync( EventGroupHandle_t xEventGroup,
                                  TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1216,8 +1286,9 @@ EventBits_t MPU_xEventGroupSync( EventGroupHandle_t xEventGroup,
 
 void MPU_vEventGroupDelete( EventGroupHandle_t xEventGroup ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     vEventGroupDelete( xEventGroup );
     vPortResetPrivilege( xRunningPrivileged );
 }
@@ -1229,8 +1300,9 @@ size_t MPU_xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
                               TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1241,8 +1313,9 @@ size_t MPU_xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
 size_t MPU_xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferNextMessageLengthBytes( xStreamBuffer );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1256,8 +1329,9 @@ size_t MPU_xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
                                  TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1267,8 +1341,9 @@ size_t MPU_xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
 
 void MPU_vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     vStreamBufferDelete( xStreamBuffer );
     vPortResetPrivilege( xRunningPrivileged );
 }
@@ -1276,9 +1351,9 @@ void MPU_vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_S
 
 BaseType_t MPU_xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferIsFull( xStreamBuffer );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1288,9 +1363,9 @@ BaseType_t MPU_xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer ) /* FREE
 
 BaseType_t MPU_xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferIsEmpty( xStreamBuffer );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1300,9 +1375,9 @@ BaseType_t MPU_xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer ) /* FRE
 
 BaseType_t MPU_xStreamBufferReset( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferReset( xStreamBuffer );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1313,8 +1388,9 @@ BaseType_t MPU_xStreamBufferReset( StreamBufferHandle_t xStreamBuffer ) /* FREER
 size_t MPU_xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferSpacesAvailable( xStreamBuffer );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1325,8 +1401,9 @@ size_t MPU_xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer ) /*
 size_t MPU_xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferBytesAvailable( xStreamBuffer );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1337,9 +1414,9 @@ size_t MPU_xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer ) /* 
 BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
                                              size_t xTriggerLevel ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn;
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xReturn, xRunningPrivileged;
 
+    xPortRaisePrivilege( xRunningPrivileged );
     xReturn = xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
     vPortResetPrivilege( xRunningPrivileged );
 
@@ -1353,8 +1430,9 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
                                                          BaseType_t xIsMessageBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         StreamBufferHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1371,8 +1449,9 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
                                                                StaticStreamBuffer_t * const pxStaticStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         StreamBufferHandle_t xReturn;
-        BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+        BaseType_t xRunningPrivileged;
 
+        xPortRaisePrivilege( xRunningPrivileged );
         xReturn = xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer );
         vPortResetPrivilege( xRunningPrivileged );
 
@@ -1387,13 +1466,14 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
  * must take the same format as those above whereby the privilege state on exit
  * equals the privilege state on entry.  For example:
  *
+ * void MPU_FunctionName( [parameters ] ) FREERTOS_SYSTEM_CALL;
  * void MPU_FunctionName( [parameters ] )
  * {
- * BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+ * BaseType_t xRunningPrivileged;
  *
- *  FunctionName( [parameters ] );
- *
- *  vPortResetPrivilege( xRunningPrivileged );
+ * xPortRaisePrivilege( xRunningPrivileged );
+ * FunctionName( [parameters ] );
+ * vPortResetPrivilege( xRunningPrivileged );
  * }
  */
 

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -160,17 +160,14 @@ BaseType_t xIsPrivileged( void ) __attribute__( ( naked ) );
 void vResetPrivilege( void ) __attribute__( ( naked ) );
 
 /**
- * @brief Calls the port specific code to raise the privilege.
- *
- * @return pdFALSE if privilege was raised, pdTRUE otherwise.
+ * @brief Enter critical section.
  */
-extern BaseType_t xPortRaisePrivilege( void );
+void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
 
 /**
- * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
- * code to reset the privilege, otherwise does nothing.
+ * @brief Exit from critical section.
  */
-extern void vPortResetPrivilege( BaseType_t xRunningPrivileged );
+void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
 /*-----------------------------------------------------------*/
 
 /* Each task maintains its own interrupt status in the critical nesting
@@ -483,7 +480,8 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     portDISABLE_INTERRUPTS();
     uxCriticalNesting++;
@@ -494,7 +492,8 @@ void vPortEnterCritical( void )
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     configASSERT( uxCriticalNesting );
     uxCriticalNesting--;

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -52,6 +52,11 @@
     #define portNVIC_SYSTICK_CLK    ( 0 )
 #endif
 
+#ifndef configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS
+    #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
+    #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+#endif
+
 /* Constants required to access and manipulate the NVIC. */
 #define portNVIC_SYSTICK_CTRL_REG                 ( *( ( volatile uint32_t * ) 0xe000e010 ) )
 #define portNVIC_SYSTICK_LOAD_REG                 ( *( ( volatile uint32_t * ) 0xe000e014 ) )
@@ -162,12 +167,20 @@ void vResetPrivilege( void ) __attribute__( ( naked ) );
 /**
  * @brief Enter critical section.
  */
-void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
+    void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
+#else
+    void vPortEnterCritical( void ) PRIVILEGED_FUNCTION;
+#endif
 
 /**
  * @brief Exit from critical section.
  */
-void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
+    void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
+#else
+    void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
+#endif
 /*-----------------------------------------------------------*/
 
 /* Each task maintains its own interrupt status in the critical nesting
@@ -480,20 +493,26 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     BaseType_t xRunningPrivileged;
     xPortRaisePrivilege( xRunningPrivileged );
+#endif
 
     portDISABLE_INTERRUPTS();
     uxCriticalNesting++;
 
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     vPortResetPrivilege( xRunningPrivileged );
+#endif
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     BaseType_t xRunningPrivileged;
     xPortRaisePrivilege( xRunningPrivileged );
+#endif
 
     configASSERT( uxCriticalNesting );
     uxCriticalNesting--;
@@ -503,7 +522,9 @@ void vPortExitCritical( void )
         portENABLE_INTERRUPTS();
     }
 
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     vPortResetPrivilege( xRunningPrivileged );
+#endif
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -173,17 +173,14 @@ BaseType_t xIsPrivileged( void ) __attribute__( ( naked ) );
 void vResetPrivilege( void ) __attribute__( ( naked ) );
 
 /**
- * @brief Calls the port specific code to raise the privilege.
- *
- * @return pdFALSE if privilege was raised, pdTRUE otherwise.
+ * @brief Enter critical section.
  */
-extern BaseType_t xPortRaisePrivilege( void );
+void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
 
 /**
- * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
- * code to reset the privilege, otherwise does nothing.
+ * @brief Exit from critical section.
  */
-extern void vPortResetPrivilege( BaseType_t xRunningPrivileged );
+void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
 /*-----------------------------------------------------------*/
 
 /* Each task maintains its own interrupt status in the critical nesting
@@ -519,7 +516,8 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     portDISABLE_INTERRUPTS();
     uxCriticalNesting++;
@@ -530,7 +528,8 @@ void vPortEnterCritical( void )
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     configASSERT( uxCriticalNesting );
     uxCriticalNesting--;

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -186,17 +186,14 @@ void vPortSVCHandler_C( uint32_t * pulParam );
 extern void vPortRestoreContextOfFirstTask( void ) PRIVILEGED_FUNCTION;
 
 /**
- * @brief Calls the port specific code to raise the privilege.
- *
- * @return pdFALSE if privilege was raised, pdTRUE otherwise.
+ * @brief Enter critical section.
  */
-extern BaseType_t xPortRaisePrivilege( void );
+void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
 
 /**
- * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
- * code to reset the privilege, otherwise does nothing.
+ * @brief Exit from critical section.
  */
-extern void vPortResetPrivilege( BaseType_t xRunningPrivileged );
+void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
 /*-----------------------------------------------------------*/
 
 /* Each task maintains its own interrupt status in the critical nesting
@@ -447,12 +444,11 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     portDISABLE_INTERRUPTS();
     uxCriticalNesting++;
-
-    vPortResetPrivilege( xRunningPrivileged );
 
     /* This is not the interrupt safe version of the enter critical function so
      * assert() if it is being called from an interrupt context.  Only API
@@ -463,12 +459,15 @@ void vPortEnterCritical( void )
     {
         configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
     }
+
+    vPortResetPrivilege( xRunningPrivileged );
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     configASSERT( uxCriticalNesting );
 

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -63,6 +63,11 @@
     #define portNVIC_SYSTICK_CLK_BIT    ( 0 )
 #endif
 
+#ifndef configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS
+    #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
+    #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+#endif
+
 /* Constants required to manipulate the core.  Registers first... */
 #define portNVIC_SYSTICK_CTRL_REG                 ( *( ( volatile uint32_t * ) 0xe000e010 ) )
 #define portNVIC_SYSTICK_LOAD_REG                 ( *( ( volatile uint32_t * ) 0xe000e014 ) )
@@ -188,12 +193,20 @@ extern void vPortRestoreContextOfFirstTask( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief Enter critical section.
  */
-void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
+    void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
+#else
+    void vPortEnterCritical( void ) PRIVILEGED_FUNCTION;
+#endif
 
 /**
  * @brief Exit from critical section.
  */
-void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
+    void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
+#else
+    void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
+#endif
 /*-----------------------------------------------------------*/
 
 /* Each task maintains its own interrupt status in the critical nesting
@@ -444,8 +457,10 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     BaseType_t xRunningPrivileged;
     xPortRaisePrivilege( xRunningPrivileged );
+#endif
 
     portDISABLE_INTERRUPTS();
     uxCriticalNesting++;
@@ -460,14 +475,18 @@ void vPortEnterCritical( void )
         configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
     }
 
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     vPortResetPrivilege( xRunningPrivileged );
+#endif
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     BaseType_t xRunningPrivileged;
     xPortRaisePrivilege( xRunningPrivileged );
+#endif
 
     configASSERT( uxCriticalNesting );
 
@@ -478,7 +497,9 @@ void vPortExitCritical( void )
         portENABLE_INTERRUPTS();
     }
 
+#if( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 )
     vPortResetPrivilege( xRunningPrivileged );
+#endif
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -187,17 +187,14 @@ BaseType_t xIsPrivileged( void );
 void vResetPrivilege( void );
 
 /**
- * @brief Calls the port specific code to raise the privilege.
- *
- * @return pdFALSE if privilege was raised, pdTRUE otherwise.
+ * @brief Enter critical section.
  */
-extern BaseType_t xPortRaisePrivilege( void );
+void vPortEnterCritical( void ) FREERTOS_SYSTEM_CALL;
 
 /**
- * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
- * code to reset the privilege, otherwise does nothing.
+ * @brief Exit from critical section.
  */
-extern void vPortResetPrivilege( BaseType_t xRunningPrivileged );
+void vPortExitCritical( void ) FREERTOS_SYSTEM_CALL;
 /*-----------------------------------------------------------*/
 
 /*
@@ -522,7 +519,8 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     portDISABLE_INTERRUPTS();
     uxCriticalNesting++;
@@ -533,7 +531,8 @@ void vPortEnterCritical( void )
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged = xPortRaisePrivilege();
+    BaseType_t xRunningPrivileged;
+    xPortRaisePrivilege( xRunningPrivileged );
 
     configASSERT( uxCriticalNesting );
     uxCriticalNesting--;


### PR DESCRIPTION
Description
-----------
This PR brings the fixes released in 10.4.6 to main:
* Change `xPortRaisePrivilege` and `vPortResetPrivilege` to macros.
* Add option to disable unprivileged critical sections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
