### PR TITLE
Fix #415: Compiling tasks.c with configSUPPORT_DYNAMIC_ALLOCATION = 0

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -527,7 +527,9 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  */
 static void prvResetNextTaskUnblockTime( void ) PRIVILEGED_FUNCTION;
 
-#if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
+#if ( ( ( configUSE_TRACE_FACILITY == 1 ) || ( configGENERATE_RUN_TIME_STATS == 1 ) ) &&  \
+     ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) &&                                      \
+     ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
 
 /*
  * Helper function used to pad task names with spaces when printing out
@@ -4412,7 +4414,9 @@ static void prvResetNextTaskUnblockTime( void )
 #endif /* portCRITICAL_NESTING_IN_TCB */
 /*-----------------------------------------------------------*/
 
-#if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
+#if ( ( ( configUSE_TRACE_FACILITY == 1 ) || ( configGENERATE_RUN_TIME_STATS == 1 ) ) &&  \
+     ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) &&                                      \
+     ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
 
     static char * prvWriteNameToBuffer( char * pcBuffer,
                                         const char * pcTaskName )

--- a/tasks.c
+++ b/tasks.c
@@ -527,9 +527,9 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  */
 static void prvResetNextTaskUnblockTime( void ) PRIVILEGED_FUNCTION;
 
-#if ( ( ( configUSE_TRACE_FACILITY == 1 ) || ( configGENERATE_RUN_TIME_STATS == 1 ) ) &&  \
-     ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) &&                                      \
-     ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
+#if ( ( ( configUSE_TRACE_FACILITY == 1 ) || ( configGENERATE_RUN_TIME_STATS == 1 ) ) && \
+    ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) &&                                      \
+    ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
 
 /*
  * Helper function used to pad task names with spaces when printing out
@@ -4414,9 +4414,9 @@ static void prvResetNextTaskUnblockTime( void )
 #endif /* portCRITICAL_NESTING_IN_TCB */
 /*-----------------------------------------------------------*/
 
-#if ( ( ( configUSE_TRACE_FACILITY == 1 ) || ( configGENERATE_RUN_TIME_STATS == 1 ) ) &&  \
-     ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) &&                                      \
-     ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
+#if ( ( ( configUSE_TRACE_FACILITY == 1 ) || ( configGENERATE_RUN_TIME_STATS == 1 ) ) && \
+    ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) &&                                      \
+    ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
 
     static char * prvWriteNameToBuffer( char * pcBuffer,
                                         const char * pcTaskName )


### PR DESCRIPTION
Fix #415: Compiling tasks.c with configSUPPORT_DYNAMIC_ALLOCATION = 0

Description
-----------
Add  conditionals to the declaration and definition of `prvWriteNameToBuffer` that match those of its callers.

Test Steps
-----------
Compile FreeRTOS-Kernel with configSUPPORT_DYNAMIC_ALLOCATION  = 0 and -Werror enabled.

Related Issue
-----------
None known.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
