### PR TITLE
Fix some warnings in doxygen comments

### DIFF
--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -65,8 +65,6 @@
  * be set and then tested atomically - as is the case where event groups are
  * used to create a synchronisation point between multiple tasks (a
  * 'rendezvous').
- *
- * \defgroup EventGroup
  */
 
 

--- a/include/task.h
+++ b/include/task.h
@@ -1000,7 +1000,7 @@ eTaskState eTaskGetState( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
  * filled with information about the task referenced by the handle passed using
  * the xTask parameter.
  *
- * @xGetFreeStackSpace The TaskStatus_t structure contains a member to report
+ * @param xGetFreeStackSpace The TaskStatus_t structure contains a member to report
  * the stack high water mark of the task being queried.  Calculating the stack
  * high water mark takes a relatively long time, and can make the system
  * temporarily unresponsive - so the xGetFreeStackSpace parameter is provided to


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fixes the following warnings in doxygen generation:
```
freeRTOS/Source/include/event_groups.h:68: warning: missing title after \defgroup EventGroup
freeRTOS/Source/include/task.h:996: warning: Found unknown command '@xGetFreeStackSpace'
```

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#450


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
