### PR TITLE
Remove tickless idle mode dependency with include v task suspend

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -924,12 +924,6 @@
 #endif
 
 /* Sanity check the configuration. */
-#if ( configUSE_TICKLESS_IDLE != 0 )
-    #if ( INCLUDE_vTaskSuspend != 1 )
-        #error INCLUDE_vTaskSuspend must be set to 1 if configUSE_TICKLESS_IDLE is not set to 0
-    #endif /* INCLUDE_vTaskSuspend */
-#endif /* configUSE_TICKLESS_IDLE */
-
 #if ( ( configSUPPORT_STATIC_ALLOCATION == 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 0 ) )
     #error configSUPPORT_STATIC_ALLOCATION and configSUPPORT_DYNAMIC_ALLOCATION cannot both be 0, but can both be 1.
 #endif

--- a/include/task.h
+++ b/include/task.h
@@ -169,7 +169,9 @@ typedef enum
 {
     eAbortSleep = 0,       /* A task has been made ready or a context switch pended since portSUPPRESS_TICKS_AND_SLEEP() was called - abort entering a sleep mode. */
     eStandardSleep,        /* Enter a sleep mode that will not last any longer than the expected idle time. */
-    eNoTasksWaitingTimeout /* No tasks are waiting for a timeout so it is safe to enter a sleep mode that can only be exited by an external interrupt. */
+    #if ( INCLUDE_vTaskSuspend == 1 )
+		eNoTasksWaitingTimeout /* No tasks are waiting for a timeout so it is safe to enter a sleep mode that can only be exited by an external interrupt. */
+    #endif /* INCLUDE_vTaskSuspend */
 } eSleepModeStatus;
 
 /**

--- a/include/task.h
+++ b/include/task.h
@@ -167,10 +167,10 @@ typedef struct xTASK_STATUS
 /* Possible return values for eTaskConfirmSleepModeStatus(). */
 typedef enum
 {
-    eAbortSleep = 0,       /* A task has been made ready or a context switch pended since portSUPPRESS_TICKS_AND_SLEEP() was called - abort entering a sleep mode. */
-    eStandardSleep,        /* Enter a sleep mode that will not last any longer than the expected idle time. */
+    eAbortSleep = 0,           /* A task has been made ready or a context switch pended since portSUPPRESS_TICKS_AND_SLEEP() was called - abort entering a sleep mode. */
+    eStandardSleep,            /* Enter a sleep mode that will not last any longer than the expected idle time. */
     #if ( INCLUDE_vTaskSuspend == 1 )
-		eNoTasksWaitingTimeout /* No tasks are waiting for a timeout so it is safe to enter a sleep mode that can only be exited by an external interrupt. */
+        eNoTasksWaitingTimeout /* No tasks are waiting for a timeout so it is safe to enter a sleep mode that can only be exited by an external interrupt. */
     #endif /* INCLUDE_vTaskSuspend */
 } eSleepModeStatus;
 

--- a/tasks.c
+++ b/tasks.c
@@ -3551,20 +3551,19 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
              * because the scheduler is suspended. */
             eReturn = eAbortSleep;
         }
