### PR TITLE
Port Arm Cortex-M55

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1168,6 +1168,7 @@ mutexes
 mux
 muxes
 mv
+mve
 mvfaclo
 mvtacgu
 mvtachi

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
- * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -1050,6 +1050,12 @@
  * currently used in ARMv8M ports. */
 #ifndef configENABLE_FPU
     #define configENABLE_FPU    1
+#endif
+
+/* Set configENABLE_MVE to 1 to enable MVE support and 0 to disable it. This is
+ * currently used in ARMv8M ports. */
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
 #endif
 
 /* Set configENABLE_TRUSTZONE to 1 enable TrustZone support and 0 to disable it.

--- a/portable/ARMv8M/ReadMe.txt
+++ b/portable/ARMv8M/ReadMe.txt
@@ -1,10 +1,11 @@
-This directory tree contains the master copy of the FreeeRTOS Cortex-M33 port.
+This directory tree contains the master copy of the FreeRTOS Armv8-M and
+Armv8.1-M ports.
 Do not use the files located here!  These file are copied into separate
-FreeRTOS/Source/portable/[compiler]/ARM_CM33_NNN directories prior to each
-FreeRTOS release.
+FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55]_NNN directories prior to
+each FreeRTOS release.
 
-If your Cortex-M33 application uses TrustZone then use the files from the
-FreeRTOS/Source/portable/[compiler]/ARM_CM33 directories.
+If your Armv8-M/Armv8.1-M application uses TrustZone then use the files from the
+FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55] directories.
 
-If your Cortex-M33 application does not use TrustZone then use the files from
-the FreeRTOS/Source/portable/[compiler]/ARM_CM33_NTZ directories.
+If your Armv8-M/Armv8.1-M application does not use TrustZone then use the files from
+the FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55]_NTZ directories.

--- a/portable/ARMv8M/copy_files.py
+++ b/portable/ARMv8M/copy_files.py
@@ -1,6 +1,6 @@
 #/*
 # * FreeRTOS Kernel <DEVELOPMENT BRANCH>
-# * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+# * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 # *
 # * SPDX-License-Identifier: MIT
 # *
@@ -33,11 +33,11 @@ _THIS_FILE_DIRECTORY_ = os.path.dirname(os.path.realpath(__file__))
 _FREERTOS_PORTABLE_DIRECTORY_ = os.path.dirname(_THIS_FILE_DIRECTORY_)
 
 _COMPILERS_ = ['GCC', 'IAR']
-_ARCH_NS_ = ['ARM_CM33', 'ARM_CM33_NTZ', 'ARM_CM23', 'ARM_CM23_NTZ']
-_ARCH_S_ = ['ARM_CM33', 'ARM_CM23']
+_ARCH_NS_ = ['ARM_CM55', 'ARM_CM55_NTZ', 'ARM_CM33', 'ARM_CM33_NTZ', 'ARM_CM23', 'ARM_CM23_NTZ']
+_ARCH_S_ = ['ARM_CM55', 'ARM_CM33', 'ARM_CM23']
 
 _SUPPORTED_CONFIGS_ =   {
-                            'GCC' : ['ARM_CM33', 'ARM_CM33_NTZ', 'ARM_CM23', 'ARM_CM23_NTZ'],
+                            'GCC' : ['ARM_CM55', 'ARM_CM55_NTZ', 'ARM_CM33', 'ARM_CM33_NTZ', 'ARM_CM23', 'ARM_CM23_NTZ'],
                             'IAR' : ['ARM_CM33', 'ARM_CM33_NTZ', 'ARM_CM23', 'ARM_CM23_NTZ']
                         }
 

--- a/portable/ARMv8M/non_secure/ReadMe.txt
+++ b/portable/ARMv8M/non_secure/ReadMe.txt
@@ -1,11 +1,12 @@
-This directory tree contains the master copy of the FreeeRTOS Cortex-M33 port.
+This directory tree contains the master copy of the FreeRTOS Armv8-M and
+Armv8.1-M ports.
 Do not use the files located here!  These file are copied into separate
-FreeRTOS/Source/portable/[compiler]/ARM_CM33_NNN directories prior to each
-FreeRTOS release.
+FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55]_NNN directories prior to
+each FreeRTOS release.
 
-If your Cortex-M33 application uses TrustZone then use the files from the
-FreeRTOS/Source/portable/[compiler]/ARM_CM33 directories.
+If your Armv8-M/Armv8.1-M application uses TrustZone then use the files from the
+FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55] directories.
 
-If your Cortex-M33 application does not use TrustZone then use the files from
-the FreeRTOS/Source/portable/[compiler]/ARM_CM33_NTZ directories.
+If your Armv8-M/Armv8.1-M application does not use TrustZone then use the files from
+the FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55]_NTZ directories.
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portasm.c
@@ -1,0 +1,452 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE ensures that PRIVILEGED_FUNCTION
+ * is defined correctly and privileged functions are placed in correct sections. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* Portasm includes. */
+#include "portasm.h"
+
+/* MPU_WRAPPERS_INCLUDED_FROM_API_FILE is needed to be defined only for the
+ * header files. */
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "													\n"
+        "	ldr  r2, pxCurrentTCBConst2						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr  r3, [r2]									\n"/* Read pxCurrentTCB. */
+        "	ldr  r0, [r3]									\n"/* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb											\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r2, xMPUCTRLConst2						\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]								\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1									\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r2]								\n"/* Disable MPU. */
+            "												\n"
+            "	adds r3, #4									\n"/* r3 = r3 + 4. r3 now points to MAIR0 in TCB. */
+            "	ldr  r4, [r3]								\n"/* r4 = *r3 i.e. r4 = MAIR0. */
+            "	ldr  r2, xMAIR0Const2						\n"/* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "	str  r4, [r2]								\n"/* Program MAIR0. */
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #4									\n"/* r4 = 4. */
+            "	str  r4, [r2]								\n"/* Program RNR = 4. */
+            "	adds r3, #4									\n"/* r3 = r3 + 4. r3 now points to first RBAR in TCB. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "												\n"
+        #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str  r4, [r2]								\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str  r4, [r2]								\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+        #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "												\n"
+            "	ldr r2, xMPUCTRLConst2						\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]								\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1									\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r2]								\n"/* Enable MPU. */
+            "	dsb											\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldm  r0!, {r1-r4}							\n"/* Read from stack - r1 = xSecureContext, r2 = PSPLIM, r3 = CONTROL and r4 = EXC_RETURN. */
+            "	ldr  r5, xSecureContextConst2				\n"
+            "	str  r1, [r5]								\n"/* Set xSecureContext to this task's value for the same. */
+            "	msr  psplim, r2								\n"/* Set this task's PSPLIM value. */
+            "	msr  control, r3							\n"/* Set this task's CONTROL value. */
+            "	adds r0, #32								\n"/* Discard everything up to r0. */
+            "	msr  psp, r0								\n"/* This is now the new top of stack to use in the task. */
+            "	isb											\n"
+            "	mov  r0, #0									\n"
+            "	msr  basepri, r0							\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r4										\n"/* Finally, branch to EXC_RETURN. */
+        #else /* configENABLE_MPU */
+            "	ldm  r0!, {r1-r3}							\n"/* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
+            "	ldr  r4, xSecureContextConst2				\n"
+            "	str  r1, [r4]								\n"/* Set xSecureContext to this task's value for the same. */
+            "	msr  psplim, r2								\n"/* Set this task's PSPLIM value. */
+            "	movs r1, #2									\n"/* r1 = 2. */
+            "	msr  CONTROL, r1							\n"/* Switch to use PSP in the thread mode. */
+            "	adds r0, #32								\n"/* Discard everything up to r0. */
+            "	msr  psp, r0								\n"/* This is now the new top of stack to use in the task. */
+            "	isb											\n"
+            "	mov  r0, #0									\n"
+            "	msr  basepri, r0							\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r3										\n"/* Finally, branch to EXC_RETURN. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst2: .word pxCurrentTCB				\n"
+        "xSecureContextConst2: .word xSecureContext			\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst2: .word 0xe000ed94				\n"
+            "xMAIR0Const2: .word 0xe000edc0					\n"
+            "xRNRConst2: .word 0xe000ed98					\n"
+            "xRBARConst2: .word 0xe000ed9c					\n"
+        #endif /* configENABLE_MPU */
+    );
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
+        "	ite ne											\n"
+        "	movne r0, #0									\n"/* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
+        "	moveq r0, #1									\n"/* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
+        "	bx lr											\n"/* Return. */
+        "													\n"
+        "	.align 4										\n"
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* Read the CONTROL register. */
+        "	bic r0, #1										\n"/* Clear the bit 0. */
+        "	msr control, r0									\n"/* Write back the new CONTROL value. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vResetPrivilege( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	orr r0, #1										\n"/* r0 = r0 | 1. */
+        "	msr control, r0									\n"/* CONTROL = r0. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
+        "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
+        "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
+        "	msr msp, r0										\n"/* Set the MSP back to the start of the stack. */
+        "	cpsie i											\n"/* Globally enable interrupts. */
+        "	cpsie f											\n"
+        "	dsb												\n"
+        "	isb												\n"
+        "	svc %0											\n"/* System call to start the first task. */
+        "	nop												\n"
+        "													\n"
+        "   .align 4										\n"
+        "xVTORConst: .word 0xe000ed08						\n"
+        ::"i" ( portSVC_START_SCHEDULER ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
+        "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	msr basepri, r0									\n"/* basepri = ulMask. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::: "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "	.extern SecureContext_SaveContext				\n"
+        "	.extern SecureContext_LoadContext				\n"
+        "													\n"
+        "	ldr r3, xSecureContextConst						\n"/* Read the location of xSecureContext i.e. &( xSecureContext ). */
+        "	ldr r0, [r3]									\n"/* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
+        "	mrs r2, psp										\n"/* Read PSP in r2. */
+        "													\n"
+        "	cbz r0, save_ns_context							\n"/* No secure context to save. */
+        "	push {r0-r2, r14}								\n"
+        "	bl SecureContext_SaveContext					\n"/* Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
+        "	pop {r0-r3}										\n"/* LR is now in r3. */
+        "	mov lr, r3										\n"/* LR = r3. */
+        "	lsls r1, r3, #25								\n"/* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
+        "	bpl save_ns_context								\n"/* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
+        "													\n"
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB.*/
+        #if ( configENABLE_MPU == 1 )
+            "	subs r2, r2, #16							\n"/* Make space for xSecureContext, PSPLIM, CONTROL and LR on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mrs r3, control								\n"/* r3 = CONTROL. */
+            "	mov r4, lr									\n"/* r4 = LR/EXC_RETURN. */
+            "	stmia r2!, {r0, r1, r3, r4}					\n"/* Store xSecureContext, PSPLIM, CONTROL and LR on the stack. */
+        #else /* configENABLE_MPU */
+            "	subs r2, r2, #12							\n"/* Make space for xSecureContext, PSPLIM and LR on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mov r3, lr									\n"/* r3 = LR/EXC_RETURN. */
+            "	stmia r2!, {r0, r1, r3}						\n"/* Store xSecureContext, PSPLIM and LR on the stack. */
+        #endif /* configENABLE_MPU */
+        "	b select_next_task								\n"
+        "													\n"
+        " save_ns_context:									\n"
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB. */
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst lr, #0x10								\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq										\n"
+            "	vstmdbeq r2!, {s16-s31}						\n"/* Store the additional FP context registers which are not saved automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        #if ( configENABLE_MPU == 1 )
+            "	subs r2, r2, #48							\n"/* Make space for xSecureContext, PSPLIM, CONTROL, LR and the remaining registers on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	adds r2, r2, #16							\n"/* r2 = r2 + 16. */
+            "	stm r2, {r4-r11}							\n"/* Store the registers that are not saved automatically. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mrs r3, control								\n"/* r3 = CONTROL. */
+            "	mov r4, lr									\n"/* r4 = LR/EXC_RETURN. */
+            "	subs r2, r2, #16							\n"/* r2 = r2 - 16. */
+            "	stmia r2!, {r0, r1, r3, r4}					\n"/* Store xSecureContext, PSPLIM, CONTROL and LR on the stack. */
+        #else /* configENABLE_MPU */
+            "	subs r2, r2, #44							\n"/* Make space for xSecureContext, PSPLIM, LR and the remaining registers on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	adds r2, r2, #12							\n"/* r2 = r2 + 12. */
+            "	stm r2, {r4-r11}							\n"/* Store the registers that are not saved automatically. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mov r3, lr									\n"/* r3 = LR/EXC_RETURN. */
+            "	subs r2, r2, #12							\n"/* r2 = r2 - 12. */
+            "	stmia r2!, {r0, r1, r3}						\n"/* Store xSecureContext, PSPLIM and LR on the stack. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        " select_next_task:									\n"
+        "	mov r0, %0										\n"/* r0 = configMAX_SYSCALL_INTERRUPT_PRIORITY */
+        "	msr basepri, r0									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bl vTaskSwitchContext							\n"
+        "	mov r0, #0										\n"/* r0 = 0. */
+        "	msr basepri, r0									\n"/* Enable interrupts. */
+        "													\n"
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB. */
+        "	ldr r2, [r1]									\n"/* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb											\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r3, xMPUCTRLConst						\n"/* r3 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r3]								\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1									\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r3]								\n"/* Disable MPU. */
+            "												\n"
+            "	adds r1, #4									\n"/* r1 = r1 + 4. r1 now points to MAIR0 in TCB. */
+            "	ldr r4, [r1]								\n"/* r4 = *r1 i.e. r4 = MAIR0. */
+            "	ldr r3, xMAIR0Const							\n"/* r3 = 0xe000edc0 [Location of MAIR0]. */
+            "	str r4, [r3]								\n"/* Program MAIR0. */
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #4									\n"/* r4 = 4. */
+            "	str r4, [r3]								\n"/* Program RNR = 4. */
+            "	adds r1, #4									\n"/* r1 = r1 + 4. r1 now points to first RBAR in TCB. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "												\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str r4, [r3]								\n"/* Program RNR = 8. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str r4, [r3]								\n"/* Program RNR = 12. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "												\n"
+            "	ldr r3, xMPUCTRLConst						\n"/* r3 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r3]								\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1									\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r3]								\n"/* Enable MPU. */
+            "	dsb											\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldmia r2!, {r0, r1, r3, r4}					\n"/* Read from stack - r0 = xSecureContext, r1 = PSPLIM, r3 = CONTROL and r4 = LR. */
+            "	msr psplim, r1								\n"/* Restore the PSPLIM register value for the task. */
+            "	msr control, r3								\n"/* Restore the CONTROL register value for the task. */
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	ldr r3, xSecureContextConst					\n"/* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "	str r0, [r3]								\n"/* Restore the task's xSecureContext. */
+            "	cbz r0, restore_ns_context					\n"/* If there is no secure context for the task, restore the non-secure context. */
+            "	ldr r3, pxCurrentTCBConst					\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "	ldr r1, [r3]								\n"/* Read pxCurrentTCB. */
+            "	push {r2, r4}								\n"
+            "	bl SecureContext_LoadContext				\n"/* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
+            "	pop {r2, r4}								\n"
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	lsls r1, r4, #25							\n"/* r1 = r4 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
+            "	bpl restore_ns_context						\n"/* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
+            "	msr psp, r2									\n"/* Remember the new top of stack for the task. */
+            "	bx lr										\n"
+        #else /* configENABLE_MPU */
+            "	ldmia r2!, {r0, r1, r4}						\n"/* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
+            "	msr psplim, r1								\n"/* Restore the PSPLIM register value for the task. */
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	ldr r3, xSecureContextConst					\n"/* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "	str r0, [r3]								\n"/* Restore the task's xSecureContext. */
+            "	cbz r0, restore_ns_context					\n"/* If there is no secure context for the task, restore the non-secure context. */
+            "	ldr r3, pxCurrentTCBConst					\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "	ldr r1, [r3]								\n"/* Read pxCurrentTCB. */
+            "	push {r2, r4}								\n"
+            "	bl SecureContext_LoadContext				\n"/* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
+            "	pop {r2, r4}								\n"
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	lsls r1, r4, #25							\n"/* r1 = r4 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
+            "	bpl restore_ns_context						\n"/* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
+            "	msr psp, r2									\n"/* Remember the new top of stack for the task. */
+            "	bx lr										\n"
+        #endif /* configENABLE_MPU */
+        "													\n"
+        " restore_ns_context:								\n"
+        "	ldmia r2!, {r4-r11}								\n"/* Restore the registers that are not automatically restored. */
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst lr, #0x10								\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq										\n"
+            "	vldmiaeq r2!, {s16-s31}						\n"/* Restore the additional FP context registers which are not restored automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        "	msr psp, r2										\n"/* Remember the new top of stack for the task. */
+        "	bx lr											\n"
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst: .word pxCurrentTCB				\n"
+        "xSecureContextConst: .word xSecureContext			\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst: .word 0xe000ed94				\n"
+            "xMAIR0Const: .word 0xe000edc0					\n"
+            "xRNRConst: .word 0xe000ed98					\n"
+            "xRBARConst: .word 0xe000ed9c					\n"
+        #endif /* configENABLE_MPU */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
+    );
+}
+/*-----------------------------------------------------------*/
+
+void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	tst lr, #4										\n"
+        "	ite eq											\n"
+        "	mrseq r0, msp									\n"
+        "	mrsne r0, psp									\n"
+        "	ldr r1, svchandler_address_const				\n"
+        "	bx r1											\n"
+        "													\n"
+        "	.align 4										\n"
+        "svchandler_address_const: .word vPortSVCHandler_C	\n"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	svc %0											\n"/* Secure context is allocated in the supervisor call. */
+        "	bx lr											\n"/* Return. */
+        ::"i" ( portSVC_ALLOCATE_SECURE_CONTEXT ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	ldr r2, [r0]									\n"/* The first item in the TCB is the top of the stack. */
+        "	ldr r1, [r2]									\n"/* The first item on the stack is the task's xSecureContext. */
+        "	cmp r1, #0										\n"/* Raise svc if task's xSecureContext is not NULL. */
+        "	it ne											\n"
+        "	svcne %0										\n"/* Secure context is freed in the supervisor call. */
+        "	bx lr											\n"/* Return. */
+        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
@@ -1,0 +1,319 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef PORTMACRO_H
+    #define PORTMACRO_H
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
+
+/*------------------------------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the given hardware
+ * and compiler.
+ *
+ * These settings should not be altered.
+ *------------------------------------------------------------------------------
+ */
+
+    #ifndef configENABLE_FPU
+        #error configENABLE_FPU must be defined in FreeRTOSConfig.h.  Set configENABLE_FPU to 1 to enable the FPU or 0 to disable the FPU.
+    #endif /* configENABLE_FPU */
+
+    #ifndef configENABLE_MPU
+        #error configENABLE_MPU must be defined in FreeRTOSConfig.h.  Set configENABLE_MPU to 1 to enable the MPU or 0 to disable the MPU.
+    #endif /* configENABLE_MPU */
+
+    #ifndef configENABLE_TRUSTZONE
+        #error configENABLE_TRUSTZONE must be defined in FreeRTOSConfig.h.  Set configENABLE_TRUSTZONE to 1 to enable TrustZone or 0 to disable TrustZone.
+    #endif /* configENABLE_TRUSTZONE */
+
+    #ifndef configENABLE_MVE
+        #error configENABLE_MVE must be defined in FreeRTOSConfig.h.  Set configENABLE_MVE to 1 to enable the MVE or 0 to disable the MVE.
+    #endif /* configENABLE_MVE */
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Type definitions.
+ */
+    #define portCHAR          char
+    #define portFLOAT         float
+    #define portDOUBLE        double
+    #define portLONG          long
+    #define portSHORT         short
+    #define portSTACK_TYPE    uint32_t
+    #define portBASE_TYPE     long
+
+    typedef portSTACK_TYPE   StackType_t;
+    typedef long             BaseType_t;
+    typedef unsigned long    UBaseType_t;
+
+    #if ( configUSE_16_BIT_TICKS == 1 )
+        typedef uint16_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffff
+    #else
+        typedef uint32_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+
+/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+ * not need to be guarded with a critical section. */
+        #define portTICK_TYPE_IS_ATOMIC    1
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * Architecture specifics.
+ */
+    #define portARCH_NAME                      "Cortex-M55"
+    #define portSTACK_GROWTH                   ( -1 )
+    #define portTICK_PERIOD_MS                 ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+    #define portBYTE_ALIGNMENT                 8
+    #define portNOP()
+    #define portINLINE                         __inline
+    #ifndef portFORCE_INLINE
+        #define portFORCE_INLINE               inline __attribute__( ( always_inline ) )
+    #endif
+    #define portHAS_STACK_OVERFLOW_CHECKING    1
+    #define portDONT_DISCARD                   __attribute__( ( used ) )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Extern declarations.
+ */
+    extern BaseType_t xPortIsInsideInterrupt( void );
+
+    extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
+    extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+    extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+        extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
+        extern void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */;
+    #endif /* configENABLE_TRUSTZONE */
+
+    #if ( configENABLE_MPU == 1 )
+        extern BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */;
+        extern void vResetPrivilege( void ) /* __attribute__ (( naked )) */;
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief MPU specific constants.
+ */
+    #if ( configENABLE_MPU == 1 )
+        #define portUSING_MPU_WRAPPERS    1
+        #define portPRIVILEGE_BIT         ( 0x80000000UL )
+    #else
+        #define portPRIVILEGE_BIT         ( 0x0UL )
+    #endif /* configENABLE_MPU */
+
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+/* MPU regions. */
+    #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
+    #define portUNPRIVILEGED_FLASH_REGION                 ( 1UL )
+    #define portUNPRIVILEGED_SYSCALLS_REGION              ( 2UL )
+    #define portPRIVILEGED_RAM_REGION                     ( 3UL )
+    #define portSTACK_REGION                              ( 4UL )
+    #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
+    #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
+    #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
+
+/* Device memory attributes used in MPU_MAIR registers.
+ *
+ * 8-bit values encoded as follows:
+ *  Bit[7:4] - 0000 - Device Memory
+ *  Bit[3:2] - 00 --> Device-nGnRnE
+ *				01 --> Device-nGnRE
+ *				10 --> Device-nGRE
+ *				11 --> Device-GRE
+ *  Bit[1:0] - 00, Reserved.
+ */
+    #define portMPU_DEVICE_MEMORY_nGnRnE                  ( 0x00 )   /* 0000 0000 */
+    #define portMPU_DEVICE_MEMORY_nGnRE                   ( 0x04 )   /* 0000 0100 */
+    #define portMPU_DEVICE_MEMORY_nGRE                    ( 0x08 )   /* 0000 1000 */
+    #define portMPU_DEVICE_MEMORY_GRE                     ( 0x0C )   /* 0000 1100 */
+
+/* Normal memory attributes used in MPU_MAIR registers. */
+    #define portMPU_NORMAL_MEMORY_NON_CACHEABLE           ( 0x44 )   /* Non-cacheable. */
+    #define portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE    ( 0xFF )   /* Non-Transient, Write-back, Read-Allocate and Write-Allocate. */
+
+/* Attributes used in MPU_RBAR registers. */
+    #define portMPU_REGION_NON_SHAREABLE                  ( 0UL << 3UL )
+    #define portMPU_REGION_INNER_SHAREABLE                ( 1UL << 3UL )
+    #define portMPU_REGION_OUTER_SHAREABLE                ( 2UL << 3UL )
+
+    #define portMPU_REGION_PRIVILEGED_READ_WRITE          ( 0UL << 1UL )
+    #define portMPU_REGION_READ_WRITE                     ( 1UL << 1UL )
+    #define portMPU_REGION_PRIVILEGED_READ_ONLY           ( 2UL << 1UL )
+    #define portMPU_REGION_READ_ONLY                      ( 3UL << 1UL )
+
+    #define portMPU_REGION_EXECUTE_NEVER                  ( 1UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Settings to define an MPU region.
+ */
+    typedef struct MPURegionSettings
+    {
+        uint32_t ulRBAR; /**< RBAR for the region. */
+        uint32_t ulRLAR; /**< RLAR for the region. */
+    } MPURegionSettings_t;
+
+/**
+ * @brief MPU settings as stored in the TCB.
+ */
+    typedef struct MPU_SETTINGS
+    {
+        uint32_t ulMAIR0;                                              /**< MAIR0 for the task containing attributes for all the 4 per task regions. */
+        MPURegionSettings_t xRegionsSettings[ portTOTAL_NUM_REGIONS ]; /**< Settings for 4 per task regions. */
+    } xMPU_SETTINGS;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief SVC numbers.
+ */
+    #define portSVC_ALLOCATE_SECURE_CONTEXT    0
+    #define portSVC_FREE_SECURE_CONTEXT        1
+    #define portSVC_START_SCHEDULER            2
+    #define portSVC_RAISE_PRIVILEGE            3
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Scheduler utilities.
+ */
+    #define portYIELD()                                 vPortYield()
+    #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
+    #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
+    #define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } while( 0 )
+    #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Critical section management.
+ */
+    #define portSET_INTERRUPT_MASK_FROM_ISR()         ulSetInterruptMask()
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    vClearInterruptMask( x )
+    #define portDISABLE_INTERRUPTS()                  ulSetInterruptMask()
+    #define portENABLE_INTERRUPTS()                   vClearInterruptMask( 0 )
+    #define portENTER_CRITICAL()                      vPortEnterCritical()
+    #define portEXIT_CRITICAL()                       vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+    #ifndef portSUPPRESS_TICKS_AND_SLEEP
+        extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+        #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Task function macros as described on the FreeRTOS.org WEB site.
+ */
+    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+
+/**
+ * @brief Allocate a secure context for the task.
+ *
+ * Tasks are not created with a secure context. Any task that is going to call
+ * secure functions must call portALLOCATE_SECURE_CONTEXT() to allocate itself a
+ * secure context before it calls any secure function.
+ *
+ * @param[in] ulSecureStackSize The size of the secure stack to be allocated.
+ */
+        #define portALLOCATE_SECURE_CONTEXT( ulSecureStackSize )    vPortAllocateSecureContext( ulSecureStackSize )
+
+/**
+ * @brief Called when a task is deleted to delete the task's secure context,
+ * if it has one.
+ *
+ * @param[in] pxTCB The TCB of the task being deleted.
+ */
+        #define portCLEAN_UP_TCB( pxTCB )                           vPortFreeSecureContext( ( uint32_t * ) pxTCB )
+    #endif /* configENABLE_TRUSTZONE */
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_MPU == 1 )
+
+/**
+ * @brief Checks whether or not the processor is privileged.
+ *
+ * @return 1 if the processor is already privileged, 0 otherwise.
+ */
+        #define portIS_PRIVILEGED()      xIsPrivileged()
+
+/**
+ * @brief Raise an SVC request to raise privilege.
+ *
+ * The SVC handler checks that the SVC was raised from a system call and only
+ * then it raises the privilege. If this is called from any other place,
+ * the privilege is not raised.
+ */
+        #define portRAISE_PRIVILEGE()    __asm volatile ( "svc %0 \n" ::"i" ( portSVC_RAISE_PRIVILEGE ) : "memory" );
+
+/**
+ * @brief Lowers the privilege level by setting the bit 0 of the CONTROL
+ * register.
+ */
+        #define portRESET_PRIVILEGE()    vResetPrivilege()
+    #else
+        #define portIS_PRIVILEGED()
+        #define portRAISE_PRIVILEGE()
+        #define portRESET_PRIVILEGE()
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Barriers.
+ */
+    #define portMEMORY_BARRIER()    __asm volatile ( "" ::: "memory" )
+/*-----------------------------------------------------------*/
+
+    #ifdef __cplusplus
+        }
+    #endif
+
+#endif /* PORTMACRO_H */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55_NTZ/portasm.c
@@ -1,0 +1,351 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE ensures that PRIVILEGED_FUNCTION
+ * is defined correctly and privileged functions are placed in correct sections. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* Portasm includes. */
+#include "portasm.h"
+
+/* MPU_WRAPPERS_INCLUDED_FROM_API_FILE is needed to be defined only for the
+ * header files. */
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "													\n"
+        "	ldr  r2, pxCurrentTCBConst2						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr  r1, [r2]									\n"/* Read pxCurrentTCB. */
+        "	ldr  r0, [r1]									\n"/* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb												\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r2, xMPUCTRLConst2							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1										\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Disable MPU. */
+            "													\n"
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to MAIR0 in TCB. */
+            "	ldr  r3, [r1]									\n"/* r3 = *r1 i.e. r3 = MAIR0. */
+            "	ldr  r2, xMAIR0Const2							\n"/* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "	str  r3, [r2]									\n"/* Program MAIR0. */
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #4										\n"/* r3 = 4. */
+            "	str  r3, [r2]									\n"/* Program RNR = 4. */
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to first RBAR in TCB. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str  r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str  r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "													\n"
+            "	ldr r2, xMPUCTRLConst2							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1										\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Enable MPU. */
+            "	dsb												\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldm  r0!, {r1-r3}								\n"/* Read from stack - r1 = PSPLIM, r2 = CONTROL and r3 = EXC_RETURN. */
+            "	msr  psplim, r1									\n"/* Set this task's PSPLIM value. */
+            "	msr  control, r2								\n"/* Set this task's CONTROL value. */
+            "	adds r0, #32									\n"/* Discard everything up to r0. */
+            "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
+            "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r3											\n"/* Finally, branch to EXC_RETURN. */
+        #else /* configENABLE_MPU */
+            "	ldm  r0!, {r1-r2}								\n"/* Read from stack - r1 = PSPLIM and r2 = EXC_RETURN. */
+            "	msr  psplim, r1									\n"/* Set this task's PSPLIM value. */
+            "	movs r1, #2										\n"/* r1 = 2. */
+            "	msr  CONTROL, r1								\n"/* Switch to use PSP in the thread mode. */
+            "	adds r0, #32									\n"/* Discard everything up to r0. */
+            "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
+            "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r2											\n"/* Finally, branch to EXC_RETURN. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst2: .word pxCurrentTCB				\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst2: .word 0xe000ed94					\n"
+            "xMAIR0Const2: .word 0xe000edc0						\n"
+            "xRNRConst2: .word 0xe000ed98						\n"
+            "xRBARConst2: .word 0xe000ed9c						\n"
+        #endif /* configENABLE_MPU */
+    );
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
+        "	ite ne											\n"
+        "	movne r0, #0									\n"/* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
+        "	moveq r0, #1									\n"/* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
+        "	bx lr											\n"/* Return. */
+        "													\n"
+        "	.align 4										\n"
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs  r0, control								\n"/* Read the CONTROL register. */
+        "	bic r0, #1										\n"/* Clear the bit 0. */
+        "	msr  control, r0								\n"/* Write back the new CONTROL value. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vResetPrivilege( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	orr r0, #1										\n"/* r0 = r0 | 1. */
+        "	msr control, r0									\n"/* CONTROL = r0. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
+        "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
+        "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
+        "	msr msp, r0										\n"/* Set the MSP back to the start of the stack. */
+        "	cpsie i											\n"/* Globally enable interrupts. */
+        "	cpsie f											\n"
+        "	dsb												\n"
+        "	isb												\n"
+        "	svc %0											\n"/* System call to start the first task. */
+        "	nop												\n"
+        "													\n"
+        "   .align 4										\n"
+        "xVTORConst: .word 0xe000ed08						\n"
+        ::"i" ( portSVC_START_SCHEDULER ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
+        "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	msr basepri, r0									\n"/* basepri = ulMask. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::: "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "													\n"
+        "	mrs r0, psp										\n"/* Read PSP in r0. */
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst lr, #0x10									\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq											\n"
+            "	vstmdbeq r0!, {s16-s31}							\n"/* Store the additional FP context registers which are not saved automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        #if ( configENABLE_MPU == 1 )
+            "	mrs r1, psplim									\n"/* r1 = PSPLIM. */
+            "	mrs r2, control									\n"/* r2 = CONTROL. */
+            "	mov r3, lr										\n"/* r3 = LR/EXC_RETURN. */
+            "	stmdb r0!, {r1-r11}								\n"/* Store on the stack - PSPLIM, CONTROL, LR and registers that are not automatically saved. */
+        #else /* configENABLE_MPU */
+            "	mrs r2, psplim									\n"/* r2 = PSPLIM. */
+            "	mov r3, lr										\n"/* r3 = LR/EXC_RETURN. */
+            "	stmdb r0!, {r2-r11}								\n"/* Store on the stack - PSPLIM, LR and registers that are not automatically saved. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        "	ldr r2, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r2]									\n"/* Read pxCurrentTCB. */
+        "	str r0, [r1]									\n"/* Save the new top of stack in TCB. */
+        "													\n"
+        "	mov r0, %0										\n"/* r0 = configMAX_SYSCALL_INTERRUPT_PRIORITY */
+        "	msr basepri, r0									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bl vTaskSwitchContext							\n"
+        "	mov r0, #0										\n"/* r0 = 0. */
+        "	msr basepri, r0									\n"/* Enable interrupts. */
+        "													\n"
+        "	ldr r2, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r2]									\n"/* Read pxCurrentTCB. */
+        "	ldr r0, [r1]									\n"/* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb												\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r2, xMPUCTRLConst							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1										\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Disable MPU. */
+            "													\n"
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to MAIR0 in TCB. */
+            "	ldr r3, [r1]									\n"/* r3 = *r1 i.e. r3 = MAIR0. */
+            "	ldr r2, xMAIR0Const								\n"/* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "	str r3, [r2]									\n"/* Program MAIR0. */
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #4										\n"/* r3 = 4. */
+            "	str r3, [r2]									\n"/* Program RNR = 4. */
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to first RBAR in TCB. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "													\n"
+            "	ldr r2, xMPUCTRLConst							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1										\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Enable MPU. */
+            "	dsb												\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldmia r0!, {r1-r11}								\n"/* Read from stack - r1 = PSPLIM, r2 = CONTROL, r3 = LR and r4-r11 restored. */
+        #else /* configENABLE_MPU */
+            "	ldmia r0!, {r2-r11}								\n"/* Read from stack - r2 = PSPLIM, r3 = LR and r4-r11 restored. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst r3, #0x10									\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq											\n"
+            "	vldmiaeq r0!, {s16-s31}							\n"/* Restore the additional FP context registers which are not restored automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	msr psplim, r1									\n"/* Restore the PSPLIM register value for the task. */
+            "	msr control, r2									\n"/* Restore the CONTROL register value for the task. */
+        #else /* configENABLE_MPU */
+            "	msr psplim, r2									\n"/* Restore the PSPLIM register value for the task. */
+        #endif /* configENABLE_MPU */
+        "	msr psp, r0										\n"/* Remember the new top of stack for the task. */
+        "	bx r3											\n"
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst: .word pxCurrentTCB				\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst: .word 0xe000ed94					\n"
+            "xMAIR0Const: .word 0xe000edc0						\n"
+            "xRNRConst: .word 0xe000ed98						\n"
+            "xRBARConst: .word 0xe000ed9c						\n"
+        #endif /* configENABLE_MPU */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
+    );
+}
+/*-----------------------------------------------------------*/
+
+void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	tst lr, #4										\n"
+        "	ite eq											\n"
+        "	mrseq r0, msp									\n"
+        "	mrsne r0, psp									\n"
+        "	ldr r1, svchandler_address_const				\n"
+        "	bx r1											\n"
+        "													\n"
+        "	.align 4										\n"
+        "svchandler_address_const: .word vPortSVCHandler_C	\n"
+    );
+}
+/*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55_NTZ/portmacro.h
@@ -1,0 +1,319 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef PORTMACRO_H
+    #define PORTMACRO_H
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
+
+/*------------------------------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the given hardware
+ * and compiler.
+ *
+ * These settings should not be altered.
+ *------------------------------------------------------------------------------
+ */
+
+    #ifndef configENABLE_FPU
+        #error configENABLE_FPU must be defined in FreeRTOSConfig.h.  Set configENABLE_FPU to 1 to enable the FPU or 0 to disable the FPU.
+    #endif /* configENABLE_FPU */
+
+    #ifndef configENABLE_MPU
+        #error configENABLE_MPU must be defined in FreeRTOSConfig.h.  Set configENABLE_MPU to 1 to enable the MPU or 0 to disable the MPU.
+    #endif /* configENABLE_MPU */
+
+    #ifndef configENABLE_TRUSTZONE
+        #error configENABLE_TRUSTZONE must be defined in FreeRTOSConfig.h.  Set configENABLE_TRUSTZONE to 1 to enable TrustZone or 0 to disable TrustZone.
+    #endif /* configENABLE_TRUSTZONE */
+
+    #ifndef configENABLE_MVE
+        #error configENABLE_MVE must be defined in FreeRTOSConfig.h.  Set configENABLE_MVE to 1 to enable the MVE or 0 to disable the MVE.
+    #endif /* configENABLE_MVE */
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Type definitions.
+ */
+    #define portCHAR          char
+    #define portFLOAT         float
+    #define portDOUBLE        double
+    #define portLONG          long
+    #define portSHORT         short
+    #define portSTACK_TYPE    uint32_t
+    #define portBASE_TYPE     long
+
+    typedef portSTACK_TYPE   StackType_t;
+    typedef long             BaseType_t;
+    typedef unsigned long    UBaseType_t;
+
+    #if ( configUSE_16_BIT_TICKS == 1 )
+        typedef uint16_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffff
+    #else
+        typedef uint32_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+
+/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+ * not need to be guarded with a critical section. */
+        #define portTICK_TYPE_IS_ATOMIC    1
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * Architecture specifics.
+ */
+    #define portARCH_NAME                      "Cortex-M55"
+    #define portSTACK_GROWTH                   ( -1 )
+    #define portTICK_PERIOD_MS                 ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+    #define portBYTE_ALIGNMENT                 8
+    #define portNOP()
+    #define portINLINE                         __inline
+    #ifndef portFORCE_INLINE
+        #define portFORCE_INLINE               inline __attribute__( ( always_inline ) )
+    #endif
+    #define portHAS_STACK_OVERFLOW_CHECKING    1
+    #define portDONT_DISCARD                   __attribute__( ( used ) )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Extern declarations.
+ */
+    extern BaseType_t xPortIsInsideInterrupt( void );
+
+    extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
+    extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+    extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+        extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
+        extern void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */;
+    #endif /* configENABLE_TRUSTZONE */
+
+    #if ( configENABLE_MPU == 1 )
+        extern BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */;
+        extern void vResetPrivilege( void ) /* __attribute__ (( naked )) */;
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief MPU specific constants.
+ */
+    #if ( configENABLE_MPU == 1 )
+        #define portUSING_MPU_WRAPPERS    1
+        #define portPRIVILEGE_BIT         ( 0x80000000UL )
+    #else
+        #define portPRIVILEGE_BIT         ( 0x0UL )
+    #endif /* configENABLE_MPU */
+
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+/* MPU regions. */
+    #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
+    #define portUNPRIVILEGED_FLASH_REGION                 ( 1UL )
+    #define portUNPRIVILEGED_SYSCALLS_REGION              ( 2UL )
+    #define portPRIVILEGED_RAM_REGION                     ( 3UL )
+    #define portSTACK_REGION                              ( 4UL )
+    #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
+    #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
+    #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
+
+/* Device memory attributes used in MPU_MAIR registers.
+ *
+ * 8-bit values encoded as follows:
+ *  Bit[7:4] - 0000 - Device Memory
+ *  Bit[3:2] - 00 --> Device-nGnRnE
+ *				01 --> Device-nGnRE
+ *				10 --> Device-nGRE
+ *				11 --> Device-GRE
+ *  Bit[1:0] - 00, Reserved.
+ */
+    #define portMPU_DEVICE_MEMORY_nGnRnE                  ( 0x00 )   /* 0000 0000 */
+    #define portMPU_DEVICE_MEMORY_nGnRE                   ( 0x04 )   /* 0000 0100 */
+    #define portMPU_DEVICE_MEMORY_nGRE                    ( 0x08 )   /* 0000 1000 */
+    #define portMPU_DEVICE_MEMORY_GRE                     ( 0x0C )   /* 0000 1100 */
+
+/* Normal memory attributes used in MPU_MAIR registers. */
+    #define portMPU_NORMAL_MEMORY_NON_CACHEABLE           ( 0x44 )   /* Non-cacheable. */
+    #define portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE    ( 0xFF )   /* Non-Transient, Write-back, Read-Allocate and Write-Allocate. */
+
+/* Attributes used in MPU_RBAR registers. */
+    #define portMPU_REGION_NON_SHAREABLE                  ( 0UL << 3UL )
+    #define portMPU_REGION_INNER_SHAREABLE                ( 1UL << 3UL )
+    #define portMPU_REGION_OUTER_SHAREABLE                ( 2UL << 3UL )
+
+    #define portMPU_REGION_PRIVILEGED_READ_WRITE          ( 0UL << 1UL )
+    #define portMPU_REGION_READ_WRITE                     ( 1UL << 1UL )
+    #define portMPU_REGION_PRIVILEGED_READ_ONLY           ( 2UL << 1UL )
+    #define portMPU_REGION_READ_ONLY                      ( 3UL << 1UL )
+
+    #define portMPU_REGION_EXECUTE_NEVER                  ( 1UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Settings to define an MPU region.
+ */
+    typedef struct MPURegionSettings
+    {
+        uint32_t ulRBAR; /**< RBAR for the region. */
+        uint32_t ulRLAR; /**< RLAR for the region. */
+    } MPURegionSettings_t;
+
+/**
+ * @brief MPU settings as stored in the TCB.
+ */
+    typedef struct MPU_SETTINGS
+    {
+        uint32_t ulMAIR0;                                              /**< MAIR0 for the task containing attributes for all the 4 per task regions. */
+        MPURegionSettings_t xRegionsSettings[ portTOTAL_NUM_REGIONS ]; /**< Settings for 4 per task regions. */
+    } xMPU_SETTINGS;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief SVC numbers.
+ */
+    #define portSVC_ALLOCATE_SECURE_CONTEXT    0
+    #define portSVC_FREE_SECURE_CONTEXT        1
+    #define portSVC_START_SCHEDULER            2
+    #define portSVC_RAISE_PRIVILEGE            3
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Scheduler utilities.
+ */
+    #define portYIELD()                                 vPortYield()
+    #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
+    #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
+    #define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } while( 0 )
+    #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Critical section management.
+ */
+    #define portSET_INTERRUPT_MASK_FROM_ISR()         ulSetInterruptMask()
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    vClearInterruptMask( x )
+    #define portDISABLE_INTERRUPTS()                  ulSetInterruptMask()
+    #define portENABLE_INTERRUPTS()                   vClearInterruptMask( 0 )
+    #define portENTER_CRITICAL()                      vPortEnterCritical()
+    #define portEXIT_CRITICAL()                       vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+    #ifndef portSUPPRESS_TICKS_AND_SLEEP
+        extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+        #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Task function macros as described on the FreeRTOS.org WEB site.
+ */
+    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+
+/**
+ * @brief Allocate a secure context for the task.
+ *
+ * Tasks are not created with a secure context. Any task that is going to call
+ * secure functions must call portALLOCATE_SECURE_CONTEXT() to allocate itself a
+ * secure context before it calls any secure function.
+ *
+ * @param[in] ulSecureStackSize The size of the secure stack to be allocated.
+ */
+        #define portALLOCATE_SECURE_CONTEXT( ulSecureStackSize )    vPortAllocateSecureContext( ulSecureStackSize )
+
+/**
+ * @brief Called when a task is deleted to delete the task's secure context,
+ * if it has one.
+ *
+ * @param[in] pxTCB The TCB of the task being deleted.
+ */
+        #define portCLEAN_UP_TCB( pxTCB )                           vPortFreeSecureContext( ( uint32_t * ) pxTCB )
+    #endif /* configENABLE_TRUSTZONE */
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_MPU == 1 )
+
+/**
+ * @brief Checks whether or not the processor is privileged.
+ *
+ * @return 1 if the processor is already privileged, 0 otherwise.
+ */
+        #define portIS_PRIVILEGED()      xIsPrivileged()
+
+/**
+ * @brief Raise an SVC request to raise privilege.
+ *
+ * The SVC handler checks that the SVC was raised from a system call and only
+ * then it raises the privilege. If this is called from any other place,
+ * the privilege is not raised.
+ */
+        #define portRAISE_PRIVILEGE()    __asm volatile ( "svc %0 \n" ::"i" ( portSVC_RAISE_PRIVILEGE ) : "memory" );
+
+/**
+ * @brief Lowers the privilege level by setting the bit 0 of the CONTROL
+ * register.
+ */
+        #define portRESET_PRIVILEGE()    vResetPrivilege()
+    #else
+        #define portIS_PRIVILEGED()
+        #define portRAISE_PRIVILEGE()
+        #define portRESET_PRIVILEGE()
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Barriers.
+ */
+    #define portMEMORY_BARRIER()    __asm volatile ( "" ::: "memory" )
+/*-----------------------------------------------------------*/
+
+    #ifdef __cplusplus
+        }
+    #endif
+
+#endif /* PORTMACRO_H */

