### PR TITLE
Heap improvements

### DIFF
--- a/include/portable.h
+++ b/include/portable.h
@@ -173,6 +173,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats );
  * Map to the memory management routines required for the port.
  */
 void * pvPortMalloc( size_t xSize ) PRIVILEGED_FUNCTION;
+void * pvPortCalloc( size_t xNum, size_t xSize ) PRIVILEGED_FUNCTION;
 void vPortFree( void * pv ) PRIVILEGED_FUNCTION;
 void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION;

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -69,6 +69,7 @@
  *
  */
 #include <stdlib.h>
+#include <string.h>
 
 /* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE prevents task.h from redefining
  * all the API functions to use the MPU wrappers.  That should only be done when
@@ -82,6 +83,11 @@
 
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 0 )
     #error This file must not be used if configSUPPORT_DYNAMIC_ALLOCATION is 0
+#endif
+
+#ifndef configHEAP_CLEAR_MEMORY_ON_FREE
+    #warning "configHEAP_CLEAR_MEMORY_ON_FREE is not defined. We recommend defining it to 1 in FreeRTOSConfig.h for better security."
+    #define configHEAP_CLEAR_MEMORY_ON_FREE    0
 #endif
 
 /* Block sizes must not get too small. */
@@ -307,6 +313,11 @@ void vPortFree( void * pv )
                 /* The block is being returned to the heap - it is no longer
                  * allocated. */
                 pxLink->xBlockSize &= ~xBlockAllocatedBit;
+                #if ( configHEAP_CLEAR_MEMORY_ON_FREE == 1 )
+                {
+                    memset( puc + xHeapStructSize, 0, pxLink->xBlockSize - xHeapStructSize );
+                }
+                #endif
 
                 vTaskSuspendAll();
                 {
@@ -340,6 +351,20 @@ size_t xPortGetFreeHeapSize( void )
 size_t xPortGetMinimumEverFreeHeapSize( void )
 {
     return xMinimumEverFreeBytesRemaining;
+}
+/*-----------------------------------------------------------*/
+
+void * pvPortCalloc( size_t xNum, size_t xSize )
+{
+    void * pv = NULL;
+
+    pv = pvPortMalloc( xNum * xSize );
+    if( pv != NULL )
+    {
+        memset( pv, 0, xNum * xSize );
+    }
+
+    return pv;
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
This PR makes the following improvements:

1. Add a check to `heap_2` to track if a memory block is allocated to the application or not. The MSB of the size field is used for this purpose. The same check already exists in `heap_4` and `heap_5`. This check prevents against double free.

1. Add a new flag `configHEAP_CLEAR_MEMORY_ON_FREE` to `heap_2`, `heap_4` and `heap_5`. The application writer can set it to 1 in their `FreeRTOSConfig.h` to ensure that a block of memory allocated using `pvPortMalloc` is cleared (i.e. set to zero) when it is freed using `vPortFree`. If left undefined, `configHEAP_CLEAR_MEMORY_ON_FREE` defaults to 0 for backward compatiablity and a warning is generated. The application writer can set it to 0 in their `FreeRTOSConfig.h` to remove the warning and keep the behaviour same (possibly for performance reasons). We recommend setting    `configHEAP_CLEAR_MEMORY_ON_FREE` to 1 for better security.

1. Add a new API `pvPortCalloc` to `heap_2`, `heap_4` and `heap_5`. This API has the following signature:
    ```c
    void * pvPortCalloc( size_t xNum, size_t xSize );
    ```
    It allocates memory for an array of `xNum` objects each of which is of size `xSize` and initializes all bytes in the allocated storage to zero. If allocation succeeds, it returns a pointer to the lowest byte in the allocated memory block. On failure, it returns a null pointer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
