### PR TITLE
Fix keil compilation error

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -2756,10 +2756,9 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                               const char * pcQueueName ) /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
     {
         UBaseType_t ux;
-
-        configASSERT( xQueue );
-
         QueueRegistryItem_t * pxEntryToWrite = NULL;
+			
+        configASSERT( xQueue );
 
         if( pcQueueName != NULL )
         {

--- a/queue.c
+++ b/queue.c
@@ -2757,7 +2757,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         UBaseType_t ux;
         QueueRegistryItem_t * pxEntryToWrite = NULL;
-			
+
         configASSERT( xQueue );
 
         if( pcQueueName != NULL )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Move the configASSERT() call to after the variable declaration to prevent the following compiler error using the Keil tools:
..\..\..\Source\queue.c(2762): error:  #268: declaration may not appear after executable statement in block


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
