### PR TITLE
Add support for 16 MPU regions to GCC Cortex-M33 ports

### DIFF
--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
@@ -69,6 +69,21 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
             "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
             "												\n"
+        #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str  r4, [r2]								\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str  r4, [r2]								\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+        #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "												\n"
             "	ldr r2, xMPUCTRLConst2						\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r2]								\n"/* Read the value of MPU_CTRL. */
             "	orr r4, #1									\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
@@ -309,6 +324,21 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
             "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
             "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
             "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "												\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str r4, [r3]								\n"/* Program RNR = 8. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str r4, [r3]								\n"/* Program RNR = 12. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
             "												\n"
             "	ldr r3, xMPUCTRLConst						\n"/* r3 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r3]								\n"/* Read the value of MPU_CTRL. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -135,6 +135,11 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +148,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
@@ -69,6 +69,21 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
             "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
             "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str  r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str  r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "													\n"
             "	ldr r2, xMPUCTRLConst2							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
             "	orr r4, #1										\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
@@ -261,6 +276,21 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
             "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
             "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
             "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
             "													\n"
             "	ldr r2, xMPUCTRLConst							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -141,10 +141,6 @@
     #define configTOTAL_MPU_REGIONS       ( 8UL )
 #endif
 
-#if( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
     #define portUNPRIVILEGED_FLASH_REGION                 ( 1UL )

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -69,6 +69,21 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
             "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
             "												\n"
+        #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str  r4, [r2]								\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str  r4, [r2]								\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+        #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "												\n"
             "	ldr r2, xMPUCTRLConst2						\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r2]								\n"/* Read the value of MPU_CTRL. */
             "	orr r4, #1									\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
@@ -309,6 +324,21 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
             "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
             "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
             "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "												\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str r4, [r3]								\n"/* Program RNR = 8. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str r4, [r3]								\n"/* Program RNR = 12. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
             "												\n"
             "	ldr r3, xMPUCTRLConst						\n"/* r3 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r3]								\n"/* Read the value of MPU_CTRL. */

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -135,6 +135,11 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +148,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -69,6 +69,21 @@ void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_
             "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
             "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
             "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str  r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str  r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "													\n"
             "	ldr r2, xMPUCTRLConst2							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
             "	orr r4, #1										\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
@@ -261,6 +276,21 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
             "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
             "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
             "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
             "													\n"
             "	ldr r2, xMPUCTRLConst							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
             "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -141,10 +141,6 @@
     #define configTOTAL_MPU_REGIONS       ( 8UL )
 #endif
 
-#if( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
     #define portUNPRIVILEGED_FLASH_REGION                 ( 1UL )

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -184,7 +184,7 @@
 #define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
 
 /* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE           ( 8UL << 8UL ) /* 8 regions, unified. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -624,6 +624,12 @@ static void prvTaskExitError( void )
             extern uint32_t __privileged_sram_start__[];
             extern uint32_t __privileged_sram_end__[];
         #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
         /* Check that the MPU is present. */
         if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
@@ -1156,7 +1162,7 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 }
                 else
                 {
-                    /* Attr1 in MAIR0 is configured as normal memory. */
+                    /* Attr0 in MAIR0 is configured as normal memory. */
                     xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
                 }
             }

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -135,6 +135,15 @@
         #define portPRIVILEGE_BIT         ( 0x0UL )
     #endif /* configENABLE_MPU */
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+#if( configTOTAL_MPU_REGIONS == 16 )
+    #error 16 MPU regions are not yet supported for this port.
+#endif
 
 /* MPU regions. */
     #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
@@ -143,7 +152,7 @@
     #define portPRIVILEGED_RAM_REGION                     ( 3UL )
     #define portSTACK_REGION                              ( 4UL )
     #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                  ( 7UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
     #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
     #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
 


### PR DESCRIPTION
Description
-----------
This PR adds support for 16 MPU regions to GCC Cortex-M33 ports.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
