### PR TITLE
SMP: Set Idle task affinity on creation

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2744,6 +2744,9 @@ static BaseType_t prvCreateIdleTasks( void )
                 #endif
             }
         #endif /* configSUPPORT_STATIC_ALLOCATION */
+
+        /* Pin the created idle task to its target core. */
+        vTaskCoreAffinitySet( xIdleTaskHandle[ xCoreID ], ( 1 << xCoreID ) );
     }
 
     return xReturn;


### PR DESCRIPTION
Description
---------------
Idle tasks created in `prvCreateIdleTasks()` should be pinned to their target core on creation. Not doing can result in `prvMinimalIdleTask()` running on core 0 and `prvIdleTask()` running on cores 1 to N-1.

Test Steps
--------------
In `vApplicationIdleHook()`, assert that the current core ID is always 0

Related Issue
------------------