### PR TITLE
add portDONT_DISCARD to pxCurrentTCB

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -337,7 +337,7 @@ typedef tskTCB TCB_t;
 
 /*lint -save -e956 A manual analysis and inspection has been used to determine
  * which static variables must be declared volatile. */
-PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB = NULL;
+portDONT_DISCARD PRIVILEGED_DATA TCB_t * volatile pxCurrentTCB = NULL;
 
 /* Lists for ready and blocked tasks. --------------------
  * xDelayedTaskList1 and xDelayedTaskList2 could be moved to function scope but


### PR DESCRIPTION
This fixes link failures with LTO:

```
/tmp/ccJbaKaD.ltrans0.ltrans.o: in function `pxCurrentTCBConst2':
/root/project/FreeRTOS/portable/GCC/ARM_CM4F/port.c:249: undefined reference to `pxCurrentTCB'
/usr/lib/gcc/arm-none-eabi/11.2.0/../../../../arm-none-eabi/bin/ld: /tmp/ccJbaKaD.ltrans0.ltrans.o: in function `pxCurrentTCBConst':
/root/project/FreeRTOS/portable/GCC/ARM_CM4F/port.c:443: undefined reference to `pxCurrentTCB'
```