### PR TITLE
smp branch: bugfix for race condition on RP2040

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -375,8 +375,9 @@ void vPortEnableInterrupts( void )
     #if ( configSUPPORT_PICO_SYNC_INTEROP == 1 )
         if( pxYieldSpinLock )
         {
-            spin_unlock(pxYieldSpinLock, ulYieldSpinLockSaveValue);
+            spin_lock_t* const pxTmpLock = pxYieldSpinLock;
             pxYieldSpinLock = NULL;
+            spin_unlock( pxTmpLock, ulYieldSpinLockSaveValue );
         }
     #endif
     __asm volatile ( " cpsie i " ::: "memory" );

--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -783,9 +783,6 @@ __attribute__( ( weak ) ) void vPortSetupTimerInterrupt( void )
             ulYieldSpinLockSaveValue = ulSave;
             xEventGroupWaitBits( xEventGroup, prvGetEventGroupBit(pxLock->spin_lock),
                                  pdTRUE, pdFALSE, portMAX_DELAY);
-            /* sanity check that interrupts were disabled, then re-enabled during the call, which will have
-             * taken care of the yield */
-            configASSERT( pxYieldSpinLock == NULL);
         }
     }
 
@@ -858,9 +855,6 @@ __attribute__( ( weak ) ) void vPortSetupTimerInterrupt( void )
                 xEventGroupWaitBits( xEventGroup,
                                      prvGetEventGroupBit(pxLock->spin_lock), pdTRUE,
                                      pdFALSE, uxTicksToWait );
-                /* sanity check that interrupts were disabled, then re-enabled during the call, which will have
-                 * taken care of the yield */
-                configASSERT( pxYieldSpinLock == NULL );
             }
             else
             {


### PR DESCRIPTION
SMP: Bugfix for race condition on RP2040 in `vPortEnableInterrupts()` and invalid sanity checks

Description
-----------
1. RP2040 SMP port: Since `spin_unlock()` re-enables interrupts, `pxYieldSpinLock` has to be updated first to avoid a possible race condition in [ `vPortEnableInterrupts()` ](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/7d11089624cb18ef0052fd2fc96bb86d0d6d4109/portable/ThirdParty/GCC/RP2040/port.c#L378).
1. RP2040 SMP port: Testing `pxYieldSpinLock` for `NULL` does not work reliable in [ `vPortLockInternalSpinUnlockWithWait()` ](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/7d11089624cb18ef0052fd2fc96bb86d0d6d4109/portable/ThirdParty/GCC/RP2040/port.c#L787) and [ `xPortLockInternalSpinUnlockWithBestEffortWaitOrTimeout()` ](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/7d11089624cb18ef0052fd2fc96bb86d0d6d4109/portable/ThirdParty/GCC/RP2040/port.c#L862), because another/new lock might already be set after `xEventGroupWaitBits()` returns and before the `configASSERT()` statement is executed.

Test Steps
-----------
Validated on a Raspberry Pi Pico board with two tasks which both continuously try to lock (and unlock) a mutex. 

Related Issue
-----------
None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
