### PR TITLE
Fix a compiler warning in the Cortex-A9 port layer

### DIFF
--- a/portable/GCC/ARM_CA9/port.c
+++ b/portable/GCC/ARM_CA9/port.c
@@ -28,6 +28,7 @@
 
 /* Standard includes. */
 #include <stdlib.h>
+#include <string.h>
 
 /* Scheduler includes. */
 #include "FreeRTOS.h"


### PR DESCRIPTION
Description
-----------
Include string.h at the top of portable/GCC/ARM_CA9/port.c to prevent memset() generating a warning.

Test Steps
-----------
Build a Cortex-A9 GCC demo to ensure there is no warning.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
