### PR TITLE
fix: add additional .ltorg directives to GCC CM3/CM4 mpu ports

### DIFF
--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -369,6 +369,7 @@ static void prvRestoreContextOfFirstTask( void )
         "	ldr r14, =0xfffffffd			\n"/* Load exec return code. */
         "	bx r14							\n"
         "									\n"
+        "	.ltorg							\n"/* Assemble current literal pool to avoid offset-out-of-bound errors with lto. */
         "	.align 4						\n"
         "pxCurrentTCBConst2: .word pxCurrentTCB	\n"
     );
@@ -579,6 +580,7 @@ void xPortPendSVHandler( void )
         "	msr psp, r0							\n"
         "	bx r14								\n"
         "										\n"
+        "	.ltorg								\n"/* Assemble current literal pool to avoid offset-out-of-bound errors with lto. */
         "	.align 4							\n"
         "pxCurrentTCBConst: .word pxCurrentTCB	\n"
         ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -394,6 +394,7 @@ static void prvRestoreContextOfFirstTask( void )
         "	msr	basepri, r0					\n"
         "	bx r14							\n"
         "									\n"
+        "	.ltorg							\n"/* Assemble current literal pool to avoid offset-out-of-bound errors with lto. */
         "	.align 4						\n"
         "pxCurrentTCBConst2: .word pxCurrentTCB	\n"
     );
@@ -631,6 +632,7 @@ void xPortPendSVHandler( void )
         "	msr psp, r0							\n"
         "	bx r14								\n"
         "										\n"
+        "	.ltorg								\n"/* Assemble the current literal pool to avoid offset-out-of-bound errors with lto. */
         "	.align 4							\n"
         "pxCurrentTCBConst: .word pxCurrentTCB	\n"
         ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
When link-time-optimization is enabled, we ran into issues with offset-out-of-range errors. There has been a previous fix for this issue (https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/71), which seems to be insufficient for the MPU ports.

This PR adds the fix of the previous PR, i.e., the `.ltorg` directive, to the remaining places where `LDR Rd, =label` is used (a pseudo instruction which utilizes the literal pool) in the GCC/ARM_CM3_MPU and ARM_CM4_MPU ports.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
