### PR TITLE
SMP: Add port local storage feature

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1201,6 +1201,9 @@ typedef struct xSTATIC_TCB
     #if ( portUSING_MPU_WRAPPERS == 1 )
         xMPU_SETTINGS xDummy2;
     #endif
+    #if ( portUSING_LOCAL_STORAGE == 1 )
+        xPORT_LOCAL_STORAGE xDummy2b;
+    #endif
     #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
         UBaseType_t uxDummy25;
     #endif

--- a/tasks.c
+++ b/tasks.c
@@ -240,6 +240,10 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
         xMPU_SETTINGS xMPUSettings; /*< The MPU settings are defined as part of the port layer.  THIS MUST BE THE SECOND MEMBER OF THE TCB STRUCT. */
     #endif
 
+    #if ( portUSING_LOCAL_STORAGE == 1 )
+        xPORT_LOCAL_STORAGE xPortLocalStorage;  /*< A port can store custom data in each TCB using this struct */
+    #endif
+
     #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
         UBaseType_t uxCoreAffinityMask; /*< Used to link the task to certain cores.  UBaseType_t must have >= the same number of bits as SMP confNUM_CORES */
     #endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------

The ESP-IDF port of FreeRTOS currently reserves a significant amount of space at the [start of a task's stack](https://github.com/espressif/esp-idf/blob/121ddb87e5130314e4fcc5e9cb260a81b7d30d36/components/freertos/port/xtensa/port.c#L142) to store some task specific data such as:

- FPU/Coprocessor context save area (for lazy context saving)
- Space for [GCC thread local storage variables](https://gcc.gnu.org/onlinedocs/gcc/Thread-Local.html)

The data above is accessed from assembly routines (e.g., during an exception or context switch) by either:

- Calculating a offset pointer to the data area base off of `pxTCB->pxEndOfStack`. This calculation of this offset can be tedious in assembly due to the lack of `sizeof()`.
- [In the case of the Xtensa port](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/9c048e0c71ee43630394981a86f5265bc57131e4/portable/ThirdParty/XCC/Xtensa/port.c#L215), it uses `pxTCB->xMPUSettings` to act as a pointer to those data areas as a workaround.

It would be easier if there was some way for ports to store arbitrary data directly in a task's TCB, thus can be easily accessed from variously assembly routines. Therefore, this PR proposes adding a new `pxTCB->xPortLocalStorage` entry who's size and type can be specified by the port. The Port Local Storage data is initialized by a hook function on task creation, and deinitialized on task deletion.

Some useful things that ports might want want to store a in the TCB include:

- Pointers to various FPU/Coprocessor register save areas
- Additional port specific run time stats information (e.g., total task cache miss cycles)
- List of opened resources (e.g., files) that can be shut auto-closed (e.g., from `portCLEAN_UP_TCB()`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
