### PR TITLE
Allow tickless idle with INCLUDE_vTaskSuspend set to 0

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -924,12 +924,6 @@
 #endif
 
 /* Sanity check the configuration. */
-#if ( configUSE_TICKLESS_IDLE != 0 )
-    #if ( INCLUDE_vTaskSuspend != 1 )
-        #error INCLUDE_vTaskSuspend must be set to 1 if configUSE_TICKLESS_IDLE is not set to 0
-    #endif /* INCLUDE_vTaskSuspend */
-#endif /* configUSE_TICKLESS_IDLE */
-
 #if ( ( configSUPPORT_STATIC_ALLOCATION == 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 0 ) )
     #error configSUPPORT_STATIC_ALLOCATION and configSUPPORT_DYNAMIC_ALLOCATION cannot both be 0, but can both be 1.
 #endif

--- a/include/task.h
+++ b/include/task.h
@@ -167,9 +167,16 @@ typedef struct xTASK_STATUS
 /* Possible return values for eTaskConfirmSleepModeStatus(). */
 typedef enum
 {
-    eAbortSleep = 0,       /* A task has been made ready or a context switch pended since portSUPPRESS_TICKS_AND_SLEEP() was called - abort entering a sleep mode. */
-    eStandardSleep,        /* Enter a sleep mode that will not last any longer than the expected idle time. */
-    eNoTasksWaitingTimeout /* No tasks are waiting for a timeout so it is safe to enter a sleep mode that can only be exited by an external interrupt. */
+    eAbortSleep = 0, /* A task has been made ready or a context switch pended since portSUPPRESS_TICKS_AND_SLEEP() was called - abort entering a sleep mode. */
+    eStandardSleep,  /* Enter a sleep mode that will not last any longer than the expected idle time. */
+
+    /* Define eNoTasksWaitingTimeout only if INCLUDE_vTaskSuspend is 1.  The
+     * conditions identified by eNoTasksWaitingTimeout do not occur when
+     * INCLUDE_vTaskSuspend is 0.  Remember that portMAX_DELAY corresponds
+     * to an indefinite timeout only when INCLUDE_vTaskSuspend is 1. */
+    #if ( INCLUDE_vTaskSuspend == 1 )
+        eNoTasksWaitingTimeout /* No tasks are waiting for a timeout so it is safe to enter a sleep mode that can only be exited by an external interrupt. */
+    #endif
 } eSleepModeStatus;
 
 /**

--- a/tasks.c
+++ b/tasks.c
@@ -3529,9 +3529,11 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 
     eSleepModeStatus eTaskConfirmSleepModeStatus( void )
     {
-        /* The idle task exists in addition to the application tasks. */
-        const UBaseType_t uxNonApplicationTasks = 1;
-        eSleepModeStatus eReturn = eStandardSleep;
+        #if ( INCLUDE_vTaskSuspend == 1 )
+            /* The idle task exists in addition to the application tasks. */
+            const UBaseType_t uxNonApplicationTasks = 1;
+        #endif /* INCLUDE_vTaskSuspend */
+        eSleepModeStatus eReturn;
 
         /* This function must be called from a critical section. */
 
@@ -3551,20 +3553,20 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
              * because the scheduler is suspended. */
             eReturn = eAbortSleep;
         }
-        else
-        {
-            /* If all the tasks are in the suspended list (which might mean they
-             * have an infinite block time rather than actually being suspended)
-             * then it is safe to turn all clocks off and just wait for external
-             * interrupts. */
-            if( listCURRENT_LIST_LENGTH( &xSuspendedTaskList ) == ( uxCurrentNumberOfTasks - uxNonApplicationTasks ) )
+
+        #if ( INCLUDE_vTaskSuspend == 1 )
+            else if( listCURRENT_LIST_LENGTH( &xSuspendedTaskList ) == ( uxCurrentNumberOfTasks - uxNonApplicationTasks ) )
             {
+                /* All the tasks are in the suspended list (which might mean they
+                 * have an infinite block time rather than actually being suspended)
+                 * so it is safe to turn all clocks off and just wait for external
+                 * interrupts. */
                 eReturn = eNoTasksWaitingTimeout;
             }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
+        #endif /* INCLUDE_vTaskSuspend */
+        else
+        {
+            eReturn = eStandardSleep;
         }
 
         return eReturn;


### PR DESCRIPTION
Description
-----------
This PR allows a configuration to include tickless idle even with `INCLUDE_vTaskSuspend` set to 0.  This PR also clarifies the true dependency between tickless idle and `INCLUDE_vTaskSuspend`.

Before this PR, FreeRTOS required `INCLUDE_vTaskSuspend` to be defined as 1 in order to enable tickless idle.  After this PR, a configuration may include tickless idle with `INCLUDE_vTaskSuspend` defined as zero, and only functionality related to `eNoTasksWaitingTimeout` is lost.  All other tickless-idle functionality is retained.

Test Steps
-----------
Use one of the low-power demos.  In FreeRTOSConfig.h, define `configUSE_TICKLESS_IDLE` to 1 and define `INCLUDE_vTaskSuspend` to 0.  The build fails before this PR, and the build succeeds after this PR (unless the application code uses symbol `eNoTasksWaitingTimeout`).

Related Issue
-----------
https://forums.freertos.org/t/tickless-idle-mode-and-vtasksuspend-dependency/13977


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