-        else
-        {
-            /* If all the tasks are in the suspended list (which might mean they
-             * have an infinite block time rather than actually being suspended)
-             * then it is safe to turn all clocks off and just wait for external
-             * interrupts. */
-            if( listCURRENT_LIST_LENGTH( &xSuspendedTaskList ) == ( uxCurrentNumberOfTasks - uxNonApplicationTasks ) )
-            {
+        #if ( INCLUDE_vTaskSuspend == 1 )
+        	else if( listCURRENT_LIST_LENGTH( &xSuspendedTaskList ) == ( uxCurrentNumberOfTasks - uxNonApplicationTasks ) )
+        	{
+        		/* If all the tasks are in the suspended list (which might mean they
+        		 * have an infinite block time rather than actually being suspended)
+        		 * then it is safe to turn all clocks off and just wait for external
+        		 * interrupts. */
                 eReturn = eNoTasksWaitingTimeout;
             }
-            else
-            {
+		#endif /* INCLUDE_vTaskSuspend */
+        else
+        {
                 mtCOVERAGE_TEST_MARKER();
-            }
         }
 
         return eReturn;

--- a/tasks.c
+++ b/tasks.c
@@ -3529,8 +3529,11 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 
     eSleepModeStatus eTaskConfirmSleepModeStatus( void )
     {
-        /* The idle task exists in addition to the application tasks. */
-        const UBaseType_t uxNonApplicationTasks = 1;
+		#if ( INCLUDE_vTaskSuspend == 1 )
+    		/* The idle task exists in addition to the application tasks. */
+        	const UBaseType_t uxNonApplicationTasks = 1;
+		#endif /* INCLUDE_vTaskSuspend */
+
         eSleepModeStatus eReturn = eStandardSleep;
 
         /* This function must be called from a critical section. */

--- a/tasks.c
+++ b/tasks.c
@@ -3529,10 +3529,10 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 
     eSleepModeStatus eTaskConfirmSleepModeStatus( void )
     {
-		#if ( INCLUDE_vTaskSuspend == 1 )
-    		/* The idle task exists in addition to the application tasks. */
-        	const UBaseType_t uxNonApplicationTasks = 1;
-		#endif /* INCLUDE_vTaskSuspend */
+        #if ( INCLUDE_vTaskSuspend == 1 )
+            /* The idle task exists in addition to the application tasks. */
+            const UBaseType_t uxNonApplicationTasks = 1;
+        #endif /* INCLUDE_vTaskSuspend */
 
         eSleepModeStatus eReturn = eStandardSleep;
 
@@ -3554,19 +3554,20 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
              * because the scheduler is suspended. */
             eReturn = eAbortSleep;
         }
+
         #if ( INCLUDE_vTaskSuspend == 1 )
-        	else if( listCURRENT_LIST_LENGTH( &xSuspendedTaskList ) == ( uxCurrentNumberOfTasks - uxNonApplicationTasks ) )
-        	{
-        		/* If all the tasks are in the suspended list (which might mean they
-        		 * have an infinite block time rather than actually being suspended)
-        		 * then it is safe to turn all clocks off and just wait for external
-        		 * interrupts. */
+            else if( listCURRENT_LIST_LENGTH( &xSuspendedTaskList ) == ( uxCurrentNumberOfTasks - uxNonApplicationTasks ) )
+            {
+                /* If all the tasks are in the suspended list (which might mean they
+                 * have an infinite block time rather than actually being suspended)
+                 * then it is safe to turn all clocks off and just wait for external
+                 * interrupts. */
                 eReturn = eNoTasksWaitingTimeout;
             }
-		#endif /* INCLUDE_vTaskSuspend */
+        #endif /* INCLUDE_vTaskSuspend */
         else
         {
-                mtCOVERAGE_TEST_MARKER();
+            mtCOVERAGE_TEST_MARKER();
         }
 
         return eReturn;


### PR DESCRIPTION
Remove tickless idle feature dependency with `INCLUDE_vTaskSuspend`

Description
-----------
There was a build error in `eTaskConfirmSleepModeStatus()` when `configUSE_TICKLESS_IDLE` is enabled. 
This was forcing user to enable `INCLUDE_vTaskSuspend` (set as 1).

This Pull request removes the need for  `INCLUDE_vTaskSuspend` to be set 1 when `configUSE_TICKLESS_IDLE` is enabled.

All codes accessing `xSuspendedTaskList` is now moved under` #if ( INCLUDE_vTaskSuspend == 1 ) `checks.

Test Steps
-----------
Use any of the FreeRTOS demo project.
Make these changes in `FreeRTOSConfig.h` file -
```
#define configUSE_TICKLESS_IDLE 	1
#define INCLUDE_vTaskSuspend		0
```
Build fails without changes in this PR
 
Related Issue
-----------
https://forums.freertos.org/t/tickless-idle-mode-and-vtasksuspend-dependency/13977

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
