### PR TITLE
Move MSB check after final size calculation

### DIFF
--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -157,43 +157,43 @@ void * pvPortMalloc( size_t xWantedSize )
 
     vTaskSuspendAll();
     {
-        /* Check the requested block size is not so large that the top bit is
-         * set.  The top bit of the block size member of the BlockLink_t structure
-         * is used to determine who owns the block - the application or the
-         * kernel, so it must be free. */
-        if( heapBLOCK_SIZE_IS_VALID( xWantedSize ) )
+        /* The wanted size is increased so it can contain a BlockLink_t
+         * structure in addition to the requested amount of bytes. */
+        if( ( xWantedSize > 0 ) &&
+            ( ( xWantedSize + xHeapStructSize ) > xWantedSize ) ) /* Overflow check. */
         {
-            /* The wanted size is increased so it can contain a BlockLink_t
-             * structure in addition to the requested amount of bytes. */
-            if( ( xWantedSize > 0 ) &&
-                ( ( xWantedSize + xHeapStructSize ) > xWantedSize ) ) /* Overflow check */
-            {
-                xWantedSize += xHeapStructSize;
+            xWantedSize += xHeapStructSize;
 
-                /* Ensure that blocks are always aligned */
-                if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
+            /* Ensure that blocks are always aligned */
+            if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
+            {
+                /* Byte alignment required. Check for overflow */
+                if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) >
+                    xWantedSize )
                 {
-                    /* Byte alignment required. Check for overflow */
-                    if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) >
-                        xWantedSize )
-                    {
-                        xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
-                    }
-                    else
-                    {
-                        xWantedSize = 0;
-                    }
+                    xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = 0;
                 }
             }
             else
             {
-                xWantedSize = 0;
+                mtCOVERAGE_TEST_MARKER();
             }
+        }
+        else
+        {
+            xWantedSize = 0;
+        }
 
+        /* Check the block size we are trying to allocate is not so large that the
+         * top bit is set.  The top bit of the block size member of the BlockLink_t
+         * structure is used to determine who owns the block - the application or
+         * the kernel, so it must be free. */
+        if( heapBLOCK_SIZE_IS_VALID( xWantedSize ) != 0 )
+        {
             if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
             {
                 /* Traverse the list from the start (lowest address) block until
@@ -310,10 +310,10 @@ void vPortFree( void * pv )
         /* This casting is to keep the compiler from issuing warnings. */
         pxLink = ( void * ) puc;
 
-        configASSERT( heapBLOCK_IS_ALLOCATED( pxLink ) );
+        configASSERT( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 );
         configASSERT( pxLink->pxNextFreeBlock == NULL );
 
-        if( heapBLOCK_IS_ALLOCATED( pxLink ) )
+        if( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 )
         {
             if( pxLink->pxNextFreeBlock == NULL )
             {


### PR DESCRIPTION
Description
-----------
We use the MSB of the size member of a BlockLink_t to track whether not a block is allocated. Consequently, the size must not be so large that the MSB is set. The check to see if the MSB in the size is set needs to be done after the final size (metadata + alignment) is calculated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