--- a/portable/ARMv8M/secure/ReadMe.txt
+++ b/portable/ARMv8M/secure/ReadMe.txt
@@ -1,10 +1,11 @@
-This directory tree contains the master copy of the FreeeRTOS Cortex-M33 port.
+This directory tree contains the master copy of the FreeRTOS Armv8-M and
+Armv8.1-M ports.
 Do not use the files located here!  These file are copied into separate
-FreeRTOS/Source/portable/[compiler]/ARM_CM33_NNN directories prior to each
-FreeRTOS release.
+FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55]_NNN directories prior to
+each FreeRTOS release.
 
-If your Cortex-M33 application uses TrustZone then use the files from the
-FreeRTOS/Source/portable/[compiler]/ARM_CM33 directories.
+If your Armv8-M/Armv8.1-M application uses TrustZone then use the files from the
+FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55] directories.
 
-If your Cortex-M33 application does not use TrustZone then use the files from
-the FreeRTOS/Source/portable/[compiler]/ARM_CM33_NTZ directories.
+If your Armv8-M/Armv8.1-M application does not use TrustZone then use the files from
+the FreeRTOS/Source/portable/[compiler]/ARM_CM[23|33|55]_NTZ directories.

--- a/portable/ARMv8M/secure/context/portable/GCC/ARM_CM55/secure_context_port.c
+++ b/portable/ARMv8M/secure/context/portable/GCC/ARM_CM55/secure_context_port.c
@@ -1,0 +1,97 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Secure context includes. */
+#include "secure_context.h"
+
+/* Secure port macros. */
+#include "secure_port_macros.h"
+
+void SecureContext_LoadContextAsm( SecureContext_t * pxSecureContext ) __attribute__( ( naked ) );
+void SecureContext_SaveContextAsm( SecureContext_t * pxSecureContext ) __attribute__( ( naked ) );
+
+void SecureContext_LoadContextAsm( SecureContext_t * pxSecureContext )
+{
+    /* pxSecureContext value is in r0. */
+    __asm volatile
+    (
+        " .syntax unified                   \n"
+        "                                   \n"
+        " mrs r1, ipsr                      \n" /* r1 = IPSR. */
+        " cbz r1, load_ctx_therad_mode      \n" /* Do nothing if the processor is running in the Thread Mode. */
+        " ldmia r0!, {r1, r2}               \n" /* r1 = pxSecureContext->pucCurrentStackPointer, r2 = pxSecureContext->pucStackLimit. */
+        "                                   \n"
+        #if ( configENABLE_MPU == 1 )
+            " ldmia r1!, {r3}               \n" /* Read CONTROL register value from task's stack. r3 = CONTROL. */
+            " msr control, r3               \n" /* CONTROL = r3. */
+        #endif /* configENABLE_MPU */
+        "                                   \n"
+        " msr psplim, r2                    \n" /* PSPLIM = r2. */
+        " msr psp, r1                       \n" /* PSP = r1. */
+        "                                   \n"
+        " load_ctx_therad_mode:             \n"
+        "    bx lr                          \n"
+        "                                   \n"
+        ::: "r0", "r1", "r2"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void SecureContext_SaveContextAsm( SecureContext_t * pxSecureContext )
+{
+    /* pxSecureContext value is in r0. */
+    __asm volatile
+    (
+        " .syntax unified                   \n"
+        "                                   \n"
+        " mrs r1, ipsr                      \n" /* r1 = IPSR. */
+        " cbz r1, save_ctx_therad_mode      \n" /* Do nothing if the processor is running in the Thread Mode. */
+        " mrs r1, psp                       \n" /* r1 = PSP. */
+        "                                   \n"
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            " vstmdb r1!, {s0}              \n" /* Trigger the defferred stacking of FPU registers. */
+            " vldmia r1!, {s0}              \n" /* Nullify the effect of the pervious statement. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        "                                   \n"
+        #if ( configENABLE_MPU == 1 )
+            " mrs r2, control               \n" /* r2 = CONTROL. */
+            " stmdb r1!, {r2}               \n" /* Store CONTROL value on the stack. */
+        #endif /* configENABLE_MPU */
+        "                                   \n"
+        " str r1, [r0]                      \n" /* Save the top of stack in context. pxSecureContext->pucCurrentStackPointer = r1. */
+        " movs r1, %0                       \n" /* r1 = securecontextNO_STACK. */
+        " msr psplim, r1                    \n" /* PSPLIM = securecontextNO_STACK. */
+        " msr psp, r1                       \n" /* PSP = securecontextNO_STACK i.e. No stack for thread mode until next task's context is loaded. */
+        "                                   \n"
+        " save_ctx_therad_mode:             \n"
+        "    bx lr                          \n"
+        "                                   \n"
+        ::"i" ( securecontextNO_STACK ) : "r1", "memory"
+    );
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -1,0 +1,1203 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE prevents task.h from redefining
+ * all the API functions to use the MPU wrappers. That should only be done when
+ * task.h is included from an application file. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* MPU wrappers includes. */
+#include "mpu_wrappers.h"
+
+/* Portasm includes. */
+#include "portasm.h"
+
+#if ( configENABLE_TRUSTZONE == 1 )
+    /* Secure components includes. */
+    #include "secure_context.h"
+    #include "secure_init.h"
+#endif /* configENABLE_TRUSTZONE */
+
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/**
+ * The FreeRTOS Cortex M33 port can be configured to run on the Secure Side only
+ * i.e. the processor boots as secure and never jumps to the non-secure side.
+ * The Trust Zone support in the port must be disabled in order to run FreeRTOS
+ * on the secure side. The following are the valid configuration seetings:
+ *
+ * 1. Run FreeRTOS on the Secure Side:
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *
+ * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *
+ * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ */
+#if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
+    #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
+#endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the NVIC.
+ */
+#define portNVIC_SYSTICK_CTRL_REG             ( *( ( volatile uint32_t * ) 0xe000e010 ) )
+#define portNVIC_SYSTICK_LOAD_REG             ( *( ( volatile uint32_t * ) 0xe000e014 ) )
+#define portNVIC_SYSTICK_CURRENT_VALUE_REG    ( *( ( volatile uint32_t * ) 0xe000e018 ) )
+#define portNVIC_SHPR3_REG                    ( *( ( volatile uint32_t * ) 0xe000ed20 ) )
+#define portNVIC_SYSTICK_ENABLE_BIT           ( 1UL << 0UL )
+#define portNVIC_SYSTICK_INT_BIT              ( 1UL << 1UL )
+#define portNVIC_SYSTICK_COUNT_FLAG_BIT       ( 1UL << 16UL )
+#define portMIN_INTERRUPT_PRIORITY            ( 255UL )
+#define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
+#define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#ifndef configSYSTICK_CLOCK_HZ
+    #define configSYSTICK_CLOCK_HZ            configCPU_CLOCK_HZ
+    /* Ensure the SysTick is clocked at the same frequency as the core. */
+    #define portNVIC_SYSTICK_CLK_BIT          ( 1UL << 2UL )
+#else
+
+/* The way the SysTick is clocked is not modified in case it is not the
+ * same a the core. */
+    #define portNVIC_SYSTICK_CLK_BIT    ( 0 )
+#endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the SCB.
+ */
+#define portSCB_SYS_HANDLER_CTRL_STATE_REG    ( *( volatile uint32_t * ) 0xe000ed24 )
+#define portSCB_MEM_FAULT_ENABLE_BIT          ( 1UL << 16UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the FPU.
+ */
+#define portCPACR               ( ( volatile uint32_t * ) 0xe000ed88 )              /* Coprocessor Access Control Register. */
+#define portCPACR_CP10_VALUE    ( 3UL )
+#define portCPACR_CP11_VALUE    portCPACR_CP10_VALUE
+#define portCPACR_CP10_POS      ( 20UL )
+#define portCPACR_CP11_POS      ( 22UL )
+
+#define portFPCCR               ( ( volatile uint32_t * ) 0xe000ef34 )              /* Floating Point Context Control Register. */
+#define portFPCCR_ASPEN_POS     ( 31UL )
+#define portFPCCR_ASPEN_MASK    ( 1UL << portFPCCR_ASPEN_POS )
+#define portFPCCR_LSPEN_POS     ( 30UL )
+#define portFPCCR_LSPEN_MASK    ( 1UL << portFPCCR_LSPEN_POS )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the MPU.
+ */
+#define portMPU_TYPE_REG                      ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                      ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                       ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+
+#define portMPU_RBAR_REG                      ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                      ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+
+#define portMPU_RBAR_A1_REG                   ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                   ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+
+#define portMPU_RBAR_A2_REG                   ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                   ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+
+#define portMPU_RBAR_A3_REG                   ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                   ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+
+#define portMPU_MAIR0_REG                     ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                     ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+
+#define portMPU_RBAR_ADDRESS_MASK             ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK             ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+
+#define portMPU_MAIR_ATTR0_POS                ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK               ( 0x000000ff )
+
+#define portMPU_MAIR_ATTR1_POS                ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK               ( 0x0000ff00 )
+
+#define portMPU_MAIR_ATTR2_POS                ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK               ( 0x00ff0000 )
+
+#define portMPU_MAIR_ATTR3_POS                ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK               ( 0xff000000 )
+
+#define portMPU_MAIR_ATTR4_POS                ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK               ( 0x000000ff )
+
+#define portMPU_MAIR_ATTR5_POS                ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK               ( 0x0000ff00 )
+
+#define portMPU_MAIR_ATTR6_POS                ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK               ( 0x00ff0000 )
+
+#define portMPU_MAIR_ATTR7_POS                ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK               ( 0xff000000 )
+
+#define portMPU_RLAR_ATTR_INDEX0              ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1              ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2              ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3              ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4              ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5              ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6              ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7              ( 7UL << 1UL )
+
+#define portMPU_RLAR_REGION_ENABLE            ( 1UL )
+
+/* Enable privileged access to unmapped region. */
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT    ( 1UL << 2UL )
+
+/* Enable MPU. */
+#define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
+
+/* Expected value of the portMPU_TYPE register. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The maximum 24-bit number.
+ *
+ * It is needed because the systick is a 24-bit counter.
+ */
+#define portMAX_24_BIT_NUMBER       ( 0xffffffUL )
+
+/**
+ * @brief A fiddle factor to estimate the number of SysTick counts that would
+ * have occurred while the SysTick counter is stopped during tickless idle
+ * calculations.
+ */
+#define portMISSED_COUNTS_FACTOR    ( 45UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to set up the initial stack.
+ */
+#define portINITIAL_XPSR    ( 0x01000000 )
+
+#if ( configRUN_FREERTOS_SECURE_ONLY == 1 )
+
+/**
+ * @brief Initial EXC_RETURN value.
+ *
+ *     FF         FF         FF         FD
+ * 1111 1111  1111 1111  1111 1111  1111 1101
+ *
+ * Bit[6] - 1 --> The exception was taken from the Secure state.
+ * Bit[5] - 1 --> Do not skip stacking of additional state context.
+ * Bit[4] - 1 --> The PE did not allocate space on the stack for FP context.
+ * Bit[3] - 1 --> Return to the Thread mode.
+ * Bit[2] - 1 --> Restore registers from the process stack.
+ * Bit[1] - 0 --> Reserved, 0.
+ * Bit[0] - 1 --> The exception was taken to the Secure state.
+ */
+    #define portINITIAL_EXC_RETURN    ( 0xfffffffd )
+#else
+
+/**
+ * @brief Initial EXC_RETURN value.
+ *
+ *     FF         FF         FF         BC
+ * 1111 1111  1111 1111  1111 1111  1011 1100
+ *
+ * Bit[6] - 0 --> The exception was taken from the Non-Secure state.
+ * Bit[5] - 1 --> Do not skip stacking of additional state context.
+ * Bit[4] - 1 --> The PE did not allocate space on the stack for FP context.
+ * Bit[3] - 1 --> Return to the Thread mode.
+ * Bit[2] - 1 --> Restore registers from the process stack.
+ * Bit[1] - 0 --> Reserved, 0.
+ * Bit[0] - 0 --> The exception was taken to the Non-Secure state.
+ */
+    #define portINITIAL_EXC_RETURN    ( 0xffffffbc )
+#endif /* configRUN_FREERTOS_SECURE_ONLY */
+
+/**
+ * @brief CONTROL register privileged bit mask.
+ *
+ * Bit[0] in CONTROL register tells the privilege:
+ *  Bit[0] = 0 ==> The task is privileged.
+ *  Bit[0] = 1 ==> The task is not privileged.
+ */
+#define portCONTROL_PRIVILEGED_MASK         ( 1UL << 0UL )
+
+/**
+ * @brief Initial CONTROL register values.
+ */
+#define portINITIAL_CONTROL_UNPRIVILEGED    ( 0x3 )
+#define portINITIAL_CONTROL_PRIVILEGED      ( 0x2 )
+
+/**
+ * @brief Let the user override the pre-loading of the initial LR with the
+ * address of prvTaskExitError() in case it messes up unwinding of the stack
+ * in the debugger.
+ */
+#ifdef configTASK_RETURN_ADDRESS
+    #define portTASK_RETURN_ADDRESS    configTASK_RETURN_ADDRESS
+#else
+    #define portTASK_RETURN_ADDRESS    prvTaskExitError
+#endif
+
+/**
+ * @brief If portPRELOAD_REGISTERS then registers will be given an initial value
+ * when a task is created. This helps in debugging at the cost of code size.
+ */
+#define portPRELOAD_REGISTERS    1
+
+/**
+ * @brief A task is created without a secure context, and must call
+ * portALLOCATE_SECURE_CONTEXT() to give itself a secure context before it makes
+ * any secure calls.
+ */
+#define portNO_SECURE_CONTEXT    0
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Used to catch tasks that attempt to return from their implementing
+ * function.
+ */
+static void prvTaskExitError( void );
+
+#if ( configENABLE_MPU == 1 )
+
+/**
+ * @brief Setup the Memory Protection Unit (MPU).
+ */
+    static void prvSetupMPU( void ) PRIVILEGED_FUNCTION;
+#endif /* configENABLE_MPU */
+
+#if ( configENABLE_FPU == 1 )
+
+/**
+ * @brief Setup the Floating Point Unit (FPU).
+ */
+    static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
+#endif /* configENABLE_FPU */
+
+/**
+ * @brief Setup the timer to generate the tick interrupts.
+ *
+ * The implementation in this file is weak to allow application writers to
+ * change the timer used to generate the tick interrupt.
+ */
+void vPortSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether the current execution context is interrupt.
+ *
+ * @return pdTRUE if the current execution context is interrupt, pdFALSE
+ * otherwise.
+ */
+BaseType_t xPortIsInsideInterrupt( void );
+
+/**
+ * @brief Yield the processor.
+ */
+void vPortYield( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Enter critical section.
+ */
+void vPortEnterCritical( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Exit from critical section.
+ */
+void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief SysTick handler.
+ */
+void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief C part of SVC handler.
+ */
+portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIVILEGED_FUNCTION;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Each task maintains its own interrupt status in the critical nesting
+ * variable.
+ */
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+
+#if ( configENABLE_TRUSTZONE == 1 )
+
+/**
+ * @brief Saved as part of the task context to indicate which context the
+ * task is using on the secure side.
+ */
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+#endif /* configENABLE_TRUSTZONE */
+
+#if ( configUSE_TICKLESS_IDLE == 1 )
+
+/**
+ * @brief The number of SysTick increments that make up one tick period.
+ */
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
+
+/**
+ * @brief The maximum number of tick periods that can be suppressed is
+ * limited by the 24 bit resolution of the SysTick timer.
+ */
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
+
+/**
+ * @brief Compensate for the CPU cycles that pass while the SysTick is
+ * stopped (low power functionality only).
+ */
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TICKLESS_IDLE == 1 )
+    __attribute__( ( weak ) ) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+    {
+        uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+        TickType_t xModifiableIdleTime;
+
+        /* Make sure the SysTick reload value does not overflow the counter. */
+        if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+        {
+            xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+        }
+
+        /* Stop the SysTick momentarily. The time the SysTick is stopped for is
+         * accounted for as best it can be, but using the tickless mode will
+         * inevitably result in some tiny drift of the time maintained by the
+         * kernel with respect to calendar time. */
+        portNVIC_SYSTICK_CTRL_REG &= ~portNVIC_SYSTICK_ENABLE_BIT;
+
+        /* Calculate the reload value required to wait xExpectedIdleTime
+         * tick periods. -1 is used because this code will execute part way
+         * through one of the tick periods. */
+        ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE_REG + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+
+        if( ulReloadValue > ulStoppedTimerCompensation )
+        {
+            ulReloadValue -= ulStoppedTimerCompensation;
+        }
+
+        /* Enter a critical section but don't use the taskENTER_CRITICAL()
+         * method as that will mask interrupts that should exit sleep mode. */
+        __asm volatile ( "cpsid i" ::: "memory" );
+        __asm volatile ( "dsb" );
+        __asm volatile ( "isb" );
+
+        /* If a context switch is pending or a task is waiting for the scheduler
+         * to be un-suspended then abandon the low power entry. */
+        if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+        {
+            /* Restart from whatever is left in the count register to complete
+             * this tick period. */
+            portNVIC_SYSTICK_LOAD_REG = portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+            /* Restart SysTick. */
+            portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+            /* Reset the reload register to the value required for normal tick
+             * periods. */
+            portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+            /* Re-enable interrupts - see comments above the cpsid instruction()
+             * above. */
+            __asm volatile ( "cpsie i" ::: "memory" );
+        }
+        else
+        {
+            /* Set the new reload value. */
+            portNVIC_SYSTICK_LOAD_REG = ulReloadValue;
+
+            /* Clear the SysTick count flag and set the count value back to
+             * zero. */
+            portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+            /* Restart SysTick. */
+            portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+            /* Sleep until something happens. configPRE_SLEEP_PROCESSING() can
+             * set its parameter to 0 to indicate that its implementation
+             * contains its own wait for interrupt or wait for event
+             * instruction, and so wfi should not be executed again. However,
+             * the original expected idle time variable must remain unmodified,
+             * so a copy is taken. */
+            xModifiableIdleTime = xExpectedIdleTime;
+            configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+
+            if( xModifiableIdleTime > 0 )
+            {
+                __asm volatile ( "dsb" ::: "memory" );
+                __asm volatile ( "wfi" );
+                __asm volatile ( "isb" );
+            }
+
+            configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+            /* Re-enable interrupts to allow the interrupt that brought the MCU
+             * out of sleep mode to execute immediately. See comments above
+             * the cpsid instruction above. */
+            __asm volatile ( "cpsie i" ::: "memory" );
+            __asm volatile ( "dsb" );
+            __asm volatile ( "isb" );
+
+            /* Disable interrupts again because the clock is about to be stopped
+             * and interrupts that execute while the clock is stopped will
+             * increase any slippage between the time maintained by the RTOS and
+             * calendar time. */
+            __asm volatile ( "cpsid i" ::: "memory" );
+            __asm volatile ( "dsb" );
+            __asm volatile ( "isb" );
+
+            /* Disable the SysTick clock without reading the
+             * portNVIC_SYSTICK_CTRL_REG register to ensure the
+             * portNVIC_SYSTICK_COUNT_FLAG_BIT is not cleared if it is set.
+             * Again, the time the SysTick is stopped for is accounted for as
+             * best it can be, but using the tickless mode will inevitably
+             * result in some tiny drift of the time maintained by the kernel
+             * with respect to calendar time*/
+            portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT );
+
+            /* Determine if the SysTick clock has already counted to zero and
+             * been set back to the current reload value (the reload back being
+             * correct for the entire expected idle time) or if the SysTick is
+             * yet to count to zero (in which case an interrupt other than the
+             * SysTick must have brought the system out of sleep mode). */
+            if( ( portNVIC_SYSTICK_CTRL_REG & portNVIC_SYSTICK_COUNT_FLAG_BIT ) != 0 )
+            {
+                uint32_t ulCalculatedLoadValue;
+
+                /* The tick interrupt is already pending, and the SysTick count
+                 * reloaded with ulReloadValue.  Reset the
+                 * portNVIC_SYSTICK_LOAD_REG with whatever remains of this tick
+                 * period. */
+                ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE_REG );
+
+                /* Don't allow a tiny value, or values that have somehow
+                 * underflowed because the post sleep hook did something
+                 * that took too long. */
+                if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+                {
+                    ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+                }
+
+                portNVIC_SYSTICK_LOAD_REG = ulCalculatedLoadValue;
+
+                /* As the pending tick will be processed as soon as this
+                 * function exits, the tick value maintained by the tick is
+                 * stepped forward by one less than the time spent waiting. */
+                ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+            }
+            else
+            {
+                /* Something other than the tick interrupt ended the sleep.
+                 * Work out how long the sleep lasted rounded to complete tick
+                 * periods (not the ulReload value which accounted for part
+                 * ticks). */
+                ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+                /* How many complete tick periods passed while the processor
+                 * was waiting? */
+                ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+                /* The reload value is set to whatever fraction of a single tick
+                 * period remains. */
+                portNVIC_SYSTICK_LOAD_REG = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+            }
+
+            /* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD_REG
+             * again, then set portNVIC_SYSTICK_LOAD_REG back to its standard
+             * value. */
+            portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+            portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+            vTaskStepTick( ulCompleteTickPeriods );
+            portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+            /* Exit with interrupts enabled. */
+            __asm volatile ( "cpsie i" ::: "memory" );
+        }
+    }
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+__attribute__( ( weak ) ) void vPortSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Calculate the constants required to configure the tick interrupt. */
+    #if ( configUSE_TICKLESS_IDLE == 1 )
+        {
+            ulTimerCountsForOneTick = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ );
+            xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+            ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR / ( configCPU_CLOCK_HZ / configSYSTICK_CLOCK_HZ );
+        }
+    #endif /* configUSE_TICKLESS_IDLE */
+
+    /* Stop and reset the SysTick. */
+    portNVIC_SYSTICK_CTRL_REG = 0UL;
+    portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+    /* Configure SysTick to interrupt at the requested rate. */
+    portNVIC_SYSTICK_LOAD_REG = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+    portNVIC_SYSTICK_CTRL_REG = portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT;
+}
+/*-----------------------------------------------------------*/
+
+static void prvTaskExitError( void )
+{
+    volatile uint32_t ulDummy = 0UL;
+
+    /* A function that implements a task must not exit or attempt to return to
+     * its caller as there is nothing to return to. If a task wants to exit it
+     * should instead call vTaskDelete( NULL ). Artificially force an assert()
+     * to be triggered if configASSERT() is defined, then stop here so
+     * application writers can catch the error. */
+    configASSERT( ulCriticalNesting == ~0UL );
+    portDISABLE_INTERRUPTS();
+
+    while( ulDummy == 0 )
+    {
+        /* This file calls prvTaskExitError() after the scheduler has been
+         * started to remove a compiler warning about the function being
+         * defined but never called.  ulDummy is used purely to quieten other
+         * warnings about code appearing after this function is called - making
+         * ulDummy volatile makes the compiler think the function could return
+         * and therefore not output an 'unreachable code' warning for code that
+         * appears after it. */
+    }
+}
+/*-----------------------------------------------------------*/
+
+#if ( configENABLE_MPU == 1 )
+    static void prvSetupMPU( void ) /* PRIVILEGED_FUNCTION */
+    {
+        #if defined( __ARMCC_VERSION )
+
+            /* Declaration when these variable are defined in code instead of being
+             * exported from linker scripts. */
+            extern uint32_t * __privileged_functions_start__;
+            extern uint32_t * __privileged_functions_end__;
+            extern uint32_t * __syscalls_flash_start__;
+            extern uint32_t * __syscalls_flash_end__;
+            extern uint32_t * __unprivileged_flash_start__;
+            extern uint32_t * __unprivileged_flash_end__;
+            extern uint32_t * __privileged_sram_start__;
+            extern uint32_t * __privileged_sram_end__;
+        #else /* if defined( __ARMCC_VERSION ) */
+            /* Declaration when these variable are exported from linker scripts. */
+            extern uint32_t __privileged_functions_start__[];
+            extern uint32_t __privileged_functions_end__[];
+            extern uint32_t __syscalls_flash_start__[];
+            extern uint32_t __syscalls_flash_end__[];
+            extern uint32_t __unprivileged_flash_start__[];
+            extern uint32_t __unprivileged_flash_end__[];
+            extern uint32_t __privileged_sram_start__[];
+            extern uint32_t __privileged_sram_end__[];
+        #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
+
+        /* Check that the MPU is present. */
+        if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
+        {
+            /* MAIR0 - Index 0. */
+            portMPU_MAIR0_REG |= ( ( portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE << portMPU_MAIR_ATTR0_POS ) & portMPU_MAIR_ATTR0_MASK );
+            /* MAIR0 - Index 1. */
+            portMPU_MAIR0_REG |= ( ( portMPU_DEVICE_MEMORY_nGnRE << portMPU_MAIR_ATTR1_POS ) & portMPU_MAIR_ATTR1_MASK );
+
+            /* Setup privileged flash as Read Only so that privileged tasks can
+             * read it but not modify. */
+            portMPU_RNR_REG = portPRIVILEGED_FLASH_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __privileged_functions_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_PRIVILEGED_READ_ONLY );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __privileged_functions_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Setup unprivileged flash as Read Only by both privileged and
+             * unprivileged tasks. All tasks can read it but no-one can modify. */
+            portMPU_RNR_REG = portUNPRIVILEGED_FLASH_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __unprivileged_flash_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_READ_ONLY );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __unprivileged_flash_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Setup unprivileged syscalls flash as Read Only by both privileged
+             * and unprivileged tasks. All tasks can read it but no-one can modify. */
+            portMPU_RNR_REG = portUNPRIVILEGED_SYSCALLS_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __syscalls_flash_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_READ_ONLY );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __syscalls_flash_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Setup RAM containing kernel data for privileged access only. */
+            portMPU_RNR_REG = portPRIVILEGED_RAM_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __privileged_sram_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
+                               ( portMPU_REGION_EXECUTE_NEVER );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __privileged_sram_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Enable mem fault. */
+            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE_BIT;
+
+            /* Enable MPU with privileged background access i.e. unmapped
+             * regions have privileged access. */
+            portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE_BIT | portMPU_ENABLE_BIT );
+        }
+    }
+#endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+#if ( configENABLE_FPU == 1 )
+    static void prvSetupFPU( void ) /* PRIVILEGED_FUNCTION */
+    {
+        #if ( configENABLE_TRUSTZONE == 1 )
+            {
+                /* Enable non-secure access to the FPU. */
+                SecureInit_EnableNSFPUAccess();
+            }
+        #endif /* configENABLE_TRUSTZONE */
+
+        /* CP10 = 11 ==> Full access to FPU i.e. both privileged and
+         * unprivileged code should be able to access FPU. CP11 should be
+         * programmed to the same value as CP10. */
+        *( portCPACR ) |= ( ( portCPACR_CP10_VALUE << portCPACR_CP10_POS ) |
+                            ( portCPACR_CP11_VALUE << portCPACR_CP11_POS )
+                            );
+
+        /* ASPEN = 1 ==> Hardware should automatically preserve floating point
+         * context on exception entry and restore on exception return.
+         * LSPEN = 1 ==> Enable lazy context save of FP state. */
+        *( portFPCCR ) |= ( portFPCCR_ASPEN_MASK | portFPCCR_LSPEN_MASK );
+    }
+#endif /* configENABLE_FPU */
+/*-----------------------------------------------------------*/
+
+void vPortYield( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Set a PendSV to request a context switch. */
+    portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+
+    /* Barriers are normally not required but do ensure the code is
+     * completely within the specified behaviour for the architecture. */
+    __asm volatile ( "dsb" ::: "memory" );
+    __asm volatile ( "isb" );
+}
+/*-----------------------------------------------------------*/
+
+void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */
+{
+    portDISABLE_INTERRUPTS();
+    ulCriticalNesting++;
+
+    /* Barriers are normally not required but do ensure the code is
+     * completely within the specified behaviour for the architecture. */
+    __asm volatile ( "dsb" ::: "memory" );
+    __asm volatile ( "isb" );
+}
+/*-----------------------------------------------------------*/
+
+void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
+{
+    configASSERT( ulCriticalNesting );
+    ulCriticalNesting--;
+
+    if( ulCriticalNesting == 0 )
+    {
+        portENABLE_INTERRUPTS();
+    }
+}
+/*-----------------------------------------------------------*/
+
+void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+{
+    uint32_t ulPreviousMask;
+
+    ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    {
+        /* Increment the RTOS tick. */
+        if( xTaskIncrementTick() != pdFALSE )
+        {
+            /* Pend a context switch. */
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+    }
+    portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );
+}
+/*-----------------------------------------------------------*/
+
+void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTION portDONT_DISCARD */
+{
+    #if ( configENABLE_MPU == 1 )
+        #if defined( __ARMCC_VERSION )
+
+            /* Declaration when these variable are defined in code instead of being
+             * exported from linker scripts. */
+            extern uint32_t * __syscalls_flash_start__;
+            extern uint32_t * __syscalls_flash_end__;
+        #else
+            /* Declaration when these variable are exported from linker scripts. */
+            extern uint32_t __syscalls_flash_start__[];
+            extern uint32_t __syscalls_flash_end__[];
+        #endif /* defined( __ARMCC_VERSION ) */
+    #endif /* configENABLE_MPU */
+
+    uint32_t ulPC;
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+        uint32_t ulR0, ulR1;
+        extern TaskHandle_t pxCurrentTCB;
+        #if ( configENABLE_MPU == 1 )
+            uint32_t ulControl, ulIsTaskPrivileged;
+        #endif /* configENABLE_MPU */
+    #endif /* configENABLE_TRUSTZONE */
+    uint8_t ucSVCNumber;
+
+    /* Register are stored on the stack in the following order - R0, R1, R2, R3,
+     * R12, LR, PC, xPSR. */
+    ulPC = pulCallerStackAddress[ 6 ];
+    ucSVCNumber = ( ( uint8_t * ) ulPC )[ -2 ];
+
+    switch( ucSVCNumber )
+    {
+        #if ( configENABLE_TRUSTZONE == 1 )
+            case portSVC_ALLOCATE_SECURE_CONTEXT:
+
+                /* R0 contains the stack size passed as parameter to the
+                 * vPortAllocateSecureContext function. */
+                ulR0 = pulCallerStackAddress[ 0 ];
+
+                #if ( configENABLE_MPU == 1 )
+                    {
+                        /* Read the CONTROL register value. */
+                        __asm volatile ( "mrs %0, control"  : "=r" ( ulControl ) );
+
+                        /* The task that raised the SVC is privileged if Bit[0]
+                         * in the CONTROL register is 0. */
+                        ulIsTaskPrivileged = ( ( ulControl & portCONTROL_PRIVILEGED_MASK ) == 0 );
+
+                        /* Allocate and load a context for the secure task. */
+                        xSecureContext = SecureContext_AllocateContext( ulR0, ulIsTaskPrivileged, pxCurrentTCB );
+                    }
+                #else /* if ( configENABLE_MPU == 1 ) */
+                    {
+                        /* Allocate and load a context for the secure task. */
+                        xSecureContext = SecureContext_AllocateContext( ulR0, pxCurrentTCB );
+                    }
+                #endif /* configENABLE_MPU */
+
+                configASSERT( xSecureContext != securecontextINVALID_CONTEXT_ID );
+                SecureContext_LoadContext( xSecureContext, pxCurrentTCB );
+                break;
+
+            case portSVC_FREE_SECURE_CONTEXT:
+                /* R0 contains TCB being freed and R1 contains the secure
+                 * context handle to be freed. */
+                ulR0 = pulCallerStackAddress[ 0 ];
+                ulR1 = pulCallerStackAddress[ 1 ];
+
+                /* Free the secure context. */
+                SecureContext_FreeContext( ( SecureContextHandle_t ) ulR1, ( void * ) ulR0 );
+                break;
+        #endif /* configENABLE_TRUSTZONE */
+
+        case portSVC_START_SCHEDULER:
+            #if ( configENABLE_TRUSTZONE == 1 )
+                {
+                    /* De-prioritize the non-secure exceptions so that the
+                     * non-secure pendSV runs at the lowest priority. */
+                    SecureInit_DePrioritizeNSExceptions();
+
+                    /* Initialize the secure context management system. */
+                    SecureContext_Init();
+                }
+            #endif /* configENABLE_TRUSTZONE */
+
+            #if ( configENABLE_FPU == 1 )
+                {
+                    /* Setup the Floating Point Unit (FPU). */
+                    prvSetupFPU();
+                }
+            #endif /* configENABLE_FPU */
+
+            /* Setup the context of the first task so that the first task starts
+             * executing. */
+            vRestoreContextOfFirstTask();
+            break;
+
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_RAISE_PRIVILEGE:
+
+                    /* Only raise the privilege, if the svc was raised from any of
+                     * the system calls. */
+                    if( ( ulPC >= ( uint32_t ) __syscalls_flash_start__ ) &&
+                        ( ulPC <= ( uint32_t ) __syscalls_flash_end__ ) )
+                    {
+                        vRaisePrivilege();
+                    }
+                    break;
+            #endif /* configENABLE_MPU */
+
+        default:
+            /* Incorrect SVC call. */
+            configASSERT( pdFALSE );
+    }
+}
+/*-----------------------------------------------------------*/
+/* *INDENT-OFF* */
+#if ( configENABLE_MPU == 1 )
+    StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                         StackType_t * pxEndOfStack,
+                                         TaskFunction_t pxCode,
+                                         void * pvParameters,
+                                         BaseType_t xRunPrivileged ) /* PRIVILEGED_FUNCTION */
+#else
+    StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                         StackType_t * pxEndOfStack,
+                                         TaskFunction_t pxCode,
+                                         void * pvParameters ) /* PRIVILEGED_FUNCTION */
+#endif /* configENABLE_MPU */
+/* *INDENT-ON* */
+{
+    /* Simulate the stack frame as it would be created by a context switch
+     * interrupt. */
+    #if ( portPRELOAD_REGISTERS == 0 )
+        {
+            pxTopOfStack--;                                          /* Offset added to account for the way the MCU uses the stack on entry/exit of interrupts. */
+            *pxTopOfStack = portINITIAL_XPSR;                        /* xPSR */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxCode;                  /* PC */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS; /* LR */
+            pxTopOfStack -= 5;                                       /* R12, R3, R2 and R1. */
+            *pxTopOfStack = ( StackType_t ) pvParameters;            /* R0 */
+            pxTopOfStack -= 9;                                       /* R11..R4, EXC_RETURN. */
+            *pxTopOfStack = portINITIAL_EXC_RETURN;
+
+            #if ( configENABLE_MPU == 1 )
+                {
+                    pxTopOfStack--;
+
+                    if( xRunPrivileged == pdTRUE )
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_PRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                    else
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_UNPRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                }
+            #endif /* configENABLE_MPU */
+
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxEndOfStack; /* Slot used to hold this task's PSPLIM value. */
+
+            #if ( configENABLE_TRUSTZONE == 1 )
+                {
+                    pxTopOfStack--;
+                    *pxTopOfStack = portNO_SECURE_CONTEXT; /* Slot used to hold this task's xSecureContext value. */
+                }
+            #endif /* configENABLE_TRUSTZONE */
+        }
+    #else /* portPRELOAD_REGISTERS */
+        {
+            pxTopOfStack--;                                          /* Offset added to account for the way the MCU uses the stack on entry/exit of interrupts. */
+            *pxTopOfStack = portINITIAL_XPSR;                        /* xPSR */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxCode;                  /* PC */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS; /* LR */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x12121212UL;            /* R12 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x03030303UL;            /* R3 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x02020202UL;            /* R2 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x01010101UL;            /* R1 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pvParameters;            /* R0 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x11111111UL;            /* R11 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x10101010UL;            /* R10 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x09090909UL;            /* R09 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x08080808UL;            /* R08 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x07070707UL;            /* R07 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x06060606UL;            /* R06 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x05050505UL;            /* R05 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x04040404UL;            /* R04 */
+            pxTopOfStack--;
+            *pxTopOfStack = portINITIAL_EXC_RETURN;                  /* EXC_RETURN */
+
+            #if ( configENABLE_MPU == 1 )
+                {
+                    pxTopOfStack--;
+
+                    if( xRunPrivileged == pdTRUE )
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_PRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                    else
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_UNPRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                }
+            #endif /* configENABLE_MPU */
+
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxEndOfStack; /* Slot used to hold this task's PSPLIM value. */
+
+            #if ( configENABLE_TRUSTZONE == 1 )
+                {
+                    pxTopOfStack--;
+                    *pxTopOfStack = portNO_SECURE_CONTEXT; /* Slot used to hold this task's xSecureContext value. */
+                }
+            #endif /* configENABLE_TRUSTZONE */
+        }
+    #endif /* portPRELOAD_REGISTERS */
+
+    return pxTopOfStack;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Make PendSV, CallSV and SysTick the same priority as the kernel. */
+    portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
+    portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
+
+    #if ( configENABLE_MPU == 1 )
+        {
+            /* Setup the Memory Protection Unit (MPU). */
+            prvSetupMPU();
+        }
+    #endif /* configENABLE_MPU */
+
+    /* Start the timer that generates the tick ISR. Interrupts are disabled
+     * here already. */
+    vPortSetupTimerInterrupt();
+
+    /* Initialize the critical nesting count ready for the first task. */
+    ulCriticalNesting = 0;
+
+    /* Start the first task. */
+    vStartFirstTask();
+
+    /* Should never get here as the tasks will now be executing. Call the task
+     * exit error function to prevent compiler warnings about a static function
+     * not being called in the case that the application writer overrides this
+     * functionality by defining configTASK_RETURN_ADDRESS. Call
+     * vTaskSwitchContext() so link time optimization does not remove the
+     * symbol. */
+    vTaskSwitchContext();
+    prvTaskExitError();
+
+    /* Should not get here. */
+    return 0;
+}
+/*-----------------------------------------------------------*/
+
+void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Not implemented in ports where there is nothing to return to.
+     * Artificially force an assert. */
+    configASSERT( ulCriticalNesting == 1000UL );
+}
+/*-----------------------------------------------------------*/
+
+#if ( configENABLE_MPU == 1 )
+    void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
+                                    const struct xMEMORY_REGION * const xRegions,
+                                    StackType_t * pxBottomOfStack,
+                                    uint32_t ulStackDepth )
+    {
+        uint32_t ulRegionStartAddress, ulRegionEndAddress, ulRegionNumber;
+        int32_t lIndex = 0;
+
+        #if defined( __ARMCC_VERSION )
+
+            /* Declaration when these variable are defined in code instead of being
+             * exported from linker scripts. */
+            extern uint32_t * __privileged_sram_start__;
+            extern uint32_t * __privileged_sram_end__;
+        #else
+            /* Declaration when these variable are exported from linker scripts. */
+            extern uint32_t __privileged_sram_start__[];
+            extern uint32_t __privileged_sram_end__[];
+        #endif /* defined( __ARMCC_VERSION ) */
+
+        /* Setup MAIR0. */
+        xMPUSettings->ulMAIR0 = ( ( portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE << portMPU_MAIR_ATTR0_POS ) & portMPU_MAIR_ATTR0_MASK );
+        xMPUSettings->ulMAIR0 |= ( ( portMPU_DEVICE_MEMORY_nGnRE << portMPU_MAIR_ATTR1_POS ) & portMPU_MAIR_ATTR1_MASK );
+
+        /* This function is called automatically when the task is created - in
+         * which case the stack region parameters will be valid.  At all other
+         * times the stack parameters will not be valid and it is assumed that
+         * the stack region has already been configured. */
+        if( ulStackDepth > 0 )
+        {
+            ulRegionStartAddress = ( uint32_t ) pxBottomOfStack;
+            ulRegionEndAddress = ( uint32_t ) pxBottomOfStack + ( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) - 1;
+
+            /* If the stack is within the privileged SRAM, do not protect it
+             * using a separate MPU region. This is needed because privileged
+             * SRAM is already protected using an MPU region and ARMv8-M does
+             * not allow overlapping MPU regions. */
+            if( ( ulRegionStartAddress >= ( uint32_t ) __privileged_sram_start__ ) &&
+                ( ulRegionEndAddress <= ( uint32_t ) __privileged_sram_end__ ) )
+            {
+                xMPUSettings->xRegionsSettings[ 0 ].ulRBAR = 0;
+                xMPUSettings->xRegionsSettings[ 0 ].ulRLAR = 0;
+            }
+            else
+            {
+                /* Define the region that allows access to the stack. */
+                ulRegionStartAddress &= portMPU_RBAR_ADDRESS_MASK;
+                ulRegionEndAddress &= portMPU_RLAR_ADDRESS_MASK;
+
+                xMPUSettings->xRegionsSettings[ 0 ].ulRBAR = ( ulRegionStartAddress ) |
+                                                             ( portMPU_REGION_NON_SHAREABLE ) |
+                                                             ( portMPU_REGION_READ_WRITE ) |
+                                                             ( portMPU_REGION_EXECUTE_NEVER );
+
+                xMPUSettings->xRegionsSettings[ 0 ].ulRLAR = ( ulRegionEndAddress ) |
+                                                             ( portMPU_RLAR_ATTR_INDEX0 ) |
+                                                             ( portMPU_RLAR_REGION_ENABLE );
+            }
+        }
+
+        /* User supplied configurable regions. */
+        for( ulRegionNumber = 1; ulRegionNumber <= portNUM_CONFIGURABLE_REGIONS; ulRegionNumber++ )
+        {
+            /* If xRegions is NULL i.e. the task has not specified any MPU
+             * region, the else part ensures that all the configurable MPU
+             * regions are invalidated. */
+            if( ( xRegions != NULL ) && ( xRegions[ lIndex ].ulLengthInBytes > 0UL ) )
+            {
+                /* Translate the generic region definition contained in xRegions
+                 * into the ARMv8 specific MPU settings that are then stored in
+                 * xMPUSettings. */
+                ulRegionStartAddress = ( ( uint32_t ) xRegions[ lIndex ].pvBaseAddress ) & portMPU_RBAR_ADDRESS_MASK;
+                ulRegionEndAddress = ( uint32_t ) xRegions[ lIndex ].pvBaseAddress + xRegions[ lIndex ].ulLengthInBytes - 1;
+                ulRegionEndAddress &= portMPU_RLAR_ADDRESS_MASK;
+
+                /* Start address. */
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR = ( ulRegionStartAddress ) |
+                                                                          ( portMPU_REGION_NON_SHAREABLE );
+
+                /* RO/RW. */
+                if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_READ_ONLY ) != 0 )
+                {
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR |= ( portMPU_REGION_READ_ONLY );
+                }
+                else
+                {
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR |= ( portMPU_REGION_READ_WRITE );
+                }
+
+                /* XN. */
+                if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_EXECUTE_NEVER ) != 0 )
+                {
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR |= ( portMPU_REGION_EXECUTE_NEVER );
+                }
+
+                /* End Address. */
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
+                                                                          ( portMPU_RLAR_REGION_ENABLE );
+
+                /* Normal memory/ Device memory. */
+                if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )
+                {
+                    /* Attr1 in MAIR0 is configured as device memory. */
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX1;
+                }
+                else
+                {
+                    /* Attr0 in MAIR0 is configured as normal memory. */
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
+                }
+            }
+            else
+            {
+                /* Invalidate the region. */
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR = 0UL;
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = 0UL;
+            }
+
+            lIndex++;
+        }
+    }
+#endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortIsInsideInterrupt( void )
+{
+    uint32_t ulCurrentInterrupt;
+    BaseType_t xReturn;
+
+    /* Obtain the number of the currently executing interrupt. Interrupt Program
+     * Status Register (IPSR) holds the exception number of the currently-executing
+     * exception or zero for Thread mode.*/
+    __asm volatile ( "mrs %0, ipsr" : "=r" ( ulCurrentInterrupt )::"memory" );
+
+    if( ulCurrentInterrupt == 0 )
+    {
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55/non_secure/portasm.c
@@ -1,0 +1,452 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE ensures that PRIVILEGED_FUNCTION
+ * is defined correctly and privileged functions are placed in correct sections. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* Portasm includes. */
+#include "portasm.h"
+
+/* MPU_WRAPPERS_INCLUDED_FROM_API_FILE is needed to be defined only for the
+ * header files. */
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "													\n"
+        "	ldr  r2, pxCurrentTCBConst2						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr  r3, [r2]									\n"/* Read pxCurrentTCB. */
+        "	ldr  r0, [r3]									\n"/* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb											\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r2, xMPUCTRLConst2						\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]								\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1									\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r2]								\n"/* Disable MPU. */
+            "												\n"
+            "	adds r3, #4									\n"/* r3 = r3 + 4. r3 now points to MAIR0 in TCB. */
+            "	ldr  r4, [r3]								\n"/* r4 = *r3 i.e. r4 = MAIR0. */
+            "	ldr  r2, xMAIR0Const2						\n"/* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "	str  r4, [r2]								\n"/* Program MAIR0. */
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #4									\n"/* r4 = 4. */
+            "	str  r4, [r2]								\n"/* Program RNR = 4. */
+            "	adds r3, #4									\n"/* r3 = r3 + 4. r3 now points to first RBAR in TCB. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "												\n"
+        #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str  r4, [r2]								\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2							\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str  r4, [r2]								\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2						\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r3!, {r4-r11}							\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+        #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "												\n"
+            "	ldr r2, xMPUCTRLConst2						\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]								\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1									\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r2]								\n"/* Enable MPU. */
+            "	dsb											\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldm  r0!, {r1-r4}							\n"/* Read from stack - r1 = xSecureContext, r2 = PSPLIM, r3 = CONTROL and r4 = EXC_RETURN. */
+            "	ldr  r5, xSecureContextConst2				\n"
+            "	str  r1, [r5]								\n"/* Set xSecureContext to this task's value for the same. */
+            "	msr  psplim, r2								\n"/* Set this task's PSPLIM value. */
+            "	msr  control, r3							\n"/* Set this task's CONTROL value. */
+            "	adds r0, #32								\n"/* Discard everything up to r0. */
+            "	msr  psp, r0								\n"/* This is now the new top of stack to use in the task. */
+            "	isb											\n"
+            "	mov  r0, #0									\n"
+            "	msr  basepri, r0							\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r4										\n"/* Finally, branch to EXC_RETURN. */
+        #else /* configENABLE_MPU */
+            "	ldm  r0!, {r1-r3}							\n"/* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
+            "	ldr  r4, xSecureContextConst2				\n"
+            "	str  r1, [r4]								\n"/* Set xSecureContext to this task's value for the same. */
+            "	msr  psplim, r2								\n"/* Set this task's PSPLIM value. */
+            "	movs r1, #2									\n"/* r1 = 2. */
+            "	msr  CONTROL, r1							\n"/* Switch to use PSP in the thread mode. */
+            "	adds r0, #32								\n"/* Discard everything up to r0. */
+            "	msr  psp, r0								\n"/* This is now the new top of stack to use in the task. */
+            "	isb											\n"
+            "	mov  r0, #0									\n"
+            "	msr  basepri, r0							\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r3										\n"/* Finally, branch to EXC_RETURN. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst2: .word pxCurrentTCB				\n"
+        "xSecureContextConst2: .word xSecureContext			\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst2: .word 0xe000ed94				\n"
+            "xMAIR0Const2: .word 0xe000edc0					\n"
+            "xRNRConst2: .word 0xe000ed98					\n"
+            "xRBARConst2: .word 0xe000ed9c					\n"
+        #endif /* configENABLE_MPU */
+    );
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
+        "	ite ne											\n"
+        "	movne r0, #0									\n"/* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
+        "	moveq r0, #1									\n"/* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
+        "	bx lr											\n"/* Return. */
+        "													\n"
+        "	.align 4										\n"
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* Read the CONTROL register. */
+        "	bic r0, #1										\n"/* Clear the bit 0. */
+        "	msr control, r0									\n"/* Write back the new CONTROL value. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vResetPrivilege( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	orr r0, #1										\n"/* r0 = r0 | 1. */
+        "	msr control, r0									\n"/* CONTROL = r0. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
+        "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
+        "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
+        "	msr msp, r0										\n"/* Set the MSP back to the start of the stack. */
+        "	cpsie i											\n"/* Globally enable interrupts. */
+        "	cpsie f											\n"
+        "	dsb												\n"
+        "	isb												\n"
+        "	svc %0											\n"/* System call to start the first task. */
+        "	nop												\n"
+        "													\n"
+        "   .align 4										\n"
+        "xVTORConst: .word 0xe000ed08						\n"
+        ::"i" ( portSVC_START_SCHEDULER ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
+        "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	msr basepri, r0									\n"/* basepri = ulMask. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::: "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "	.extern SecureContext_SaveContext				\n"
+        "	.extern SecureContext_LoadContext				\n"
+        "													\n"
+        "	ldr r3, xSecureContextConst						\n"/* Read the location of xSecureContext i.e. &( xSecureContext ). */
+        "	ldr r0, [r3]									\n"/* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
+        "	mrs r2, psp										\n"/* Read PSP in r2. */
+        "													\n"
+        "	cbz r0, save_ns_context							\n"/* No secure context to save. */
+        "	push {r0-r2, r14}								\n"
+        "	bl SecureContext_SaveContext					\n"/* Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
+        "	pop {r0-r3}										\n"/* LR is now in r3. */
+        "	mov lr, r3										\n"/* LR = r3. */
+        "	lsls r1, r3, #25								\n"/* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
+        "	bpl save_ns_context								\n"/* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
+        "													\n"
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB.*/
+        #if ( configENABLE_MPU == 1 )
+            "	subs r2, r2, #16							\n"/* Make space for xSecureContext, PSPLIM, CONTROL and LR on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mrs r3, control								\n"/* r3 = CONTROL. */
+            "	mov r4, lr									\n"/* r4 = LR/EXC_RETURN. */
+            "	stmia r2!, {r0, r1, r3, r4}					\n"/* Store xSecureContext, PSPLIM, CONTROL and LR on the stack. */
+        #else /* configENABLE_MPU */
+            "	subs r2, r2, #12							\n"/* Make space for xSecureContext, PSPLIM and LR on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mov r3, lr									\n"/* r3 = LR/EXC_RETURN. */
+            "	stmia r2!, {r0, r1, r3}						\n"/* Store xSecureContext, PSPLIM and LR on the stack. */
+        #endif /* configENABLE_MPU */
+        "	b select_next_task								\n"
+        "													\n"
+        " save_ns_context:									\n"
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB. */
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst lr, #0x10								\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq										\n"
+            "	vstmdbeq r2!, {s16-s31}						\n"/* Store the additional FP context registers which are not saved automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        #if ( configENABLE_MPU == 1 )
+            "	subs r2, r2, #48							\n"/* Make space for xSecureContext, PSPLIM, CONTROL, LR and the remaining registers on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	adds r2, r2, #16							\n"/* r2 = r2 + 16. */
+            "	stm r2, {r4-r11}							\n"/* Store the registers that are not saved automatically. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mrs r3, control								\n"/* r3 = CONTROL. */
+            "	mov r4, lr									\n"/* r4 = LR/EXC_RETURN. */
+            "	subs r2, r2, #16							\n"/* r2 = r2 - 16. */
+            "	stmia r2!, {r0, r1, r3, r4}					\n"/* Store xSecureContext, PSPLIM, CONTROL and LR on the stack. */
+        #else /* configENABLE_MPU */
+            "	subs r2, r2, #44							\n"/* Make space for xSecureContext, PSPLIM, LR and the remaining registers on the stack. */
+            "	str r2, [r1]								\n"/* Save the new top of stack in TCB. */
+            "	adds r2, r2, #12							\n"/* r2 = r2 + 12. */
+            "	stm r2, {r4-r11}							\n"/* Store the registers that are not saved automatically. */
+            "	mrs r1, psplim								\n"/* r1 = PSPLIM. */
+            "	mov r3, lr									\n"/* r3 = LR/EXC_RETURN. */
+            "	subs r2, r2, #12							\n"/* r2 = r2 - 12. */
+            "	stmia r2!, {r0, r1, r3}						\n"/* Store xSecureContext, PSPLIM and LR on the stack. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        " select_next_task:									\n"
+        "	mov r0, %0										\n"/* r0 = configMAX_SYSCALL_INTERRUPT_PRIORITY */
+        "	msr basepri, r0									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bl vTaskSwitchContext							\n"
+        "	mov r0, #0										\n"/* r0 = 0. */
+        "	msr basepri, r0									\n"/* Enable interrupts. */
+        "													\n"
+        "	ldr r3, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r3]									\n"/* Read pxCurrentTCB. */
+        "	ldr r2, [r1]									\n"/* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb											\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r3, xMPUCTRLConst						\n"/* r3 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r3]								\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1									\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r3]								\n"/* Disable MPU. */
+            "												\n"
+            "	adds r1, #4									\n"/* r1 = r1 + 4. r1 now points to MAIR0 in TCB. */
+            "	ldr r4, [r1]								\n"/* r4 = *r1 i.e. r4 = MAIR0. */
+            "	ldr r3, xMAIR0Const							\n"/* r3 = 0xe000edc0 [Location of MAIR0]. */
+            "	str r4, [r3]								\n"/* Program MAIR0. */
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #4									\n"/* r4 = 4. */
+            "	str r4, [r3]								\n"/* Program RNR = 4. */
+            "	adds r1, #4									\n"/* r1 = r1 + 4. r1 now points to first RBAR in TCB. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "												\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #8									\n"/* r4 = 8. */
+            "	str r4, [r3]								\n"/* Program RNR = 8. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r3, xRNRConst							\n"/* r3 = 0xe000ed98 [Location of RNR]. */
+            "	movs r4, #12								\n"/* r4 = 12. */
+            "	str r4, [r3]								\n"/* Program RNR = 12. */
+            "	ldr r3, xRBARConst							\n"/* r3 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}							\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r3!, {r4-r11}							\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "												\n"
+            "	ldr r3, xMPUCTRLConst						\n"/* r3 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r3]								\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1									\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r3]								\n"/* Enable MPU. */
+            "	dsb											\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldmia r2!, {r0, r1, r3, r4}					\n"/* Read from stack - r0 = xSecureContext, r1 = PSPLIM, r3 = CONTROL and r4 = LR. */
+            "	msr psplim, r1								\n"/* Restore the PSPLIM register value for the task. */
+            "	msr control, r3								\n"/* Restore the CONTROL register value for the task. */
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	ldr r3, xSecureContextConst					\n"/* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "	str r0, [r3]								\n"/* Restore the task's xSecureContext. */
+            "	cbz r0, restore_ns_context					\n"/* If there is no secure context for the task, restore the non-secure context. */
+            "	ldr r3, pxCurrentTCBConst					\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "	ldr r1, [r3]								\n"/* Read pxCurrentTCB. */
+            "	push {r2, r4}								\n"
+            "	bl SecureContext_LoadContext				\n"/* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
+            "	pop {r2, r4}								\n"
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	lsls r1, r4, #25							\n"/* r1 = r4 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
+            "	bpl restore_ns_context						\n"/* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
+            "	msr psp, r2									\n"/* Remember the new top of stack for the task. */
+            "	bx lr										\n"
+        #else /* configENABLE_MPU */
+            "	ldmia r2!, {r0, r1, r4}						\n"/* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
+            "	msr psplim, r1								\n"/* Restore the PSPLIM register value for the task. */
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	ldr r3, xSecureContextConst					\n"/* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "	str r0, [r3]								\n"/* Restore the task's xSecureContext. */
+            "	cbz r0, restore_ns_context					\n"/* If there is no secure context for the task, restore the non-secure context. */
+            "	ldr r3, pxCurrentTCBConst					\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "	ldr r1, [r3]								\n"/* Read pxCurrentTCB. */
+            "	push {r2, r4}								\n"
+            "	bl SecureContext_LoadContext				\n"/* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
+            "	pop {r2, r4}								\n"
+            "	mov lr, r4									\n"/* LR = r4. */
+            "	lsls r1, r4, #25							\n"/* r1 = r4 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
+            "	bpl restore_ns_context						\n"/* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
+            "	msr psp, r2									\n"/* Remember the new top of stack for the task. */
+            "	bx lr										\n"
+        #endif /* configENABLE_MPU */
+        "													\n"
+        " restore_ns_context:								\n"
+        "	ldmia r2!, {r4-r11}								\n"/* Restore the registers that are not automatically restored. */
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst lr, #0x10								\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq										\n"
+            "	vldmiaeq r2!, {s16-s31}						\n"/* Restore the additional FP context registers which are not restored automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        "	msr psp, r2										\n"/* Remember the new top of stack for the task. */
+        "	bx lr											\n"
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst: .word pxCurrentTCB				\n"
+        "xSecureContextConst: .word xSecureContext			\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst: .word 0xe000ed94				\n"
+            "xMAIR0Const: .word 0xe000edc0					\n"
+            "xRNRConst: .word 0xe000ed98					\n"
+            "xRBARConst: .word 0xe000ed9c					\n"
+        #endif /* configENABLE_MPU */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
+    );
+}
+/*-----------------------------------------------------------*/
+
+void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	tst lr, #4										\n"
+        "	ite eq											\n"
+        "	mrseq r0, msp									\n"
+        "	mrsne r0, psp									\n"
+        "	ldr r1, svchandler_address_const				\n"
+        "	bx r1											\n"
+        "													\n"
+        "	.align 4										\n"
+        "svchandler_address_const: .word vPortSVCHandler_C	\n"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	svc %0											\n"/* Secure context is allocated in the supervisor call. */
+        "	bx lr											\n"/* Return. */
+        ::"i" ( portSVC_ALLOCATE_SECURE_CONTEXT ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	ldr r2, [r0]									\n"/* The first item in the TCB is the top of the stack. */
+        "	ldr r1, [r2]									\n"/* The first item on the stack is the task's xSecureContext. */
+        "	cmp r1, #0										\n"/* Raise svc if task's xSecureContext is not NULL. */
+        "	it ne											\n"
+        "	svcne %0										\n"/* Secure context is freed in the supervisor call. */
+        "	bx lr											\n"/* Return. */
+        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM55/non_secure/portasm.h
@@ -1,0 +1,114 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef __PORT_ASM_H__
+#define __PORT_ASM_H__
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+
+/* MPU wrappers includes. */
+#include "mpu_wrappers.h"
+
+/**
+ * @brief Restore the context of the first task so that the first task starts
+ * executing.
+ */
+void vRestoreContextOfFirstTask( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether or not the processor is privileged.
+ *
+ * @return 1 if the processor is already privileged, 0 otherwise.
+ */
+BaseType_t xIsPrivileged( void ) __attribute__( ( naked ) );
+
+/**
+ * @brief Raises the privilege level by clearing the bit 0 of the CONTROL
+ * register.
+ *
+ * @note This is a privileged function and should only be called from the kenrel
+ * code.
+ *
+ * Bit 0 of the CONTROL register defines the privilege level of Thread Mode.
+ *  Bit[0] = 0 --> The processor is running privileged
+ *  Bit[0] = 1 --> The processor is running unprivileged.
+ */
+void vRaisePrivilege( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Lowers the privilege level by setting the bit 0 of the CONTROL
+ * register.
+ *
+ * Bit 0 of the CONTROL register defines the privilege level of Thread Mode.
+ *  Bit[0] = 0 --> The processor is running privileged
+ *  Bit[0] = 1 --> The processor is running unprivileged.
+ */
+void vResetPrivilege( void ) __attribute__( ( naked ) );
+
+/**
+ * @brief Starts the first task.
+ */
+void vStartFirstTask( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Disables interrupts.
+ */
+uint32_t ulSetInterruptMask( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Enables interrupts.
+ */
+void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief PendSV Exception handler.
+ */
+void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief SVC Handler.
+ */
+void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Allocate a Secure context for the calling task.
+ *
+ * @param[in] ulSecureStackSize The size of the stack to be allocated on the
+ * secure side for the calling task.
+ */
+void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) __attribute__( ( naked ) );
+
+/**
+ * @brief Free the task's secure context.
+ *
+ * @param[in] pulTCB Pointer to the Task Control Block (TCB) of the task.
+ */
+void vPortFreeSecureContext( uint32_t * pulTCB ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+#endif /* __PORT_ASM_H__ */

--- a/portable/GCC/ARM_CM55/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacro.h
@@ -1,0 +1,319 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef PORTMACRO_H
+    #define PORTMACRO_H
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
+
+/*------------------------------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the given hardware
+ * and compiler.
+ *
+ * These settings should not be altered.
+ *------------------------------------------------------------------------------
+ */
+
+    #ifndef configENABLE_FPU
+        #error configENABLE_FPU must be defined in FreeRTOSConfig.h.  Set configENABLE_FPU to 1 to enable the FPU or 0 to disable the FPU.
+    #endif /* configENABLE_FPU */
+
+    #ifndef configENABLE_MPU
+        #error configENABLE_MPU must be defined in FreeRTOSConfig.h.  Set configENABLE_MPU to 1 to enable the MPU or 0 to disable the MPU.
+    #endif /* configENABLE_MPU */
+
+    #ifndef configENABLE_TRUSTZONE
+        #error configENABLE_TRUSTZONE must be defined in FreeRTOSConfig.h.  Set configENABLE_TRUSTZONE to 1 to enable TrustZone or 0 to disable TrustZone.
+    #endif /* configENABLE_TRUSTZONE */
+
+    #ifndef configENABLE_MVE
+        #error configENABLE_MVE must be defined in FreeRTOSConfig.h.  Set configENABLE_MVE to 1 to enable the MVE or 0 to disable the MVE.
+    #endif /* configENABLE_MVE */
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Type definitions.
+ */
+    #define portCHAR          char
+    #define portFLOAT         float
+    #define portDOUBLE        double
+    #define portLONG          long
+    #define portSHORT         short
+    #define portSTACK_TYPE    uint32_t
+    #define portBASE_TYPE     long
+
+    typedef portSTACK_TYPE   StackType_t;
+    typedef long             BaseType_t;
+    typedef unsigned long    UBaseType_t;
+
+    #if ( configUSE_16_BIT_TICKS == 1 )
+        typedef uint16_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffff
+    #else
+        typedef uint32_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+
+/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+ * not need to be guarded with a critical section. */
+        #define portTICK_TYPE_IS_ATOMIC    1
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * Architecture specifics.
+ */
+    #define portARCH_NAME                      "Cortex-M55"
+    #define portSTACK_GROWTH                   ( -1 )
+    #define portTICK_PERIOD_MS                 ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+    #define portBYTE_ALIGNMENT                 8
+    #define portNOP()
+    #define portINLINE                         __inline
+    #ifndef portFORCE_INLINE
+        #define portFORCE_INLINE               inline __attribute__( ( always_inline ) )
+    #endif
+    #define portHAS_STACK_OVERFLOW_CHECKING    1
+    #define portDONT_DISCARD                   __attribute__( ( used ) )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Extern declarations.
+ */
+    extern BaseType_t xPortIsInsideInterrupt( void );
+
+    extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
+    extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+    extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+        extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
+        extern void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */;
+    #endif /* configENABLE_TRUSTZONE */
+
+    #if ( configENABLE_MPU == 1 )
+        extern BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */;
+        extern void vResetPrivilege( void ) /* __attribute__ (( naked )) */;
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief MPU specific constants.
+ */
+    #if ( configENABLE_MPU == 1 )
+        #define portUSING_MPU_WRAPPERS    1
+        #define portPRIVILEGE_BIT         ( 0x80000000UL )
+    #else
+        #define portPRIVILEGE_BIT         ( 0x0UL )
+    #endif /* configENABLE_MPU */
+
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+/* MPU regions. */
+    #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
+    #define portUNPRIVILEGED_FLASH_REGION                 ( 1UL )
+    #define portUNPRIVILEGED_SYSCALLS_REGION              ( 2UL )
+    #define portPRIVILEGED_RAM_REGION                     ( 3UL )
+    #define portSTACK_REGION                              ( 4UL )
+    #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
+    #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
+    #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
+
+/* Device memory attributes used in MPU_MAIR registers.
+ *
+ * 8-bit values encoded as follows:
+ *  Bit[7:4] - 0000 - Device Memory
+ *  Bit[3:2] - 00 --> Device-nGnRnE
+ *				01 --> Device-nGnRE
+ *				10 --> Device-nGRE
+ *				11 --> Device-GRE
+ *  Bit[1:0] - 00, Reserved.
+ */
+    #define portMPU_DEVICE_MEMORY_nGnRnE                  ( 0x00 )   /* 0000 0000 */
+    #define portMPU_DEVICE_MEMORY_nGnRE                   ( 0x04 )   /* 0000 0100 */
+    #define portMPU_DEVICE_MEMORY_nGRE                    ( 0x08 )   /* 0000 1000 */
+    #define portMPU_DEVICE_MEMORY_GRE                     ( 0x0C )   /* 0000 1100 */
+
+/* Normal memory attributes used in MPU_MAIR registers. */
+    #define portMPU_NORMAL_MEMORY_NON_CACHEABLE           ( 0x44 )   /* Non-cacheable. */
+    #define portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE    ( 0xFF )   /* Non-Transient, Write-back, Read-Allocate and Write-Allocate. */
+
+/* Attributes used in MPU_RBAR registers. */
+    #define portMPU_REGION_NON_SHAREABLE                  ( 0UL << 3UL )
+    #define portMPU_REGION_INNER_SHAREABLE                ( 1UL << 3UL )
+    #define portMPU_REGION_OUTER_SHAREABLE                ( 2UL << 3UL )
+
+    #define portMPU_REGION_PRIVILEGED_READ_WRITE          ( 0UL << 1UL )
+    #define portMPU_REGION_READ_WRITE                     ( 1UL << 1UL )
+    #define portMPU_REGION_PRIVILEGED_READ_ONLY           ( 2UL << 1UL )
+    #define portMPU_REGION_READ_ONLY                      ( 3UL << 1UL )
+
+    #define portMPU_REGION_EXECUTE_NEVER                  ( 1UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Settings to define an MPU region.
+ */
+    typedef struct MPURegionSettings
+    {
+        uint32_t ulRBAR; /**< RBAR for the region. */
+        uint32_t ulRLAR; /**< RLAR for the region. */
+    } MPURegionSettings_t;
+
+/**
+ * @brief MPU settings as stored in the TCB.
+ */
+    typedef struct MPU_SETTINGS
+    {
+        uint32_t ulMAIR0;                                              /**< MAIR0 for the task containing attributes for all the 4 per task regions. */
+        MPURegionSettings_t xRegionsSettings[ portTOTAL_NUM_REGIONS ]; /**< Settings for 4 per task regions. */
+    } xMPU_SETTINGS;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief SVC numbers.
+ */
+    #define portSVC_ALLOCATE_SECURE_CONTEXT    0
+    #define portSVC_FREE_SECURE_CONTEXT        1
+    #define portSVC_START_SCHEDULER            2
+    #define portSVC_RAISE_PRIVILEGE            3
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Scheduler utilities.
+ */
+    #define portYIELD()                                 vPortYield()
+    #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
+    #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
+    #define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } while( 0 )
+    #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Critical section management.
+ */
+    #define portSET_INTERRUPT_MASK_FROM_ISR()         ulSetInterruptMask()
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    vClearInterruptMask( x )
+    #define portDISABLE_INTERRUPTS()                  ulSetInterruptMask()
+    #define portENABLE_INTERRUPTS()                   vClearInterruptMask( 0 )
+    #define portENTER_CRITICAL()                      vPortEnterCritical()
+    #define portEXIT_CRITICAL()                       vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+    #ifndef portSUPPRESS_TICKS_AND_SLEEP
+        extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+        #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Task function macros as described on the FreeRTOS.org WEB site.
+ */
+    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+
+/**
+ * @brief Allocate a secure context for the task.
+ *
+ * Tasks are not created with a secure context. Any task that is going to call
+ * secure functions must call portALLOCATE_SECURE_CONTEXT() to allocate itself a
+ * secure context before it calls any secure function.
+ *
+ * @param[in] ulSecureStackSize The size of the secure stack to be allocated.
+ */
+        #define portALLOCATE_SECURE_CONTEXT( ulSecureStackSize )    vPortAllocateSecureContext( ulSecureStackSize )
+
+/**
+ * @brief Called when a task is deleted to delete the task's secure context,
+ * if it has one.
+ *
+ * @param[in] pxTCB The TCB of the task being deleted.
+ */
+        #define portCLEAN_UP_TCB( pxTCB )                           vPortFreeSecureContext( ( uint32_t * ) pxTCB )
+    #endif /* configENABLE_TRUSTZONE */
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_MPU == 1 )
+
+/**
+ * @brief Checks whether or not the processor is privileged.
+ *
+ * @return 1 if the processor is already privileged, 0 otherwise.
+ */
+        #define portIS_PRIVILEGED()      xIsPrivileged()
+
+/**
+ * @brief Raise an SVC request to raise privilege.
+ *
+ * The SVC handler checks that the SVC was raised from a system call and only
+ * then it raises the privilege. If this is called from any other place,
+ * the privilege is not raised.
+ */
+        #define portRAISE_PRIVILEGE()    __asm volatile ( "svc %0 \n" ::"i" ( portSVC_RAISE_PRIVILEGE ) : "memory" );
+
+/**
+ * @brief Lowers the privilege level by setting the bit 0 of the CONTROL
+ * register.
+ */
+        #define portRESET_PRIVILEGE()    vResetPrivilege()
+    #else
+        #define portIS_PRIVILEGED()
+        #define portRAISE_PRIVILEGE()
+        #define portRESET_PRIVILEGE()
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Barriers.
+ */
+    #define portMEMORY_BARRIER()    __asm volatile ( "" ::: "memory" )
+/*-----------------------------------------------------------*/
+
+    #ifdef __cplusplus
+        }
+    #endif
+
+#endif /* PORTMACRO_H */

--- a/portable/GCC/ARM_CM55/secure/secure_context.c
+++ b/portable/GCC/ARM_CM55/secure/secure_context.c
@@ -1,0 +1,351 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Secure context includes. */
+#include "secure_context.h"
+
+/* Secure heap includes. */
+#include "secure_heap.h"
+
+/* Secure port macros. */
+#include "secure_port_macros.h"
+
+/**
+ * @brief CONTROL value for privileged tasks.
+ *
+ * Bit[0] - 0 --> Thread mode is privileged.
+ * Bit[1] - 1 --> Thread mode uses PSP.
+ */
+#define securecontextCONTROL_VALUE_PRIVILEGED      0x02
+
+/**
+ * @brief CONTROL value for un-privileged tasks.
+ *
+ * Bit[0] - 1 --> Thread mode is un-privileged.
+ * Bit[1] - 1 --> Thread mode uses PSP.
+ */
+#define securecontextCONTROL_VALUE_UNPRIVILEGED    0x03
+
+/**
+ * @brief Size of stack seal values in bytes.
+ */
+#define securecontextSTACK_SEAL_SIZE               8
+
+/**
+ * @brief Stack seal value as recommended by ARM.
+ */
+#define securecontextSTACK_SEAL_VALUE              0xFEF5EDA5
+
+/**
+ * @brief Maximum number of secure contexts.
+ */
+#ifndef secureconfigMAX_SECURE_CONTEXTS
+    #define secureconfigMAX_SECURE_CONTEXTS        8UL
+#endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Pre-allocated array of secure contexts.
+ */
+SecureContext_t xSecureContexts[ secureconfigMAX_SECURE_CONTEXTS ];
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get a free secure context for a task from the secure context pool (xSecureContexts).
+ *
+ * This function ensures that only one secure context is allocated for a task.
+ *
+ * @param[in] pvTaskHandle The task handle for which the secure context is allocated.
+ *
+ * @return Index of a free secure context in the xSecureContexts array.
+ */
+static uint32_t ulGetSecureContext( void * pvTaskHandle );
+
+/**
+ * @brief Return the secure context to the secure context pool (xSecureContexts).
+ *
+ * @param[in] ulSecureContextIndex Index of the context in the xSecureContexts array.
+ */
+static void vReturnSecureContext( uint32_t ulSecureContextIndex );
+
+/* These are implemented in assembly. */
+extern void SecureContext_LoadContextAsm( SecureContext_t * pxSecureContext );
+extern void SecureContext_SaveContextAsm( SecureContext_t * pxSecureContext );
+/*-----------------------------------------------------------*/
+
+static uint32_t ulGetSecureContext( void * pvTaskHandle )
+{
+    /* Start with invalid index. */
+    uint32_t i, ulSecureContextIndex = secureconfigMAX_SECURE_CONTEXTS;
+
+    for( i = 0; i < secureconfigMAX_SECURE_CONTEXTS; i++ )
+    {
+        if( ( xSecureContexts[ i ].pucCurrentStackPointer == NULL ) &&
+            ( xSecureContexts[ i ].pucStackLimit == NULL ) &&
+            ( xSecureContexts[ i ].pucStackStart == NULL ) &&
+            ( xSecureContexts[ i ].pvTaskHandle == NULL ) &&
+            ( ulSecureContextIndex == secureconfigMAX_SECURE_CONTEXTS ) )
+        {
+            ulSecureContextIndex = i;
+        }
+        else if( xSecureContexts[ i ].pvTaskHandle == pvTaskHandle )
+        {
+            /* A task can only have one secure context. Do not allocate a second
+             * context for the same task. */
+            ulSecureContextIndex = secureconfigMAX_SECURE_CONTEXTS;
+            break;
+        }
+    }
+
+    return ulSecureContextIndex;
+}
+/*-----------------------------------------------------------*/
+
+static void vReturnSecureContext( uint32_t ulSecureContextIndex )
+{
+    xSecureContexts[ ulSecureContextIndex ].pucCurrentStackPointer = NULL;
+    xSecureContexts[ ulSecureContextIndex ].pucStackLimit = NULL;
+    xSecureContexts[ ulSecureContextIndex ].pucStackStart = NULL;
+    xSecureContexts[ ulSecureContextIndex ].pvTaskHandle = NULL;
+}
+/*-----------------------------------------------------------*/
+
+secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
+{
+    uint32_t ulIPSR, i;
+    static uint32_t ulSecureContextsInitialized = 0;
+
+    /* Read the Interrupt Program Status Register (IPSR) value. */
+    secureportREAD_IPSR( ulIPSR );
+
+    /* Do nothing if the processor is running in the Thread Mode. IPSR is zero
+     * when the processor is running in the Thread Mode. */
+    if( ( ulIPSR != 0 ) && ( ulSecureContextsInitialized == 0 ) )
+    {
+        /* Ensure to initialize secure contexts only once. */
+        ulSecureContextsInitialized = 1;
+
+        /* No stack for thread mode until a task's context is loaded. */
+        secureportSET_PSPLIM( securecontextNO_STACK );
+        secureportSET_PSP( securecontextNO_STACK );
+
+        /* Initialize all secure contexts. */
+        for( i = 0; i < secureconfigMAX_SECURE_CONTEXTS; i++ )
+        {
+            xSecureContexts[ i ].pucCurrentStackPointer = NULL;
+            xSecureContexts[ i ].pucStackLimit = NULL;
+            xSecureContexts[ i ].pucStackStart = NULL;
+            xSecureContexts[ i ].pvTaskHandle = NULL;
+        }
+
+        #if ( configENABLE_MPU == 1 )
+            {
+                /* Configure thread mode to use PSP and to be unprivileged. */
+                secureportSET_CONTROL( securecontextCONTROL_VALUE_UNPRIVILEGED );
+            }
+        #else /* configENABLE_MPU */
+            {
+                /* Configure thread mode to use PSP and to be privileged. */
+                secureportSET_CONTROL( securecontextCONTROL_VALUE_PRIVILEGED );
+            }
+        #endif /* configENABLE_MPU */
+    }
+}
+/*-----------------------------------------------------------*/
+
+#if ( configENABLE_MPU == 1 )
+    secureportNON_SECURE_CALLABLE SecureContextHandle_t SecureContext_AllocateContext( uint32_t ulSecureStackSize,
+                                                                                       uint32_t ulIsTaskPrivileged,
+                                                                                       void * pvTaskHandle )
+#else /* configENABLE_MPU */
+    secureportNON_SECURE_CALLABLE SecureContextHandle_t SecureContext_AllocateContext( uint32_t ulSecureStackSize,
+                                                                                       void * pvTaskHandle )
+#endif /* configENABLE_MPU */
+{
+    uint8_t * pucStackMemory = NULL;
+    uint8_t * pucStackLimit;
+    uint32_t ulIPSR, ulSecureContextIndex;
+    SecureContextHandle_t xSecureContextHandle = securecontextINVALID_CONTEXT_ID;
+
+    #if ( configENABLE_MPU == 1 )
+        uint32_t * pulCurrentStackPointer = NULL;
+    #endif /* configENABLE_MPU */
+
+    /* Read the Interrupt Program Status Register (IPSR) and Process Stack Limit
+     * Register (PSPLIM) value. */
+    secureportREAD_IPSR( ulIPSR );
+    secureportREAD_PSPLIM( pucStackLimit );
+
+    /* Do nothing if the processor is running in the Thread Mode. IPSR is zero
+     * when the processor is running in the Thread Mode.
+     * Also do nothing, if a secure context us already loaded. PSPLIM is set to
+     * securecontextNO_STACK when no secure context is loaded. */
+    if( ( ulIPSR != 0 ) && ( pucStackLimit == securecontextNO_STACK ) )
+    {
+        /* Ontain a free secure context. */
+        ulSecureContextIndex = ulGetSecureContext( pvTaskHandle );
+
+        /* Were we able to get a free context? */
+        if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
+        {
+            /* Allocate the stack space. */
+            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+
+            if( pucStackMemory != NULL )
+            {
+                /* Since stack grows down, the starting point will be the last
+                 * location. Note that this location is next to the last
+                 * allocated byte for stack (excluding the space for seal values)
+                 * because the hardware decrements the stack pointer before
+                 * writing i.e. if stack pointer is 0x2, a push operation will
+                 * decrement the stack pointer to 0x1 and then write at 0x1. */
+                xSecureContexts[ ulSecureContextIndex ].pucStackStart = pucStackMemory + ulSecureStackSize;
+
+                /* Seal the created secure process stack. */
+                *( uint32_t * )( pucStackMemory + ulSecureStackSize ) = securecontextSTACK_SEAL_VALUE;
+                *( uint32_t * )( pucStackMemory + ulSecureStackSize + 4 ) = securecontextSTACK_SEAL_VALUE;
+
+                /* The stack cannot go beyond this location. This value is
+                 * programmed in the PSPLIM register on context switch.*/
+                xSecureContexts[ ulSecureContextIndex ].pucStackLimit = pucStackMemory;
+
+                xSecureContexts[ ulSecureContextIndex ].pvTaskHandle = pvTaskHandle;
+
+                #if ( configENABLE_MPU == 1 )
+                    {
+                        /* Store the correct CONTROL value for the task on the stack.
+                         * This value is programmed in the CONTROL register on
+                         * context switch. */
+                        pulCurrentStackPointer = ( uint32_t * ) xSecureContexts[ ulSecureContextIndex ].pucStackStart;
+                        pulCurrentStackPointer--;
+
+                        if( ulIsTaskPrivileged )
+                        {
+                            *( pulCurrentStackPointer ) = securecontextCONTROL_VALUE_PRIVILEGED;
+                        }
+                        else
+                        {
+                            *( pulCurrentStackPointer ) = securecontextCONTROL_VALUE_UNPRIVILEGED;
+                        }
+
+                        /* Store the current stack pointer. This value is programmed in
+                         * the PSP register on context switch. */
+                        xSecureContexts[ ulSecureContextIndex ].pucCurrentStackPointer = ( uint8_t * ) pulCurrentStackPointer;
+                    }
+                #else /* configENABLE_MPU */
+                    {
+                        /* Current SP is set to the starting of the stack. This
+                         * value programmed in the PSP register on context switch. */
+                        xSecureContexts[ ulSecureContextIndex ].pucCurrentStackPointer = xSecureContexts[ ulSecureContextIndex ].pucStackStart;
+                    }
+                #endif /* configENABLE_MPU */
+
+                /* Ensure to never return 0 as a valid context handle. */
+                xSecureContextHandle = ulSecureContextIndex + 1UL;
+            }
+        }
+    }
+
+    return xSecureContextHandle;
+}
+/*-----------------------------------------------------------*/
+
+secureportNON_SECURE_CALLABLE void SecureContext_FreeContext( SecureContextHandle_t xSecureContextHandle, void * pvTaskHandle )
+{
+    uint32_t ulIPSR, ulSecureContextIndex;
+
+    /* Read the Interrupt Program Status Register (IPSR) value. */
+    secureportREAD_IPSR( ulIPSR );
+
+    /* Do nothing if the processor is running in the Thread Mode. IPSR is zero
+     * when the processor is running in the Thread Mode. */
+    if( ulIPSR != 0 )
+    {
+        /* Only free if a valid context handle is passed. */
+        if( ( xSecureContextHandle > 0UL ) && ( xSecureContextHandle <= secureconfigMAX_SECURE_CONTEXTS ) )
+        {
+            ulSecureContextIndex = xSecureContextHandle - 1UL;
+
+            /* Ensure that the secure context being deleted is associated with
+             * the task. */
+            if( xSecureContexts[ ulSecureContextIndex ].pvTaskHandle == pvTaskHandle )
+            {
+                /* Free the stack space. */
+                vPortFree( xSecureContexts[ ulSecureContextIndex ].pucStackLimit );
+
+                /* Return the secure context back to the free secure contexts pool. */
+                vReturnSecureContext( ulSecureContextIndex );
+            }
+        }
+    }
+}
+/*-----------------------------------------------------------*/
+
+secureportNON_SECURE_CALLABLE void SecureContext_LoadContext( SecureContextHandle_t xSecureContextHandle, void * pvTaskHandle )
+{
+    uint8_t * pucStackLimit;
+    uint32_t ulSecureContextIndex;
+
+    if( ( xSecureContextHandle > 0UL ) && ( xSecureContextHandle <= secureconfigMAX_SECURE_CONTEXTS ) )
+    {
+        ulSecureContextIndex = xSecureContextHandle - 1UL;
+
+        secureportREAD_PSPLIM( pucStackLimit );
+
+        /* Ensure that no secure context is loaded and the task is loading it's
+         * own context. */
+        if( ( pucStackLimit == securecontextNO_STACK ) &&
+            ( xSecureContexts[ ulSecureContextIndex ].pvTaskHandle == pvTaskHandle ) )
+        {
+            SecureContext_LoadContextAsm( &( xSecureContexts[ ulSecureContextIndex ] ) );
+        }
+    }
+}
+/*-----------------------------------------------------------*/
+
+secureportNON_SECURE_CALLABLE void SecureContext_SaveContext( SecureContextHandle_t xSecureContextHandle, void * pvTaskHandle )
+{
+    uint8_t * pucStackLimit;
+    uint32_t ulSecureContextIndex;
+
+    if( ( xSecureContextHandle > 0UL ) && ( xSecureContextHandle <= secureconfigMAX_SECURE_CONTEXTS ) )
+    {
+        ulSecureContextIndex = xSecureContextHandle - 1UL;
+
+        secureportREAD_PSPLIM( pucStackLimit );
+
+        /* Ensure that task's context is loaded and the task is saving it's own
+         * context. */
+        if( ( xSecureContexts[ ulSecureContextIndex ].pucStackLimit == pucStackLimit ) &&
+            ( xSecureContexts[ ulSecureContextIndex ].pvTaskHandle == pvTaskHandle ) )
+        {
+            SecureContext_SaveContextAsm( &( xSecureContexts[ ulSecureContextIndex ] ) );
+        }
+    }
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/secure/secure_context.h
+++ b/portable/GCC/ARM_CM55/secure/secure_context.h
@@ -1,0 +1,135 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef __SECURE_CONTEXT_H__
+#define __SECURE_CONTEXT_H__
+
+/* Standard includes. */
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOSConfig.h"
+
+/**
+ * @brief PSP value when no secure context is loaded.
+ */
+#define securecontextNO_STACK               0x0
+
+/**
+ * @brief Invalid context ID.
+ */
+#define securecontextINVALID_CONTEXT_ID     0UL
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Structure to represent a secure context.
+ *
+ * @note Since stack grows down, pucStackStart is the highest address while
+ * pucStackLimit is the first address of the allocated memory.
+ */
+typedef struct SecureContext
+{
+    uint8_t * pucCurrentStackPointer; /**< Current value of stack pointer (PSP). */
+    uint8_t * pucStackLimit;          /**< Last location of the stack memory (PSPLIM). */
+    uint8_t * pucStackStart;          /**< First location of the stack memory. */
+    void * pvTaskHandle;              /**< Task handle of the task this context is associated with. */
+} SecureContext_t;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Opaque handle for a secure context.
+ */
+typedef uint32_t SecureContextHandle_t;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Initializes the secure context management system.
+ *
+ * PSP is set to NULL and therefore a task must allocate and load a context
+ * before calling any secure side function in the thread mode.
+ *
+ * @note This function must be called in the handler mode. It is no-op if called
+ * in the thread mode.
+ */
+void SecureContext_Init( void );
+
+/**
+ * @brief Allocates a context on the secure side.
+ *
+ * @note This function must be called in the handler mode. It is no-op if called
+ * in the thread mode.
+ *
+ * @param[in] ulSecureStackSize Size of the stack to allocate on secure side.
+ * @param[in] ulIsTaskPrivileged 1 if the calling task is privileged, 0 otherwise.
+ *
+ * @return Opaque context handle if context is successfully allocated, NULL
+ * otherwise.
+ */
+#if ( configENABLE_MPU == 1 )
+    SecureContextHandle_t SecureContext_AllocateContext( uint32_t ulSecureStackSize,
+                                                         uint32_t ulIsTaskPrivileged,
+                                                         void * pvTaskHandle );
+#else /* configENABLE_MPU */
+    SecureContextHandle_t SecureContext_AllocateContext( uint32_t ulSecureStackSize,
+                                                         void * pvTaskHandle );
+#endif /* configENABLE_MPU */
+
+/**
+ * @brief Frees the given context.
+ *
+ * @note This function must be called in the handler mode. It is no-op if called
+ * in the thread mode.
+ *
+ * @param[in] xSecureContextHandle Context handle corresponding to the
+ * context to be freed.
+ */
+void SecureContext_FreeContext( SecureContextHandle_t xSecureContextHandle, void * pvTaskHandle );
+
+/**
+ * @brief Loads the given context.
+ *
+ * @note This function must be called in the handler mode. It is no-op if called
+ * in the thread mode.
+ *
+ * @param[in] xSecureContextHandle Context handle corresponding to the context
+ * to be loaded.
+ */
+void SecureContext_LoadContext( SecureContextHandle_t xSecureContextHandle, void * pvTaskHandle );
+
+/**
+ * @brief Saves the given context.
+ *
+ * @note This function must be called in the handler mode. It is no-op if called
+ * in the thread mode.
+ *
+ * @param[in] xSecureContextHandle Context handle corresponding to the context
+ * to be saved.
+ */
+void SecureContext_SaveContext( SecureContextHandle_t xSecureContextHandle, void * pvTaskHandle );
+
+#endif /* __SECURE_CONTEXT_H__ */

--- a/portable/GCC/ARM_CM55/secure/secure_context_port.c
+++ b/portable/GCC/ARM_CM55/secure/secure_context_port.c
@@ -1,0 +1,97 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Secure context includes. */
+#include "secure_context.h"
+
+/* Secure port macros. */
+#include "secure_port_macros.h"
+
+void SecureContext_LoadContextAsm( SecureContext_t * pxSecureContext ) __attribute__( ( naked ) );
+void SecureContext_SaveContextAsm( SecureContext_t * pxSecureContext ) __attribute__( ( naked ) );
+
+void SecureContext_LoadContextAsm( SecureContext_t * pxSecureContext )
+{
+    /* pxSecureContext value is in r0. */
+    __asm volatile
+    (
+        " .syntax unified                   \n"
+        "                                   \n"
+        " mrs r1, ipsr                      \n" /* r1 = IPSR. */
+        " cbz r1, load_ctx_therad_mode      \n" /* Do nothing if the processor is running in the Thread Mode. */
+        " ldmia r0!, {r1, r2}               \n" /* r1 = pxSecureContext->pucCurrentStackPointer, r2 = pxSecureContext->pucStackLimit. */
+        "                                   \n"
+        #if ( configENABLE_MPU == 1 )
+            " ldmia r1!, {r3}               \n" /* Read CONTROL register value from task's stack. r3 = CONTROL. */
+            " msr control, r3               \n" /* CONTROL = r3. */
+        #endif /* configENABLE_MPU */
+        "                                   \n"
+        " msr psplim, r2                    \n" /* PSPLIM = r2. */
+        " msr psp, r1                       \n" /* PSP = r1. */
+        "                                   \n"
+        " load_ctx_therad_mode:             \n"
+        "    bx lr                          \n"
+        "                                   \n"
+        ::: "r0", "r1", "r2"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void SecureContext_SaveContextAsm( SecureContext_t * pxSecureContext )
+{
+    /* pxSecureContext value is in r0. */
+    __asm volatile
+    (
+        " .syntax unified                   \n"
+        "                                   \n"
+        " mrs r1, ipsr                      \n" /* r1 = IPSR. */
+        " cbz r1, save_ctx_therad_mode      \n" /* Do nothing if the processor is running in the Thread Mode. */
+        " mrs r1, psp                       \n" /* r1 = PSP. */
+        "                                   \n"
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            " vstmdb r1!, {s0}              \n" /* Trigger the defferred stacking of FPU registers. */
+            " vldmia r1!, {s0}              \n" /* Nullify the effect of the pervious statement. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        "                                   \n"
+        #if ( configENABLE_MPU == 1 )
+            " mrs r2, control               \n" /* r2 = CONTROL. */
+            " stmdb r1!, {r2}               \n" /* Store CONTROL value on the stack. */
+        #endif /* configENABLE_MPU */
+        "                                   \n"
+        " str r1, [r0]                      \n" /* Save the top of stack in context. pxSecureContext->pucCurrentStackPointer = r1. */
+        " movs r1, %0                       \n" /* r1 = securecontextNO_STACK. */
+        " msr psplim, r1                    \n" /* PSPLIM = securecontextNO_STACK. */
+        " msr psp, r1                       \n" /* PSP = securecontextNO_STACK i.e. No stack for thread mode until next task's context is loaded. */
+        "                                   \n"
+        " save_ctx_therad_mode:             \n"
+        "    bx lr                          \n"
+        "                                   \n"
+        ::"i" ( securecontextNO_STACK ) : "r1", "memory"
+    );
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM55/secure/secure_heap.c
@@ -1,0 +1,451 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+
+/* Secure context heap includes. */
+#include "secure_heap.h"
+
+/* Secure port macros. */
+#include "secure_port_macros.h"
+
+/**
+ * @brief Total heap size.
+ */
+#ifndef secureconfigTOTAL_HEAP_SIZE
+    #define secureconfigTOTAL_HEAP_SIZE    ( ( ( size_t ) ( 10 * 1024 ) ) )
+#endif
+
+/* No test marker by default. */
+#ifndef mtCOVERAGE_TEST_MARKER
+    #define mtCOVERAGE_TEST_MARKER()
+#endif
+
+/* No tracing by default. */
+#ifndef traceMALLOC
+    #define traceMALLOC( pvReturn, xWantedSize )
+#endif
+
+/* No tracing by default. */
+#ifndef traceFREE
+    #define traceFREE( pv, xBlockSize )
+#endif
+
+/* Block sizes must not get too small. */
+#define secureheapMINIMUM_BLOCK_SIZE    ( ( size_t ) ( xHeapStructSize << 1 ) )
+
+/* Assumes 8bit bytes! */
+#define secureheapBITS_PER_BYTE         ( ( size_t ) 8 )
+/*-----------------------------------------------------------*/
+
+/* Allocate the memory for the heap. */
+#if ( configAPPLICATION_ALLOCATED_HEAP == 1 )
+
+/* The application writer has already defined the array used for the RTOS
+* heap - probably so it can be placed in a special segment or address. */
+    extern uint8_t ucHeap[ secureconfigTOTAL_HEAP_SIZE ];
+#else /* configAPPLICATION_ALLOCATED_HEAP */
+    static uint8_t ucHeap[ secureconfigTOTAL_HEAP_SIZE ];
+#endif /* configAPPLICATION_ALLOCATED_HEAP */
+
+/**
+ * @brief The linked list structure.
+ *
+ * This is used to link free blocks in order of their memory address.
+ */
+typedef struct A_BLOCK_LINK
+{
+    struct A_BLOCK_LINK * pxNextFreeBlock; /**< The next free block in the list. */
+    size_t xBlockSize;                     /**< The size of the free block. */
+} BlockLink_t;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Called automatically to setup the required heap structures the first
+ * time pvPortMalloc() is called.
+ */
+static void prvHeapInit( void );
+
+/**
+ * @brief Inserts a block of memory that is being freed into the correct
+ * position in the list of free memory blocks.
+ *
+ * The block being freed will be merged with the block in front it and/or the
+ * block behind it if the memory blocks are adjacent to each other.
+ *
+ * @param[in] pxBlockToInsert The block being freed.
+ */
+static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert );
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The size of the structure placed at the beginning of each allocated
+ * memory block must by correctly byte aligned.
+ */
+static const size_t xHeapStructSize = ( sizeof( BlockLink_t ) + ( ( size_t ) ( secureportBYTE_ALIGNMENT - 1 ) ) ) & ~( ( size_t ) secureportBYTE_ALIGNMENT_MASK );
+
+/**
+ * @brief Create a couple of list links to mark the start and end of the list.
+ */
+static BlockLink_t xStart, * pxEnd = NULL;
+
+/**
+ * @brief Keeps track of the number of free bytes remaining, but says nothing
+ * about fragmentation.
+ */
+static size_t xFreeBytesRemaining = 0U;
+static size_t xMinimumEverFreeBytesRemaining = 0U;
+
+/**
+ * @brief Gets set to the top bit of an size_t type.
+ *
+ * When this bit in the xBlockSize member of an BlockLink_t structure is set
+ * then the block belongs to the application. When the bit is free the block is
+ * still part of the free heap space.
+ */
+static size_t xBlockAllocatedBit = 0;
+/*-----------------------------------------------------------*/
+
+static void prvHeapInit( void )
+{
+    BlockLink_t * pxFirstFreeBlock;
+    uint8_t * pucAlignedHeap;
+    size_t uxAddress;
+    size_t xTotalHeapSize = secureconfigTOTAL_HEAP_SIZE;
+
+    /* Ensure the heap starts on a correctly aligned boundary. */
+    uxAddress = ( size_t ) ucHeap;
+
+    if( ( uxAddress & secureportBYTE_ALIGNMENT_MASK ) != 0 )
+    {
+        uxAddress += ( secureportBYTE_ALIGNMENT - 1 );
+        uxAddress &= ~( ( size_t ) secureportBYTE_ALIGNMENT_MASK );
+        xTotalHeapSize -= uxAddress - ( size_t ) ucHeap;
+    }
+
+    pucAlignedHeap = ( uint8_t * ) uxAddress;
+
+    /* xStart is used to hold a pointer to the first item in the list of free
+     * blocks.  The void cast is used to prevent compiler warnings. */
+    xStart.pxNextFreeBlock = ( void * ) pucAlignedHeap;
+    xStart.xBlockSize = ( size_t ) 0;
+
+    /* pxEnd is used to mark the end of the list of free blocks and is inserted
+     * at the end of the heap space. */
+    uxAddress = ( ( size_t ) pucAlignedHeap ) + xTotalHeapSize;
+    uxAddress -= xHeapStructSize;
+    uxAddress &= ~( ( size_t ) secureportBYTE_ALIGNMENT_MASK );
+    pxEnd = ( void * ) uxAddress;
+    pxEnd->xBlockSize = 0;
+    pxEnd->pxNextFreeBlock = NULL;
+
+    /* To start with there is a single free block that is sized to take up the
+     * entire heap space, minus the space taken by pxEnd. */
+    pxFirstFreeBlock = ( void * ) pucAlignedHeap;
+    pxFirstFreeBlock->xBlockSize = uxAddress - ( size_t ) pxFirstFreeBlock;
+    pxFirstFreeBlock->pxNextFreeBlock = pxEnd;
+
+    /* Only one block exists - and it covers the entire usable heap space. */
+    xMinimumEverFreeBytesRemaining = pxFirstFreeBlock->xBlockSize;
+    xFreeBytesRemaining = pxFirstFreeBlock->xBlockSize;
+
+    /* Work out the position of the top bit in a size_t variable. */
+    xBlockAllocatedBit = ( ( size_t ) 1 ) << ( ( sizeof( size_t ) * secureheapBITS_PER_BYTE ) - 1 );
+}
+/*-----------------------------------------------------------*/
+
+static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert )
+{
+    BlockLink_t * pxIterator;
+    uint8_t * puc;
+
+    /* Iterate through the list until a block is found that has a higher address
+     * than the block being inserted. */
+    for( pxIterator = &xStart; pxIterator->pxNextFreeBlock < pxBlockToInsert; pxIterator = pxIterator->pxNextFreeBlock )
+    {
+        /* Nothing to do here, just iterate to the right position. */
+    }
+
+    /* Do the block being inserted, and the block it is being inserted after
+     * make a contiguous block of memory? */
+    puc = ( uint8_t * ) pxIterator;
+
+    if( ( puc + pxIterator->xBlockSize ) == ( uint8_t * ) pxBlockToInsert )
+    {
+        pxIterator->xBlockSize += pxBlockToInsert->xBlockSize;
+        pxBlockToInsert = pxIterator;
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
+
+    /* Do the block being inserted, and the block it is being inserted before
+     * make a contiguous block of memory? */
+    puc = ( uint8_t * ) pxBlockToInsert;
+
+    if( ( puc + pxBlockToInsert->xBlockSize ) == ( uint8_t * ) pxIterator->pxNextFreeBlock )
+    {
+        if( pxIterator->pxNextFreeBlock != pxEnd )
+        {
+            /* Form one big block from the two blocks. */
+            pxBlockToInsert->xBlockSize += pxIterator->pxNextFreeBlock->xBlockSize;
+            pxBlockToInsert->pxNextFreeBlock = pxIterator->pxNextFreeBlock->pxNextFreeBlock;
+        }
+        else
+        {
+            pxBlockToInsert->pxNextFreeBlock = pxEnd;
+        }
+    }
+    else
+    {
+        pxBlockToInsert->pxNextFreeBlock = pxIterator->pxNextFreeBlock;
+    }
+
+    /* If the block being inserted plugged a gab, so was merged with the block
+     * before and the block after, then it's pxNextFreeBlock pointer will have
+     * already been set, and should not be set here as that would make it point
+     * to itself. */
+    if( pxIterator != pxBlockToInsert )
+    {
+        pxIterator->pxNextFreeBlock = pxBlockToInsert;
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
+}
+/*-----------------------------------------------------------*/
+
+void * pvPortMalloc( size_t xWantedSize )
+{
+    BlockLink_t * pxBlock, * pxPreviousBlock, * pxNewBlockLink;
+    void * pvReturn = NULL;
+
+    /* If this is the first call to malloc then the heap will require
+     * initialisation to setup the list of free blocks. */
+    if( pxEnd == NULL )
+    {
+        prvHeapInit();
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
+
+    /* Check the requested block size is not so large that the top bit is set.
+     * The top bit of the block size member of the BlockLink_t structure is used
+     * to determine who owns the block - the application or the kernel, so it
+     * must be free. */
+    if( ( xWantedSize & xBlockAllocatedBit ) == 0 )
+    {
+        /* The wanted size is increased so it can contain a BlockLink_t
+         * structure in addition to the requested amount of bytes. */
+        if( xWantedSize > 0 )
+        {
+            xWantedSize += xHeapStructSize;
+
+            /* Ensure that blocks are always aligned to the required number of
+             * bytes. */
+            if( ( xWantedSize & secureportBYTE_ALIGNMENT_MASK ) != 0x00 )
+            {
+                /* Byte alignment required. */
+                xWantedSize += ( secureportBYTE_ALIGNMENT - ( xWantedSize & secureportBYTE_ALIGNMENT_MASK ) );
+                secureportASSERT( ( xWantedSize & secureportBYTE_ALIGNMENT_MASK ) == 0 );
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+
+        if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
+        {
+            /* Traverse the list from the start (lowest address) block until
+             * one of adequate size is found. */
+            pxPreviousBlock = &xStart;
+            pxBlock = xStart.pxNextFreeBlock;
+
+            while( ( pxBlock->xBlockSize < xWantedSize ) && ( pxBlock->pxNextFreeBlock != NULL ) )
+            {
+                pxPreviousBlock = pxBlock;
+                pxBlock = pxBlock->pxNextFreeBlock;
+            }
+
+            /* If the end marker was reached then a block of adequate size was
+             * not found. */
+            if( pxBlock != pxEnd )
+            {
+                /* Return the memory space pointed to - jumping over the
+                 * BlockLink_t structure at its start. */
+                pvReturn = ( void * ) ( ( ( uint8_t * ) pxPreviousBlock->pxNextFreeBlock ) + xHeapStructSize );
+
+                /* This block is being returned for use so must be taken out
+                 * of the list of free blocks. */
+                pxPreviousBlock->pxNextFreeBlock = pxBlock->pxNextFreeBlock;
+
+                /* If the block is larger than required it can be split into
+                 * two. */
+                if( ( pxBlock->xBlockSize - xWantedSize ) > secureheapMINIMUM_BLOCK_SIZE )
+                {
+                    /* This block is to be split into two.  Create a new
+                     * block following the number of bytes requested. The void
+                     * cast is used to prevent byte alignment warnings from the
+                     * compiler. */
+                    pxNewBlockLink = ( void * ) ( ( ( uint8_t * ) pxBlock ) + xWantedSize );
+                    secureportASSERT( ( ( ( size_t ) pxNewBlockLink ) & secureportBYTE_ALIGNMENT_MASK ) == 0 );
+
+                    /* Calculate the sizes of two blocks split from the single
+                     * block. */
+                    pxNewBlockLink->xBlockSize = pxBlock->xBlockSize - xWantedSize;
+                    pxBlock->xBlockSize = xWantedSize;
+
+                    /* Insert the new block into the list of free blocks. */
+                    prvInsertBlockIntoFreeList( pxNewBlockLink );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                xFreeBytesRemaining -= pxBlock->xBlockSize;
+
+                if( xFreeBytesRemaining < xMinimumEverFreeBytesRemaining )
+                {
+                    xMinimumEverFreeBytesRemaining = xFreeBytesRemaining;
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                /* The block is being returned - it is allocated and owned by
+                 * the application and has no "next" block. */
+                pxBlock->xBlockSize |= xBlockAllocatedBit;
+                pxBlock->pxNextFreeBlock = NULL;
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
+
+    traceMALLOC( pvReturn, xWantedSize );
+
+    #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
+        {
+            if( pvReturn == NULL )
+            {
+                extern void vApplicationMallocFailedHook( void );
+                vApplicationMallocFailedHook();
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+        }
+    #endif /* if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 ) */
+
+    secureportASSERT( ( ( ( size_t ) pvReturn ) & ( size_t ) secureportBYTE_ALIGNMENT_MASK ) == 0 );
+    return pvReturn;
+}
+/*-----------------------------------------------------------*/
+
+void vPortFree( void * pv )
+{
+    uint8_t * puc = ( uint8_t * ) pv;
+    BlockLink_t * pxLink;
+
+    if( pv != NULL )
+    {
+        /* The memory being freed will have an BlockLink_t structure immediately
+         * before it. */
+        puc -= xHeapStructSize;
+
+        /* This casting is to keep the compiler from issuing warnings. */
+        pxLink = ( void * ) puc;
+
+        /* Check the block is actually allocated. */
+        secureportASSERT( ( pxLink->xBlockSize & xBlockAllocatedBit ) != 0 );
+        secureportASSERT( pxLink->pxNextFreeBlock == NULL );
+
+        if( ( pxLink->xBlockSize & xBlockAllocatedBit ) != 0 )
+        {
+            if( pxLink->pxNextFreeBlock == NULL )
+            {
+                /* The block is being returned to the heap - it is no longer
+                 * allocated. */
+                pxLink->xBlockSize &= ~xBlockAllocatedBit;
+
+                secureportDISABLE_NON_SECURE_INTERRUPTS();
+                {
+                    /* Add this block to the list of free blocks. */
+                    xFreeBytesRemaining += pxLink->xBlockSize;
+                    traceFREE( pv, pxLink->xBlockSize );
+                    prvInsertBlockIntoFreeList( ( ( BlockLink_t * ) pxLink ) );
+                }
+                secureportENABLE_NON_SECURE_INTERRUPTS();
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+    }
+}
+/*-----------------------------------------------------------*/
+
+size_t xPortGetFreeHeapSize( void )
+{
+    return xFreeBytesRemaining;
+}
+/*-----------------------------------------------------------*/
+
+size_t xPortGetMinimumEverFreeHeapSize( void )
+{
+    return xMinimumEverFreeBytesRemaining;
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/secure/secure_heap.h
+++ b/portable/GCC/ARM_CM55/secure/secure_heap.h
@@ -1,0 +1,66 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef __SECURE_HEAP_H__
+#define __SECURE_HEAP_H__
+
+/* Standard includes. */
+#include <stdlib.h>
+
+/**
+ * @brief Allocates memory from heap.
+ *
+ * @param[in] xWantedSize The size of the memory to be allocated.
+ *
+ * @return Pointer to the memory region if the allocation is successful, NULL
+ * otherwise.
+ */
+void * pvPortMalloc( size_t xWantedSize );
+
+/**
+ * @brief Frees the previously allocated memory.
+ *
+ * @param[in] pv Pointer to the memory to be freed.
+ */
+void vPortFree( void * pv );
+
+/**
+ * @brief Get the free heap size.
+ *
+ * @return Free heap size.
+ */
+size_t xPortGetFreeHeapSize( void );
+
+/**
+ * @brief Get the minimum ever free heap size.
+ *
+ * @return Minimum ever free heap size.
+ */
+size_t xPortGetMinimumEverFreeHeapSize( void );
+
+#endif /* __SECURE_HEAP_H__ */

--- a/portable/GCC/ARM_CM55/secure/secure_init.c
+++ b/portable/GCC/ARM_CM55/secure/secure_init.c
@@ -1,0 +1,106 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+
+/* Secure init includes. */
+#include "secure_init.h"
+
+/* Secure port macros. */
+#include "secure_port_macros.h"
+
+/**
+ * @brief Constants required to manipulate the SCB.
+ */
+#define secureinitSCB_AIRCR                 ( ( volatile uint32_t * ) 0xe000ed0c )  /* Application Interrupt and Reset Control Register. */
+#define secureinitSCB_AIRCR_VECTKEY_POS     ( 16UL )
+#define secureinitSCB_AIRCR_VECTKEY_MASK    ( 0xFFFFUL << secureinitSCB_AIRCR_VECTKEY_POS )
+#define secureinitSCB_AIRCR_PRIS_POS        ( 14UL )
+#define secureinitSCB_AIRCR_PRIS_MASK       ( 1UL << secureinitSCB_AIRCR_PRIS_POS )
+
+/**
+ * @brief Constants required to manipulate the FPU.
+ */
+#define secureinitFPCCR                     ( ( volatile uint32_t * ) 0xe000ef34 )  /* Floating Point Context Control Register. */
+#define secureinitFPCCR_LSPENS_POS          ( 29UL )
+#define secureinitFPCCR_LSPENS_MASK         ( 1UL << secureinitFPCCR_LSPENS_POS )
+#define secureinitFPCCR_TS_POS              ( 26UL )
+#define secureinitFPCCR_TS_MASK             ( 1UL << secureinitFPCCR_TS_POS )
+
+#define secureinitNSACR                     ( ( volatile uint32_t * ) 0xe000ed8c )  /* Non-secure Access Control Register. */
+#define secureinitNSACR_CP10_POS            ( 10UL )
+#define secureinitNSACR_CP10_MASK           ( 1UL << secureinitNSACR_CP10_POS )
+#define secureinitNSACR_CP11_POS            ( 11UL )
+#define secureinitNSACR_CP11_MASK           ( 1UL << secureinitNSACR_CP11_POS )
+/*-----------------------------------------------------------*/
+
+secureportNON_SECURE_CALLABLE void SecureInit_DePrioritizeNSExceptions( void )
+{
+    uint32_t ulIPSR;
+
+    /* Read the Interrupt Program Status Register (IPSR) value. */
+    secureportREAD_IPSR( ulIPSR );
+
+    /* Do nothing if the processor is running in the Thread Mode. IPSR is zero
+     * when the processor is running in the Thread Mode. */
+    if( ulIPSR != 0 )
+    {
+        *( secureinitSCB_AIRCR ) = ( *( secureinitSCB_AIRCR ) & ~( secureinitSCB_AIRCR_VECTKEY_MASK | secureinitSCB_AIRCR_PRIS_MASK ) ) |
+                                   ( ( 0x05FAUL << secureinitSCB_AIRCR_VECTKEY_POS ) & secureinitSCB_AIRCR_VECTKEY_MASK ) |
+                                   ( ( 0x1UL << secureinitSCB_AIRCR_PRIS_POS ) & secureinitSCB_AIRCR_PRIS_MASK );
+    }
+}
+/*-----------------------------------------------------------*/
+
+secureportNON_SECURE_CALLABLE void SecureInit_EnableNSFPUAccess( void )
+{
+    uint32_t ulIPSR;
+
+    /* Read the Interrupt Program Status Register (IPSR) value. */
+    secureportREAD_IPSR( ulIPSR );
+
+    /* Do nothing if the processor is running in the Thread Mode. IPSR is zero
+     * when the processor is running in the Thread Mode. */
+    if( ulIPSR != 0 )
+    {
+        /* CP10 = 1 ==> Non-secure access to the Floating Point Unit is
+         * permitted. CP11 should be programmed to the same value as CP10. */
+        *( secureinitNSACR ) |= ( secureinitNSACR_CP10_MASK | secureinitNSACR_CP11_MASK );
+
+        /* LSPENS = 0 ==> LSPEN is writable fron non-secure state. This ensures
+         * that we can enable/disable lazy stacking in port.c file. */
+        *( secureinitFPCCR ) &= ~( secureinitFPCCR_LSPENS_MASK );
+
+        /* TS = 1 ==> Treat FP registers as secure i.e. callee saved FP
+         * registers (S16-S31) are also pushed to stack on exception entry and
+         * restored on exception return. */
+        *( secureinitFPCCR ) |= ( secureinitFPCCR_TS_MASK );
+    }
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/secure/secure_init.h
+++ b/portable/GCC/ARM_CM55/secure/secure_init.h
@@ -1,0 +1,54 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef __SECURE_INIT_H__
+#define __SECURE_INIT_H__
+
+/**
+ * @brief De-prioritizes the non-secure exceptions.
+ *
+ * This is needed to ensure that the non-secure PendSV runs at the lowest
+ * priority. Context switch is done in the non-secure PendSV handler.
+ *
+ * @note This function must be called in the handler mode. It is no-op if called
+ * in the thread mode.
+ */
+void SecureInit_DePrioritizeNSExceptions( void );
+
+/**
+ * @brief Sets up the Floating Point Unit (FPU) for Non-Secure access.
+ *
+ * Also sets FPCCR.TS=1 to ensure that the content of the Floating Point
+ * Registers are not leaked to the non-secure side.
+ *
+ * @note This function must be called in the handler mode. It is no-op if called
+ * in the thread mode.
+ */
+void SecureInit_EnableNSFPUAccess( void );
+
+#endif /* __SECURE_INIT_H__ */

--- a/portable/GCC/ARM_CM55/secure/secure_port_macros.h
+++ b/portable/GCC/ARM_CM55/secure/secure_port_macros.h
@@ -1,0 +1,140 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef __SECURE_PORT_MACROS_H__
+#define __SECURE_PORT_MACROS_H__
+
+/**
+ * @brief Byte alignment requirements.
+ */
+#define secureportBYTE_ALIGNMENT         8
+#define secureportBYTE_ALIGNMENT_MASK    ( 0x0007 )
+
+/**
+ * @brief Macro to declare a function as non-secure callable.
+ */
+#if defined( __IAR_SYSTEMS_ICC__ )
+    #define secureportNON_SECURE_CALLABLE    __cmse_nonsecure_entry __root
+#else
+    #define secureportNON_SECURE_CALLABLE    __attribute__( ( cmse_nonsecure_entry ) ) __attribute__( ( used ) )
+#endif
+
+/**
+ * @brief Set the secure PRIMASK value.
+ */
+#define secureportSET_SECURE_PRIMASK( ulPrimaskValue ) \
+    __asm volatile ( "msr primask, %0" : : "r" ( ulPrimaskValue ) : "memory" )
+
+/**
+ * @brief Set the non-secure PRIMASK value.
+ */
+#define secureportSET_NON_SECURE_PRIMASK( ulPrimaskValue ) \
+    __asm volatile ( "msr primask_ns, %0" : : "r" ( ulPrimaskValue ) : "memory" )
+
+/**
+ * @brief Read the PSP value in the given variable.
+ */
+#define secureportREAD_PSP( pucOutCurrentStackPointer ) \
+    __asm volatile ( "mrs %0, psp"  : "=r" ( pucOutCurrentStackPointer ) )
+
+/**
+ * @brief Set the PSP to the given value.
+ */
+#define secureportSET_PSP( pucCurrentStackPointer ) \
+    __asm volatile ( "msr psp, %0" : : "r" ( pucCurrentStackPointer ) )
+
+/**
+ * @brief Read the PSPLIM value in the given variable.
+ */
+#define secureportREAD_PSPLIM( pucOutStackLimit ) \
+    __asm volatile ( "mrs %0, psplim"  : "=r" ( pucOutStackLimit ) )
+
+/**
+ * @brief Set the PSPLIM to the given value.
+ */
+#define secureportSET_PSPLIM( pucStackLimit ) \
+    __asm volatile ( "msr psplim, %0" : : "r" ( pucStackLimit ) )
+
+/**
+ * @brief Set the NonSecure MSP to the given value.
+ */
+#define secureportSET_MSP_NS( pucMainStackPointer ) \
+    __asm volatile ( "msr msp_ns, %0" : : "r" ( pucMainStackPointer ) )
+
+/**
+ * @brief Set the CONTROL register to the given value.
+ */
+#define secureportSET_CONTROL( ulControl ) \
+    __asm volatile ( "msr control, %0" : : "r" ( ulControl ) : "memory" )
+
+/**
+ * @brief Read the Interrupt Program Status Register (IPSR) value in the given
+ * variable.
+ */
+#define secureportREAD_IPSR( ulIPSR ) \
+    __asm volatile ( "mrs %0, ipsr"  : "=r" ( ulIPSR ) )
+
+/**
+ * @brief PRIMASK value to enable interrupts.
+ */
+#define secureportPRIMASK_ENABLE_INTERRUPTS_VAL     0
+
+/**
+ * @brief PRIMASK value to disable interrupts.
+ */
+#define secureportPRIMASK_DISABLE_INTERRUPTS_VAL    1
+
+/**
+ * @brief Disable secure interrupts.
+ */
+#define secureportDISABLE_SECURE_INTERRUPTS()        secureportSET_SECURE_PRIMASK( secureportPRIMASK_DISABLE_INTERRUPTS_VAL )
+
+/**
+ * @brief Disable non-secure interrupts.
+ *
+ * This effectively disables context switches.
+ */
+#define secureportDISABLE_NON_SECURE_INTERRUPTS()    secureportSET_NON_SECURE_PRIMASK( secureportPRIMASK_DISABLE_INTERRUPTS_VAL )
+
+/**
+ * @brief Enable non-secure interrupts.
+ */
+#define secureportENABLE_NON_SECURE_INTERRUPTS()     secureportSET_NON_SECURE_PRIMASK( secureportPRIMASK_ENABLE_INTERRUPTS_VAL )
+
+/**
+ * @brief Assert definition.
+ */
+#define secureportASSERT( x )                      \
+    if( ( x ) == 0 )                               \
+    {                                              \
+        secureportDISABLE_SECURE_INTERRUPTS();     \
+        secureportDISABLE_NON_SECURE_INTERRUPTS(); \
+        for( ; ; ) {; }                            \
+    }
+
+#endif /* __SECURE_PORT_MACROS_H__ */

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -1,0 +1,1203 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE prevents task.h from redefining
+ * all the API functions to use the MPU wrappers. That should only be done when
+ * task.h is included from an application file. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* MPU wrappers includes. */
+#include "mpu_wrappers.h"
+
+/* Portasm includes. */
+#include "portasm.h"
+
+#if ( configENABLE_TRUSTZONE == 1 )
+    /* Secure components includes. */
+    #include "secure_context.h"
+    #include "secure_init.h"
+#endif /* configENABLE_TRUSTZONE */
+
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/**
+ * The FreeRTOS Cortex M33 port can be configured to run on the Secure Side only
+ * i.e. the processor boots as secure and never jumps to the non-secure side.
+ * The Trust Zone support in the port must be disabled in order to run FreeRTOS
+ * on the secure side. The following are the valid configuration seetings:
+ *
+ * 1. Run FreeRTOS on the Secure Side:
+ *    configRUN_FREERTOS_SECURE_ONLY = 1 and configENABLE_TRUSTZONE = 0
+ *
+ * 2. Run FreeRTOS on the Non-Secure Side with Secure Side function call support:
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 1
+ *
+ * 3. Run FreeRTOS on the Non-Secure Side only i.e. no Secure Side function call support:
+ *    configRUN_FREERTOS_SECURE_ONLY = 0 and configENABLE_TRUSTZONE = 0
+ */
+#if ( ( configRUN_FREERTOS_SECURE_ONLY == 1 ) && ( configENABLE_TRUSTZONE == 1 ) )
+    #error TrustZone needs to be disabled in order to run FreeRTOS on the Secure Side.
+#endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the NVIC.
+ */
+#define portNVIC_SYSTICK_CTRL_REG             ( *( ( volatile uint32_t * ) 0xe000e010 ) )
+#define portNVIC_SYSTICK_LOAD_REG             ( *( ( volatile uint32_t * ) 0xe000e014 ) )
+#define portNVIC_SYSTICK_CURRENT_VALUE_REG    ( *( ( volatile uint32_t * ) 0xe000e018 ) )
+#define portNVIC_SHPR3_REG                    ( *( ( volatile uint32_t * ) 0xe000ed20 ) )
+#define portNVIC_SYSTICK_ENABLE_BIT           ( 1UL << 0UL )
+#define portNVIC_SYSTICK_INT_BIT              ( 1UL << 1UL )
+#define portNVIC_SYSTICK_COUNT_FLAG_BIT       ( 1UL << 16UL )
+#define portMIN_INTERRUPT_PRIORITY            ( 255UL )
+#define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
+#define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#ifndef configSYSTICK_CLOCK_HZ
+    #define configSYSTICK_CLOCK_HZ            configCPU_CLOCK_HZ
+    /* Ensure the SysTick is clocked at the same frequency as the core. */
+    #define portNVIC_SYSTICK_CLK_BIT          ( 1UL << 2UL )
+#else
+
+/* The way the SysTick is clocked is not modified in case it is not the
+ * same a the core. */
+    #define portNVIC_SYSTICK_CLK_BIT    ( 0 )
+#endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the SCB.
+ */
+#define portSCB_SYS_HANDLER_CTRL_STATE_REG    ( *( volatile uint32_t * ) 0xe000ed24 )
+#define portSCB_MEM_FAULT_ENABLE_BIT          ( 1UL << 16UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the FPU.
+ */
+#define portCPACR               ( ( volatile uint32_t * ) 0xe000ed88 )              /* Coprocessor Access Control Register. */
+#define portCPACR_CP10_VALUE    ( 3UL )
+#define portCPACR_CP11_VALUE    portCPACR_CP10_VALUE
+#define portCPACR_CP10_POS      ( 20UL )
+#define portCPACR_CP11_POS      ( 22UL )
+
+#define portFPCCR               ( ( volatile uint32_t * ) 0xe000ef34 )              /* Floating Point Context Control Register. */
+#define portFPCCR_ASPEN_POS     ( 31UL )
+#define portFPCCR_ASPEN_MASK    ( 1UL << portFPCCR_ASPEN_POS )
+#define portFPCCR_LSPEN_POS     ( 30UL )
+#define portFPCCR_LSPEN_MASK    ( 1UL << portFPCCR_LSPEN_POS )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to manipulate the MPU.
+ */
+#define portMPU_TYPE_REG                      ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                      ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                       ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+
+#define portMPU_RBAR_REG                      ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                      ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+
+#define portMPU_RBAR_A1_REG                   ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                   ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+
+#define portMPU_RBAR_A2_REG                   ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                   ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+
+#define portMPU_RBAR_A3_REG                   ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                   ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+
+#define portMPU_MAIR0_REG                     ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                     ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+
+#define portMPU_RBAR_ADDRESS_MASK             ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK             ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+
+#define portMPU_MAIR_ATTR0_POS                ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK               ( 0x000000ff )
+
+#define portMPU_MAIR_ATTR1_POS                ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK               ( 0x0000ff00 )
+
+#define portMPU_MAIR_ATTR2_POS                ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK               ( 0x00ff0000 )
+
+#define portMPU_MAIR_ATTR3_POS                ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK               ( 0xff000000 )
+
+#define portMPU_MAIR_ATTR4_POS                ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK               ( 0x000000ff )
+
+#define portMPU_MAIR_ATTR5_POS                ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK               ( 0x0000ff00 )
+
+#define portMPU_MAIR_ATTR6_POS                ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK               ( 0x00ff0000 )
+
+#define portMPU_MAIR_ATTR7_POS                ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK               ( 0xff000000 )
+
+#define portMPU_RLAR_ATTR_INDEX0              ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1              ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2              ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3              ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4              ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5              ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6              ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7              ( 7UL << 1UL )
+
+#define portMPU_RLAR_REGION_ENABLE            ( 1UL )
+
+/* Enable privileged access to unmapped region. */
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT    ( 1UL << 2UL )
+
+/* Enable MPU. */
+#define portMPU_ENABLE_BIT                    ( 1UL << 0UL )
+
+/* Expected value of the portMPU_TYPE register. */
+#define portEXPECTED_MPU_TYPE_VALUE           ( configTOTAL_MPU_REGIONS << 8UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The maximum 24-bit number.
+ *
+ * It is needed because the systick is a 24-bit counter.
+ */
+#define portMAX_24_BIT_NUMBER       ( 0xffffffUL )
+
+/**
+ * @brief A fiddle factor to estimate the number of SysTick counts that would
+ * have occurred while the SysTick counter is stopped during tickless idle
+ * calculations.
+ */
+#define portMISSED_COUNTS_FACTOR    ( 45UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Constants required to set up the initial stack.
+ */
+#define portINITIAL_XPSR    ( 0x01000000 )
+
+#if ( configRUN_FREERTOS_SECURE_ONLY == 1 )
+
+/**
+ * @brief Initial EXC_RETURN value.
+ *
+ *     FF         FF         FF         FD
+ * 1111 1111  1111 1111  1111 1111  1111 1101
+ *
+ * Bit[6] - 1 --> The exception was taken from the Secure state.
+ * Bit[5] - 1 --> Do not skip stacking of additional state context.
+ * Bit[4] - 1 --> The PE did not allocate space on the stack for FP context.
+ * Bit[3] - 1 --> Return to the Thread mode.
+ * Bit[2] - 1 --> Restore registers from the process stack.
+ * Bit[1] - 0 --> Reserved, 0.
+ * Bit[0] - 1 --> The exception was taken to the Secure state.
+ */
+    #define portINITIAL_EXC_RETURN    ( 0xfffffffd )
+#else
+
+/**
+ * @brief Initial EXC_RETURN value.
+ *
+ *     FF         FF         FF         BC
+ * 1111 1111  1111 1111  1111 1111  1011 1100
+ *
+ * Bit[6] - 0 --> The exception was taken from the Non-Secure state.
+ * Bit[5] - 1 --> Do not skip stacking of additional state context.
+ * Bit[4] - 1 --> The PE did not allocate space on the stack for FP context.
+ * Bit[3] - 1 --> Return to the Thread mode.
+ * Bit[2] - 1 --> Restore registers from the process stack.
+ * Bit[1] - 0 --> Reserved, 0.
+ * Bit[0] - 0 --> The exception was taken to the Non-Secure state.
+ */
+    #define portINITIAL_EXC_RETURN    ( 0xffffffbc )
+#endif /* configRUN_FREERTOS_SECURE_ONLY */
+
+/**
+ * @brief CONTROL register privileged bit mask.
+ *
+ * Bit[0] in CONTROL register tells the privilege:
+ *  Bit[0] = 0 ==> The task is privileged.
+ *  Bit[0] = 1 ==> The task is not privileged.
+ */
+#define portCONTROL_PRIVILEGED_MASK         ( 1UL << 0UL )
+
+/**
+ * @brief Initial CONTROL register values.
+ */
+#define portINITIAL_CONTROL_UNPRIVILEGED    ( 0x3 )
+#define portINITIAL_CONTROL_PRIVILEGED      ( 0x2 )
+
+/**
+ * @brief Let the user override the pre-loading of the initial LR with the
+ * address of prvTaskExitError() in case it messes up unwinding of the stack
+ * in the debugger.
+ */
+#ifdef configTASK_RETURN_ADDRESS
+    #define portTASK_RETURN_ADDRESS    configTASK_RETURN_ADDRESS
+#else
+    #define portTASK_RETURN_ADDRESS    prvTaskExitError
+#endif
+
+/**
+ * @brief If portPRELOAD_REGISTERS then registers will be given an initial value
+ * when a task is created. This helps in debugging at the cost of code size.
+ */
+#define portPRELOAD_REGISTERS    1
+
+/**
+ * @brief A task is created without a secure context, and must call
+ * portALLOCATE_SECURE_CONTEXT() to give itself a secure context before it makes
+ * any secure calls.
+ */
+#define portNO_SECURE_CONTEXT    0
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Used to catch tasks that attempt to return from their implementing
+ * function.
+ */
+static void prvTaskExitError( void );
+
+#if ( configENABLE_MPU == 1 )
+
+/**
+ * @brief Setup the Memory Protection Unit (MPU).
+ */
+    static void prvSetupMPU( void ) PRIVILEGED_FUNCTION;
+#endif /* configENABLE_MPU */
+
+#if ( configENABLE_FPU == 1 )
+
+/**
+ * @brief Setup the Floating Point Unit (FPU).
+ */
+    static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
+#endif /* configENABLE_FPU */
+
+/**
+ * @brief Setup the timer to generate the tick interrupts.
+ *
+ * The implementation in this file is weak to allow application writers to
+ * change the timer used to generate the tick interrupt.
+ */
+void vPortSetupTimerInterrupt( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether the current execution context is interrupt.
+ *
+ * @return pdTRUE if the current execution context is interrupt, pdFALSE
+ * otherwise.
+ */
+BaseType_t xPortIsInsideInterrupt( void );
+
+/**
+ * @brief Yield the processor.
+ */
+void vPortYield( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Enter critical section.
+ */
+void vPortEnterCritical( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Exit from critical section.
+ */
+void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief SysTick handler.
+ */
+void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief C part of SVC handler.
+ */
+portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIVILEGED_FUNCTION;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Each task maintains its own interrupt status in the critical nesting
+ * variable.
+ */
+PRIVILEGED_DATA static volatile uint32_t ulCriticalNesting = 0xaaaaaaaaUL;
+
+#if ( configENABLE_TRUSTZONE == 1 )
+
+/**
+ * @brief Saved as part of the task context to indicate which context the
+ * task is using on the secure side.
+ */
+    PRIVILEGED_DATA portDONT_DISCARD volatile SecureContextHandle_t xSecureContext = portNO_SECURE_CONTEXT;
+#endif /* configENABLE_TRUSTZONE */
+
+#if ( configUSE_TICKLESS_IDLE == 1 )
+
+/**
+ * @brief The number of SysTick increments that make up one tick period.
+ */
+    PRIVILEGED_DATA static uint32_t ulTimerCountsForOneTick = 0;
+
+/**
+ * @brief The maximum number of tick periods that can be suppressed is
+ * limited by the 24 bit resolution of the SysTick timer.
+ */
+    PRIVILEGED_DATA static uint32_t xMaximumPossibleSuppressedTicks = 0;
+
+/**
+ * @brief Compensate for the CPU cycles that pass while the SysTick is
+ * stopped (low power functionality only).
+ */
+    PRIVILEGED_DATA static uint32_t ulStoppedTimerCompensation = 0;
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TICKLESS_IDLE == 1 )
+    __attribute__( ( weak ) ) void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
+    {
+        uint32_t ulReloadValue, ulCompleteTickPeriods, ulCompletedSysTickDecrements;
+        TickType_t xModifiableIdleTime;
+
+        /* Make sure the SysTick reload value does not overflow the counter. */
+        if( xExpectedIdleTime > xMaximumPossibleSuppressedTicks )
+        {
+            xExpectedIdleTime = xMaximumPossibleSuppressedTicks;
+        }
+
+        /* Stop the SysTick momentarily. The time the SysTick is stopped for is
+         * accounted for as best it can be, but using the tickless mode will
+         * inevitably result in some tiny drift of the time maintained by the
+         * kernel with respect to calendar time. */
+        portNVIC_SYSTICK_CTRL_REG &= ~portNVIC_SYSTICK_ENABLE_BIT;
+
+        /* Calculate the reload value required to wait xExpectedIdleTime
+         * tick periods. -1 is used because this code will execute part way
+         * through one of the tick periods. */
+        ulReloadValue = portNVIC_SYSTICK_CURRENT_VALUE_REG + ( ulTimerCountsForOneTick * ( xExpectedIdleTime - 1UL ) );
+
+        if( ulReloadValue > ulStoppedTimerCompensation )
+        {
+            ulReloadValue -= ulStoppedTimerCompensation;
+        }
+
+        /* Enter a critical section but don't use the taskENTER_CRITICAL()
+         * method as that will mask interrupts that should exit sleep mode. */
+        __asm volatile ( "cpsid i" ::: "memory" );
+        __asm volatile ( "dsb" );
+        __asm volatile ( "isb" );
+
+        /* If a context switch is pending or a task is waiting for the scheduler
+         * to be un-suspended then abandon the low power entry. */
+        if( eTaskConfirmSleepModeStatus() == eAbortSleep )
+        {
+            /* Restart from whatever is left in the count register to complete
+             * this tick period. */
+            portNVIC_SYSTICK_LOAD_REG = portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+            /* Restart SysTick. */
+            portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+            /* Reset the reload register to the value required for normal tick
+             * periods. */
+            portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+            /* Re-enable interrupts - see comments above the cpsid instruction()
+             * above. */
+            __asm volatile ( "cpsie i" ::: "memory" );
+        }
+        else
+        {
+            /* Set the new reload value. */
+            portNVIC_SYSTICK_LOAD_REG = ulReloadValue;
+
+            /* Clear the SysTick count flag and set the count value back to
+             * zero. */
+            portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+            /* Restart SysTick. */
+            portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+
+            /* Sleep until something happens. configPRE_SLEEP_PROCESSING() can
+             * set its parameter to 0 to indicate that its implementation
+             * contains its own wait for interrupt or wait for event
+             * instruction, and so wfi should not be executed again. However,
+             * the original expected idle time variable must remain unmodified,
+             * so a copy is taken. */
+            xModifiableIdleTime = xExpectedIdleTime;
+            configPRE_SLEEP_PROCESSING( xModifiableIdleTime );
+
+            if( xModifiableIdleTime > 0 )
+            {
+                __asm volatile ( "dsb" ::: "memory" );
+                __asm volatile ( "wfi" );
+                __asm volatile ( "isb" );
+            }
+
+            configPOST_SLEEP_PROCESSING( xExpectedIdleTime );
+
+            /* Re-enable interrupts to allow the interrupt that brought the MCU
+             * out of sleep mode to execute immediately. See comments above
+             * the cpsid instruction above. */
+            __asm volatile ( "cpsie i" ::: "memory" );
+            __asm volatile ( "dsb" );
+            __asm volatile ( "isb" );
+
+            /* Disable interrupts again because the clock is about to be stopped
+             * and interrupts that execute while the clock is stopped will
+             * increase any slippage between the time maintained by the RTOS and
+             * calendar time. */
+            __asm volatile ( "cpsid i" ::: "memory" );
+            __asm volatile ( "dsb" );
+            __asm volatile ( "isb" );
+
+            /* Disable the SysTick clock without reading the
+             * portNVIC_SYSTICK_CTRL_REG register to ensure the
+             * portNVIC_SYSTICK_COUNT_FLAG_BIT is not cleared if it is set.
+             * Again, the time the SysTick is stopped for is accounted for as
+             * best it can be, but using the tickless mode will inevitably
+             * result in some tiny drift of the time maintained by the kernel
+             * with respect to calendar time*/
+            portNVIC_SYSTICK_CTRL_REG = ( portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT );
+
+            /* Determine if the SysTick clock has already counted to zero and
+             * been set back to the current reload value (the reload back being
+             * correct for the entire expected idle time) or if the SysTick is
+             * yet to count to zero (in which case an interrupt other than the
+             * SysTick must have brought the system out of sleep mode). */
+            if( ( portNVIC_SYSTICK_CTRL_REG & portNVIC_SYSTICK_COUNT_FLAG_BIT ) != 0 )
+            {
+                uint32_t ulCalculatedLoadValue;
+
+                /* The tick interrupt is already pending, and the SysTick count
+                 * reloaded with ulReloadValue.  Reset the
+                 * portNVIC_SYSTICK_LOAD_REG with whatever remains of this tick
+                 * period. */
+                ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL ) - ( ulReloadValue - portNVIC_SYSTICK_CURRENT_VALUE_REG );
+
+                /* Don't allow a tiny value, or values that have somehow
+                 * underflowed because the post sleep hook did something
+                 * that took too long. */
+                if( ( ulCalculatedLoadValue < ulStoppedTimerCompensation ) || ( ulCalculatedLoadValue > ulTimerCountsForOneTick ) )
+                {
+                    ulCalculatedLoadValue = ( ulTimerCountsForOneTick - 1UL );
+                }
+
+                portNVIC_SYSTICK_LOAD_REG = ulCalculatedLoadValue;
+
+                /* As the pending tick will be processed as soon as this
+                 * function exits, the tick value maintained by the tick is
+                 * stepped forward by one less than the time spent waiting. */
+                ulCompleteTickPeriods = xExpectedIdleTime - 1UL;
+            }
+            else
+            {
+                /* Something other than the tick interrupt ended the sleep.
+                 * Work out how long the sleep lasted rounded to complete tick
+                 * periods (not the ulReload value which accounted for part
+                 * ticks). */
+                ulCompletedSysTickDecrements = ( xExpectedIdleTime * ulTimerCountsForOneTick ) - portNVIC_SYSTICK_CURRENT_VALUE_REG;
+
+                /* How many complete tick periods passed while the processor
+                 * was waiting? */
+                ulCompleteTickPeriods = ulCompletedSysTickDecrements / ulTimerCountsForOneTick;
+
+                /* The reload value is set to whatever fraction of a single tick
+                 * period remains. */
+                portNVIC_SYSTICK_LOAD_REG = ( ( ulCompleteTickPeriods + 1UL ) * ulTimerCountsForOneTick ) - ulCompletedSysTickDecrements;
+            }
+
+            /* Restart SysTick so it runs from portNVIC_SYSTICK_LOAD_REG
+             * again, then set portNVIC_SYSTICK_LOAD_REG back to its standard
+             * value. */
+            portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+            portNVIC_SYSTICK_CTRL_REG |= portNVIC_SYSTICK_ENABLE_BIT;
+            vTaskStepTick( ulCompleteTickPeriods );
+            portNVIC_SYSTICK_LOAD_REG = ulTimerCountsForOneTick - 1UL;
+
+            /* Exit with interrupts enabled. */
+            __asm volatile ( "cpsie i" ::: "memory" );
+        }
+    }
+#endif /* configUSE_TICKLESS_IDLE */
+/*-----------------------------------------------------------*/
+
+__attribute__( ( weak ) ) void vPortSetupTimerInterrupt( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Calculate the constants required to configure the tick interrupt. */
+    #if ( configUSE_TICKLESS_IDLE == 1 )
+        {
+            ulTimerCountsForOneTick = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ );
+            xMaximumPossibleSuppressedTicks = portMAX_24_BIT_NUMBER / ulTimerCountsForOneTick;
+            ulStoppedTimerCompensation = portMISSED_COUNTS_FACTOR / ( configCPU_CLOCK_HZ / configSYSTICK_CLOCK_HZ );
+        }
+    #endif /* configUSE_TICKLESS_IDLE */
+
+    /* Stop and reset the SysTick. */
+    portNVIC_SYSTICK_CTRL_REG = 0UL;
+    portNVIC_SYSTICK_CURRENT_VALUE_REG = 0UL;
+
+    /* Configure SysTick to interrupt at the requested rate. */
+    portNVIC_SYSTICK_LOAD_REG = ( configSYSTICK_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+    portNVIC_SYSTICK_CTRL_REG = portNVIC_SYSTICK_CLK_BIT | portNVIC_SYSTICK_INT_BIT | portNVIC_SYSTICK_ENABLE_BIT;
+}
+/*-----------------------------------------------------------*/
+
+static void prvTaskExitError( void )
+{
+    volatile uint32_t ulDummy = 0UL;
+
+    /* A function that implements a task must not exit or attempt to return to
+     * its caller as there is nothing to return to. If a task wants to exit it
+     * should instead call vTaskDelete( NULL ). Artificially force an assert()
+     * to be triggered if configASSERT() is defined, then stop here so
+     * application writers can catch the error. */
+    configASSERT( ulCriticalNesting == ~0UL );
+    portDISABLE_INTERRUPTS();
+
+    while( ulDummy == 0 )
+    {
+        /* This file calls prvTaskExitError() after the scheduler has been
+         * started to remove a compiler warning about the function being
+         * defined but never called.  ulDummy is used purely to quieten other
+         * warnings about code appearing after this function is called - making
+         * ulDummy volatile makes the compiler think the function could return
+         * and therefore not output an 'unreachable code' warning for code that
+         * appears after it. */
+    }
+}
+/*-----------------------------------------------------------*/
+
+#if ( configENABLE_MPU == 1 )
+    static void prvSetupMPU( void ) /* PRIVILEGED_FUNCTION */
+    {
+        #if defined( __ARMCC_VERSION )
+
+            /* Declaration when these variable are defined in code instead of being
+             * exported from linker scripts. */
+            extern uint32_t * __privileged_functions_start__;
+            extern uint32_t * __privileged_functions_end__;
+            extern uint32_t * __syscalls_flash_start__;
+            extern uint32_t * __syscalls_flash_end__;
+            extern uint32_t * __unprivileged_flash_start__;
+            extern uint32_t * __unprivileged_flash_end__;
+            extern uint32_t * __privileged_sram_start__;
+            extern uint32_t * __privileged_sram_end__;
+        #else /* if defined( __ARMCC_VERSION ) */
+            /* Declaration when these variable are exported from linker scripts. */
+            extern uint32_t __privileged_functions_start__[];
+            extern uint32_t __privileged_functions_end__[];
+            extern uint32_t __syscalls_flash_start__[];
+            extern uint32_t __syscalls_flash_end__[];
+            extern uint32_t __unprivileged_flash_start__[];
+            extern uint32_t __unprivileged_flash_end__[];
+            extern uint32_t __privileged_sram_start__[];
+            extern uint32_t __privileged_sram_end__[];
+        #endif /* defined( __ARMCC_VERSION ) */
+
+        /* The only permitted number of regions are 8 or 16. */
+        configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+        /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+        configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
+
+        /* Check that the MPU is present. */
+        if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
+        {
+            /* MAIR0 - Index 0. */
+            portMPU_MAIR0_REG |= ( ( portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE << portMPU_MAIR_ATTR0_POS ) & portMPU_MAIR_ATTR0_MASK );
+            /* MAIR0 - Index 1. */
+            portMPU_MAIR0_REG |= ( ( portMPU_DEVICE_MEMORY_nGnRE << portMPU_MAIR_ATTR1_POS ) & portMPU_MAIR_ATTR1_MASK );
+
+            /* Setup privileged flash as Read Only so that privileged tasks can
+             * read it but not modify. */
+            portMPU_RNR_REG = portPRIVILEGED_FLASH_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __privileged_functions_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_PRIVILEGED_READ_ONLY );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __privileged_functions_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Setup unprivileged flash as Read Only by both privileged and
+             * unprivileged tasks. All tasks can read it but no-one can modify. */
+            portMPU_RNR_REG = portUNPRIVILEGED_FLASH_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __unprivileged_flash_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_READ_ONLY );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __unprivileged_flash_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Setup unprivileged syscalls flash as Read Only by both privileged
+             * and unprivileged tasks. All tasks can read it but no-one can modify. */
+            portMPU_RNR_REG = portUNPRIVILEGED_SYSCALLS_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __syscalls_flash_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_READ_ONLY );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __syscalls_flash_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Setup RAM containing kernel data for privileged access only. */
+            portMPU_RNR_REG = portPRIVILEGED_RAM_REGION;
+            portMPU_RBAR_REG = ( ( ( uint32_t ) __privileged_sram_start__ ) & portMPU_RBAR_ADDRESS_MASK ) |
+                               ( portMPU_REGION_NON_SHAREABLE ) |
+                               ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
+                               ( portMPU_REGION_EXECUTE_NEVER );
+            portMPU_RLAR_REG = ( ( ( uint32_t ) __privileged_sram_end__ ) & portMPU_RLAR_ADDRESS_MASK ) |
+                               ( portMPU_RLAR_ATTR_INDEX0 ) |
+                               ( portMPU_RLAR_REGION_ENABLE );
+
+            /* Enable mem fault. */
+            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_MEM_FAULT_ENABLE_BIT;
+
+            /* Enable MPU with privileged background access i.e. unmapped
+             * regions have privileged access. */
+            portMPU_CTRL_REG |= ( portMPU_PRIV_BACKGROUND_ENABLE_BIT | portMPU_ENABLE_BIT );
+        }
+    }
+#endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+#if ( configENABLE_FPU == 1 )
+    static void prvSetupFPU( void ) /* PRIVILEGED_FUNCTION */
+    {
+        #if ( configENABLE_TRUSTZONE == 1 )
+            {
+                /* Enable non-secure access to the FPU. */
+                SecureInit_EnableNSFPUAccess();
+            }
+        #endif /* configENABLE_TRUSTZONE */
+
+        /* CP10 = 11 ==> Full access to FPU i.e. both privileged and
+         * unprivileged code should be able to access FPU. CP11 should be
+         * programmed to the same value as CP10. */
+        *( portCPACR ) |= ( ( portCPACR_CP10_VALUE << portCPACR_CP10_POS ) |
+                            ( portCPACR_CP11_VALUE << portCPACR_CP11_POS )
+                            );
+
+        /* ASPEN = 1 ==> Hardware should automatically preserve floating point
+         * context on exception entry and restore on exception return.
+         * LSPEN = 1 ==> Enable lazy context save of FP state. */
+        *( portFPCCR ) |= ( portFPCCR_ASPEN_MASK | portFPCCR_LSPEN_MASK );
+    }
+#endif /* configENABLE_FPU */
+/*-----------------------------------------------------------*/
+
+void vPortYield( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Set a PendSV to request a context switch. */
+    portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+
+    /* Barriers are normally not required but do ensure the code is
+     * completely within the specified behaviour for the architecture. */
+    __asm volatile ( "dsb" ::: "memory" );
+    __asm volatile ( "isb" );
+}
+/*-----------------------------------------------------------*/
+
+void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */
+{
+    portDISABLE_INTERRUPTS();
+    ulCriticalNesting++;
+
+    /* Barriers are normally not required but do ensure the code is
+     * completely within the specified behaviour for the architecture. */
+    __asm volatile ( "dsb" ::: "memory" );
+    __asm volatile ( "isb" );
+}
+/*-----------------------------------------------------------*/
+
+void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
+{
+    configASSERT( ulCriticalNesting );
+    ulCriticalNesting--;
+
+    if( ulCriticalNesting == 0 )
+    {
+        portENABLE_INTERRUPTS();
+    }
+}
+/*-----------------------------------------------------------*/
+
+void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+{
+    uint32_t ulPreviousMask;
+
+    ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    {
+        /* Increment the RTOS tick. */
+        if( xTaskIncrementTick() != pdFALSE )
+        {
+            /* Pend a context switch. */
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+    }
+    portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );
+}
+/*-----------------------------------------------------------*/
+
+void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTION portDONT_DISCARD */
+{
+    #if ( configENABLE_MPU == 1 )
+        #if defined( __ARMCC_VERSION )
+
+            /* Declaration when these variable are defined in code instead of being
+             * exported from linker scripts. */
+            extern uint32_t * __syscalls_flash_start__;
+            extern uint32_t * __syscalls_flash_end__;
+        #else
+            /* Declaration when these variable are exported from linker scripts. */
+            extern uint32_t __syscalls_flash_start__[];
+            extern uint32_t __syscalls_flash_end__[];
+        #endif /* defined( __ARMCC_VERSION ) */
+    #endif /* configENABLE_MPU */
+
+    uint32_t ulPC;
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+        uint32_t ulR0, ulR1;
+        extern TaskHandle_t pxCurrentTCB;
+        #if ( configENABLE_MPU == 1 )
+            uint32_t ulControl, ulIsTaskPrivileged;
+        #endif /* configENABLE_MPU */
+    #endif /* configENABLE_TRUSTZONE */
+    uint8_t ucSVCNumber;
+
+    /* Register are stored on the stack in the following order - R0, R1, R2, R3,
+     * R12, LR, PC, xPSR. */
+    ulPC = pulCallerStackAddress[ 6 ];
+    ucSVCNumber = ( ( uint8_t * ) ulPC )[ -2 ];
+
+    switch( ucSVCNumber )
+    {
+        #if ( configENABLE_TRUSTZONE == 1 )
+            case portSVC_ALLOCATE_SECURE_CONTEXT:
+
+                /* R0 contains the stack size passed as parameter to the
+                 * vPortAllocateSecureContext function. */
+                ulR0 = pulCallerStackAddress[ 0 ];
+
+                #if ( configENABLE_MPU == 1 )
+                    {
+                        /* Read the CONTROL register value. */
+                        __asm volatile ( "mrs %0, control"  : "=r" ( ulControl ) );
+
+                        /* The task that raised the SVC is privileged if Bit[0]
+                         * in the CONTROL register is 0. */
+                        ulIsTaskPrivileged = ( ( ulControl & portCONTROL_PRIVILEGED_MASK ) == 0 );
+
+                        /* Allocate and load a context for the secure task. */
+                        xSecureContext = SecureContext_AllocateContext( ulR0, ulIsTaskPrivileged, pxCurrentTCB );
+                    }
+                #else /* if ( configENABLE_MPU == 1 ) */
+                    {
+                        /* Allocate and load a context for the secure task. */
+                        xSecureContext = SecureContext_AllocateContext( ulR0, pxCurrentTCB );
+                    }
+                #endif /* configENABLE_MPU */
+
+                configASSERT( xSecureContext != securecontextINVALID_CONTEXT_ID );
+                SecureContext_LoadContext( xSecureContext, pxCurrentTCB );
+                break;
+
+            case portSVC_FREE_SECURE_CONTEXT:
+                /* R0 contains TCB being freed and R1 contains the secure
+                 * context handle to be freed. */
+                ulR0 = pulCallerStackAddress[ 0 ];
+                ulR1 = pulCallerStackAddress[ 1 ];
+
+                /* Free the secure context. */
+                SecureContext_FreeContext( ( SecureContextHandle_t ) ulR1, ( void * ) ulR0 );
+                break;
+        #endif /* configENABLE_TRUSTZONE */
+
+        case portSVC_START_SCHEDULER:
+            #if ( configENABLE_TRUSTZONE == 1 )
+                {
+                    /* De-prioritize the non-secure exceptions so that the
+                     * non-secure pendSV runs at the lowest priority. */
+                    SecureInit_DePrioritizeNSExceptions();
+
+                    /* Initialize the secure context management system. */
+                    SecureContext_Init();
+                }
+            #endif /* configENABLE_TRUSTZONE */
+
+            #if ( configENABLE_FPU == 1 )
+                {
+                    /* Setup the Floating Point Unit (FPU). */
+                    prvSetupFPU();
+                }
+            #endif /* configENABLE_FPU */
+
+            /* Setup the context of the first task so that the first task starts
+             * executing. */
+            vRestoreContextOfFirstTask();
+            break;
+
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_RAISE_PRIVILEGE:
+
+                    /* Only raise the privilege, if the svc was raised from any of
+                     * the system calls. */
+                    if( ( ulPC >= ( uint32_t ) __syscalls_flash_start__ ) &&
+                        ( ulPC <= ( uint32_t ) __syscalls_flash_end__ ) )
+                    {
+                        vRaisePrivilege();
+                    }
+                    break;
+            #endif /* configENABLE_MPU */
+
+        default:
+            /* Incorrect SVC call. */
+            configASSERT( pdFALSE );
+    }
+}
+/*-----------------------------------------------------------*/
+/* *INDENT-OFF* */
+#if ( configENABLE_MPU == 1 )
+    StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                         StackType_t * pxEndOfStack,
+                                         TaskFunction_t pxCode,
+                                         void * pvParameters,
+                                         BaseType_t xRunPrivileged ) /* PRIVILEGED_FUNCTION */
+#else
+    StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                         StackType_t * pxEndOfStack,
+                                         TaskFunction_t pxCode,
+                                         void * pvParameters ) /* PRIVILEGED_FUNCTION */
+#endif /* configENABLE_MPU */
+/* *INDENT-ON* */
+{
+    /* Simulate the stack frame as it would be created by a context switch
+     * interrupt. */
+    #if ( portPRELOAD_REGISTERS == 0 )
+        {
+            pxTopOfStack--;                                          /* Offset added to account for the way the MCU uses the stack on entry/exit of interrupts. */
+            *pxTopOfStack = portINITIAL_XPSR;                        /* xPSR */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxCode;                  /* PC */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS; /* LR */
+            pxTopOfStack -= 5;                                       /* R12, R3, R2 and R1. */
+            *pxTopOfStack = ( StackType_t ) pvParameters;            /* R0 */
+            pxTopOfStack -= 9;                                       /* R11..R4, EXC_RETURN. */
+            *pxTopOfStack = portINITIAL_EXC_RETURN;
+
+            #if ( configENABLE_MPU == 1 )
+                {
+                    pxTopOfStack--;
+
+                    if( xRunPrivileged == pdTRUE )
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_PRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                    else
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_UNPRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                }
+            #endif /* configENABLE_MPU */
+
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxEndOfStack; /* Slot used to hold this task's PSPLIM value. */
+
+            #if ( configENABLE_TRUSTZONE == 1 )
+                {
+                    pxTopOfStack--;
+                    *pxTopOfStack = portNO_SECURE_CONTEXT; /* Slot used to hold this task's xSecureContext value. */
+                }
+            #endif /* configENABLE_TRUSTZONE */
+        }
+    #else /* portPRELOAD_REGISTERS */
+        {
+            pxTopOfStack--;                                          /* Offset added to account for the way the MCU uses the stack on entry/exit of interrupts. */
+            *pxTopOfStack = portINITIAL_XPSR;                        /* xPSR */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxCode;                  /* PC */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) portTASK_RETURN_ADDRESS; /* LR */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x12121212UL;            /* R12 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x03030303UL;            /* R3 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x02020202UL;            /* R2 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x01010101UL;            /* R1 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pvParameters;            /* R0 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x11111111UL;            /* R11 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x10101010UL;            /* R10 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x09090909UL;            /* R09 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x08080808UL;            /* R08 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x07070707UL;            /* R07 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x06060606UL;            /* R06 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x05050505UL;            /* R05 */
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) 0x04040404UL;            /* R04 */
+            pxTopOfStack--;
+            *pxTopOfStack = portINITIAL_EXC_RETURN;                  /* EXC_RETURN */
+
+            #if ( configENABLE_MPU == 1 )
+                {
+                    pxTopOfStack--;
+
+                    if( xRunPrivileged == pdTRUE )
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_PRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                    else
+                    {
+                        *pxTopOfStack = portINITIAL_CONTROL_UNPRIVILEGED; /* Slot used to hold this task's CONTROL value. */
+                    }
+                }
+            #endif /* configENABLE_MPU */
+
+            pxTopOfStack--;
+            *pxTopOfStack = ( StackType_t ) pxEndOfStack; /* Slot used to hold this task's PSPLIM value. */
+
+            #if ( configENABLE_TRUSTZONE == 1 )
+                {
+                    pxTopOfStack--;
+                    *pxTopOfStack = portNO_SECURE_CONTEXT; /* Slot used to hold this task's xSecureContext value. */
+                }
+            #endif /* configENABLE_TRUSTZONE */
+        }
+    #endif /* portPRELOAD_REGISTERS */
+
+    return pxTopOfStack;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Make PendSV, CallSV and SysTick the same priority as the kernel. */
+    portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
+    portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
+
+    #if ( configENABLE_MPU == 1 )
+        {
+            /* Setup the Memory Protection Unit (MPU). */
+            prvSetupMPU();
+        }
+    #endif /* configENABLE_MPU */
+
+    /* Start the timer that generates the tick ISR. Interrupts are disabled
+     * here already. */
+    vPortSetupTimerInterrupt();
+
+    /* Initialize the critical nesting count ready for the first task. */
+    ulCriticalNesting = 0;
+
+    /* Start the first task. */
+    vStartFirstTask();
+
+    /* Should never get here as the tasks will now be executing. Call the task
+     * exit error function to prevent compiler warnings about a static function
+     * not being called in the case that the application writer overrides this
+     * functionality by defining configTASK_RETURN_ADDRESS. Call
+     * vTaskSwitchContext() so link time optimization does not remove the
+     * symbol. */
+    vTaskSwitchContext();
+    prvTaskExitError();
+
+    /* Should not get here. */
+    return 0;
+}
+/*-----------------------------------------------------------*/
+
+void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
+{
+    /* Not implemented in ports where there is nothing to return to.
+     * Artificially force an assert. */
+    configASSERT( ulCriticalNesting == 1000UL );
+}
+/*-----------------------------------------------------------*/
+
+#if ( configENABLE_MPU == 1 )
+    void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
+                                    const struct xMEMORY_REGION * const xRegions,
+                                    StackType_t * pxBottomOfStack,
+                                    uint32_t ulStackDepth )
+    {
+        uint32_t ulRegionStartAddress, ulRegionEndAddress, ulRegionNumber;
+        int32_t lIndex = 0;
+
+        #if defined( __ARMCC_VERSION )
+
+            /* Declaration when these variable are defined in code instead of being
+             * exported from linker scripts. */
+            extern uint32_t * __privileged_sram_start__;
+            extern uint32_t * __privileged_sram_end__;
+        #else
+            /* Declaration when these variable are exported from linker scripts. */
+            extern uint32_t __privileged_sram_start__[];
+            extern uint32_t __privileged_sram_end__[];
+        #endif /* defined( __ARMCC_VERSION ) */
+
+        /* Setup MAIR0. */
+        xMPUSettings->ulMAIR0 = ( ( portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE << portMPU_MAIR_ATTR0_POS ) & portMPU_MAIR_ATTR0_MASK );
+        xMPUSettings->ulMAIR0 |= ( ( portMPU_DEVICE_MEMORY_nGnRE << portMPU_MAIR_ATTR1_POS ) & portMPU_MAIR_ATTR1_MASK );
+
+        /* This function is called automatically when the task is created - in
+         * which case the stack region parameters will be valid.  At all other
+         * times the stack parameters will not be valid and it is assumed that
+         * the stack region has already been configured. */
+        if( ulStackDepth > 0 )
+        {
+            ulRegionStartAddress = ( uint32_t ) pxBottomOfStack;
+            ulRegionEndAddress = ( uint32_t ) pxBottomOfStack + ( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) - 1;
+
+            /* If the stack is within the privileged SRAM, do not protect it
+             * using a separate MPU region. This is needed because privileged
+             * SRAM is already protected using an MPU region and ARMv8-M does
+             * not allow overlapping MPU regions. */
+            if( ( ulRegionStartAddress >= ( uint32_t ) __privileged_sram_start__ ) &&
+                ( ulRegionEndAddress <= ( uint32_t ) __privileged_sram_end__ ) )
+            {
+                xMPUSettings->xRegionsSettings[ 0 ].ulRBAR = 0;
+                xMPUSettings->xRegionsSettings[ 0 ].ulRLAR = 0;
+            }
+            else
+            {
+                /* Define the region that allows access to the stack. */
+                ulRegionStartAddress &= portMPU_RBAR_ADDRESS_MASK;
+                ulRegionEndAddress &= portMPU_RLAR_ADDRESS_MASK;
+
+                xMPUSettings->xRegionsSettings[ 0 ].ulRBAR = ( ulRegionStartAddress ) |
+                                                             ( portMPU_REGION_NON_SHAREABLE ) |
+                                                             ( portMPU_REGION_READ_WRITE ) |
+                                                             ( portMPU_REGION_EXECUTE_NEVER );
+
+                xMPUSettings->xRegionsSettings[ 0 ].ulRLAR = ( ulRegionEndAddress ) |
+                                                             ( portMPU_RLAR_ATTR_INDEX0 ) |
+                                                             ( portMPU_RLAR_REGION_ENABLE );
+            }
+        }
+
+        /* User supplied configurable regions. */
+        for( ulRegionNumber = 1; ulRegionNumber <= portNUM_CONFIGURABLE_REGIONS; ulRegionNumber++ )
+        {
+            /* If xRegions is NULL i.e. the task has not specified any MPU
+             * region, the else part ensures that all the configurable MPU
+             * regions are invalidated. */
+            if( ( xRegions != NULL ) && ( xRegions[ lIndex ].ulLengthInBytes > 0UL ) )
+            {
+                /* Translate the generic region definition contained in xRegions
+                 * into the ARMv8 specific MPU settings that are then stored in
+                 * xMPUSettings. */
+                ulRegionStartAddress = ( ( uint32_t ) xRegions[ lIndex ].pvBaseAddress ) & portMPU_RBAR_ADDRESS_MASK;
+                ulRegionEndAddress = ( uint32_t ) xRegions[ lIndex ].pvBaseAddress + xRegions[ lIndex ].ulLengthInBytes - 1;
+                ulRegionEndAddress &= portMPU_RLAR_ADDRESS_MASK;
+
+                /* Start address. */
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR = ( ulRegionStartAddress ) |
+                                                                          ( portMPU_REGION_NON_SHAREABLE );
+
+                /* RO/RW. */
+                if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_READ_ONLY ) != 0 )
+                {
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR |= ( portMPU_REGION_READ_ONLY );
+                }
+                else
+                {
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR |= ( portMPU_REGION_READ_WRITE );
+                }
+
+                /* XN. */
+                if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_EXECUTE_NEVER ) != 0 )
+                {
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR |= ( portMPU_REGION_EXECUTE_NEVER );
+                }
+
+                /* End Address. */
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
+                                                                          ( portMPU_RLAR_REGION_ENABLE );
+
+                /* Normal memory/ Device memory. */
+                if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )
+                {
+                    /* Attr1 in MAIR0 is configured as device memory. */
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX1;
+                }
+                else
+                {
+                    /* Attr0 in MAIR0 is configured as normal memory. */
+                    xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= portMPU_RLAR_ATTR_INDEX0;
+                }
+            }
+            else
+            {
+                /* Invalidate the region. */
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRBAR = 0UL;
+                xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = 0UL;
+            }
+
+            lIndex++;
+        }
+    }
+#endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+BaseType_t xPortIsInsideInterrupt( void )
+{
+    uint32_t ulCurrentInterrupt;
+    BaseType_t xReturn;
+
+    /* Obtain the number of the currently executing interrupt. Interrupt Program
+     * Status Register (IPSR) holds the exception number of the currently-executing
+     * exception or zero for Thread mode.*/
+    __asm volatile ( "mrs %0, ipsr" : "=r" ( ulCurrentInterrupt )::"memory" );
+
+    if( ulCurrentInterrupt == 0 )
+    {
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
@@ -1,0 +1,351 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+
+/* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE ensures that PRIVILEGED_FUNCTION
+ * is defined correctly and privileged functions are placed in correct sections. */
+#define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+/* Portasm includes. */
+#include "portasm.h"
+
+/* MPU_WRAPPERS_INCLUDED_FROM_API_FILE is needed to be defined only for the
+ * header files. */
+#undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
+
+void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "													\n"
+        "	ldr  r2, pxCurrentTCBConst2						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr  r1, [r2]									\n"/* Read pxCurrentTCB. */
+        "	ldr  r0, [r1]									\n"/* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb												\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r2, xMPUCTRLConst2							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1										\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Disable MPU. */
+            "													\n"
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to MAIR0 in TCB. */
+            "	ldr  r3, [r1]									\n"/* r3 = *r1 i.e. r3 = MAIR0. */
+            "	ldr  r2, xMAIR0Const2							\n"/* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "	str  r3, [r2]									\n"/* Program MAIR0. */
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #4										\n"/* r3 = 4. */
+            "	str  r3, [r2]									\n"/* Program RNR = 4. */
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to first RBAR in TCB. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str  r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr  r2, xRNRConst2								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str  r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr  r2, xRBARConst2							\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 set of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "													\n"
+            "	ldr r2, xMPUCTRLConst2							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1										\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Enable MPU. */
+            "	dsb												\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldm  r0!, {r1-r3}								\n"/* Read from stack - r1 = PSPLIM, r2 = CONTROL and r3 = EXC_RETURN. */
+            "	msr  psplim, r1									\n"/* Set this task's PSPLIM value. */
+            "	msr  control, r2								\n"/* Set this task's CONTROL value. */
+            "	adds r0, #32									\n"/* Discard everything up to r0. */
+            "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
+            "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r3											\n"/* Finally, branch to EXC_RETURN. */
+        #else /* configENABLE_MPU */
+            "	ldm  r0!, {r1-r2}								\n"/* Read from stack - r1 = PSPLIM and r2 = EXC_RETURN. */
+            "	msr  psplim, r1									\n"/* Set this task's PSPLIM value. */
+            "	movs r1, #2										\n"/* r1 = 2. */
+            "	msr  CONTROL, r1								\n"/* Switch to use PSP in the thread mode. */
+            "	adds r0, #32									\n"/* Discard everything up to r0. */
+            "	msr  psp, r0									\n"/* This is now the new top of stack to use in the task. */
+            "	isb												\n"
+            "	mov  r0, #0										\n"
+            "	msr  basepri, r0								\n"/* Ensure that interrupts are enabled when the first task starts. */
+            "	bx   r2											\n"/* Finally, branch to EXC_RETURN. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst2: .word pxCurrentTCB				\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst2: .word 0xe000ed94					\n"
+            "xMAIR0Const2: .word 0xe000edc0						\n"
+            "xRNRConst2: .word 0xe000ed98						\n"
+            "xRBARConst2: .word 0xe000ed9c						\n"
+        #endif /* configENABLE_MPU */
+    );
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
+        "	ite ne											\n"
+        "	movne r0, #0									\n"/* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
+        "	moveq r0, #1									\n"/* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
+        "	bx lr											\n"/* Return. */
+        "													\n"
+        "	.align 4										\n"
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs  r0, control								\n"/* Read the CONTROL register. */
+        "	bic r0, #1										\n"/* Clear the bit 0. */
+        "	msr  control, r0								\n"/* Write back the new CONTROL value. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vResetPrivilege( void ) /* __attribute__ (( naked )) */
+{
+    __asm volatile
+    (
+        "	mrs r0, control									\n"/* r0 = CONTROL. */
+        "	orr r0, #1										\n"/* r0 = r0 | 1. */
+        "	msr control, r0									\n"/* CONTROL = r0. */
+        "	bx lr											\n"/* Return to the caller. */
+        ::: "r0", "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
+        "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
+        "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
+        "	msr msp, r0										\n"/* Set the MSP back to the start of the stack. */
+        "	cpsie i											\n"/* Globally enable interrupts. */
+        "	cpsie f											\n"
+        "	dsb												\n"
+        "	isb												\n"
+        "	svc %0											\n"/* System call to start the first task. */
+        "	nop												\n"
+        "													\n"
+        "   .align 4										\n"
+        "xVTORConst: .word 0xe000ed08						\n"
+        ::"i" ( portSVC_START_SCHEDULER ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
+        "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	msr basepri, r0									\n"/* basepri = ulMask. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bx lr											\n"/* Return. */
+        ::: "memory"
+    );
+}
+/*-----------------------------------------------------------*/
+
+void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	.syntax unified									\n"
+        "													\n"
+        "	mrs r0, psp										\n"/* Read PSP in r0. */
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst lr, #0x10									\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq											\n"
+            "	vstmdbeq r0!, {s16-s31}							\n"/* Store the additional FP context registers which are not saved automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        #if ( configENABLE_MPU == 1 )
+            "	mrs r1, psplim									\n"/* r1 = PSPLIM. */
+            "	mrs r2, control									\n"/* r2 = CONTROL. */
+            "	mov r3, lr										\n"/* r3 = LR/EXC_RETURN. */
+            "	stmdb r0!, {r1-r11}								\n"/* Store on the stack - PSPLIM, CONTROL, LR and registers that are not automatically saved. */
+        #else /* configENABLE_MPU */
+            "	mrs r2, psplim									\n"/* r2 = PSPLIM. */
+            "	mov r3, lr										\n"/* r3 = LR/EXC_RETURN. */
+            "	stmdb r0!, {r2-r11}								\n"/* Store on the stack - PSPLIM, LR and registers that are not automatically saved. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        "	ldr r2, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r2]									\n"/* Read pxCurrentTCB. */
+        "	str r0, [r1]									\n"/* Save the new top of stack in TCB. */
+        "													\n"
+        "	mov r0, %0										\n"/* r0 = configMAX_SYSCALL_INTERRUPT_PRIORITY */
+        "	msr basepri, r0									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        "	dsb												\n"
+        "	isb												\n"
+        "	bl vTaskSwitchContext							\n"
+        "	mov r0, #0										\n"/* r0 = 0. */
+        "	msr basepri, r0									\n"/* Enable interrupts. */
+        "													\n"
+        "	ldr r2, pxCurrentTCBConst						\n"/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+        "	ldr r1, [r2]									\n"/* Read pxCurrentTCB. */
+        "	ldr r0, [r1]									\n"/* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	dmb												\n"/* Complete outstanding transfers before disabling MPU. */
+            "	ldr r2, xMPUCTRLConst							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	bic r4, #1										\n"/* r4 = r4 & ~1 i.e. Clear the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Disable MPU. */
+            "													\n"
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to MAIR0 in TCB. */
+            "	ldr r3, [r1]									\n"/* r3 = *r1 i.e. r3 = MAIR0. */
+            "	ldr r2, xMAIR0Const								\n"/* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "	str r3, [r2]									\n"/* Program MAIR0. */
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #4										\n"/* r3 = 4. */
+            "	str r3, [r2]									\n"/* Program RNR = 4. */
+            "	adds r1, #4										\n"/* r1 = r1 + 4. r1 now points to first RBAR in TCB. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "													\n"
+            #if ( configTOTAL_MPU_REGIONS == 16 )
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #8										\n"/* r3 = 8. */
+            "	str r3, [r2]									\n"/* Program RNR = 8. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            "	ldr r2, xRNRConst								\n"/* r2 = 0xe000ed98 [Location of RNR]. */
+            "	movs r3, #12									\n"/* r3 = 12. */
+            "	str r3, [r2]									\n"/* Program RNR = 12. */
+            "	ldr r2, xRBARConst								\n"/* r2 = 0xe000ed9c [Location of RBAR]. */
+            "	ldmia r1!, {r4-r11}								\n"/* Read 4 sets of RBAR/RLAR registers from TCB. */
+            "	stmia r2!, {r4-r11}								\n"/* Write 4 set of RBAR/RLAR registers using alias registers. */
+            #endif /* configTOTAL_MPU_REGIONS == 16 */
+            "													\n"
+            "	ldr r2, xMPUCTRLConst							\n"/* r2 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "	ldr r4, [r2]									\n"/* Read the value of MPU_CTRL. */
+            "	orr r4, #1										\n"/* r4 = r4 | 1 i.e. Set the bit 0 in r4. */
+            "	str r4, [r2]									\n"/* Enable MPU. */
+            "	dsb												\n"/* Force memory writes before continuing. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	ldmia r0!, {r1-r11}								\n"/* Read from stack - r1 = PSPLIM, r2 = CONTROL, r3 = LR and r4-r11 restored. */
+        #else /* configENABLE_MPU */
+            "	ldmia r0!, {r2-r11}								\n"/* Read from stack - r2 = PSPLIM, r3 = LR and r4-r11 restored. */
+        #endif /* configENABLE_MPU */
+        "													\n"
+        #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
+            "	tst r3, #0x10									\n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
+            "	it eq											\n"
+            "	vldmiaeq r0!, {s16-s31}							\n"/* Restore the additional FP context registers which are not restored automatically. */
+        #endif /* configENABLE_FPU || configENABLE_MVE */
+        "													\n"
+        #if ( configENABLE_MPU == 1 )
+            "	msr psplim, r1									\n"/* Restore the PSPLIM register value for the task. */
+            "	msr control, r2									\n"/* Restore the CONTROL register value for the task. */
+        #else /* configENABLE_MPU */
+            "	msr psplim, r2									\n"/* Restore the PSPLIM register value for the task. */
+        #endif /* configENABLE_MPU */
+        "	msr psp, r0										\n"/* Remember the new top of stack for the task. */
+        "	bx r3											\n"
+        "													\n"
+        "	.align 4										\n"
+        "pxCurrentTCBConst: .word pxCurrentTCB				\n"
+        #if ( configENABLE_MPU == 1 )
+            "xMPUCTRLConst: .word 0xe000ed94					\n"
+            "xMAIR0Const: .word 0xe000edc0						\n"
+            "xRNRConst: .word 0xe000ed98						\n"
+            "xRBARConst: .word 0xe000ed9c						\n"
+        #endif /* configENABLE_MPU */
+        ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
+    );
+}
+/*-----------------------------------------------------------*/
+
+void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+{
+    __asm volatile
+    (
+        "	tst lr, #4										\n"
+        "	ite eq											\n"
+        "	mrseq r0, msp									\n"
+        "	mrsne r0, psp									\n"
+        "	ldr r1, svchandler_address_const				\n"
+        "	bx r1											\n"
+        "													\n"
+        "	.align 4										\n"
+        "svchandler_address_const: .word vPortSVCHandler_C	\n"
+    );
+}
+/*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.h
@@ -1,0 +1,114 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef __PORT_ASM_H__
+#define __PORT_ASM_H__
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+
+/* MPU wrappers includes. */
+#include "mpu_wrappers.h"
+
+/**
+ * @brief Restore the context of the first task so that the first task starts
+ * executing.
+ */
+void vRestoreContextOfFirstTask( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Checks whether or not the processor is privileged.
+ *
+ * @return 1 if the processor is already privileged, 0 otherwise.
+ */
+BaseType_t xIsPrivileged( void ) __attribute__( ( naked ) );
+
+/**
+ * @brief Raises the privilege level by clearing the bit 0 of the CONTROL
+ * register.
+ *
+ * @note This is a privileged function and should only be called from the kenrel
+ * code.
+ *
+ * Bit 0 of the CONTROL register defines the privilege level of Thread Mode.
+ *  Bit[0] = 0 --> The processor is running privileged
+ *  Bit[0] = 1 --> The processor is running unprivileged.
+ */
+void vRaisePrivilege( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Lowers the privilege level by setting the bit 0 of the CONTROL
+ * register.
+ *
+ * Bit 0 of the CONTROL register defines the privilege level of Thread Mode.
+ *  Bit[0] = 0 --> The processor is running privileged
+ *  Bit[0] = 1 --> The processor is running unprivileged.
+ */
+void vResetPrivilege( void ) __attribute__( ( naked ) );
+
+/**
+ * @brief Starts the first task.
+ */
+void vStartFirstTask( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Disables interrupts.
+ */
+uint32_t ulSetInterruptMask( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Enables interrupts.
+ */
+void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief PendSV Exception handler.
+ */
+void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief SVC Handler.
+ */
+void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Allocate a Secure context for the calling task.
+ *
+ * @param[in] ulSecureStackSize The size of the stack to be allocated on the
+ * secure side for the calling task.
+ */
+void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) __attribute__( ( naked ) );
+
+/**
+ * @brief Free the task's secure context.
+ *
+ * @param[in] pulTCB Pointer to the Task Control Block (TCB) of the task.
+ */
+void vPortFreeSecureContext( uint32_t * pulTCB ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+
+#endif /* __PORT_ASM_H__ */

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -1,0 +1,319 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef PORTMACRO_H
+    #define PORTMACRO_H
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
+
+/*------------------------------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the given hardware
+ * and compiler.
+ *
+ * These settings should not be altered.
+ *------------------------------------------------------------------------------
+ */
+
+    #ifndef configENABLE_FPU
+        #error configENABLE_FPU must be defined in FreeRTOSConfig.h.  Set configENABLE_FPU to 1 to enable the FPU or 0 to disable the FPU.
+    #endif /* configENABLE_FPU */
+
+    #ifndef configENABLE_MPU
+        #error configENABLE_MPU must be defined in FreeRTOSConfig.h.  Set configENABLE_MPU to 1 to enable the MPU or 0 to disable the MPU.
+    #endif /* configENABLE_MPU */
+
+    #ifndef configENABLE_TRUSTZONE
+        #error configENABLE_TRUSTZONE must be defined in FreeRTOSConfig.h.  Set configENABLE_TRUSTZONE to 1 to enable TrustZone or 0 to disable TrustZone.
+    #endif /* configENABLE_TRUSTZONE */
+
+    #ifndef configENABLE_MVE
+        #error configENABLE_MVE must be defined in FreeRTOSConfig.h.  Set configENABLE_MVE to 1 to enable the MVE or 0 to disable the MVE.
+    #endif /* configENABLE_MVE */
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Type definitions.
+ */
+    #define portCHAR          char
+    #define portFLOAT         float
+    #define portDOUBLE        double
+    #define portLONG          long
+    #define portSHORT         short
+    #define portSTACK_TYPE    uint32_t
+    #define portBASE_TYPE     long
+
+    typedef portSTACK_TYPE   StackType_t;
+    typedef long             BaseType_t;
+    typedef unsigned long    UBaseType_t;
+
+    #if ( configUSE_16_BIT_TICKS == 1 )
+        typedef uint16_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffff
+    #else
+        typedef uint32_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+
+/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+ * not need to be guarded with a critical section. */
+        #define portTICK_TYPE_IS_ATOMIC    1
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * Architecture specifics.
+ */
+    #define portARCH_NAME                      "Cortex-M55"
+    #define portSTACK_GROWTH                   ( -1 )
+    #define portTICK_PERIOD_MS                 ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+    #define portBYTE_ALIGNMENT                 8
+    #define portNOP()
+    #define portINLINE                         __inline
+    #ifndef portFORCE_INLINE
+        #define portFORCE_INLINE               inline __attribute__( ( always_inline ) )
+    #endif
+    #define portHAS_STACK_OVERFLOW_CHECKING    1
+    #define portDONT_DISCARD                   __attribute__( ( used ) )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Extern declarations.
+ */
+    extern BaseType_t xPortIsInsideInterrupt( void );
+
+    extern void vPortYield( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern void vPortEnterCritical( void ) /* PRIVILEGED_FUNCTION */;
+    extern void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */;
+
+    extern uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+    extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) PRIVILEGED_FUNCTION */;
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+        extern void vPortAllocateSecureContext( uint32_t ulSecureStackSize ); /* __attribute__ (( naked )) */
+        extern void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */;
+    #endif /* configENABLE_TRUSTZONE */
+
+    #if ( configENABLE_MPU == 1 )
+        extern BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */;
+        extern void vResetPrivilege( void ) /* __attribute__ (( naked )) */;
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief MPU specific constants.
+ */
+    #if ( configENABLE_MPU == 1 )
+        #define portUSING_MPU_WRAPPERS    1
+        #define portPRIVILEGE_BIT         ( 0x80000000UL )
+    #else
+        #define portPRIVILEGE_BIT         ( 0x0UL )
+    #endif /* configENABLE_MPU */
+
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS       ( 8UL )
+#endif
+
+/* MPU regions. */
+    #define portPRIVILEGED_FLASH_REGION                   ( 0UL )
+    #define portUNPRIVILEGED_FLASH_REGION                 ( 1UL )
+    #define portUNPRIVILEGED_SYSCALLS_REGION              ( 2UL )
+    #define portPRIVILEGED_RAM_REGION                     ( 3UL )
+    #define portSTACK_REGION                              ( 4UL )
+    #define portFIRST_CONFIGURABLE_REGION                 ( 5UL )
+    #define portLAST_CONFIGURABLE_REGION                  ( configTOTAL_MPU_REGIONS - 1UL )
+    #define portNUM_CONFIGURABLE_REGIONS                  ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
+    #define portTOTAL_NUM_REGIONS                         ( portNUM_CONFIGURABLE_REGIONS + 1 )   /* Plus one to make space for the stack region. */
+
+/* Device memory attributes used in MPU_MAIR registers.
+ *
+ * 8-bit values encoded as follows:
+ *  Bit[7:4] - 0000 - Device Memory
+ *  Bit[3:2] - 00 --> Device-nGnRnE
+ *				01 --> Device-nGnRE
+ *				10 --> Device-nGRE
+ *				11 --> Device-GRE
+ *  Bit[1:0] - 00, Reserved.
+ */
+    #define portMPU_DEVICE_MEMORY_nGnRnE                  ( 0x00 )   /* 0000 0000 */
+    #define portMPU_DEVICE_MEMORY_nGnRE                   ( 0x04 )   /* 0000 0100 */
+    #define portMPU_DEVICE_MEMORY_nGRE                    ( 0x08 )   /* 0000 1000 */
+    #define portMPU_DEVICE_MEMORY_GRE                     ( 0x0C )   /* 0000 1100 */
+
+/* Normal memory attributes used in MPU_MAIR registers. */
+    #define portMPU_NORMAL_MEMORY_NON_CACHEABLE           ( 0x44 )   /* Non-cacheable. */
+    #define portMPU_NORMAL_MEMORY_BUFFERABLE_CACHEABLE    ( 0xFF )   /* Non-Transient, Write-back, Read-Allocate and Write-Allocate. */
+
+/* Attributes used in MPU_RBAR registers. */
+    #define portMPU_REGION_NON_SHAREABLE                  ( 0UL << 3UL )
+    #define portMPU_REGION_INNER_SHAREABLE                ( 1UL << 3UL )
+    #define portMPU_REGION_OUTER_SHAREABLE                ( 2UL << 3UL )
+
+    #define portMPU_REGION_PRIVILEGED_READ_WRITE          ( 0UL << 1UL )
+    #define portMPU_REGION_READ_WRITE                     ( 1UL << 1UL )
+    #define portMPU_REGION_PRIVILEGED_READ_ONLY           ( 2UL << 1UL )
+    #define portMPU_REGION_READ_ONLY                      ( 3UL << 1UL )
+
+    #define portMPU_REGION_EXECUTE_NEVER                  ( 1UL )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Settings to define an MPU region.
+ */
+    typedef struct MPURegionSettings
+    {
+        uint32_t ulRBAR; /**< RBAR for the region. */
+        uint32_t ulRLAR; /**< RLAR for the region. */
+    } MPURegionSettings_t;
+
+/**
+ * @brief MPU settings as stored in the TCB.
+ */
+    typedef struct MPU_SETTINGS
+    {
+        uint32_t ulMAIR0;                                              /**< MAIR0 for the task containing attributes for all the 4 per task regions. */
+        MPURegionSettings_t xRegionsSettings[ portTOTAL_NUM_REGIONS ]; /**< Settings for 4 per task regions. */
+    } xMPU_SETTINGS;
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief SVC numbers.
+ */
+    #define portSVC_ALLOCATE_SECURE_CONTEXT    0
+    #define portSVC_FREE_SECURE_CONTEXT        1
+    #define portSVC_START_SCHEDULER            2
+    #define portSVC_RAISE_PRIVILEGE            3
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Scheduler utilities.
+ */
+    #define portYIELD()                                 vPortYield()
+    #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
+    #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
+    #define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } while( 0 )
+    #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Critical section management.
+ */
+    #define portSET_INTERRUPT_MASK_FROM_ISR()         ulSetInterruptMask()
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    vClearInterruptMask( x )
+    #define portDISABLE_INTERRUPTS()                  ulSetInterruptMask()
+    #define portENABLE_INTERRUPTS()                   vClearInterruptMask( 0 )
+    #define portENTER_CRITICAL()                      vPortEnterCritical()
+    #define portEXIT_CRITICAL()                       vPortExitCritical()
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Tickless idle/low power functionality.
+ */
+    #ifndef portSUPPRESS_TICKS_AND_SLEEP
+        extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+        #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
+    #endif
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Task function macros as described on the FreeRTOS.org WEB site.
+ */
+    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_TRUSTZONE == 1 )
+
+/**
+ * @brief Allocate a secure context for the task.
+ *
+ * Tasks are not created with a secure context. Any task that is going to call
+ * secure functions must call portALLOCATE_SECURE_CONTEXT() to allocate itself a
+ * secure context before it calls any secure function.
+ *
+ * @param[in] ulSecureStackSize The size of the secure stack to be allocated.
+ */
+        #define portALLOCATE_SECURE_CONTEXT( ulSecureStackSize )    vPortAllocateSecureContext( ulSecureStackSize )
+
+/**
+ * @brief Called when a task is deleted to delete the task's secure context,
+ * if it has one.
+ *
+ * @param[in] pxTCB The TCB of the task being deleted.
+ */
+        #define portCLEAN_UP_TCB( pxTCB )                           vPortFreeSecureContext( ( uint32_t * ) pxTCB )
+    #endif /* configENABLE_TRUSTZONE */
+/*-----------------------------------------------------------*/
+
+    #if ( configENABLE_MPU == 1 )
+
+/**
+ * @brief Checks whether or not the processor is privileged.
+ *
+ * @return 1 if the processor is already privileged, 0 otherwise.
+ */
+        #define portIS_PRIVILEGED()      xIsPrivileged()
+
+/**
+ * @brief Raise an SVC request to raise privilege.
+ *
+ * The SVC handler checks that the SVC was raised from a system call and only
+ * then it raises the privilege. If this is called from any other place,
+ * the privilege is not raised.
+ */
+        #define portRAISE_PRIVILEGE()    __asm volatile ( "svc %0 \n" ::"i" ( portSVC_RAISE_PRIVILEGE ) : "memory" );
+
+/**
+ * @brief Lowers the privilege level by setting the bit 0 of the CONTROL
+ * register.
+ */
+        #define portRESET_PRIVILEGE()    vResetPrivilege()
+    #else
+        #define portIS_PRIVILEGED()
+        #define portRAISE_PRIVILEGE()
+        #define portRESET_PRIVILEGE()
+    #endif /* configENABLE_MPU */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Barriers.
+ */
+    #define portMEMORY_BARRIER()    __asm volatile ( "" ::: "memory" )
+/*-----------------------------------------------------------*/
+
+    #ifdef __cplusplus
+        }
+    #endif
+
+#endif /* PORTMACRO_H */

--- a/portable/ThirdParty/GCC/ARM_CM55_TFM/README.md
+++ b/portable/ThirdParty/GCC/ARM_CM55_TFM/README.md
@@ -1,0 +1,23 @@
+# Target of this port
+
+This port adds support for FreeRTOS applications to call the secure services
+in Trusted Firmware M (TF-M) through Platform Security Architecture (PSA) APIs
+on ARM Cortex-M55 based platforms.
+
+To use this port please follow the documentation of the
+[ARM_CM55_TFM port](../ARM_CM33_TFM/README.md), with the following additions:
+
+* Instead of the kernel files in the
+```freertos_kernel\portable\GCC\ARM_CM33_NTZ``` folder the
+files in the ```freertos_kernel\portable\GCC\ARM_CM55_NTZ``` must be used.
+
+* The ```os_wrapper_freertos.c``` file can be reused without modification from
+the ```portable/ThirdParty/GCC/ARM_CM33_TFM``` folder.
+
+* ARM Cortex-M55 supports MVE, so FreeRTOS kernel can be configured with the
+```configENABLE_MVE`` macro. The setting of this macro is decided by the
+setting in Secure Side which is platform-specific. If the Secure Side enables
+Non-Secure access to MVE, then this macro can be configured as 0 or 1.
+Otherwise, this macro can only be configured as 0.
+
+*Copyright (c) 2022, Arm Limited. All rights reserved.*


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add Cortex-M55 support based on Cortex-M33 support.
M55 files extended only with MVE context save-restore mechanism. The same mechanism is used as in case of FPU on M33.
No assembly changed compared to M33, only `configENABLE_MVE` macro is added.
ARM_CM55_TFM port is also added.

Test Steps
-----------
TZ and MPU demos run from FreeRTOS/FreeRTOS repository.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/477


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
