### PR TITLE
Add port idle hooks

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -4257,6 +4257,20 @@ void vTaskMissedYield( void )
                 }
             #endif /* ( ( configUSE_PREEMPTION == 1 ) && ( configIDLE_SHOULD_YIELD == 1 ) ) */
 
+            #if ( portUSE_IDLE_HOOK == 1 )
+                {
+                    extern void vPortIdleHook( void );
+
+                    /* Call the port defined function from within the idle task.  This
+                    * allows the port to add background functionality without the
+                    * overhead of a separate task.
+                    *
+                    * NOTE: vPortIdleHook() MUST NOT, UNDER ANY CIRCUMSTANCES,
+                    * CALL A FUNCTION THAT MIGHT BLOCK. */
+                    vPortIdleHook();
+                }
+            #endif
+
             #if ( configUSE_MINIMAL_IDLE_HOOK == 1 )
                 {
                     extern void vApplicationMinimalIdleHook( void );
@@ -4338,6 +4352,20 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
                 }
             }
         #endif /* ( ( configUSE_PREEMPTION == 1 ) && ( configIDLE_SHOULD_YIELD == 1 ) ) */
+
+        #if ( portUSE_IDLE_HOOK == 1 )
+            {
+                extern void vPortIdleHook( void );
+
+                /* Call the port defined function from within the idle task.  This
+                 * allows the port to add background functionality without the
+                 * overhead of a separate task.
+                 *
+                 * NOTE: vPortIdleHook() MUST NOT, UNDER ANY CIRCUMSTANCES,
+                 * CALL A FUNCTION THAT MIGHT BLOCK. */
+                vPortIdleHook();
+            }
+        #endif
 
         #if ( configUSE_IDLE_HOOK == 1 )
             {


### PR DESCRIPTION
<!--- Title -->

Description
-----------

The ESP-IDF port of FreeRTOS requires that some system code be run from the Idle/Minimal Idle tasks (mainly to feed the [Task Watchdog Timer](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/system/wdts.html#task-watchdog-timer)). However, the ESP-IDF port cannot use `vApplicationIdleHook()` (or  `vApplicationMinimalIdleHook()`) as users who port FreeRTOS based applications may also require usage of those two hook functions.

This PR adds a `vPortIdleHook()` hook function that is reserved for usage by the port (thus is not exposed as public API). This hook can be enabled by the port by enabling `#define portUSE_IDLE_HOOK 1`

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->

