### PR TITLE
Use a dedicated symbol for in-function loop

### DIFF
--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -274,17 +274,19 @@ xPortStartFirstTask:
 /*-----------------------------------------------------------*/
 
 freertos_risc_v_application_exception_handler:
+__application_exception_handler_loop:
     csrr t0, mcause     /* For viewing in the debugger only. */
     csrr t1, mepc       /* For viewing in the debugger only */
     csrr t2, mstatus    /* For viewing in the debugger only */
-    j freertos_risc_v_application_exception_handler
+    j __application_exception_handler_loop
 /*-----------------------------------------------------------*/
 
 freertos_risc_v_application_interrupt_handler:
+__application_interrupt_handler_loop:
     csrr t0, mcause     /* For viewing in the debugger only. */
     csrr t1, mepc       /* For viewing in the debugger only */
     csrr t2, mstatus    /* For viewing in the debugger only */
-    j freertos_risc_v_application_interrupt_handler
+    j __application_interrupt_handler_loop
 /*-----------------------------------------------------------*/
 
 .section .text.freertos_risc_v_exception_handler


### PR DESCRIPTION
Use a dedicated symbol for in-function loop to avoid the weak symbol JAL range error when a strong symbol is defined outside.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
