### PR TITLE
Enable use of --text-section-literals in Xtensa port

### DIFF
--- a/portable/ThirdParty/XCC/Xtensa/xtensa_context.S
+++ b/portable/ThirdParty/XCC/Xtensa/xtensa_context.S
@@ -62,6 +62,7 @@ NOERROR: .error "C preprocessor needed for this file: make sure its filename\
 #endif
 
     .text
+    .literal_position
 
 /*******************************************************************************
 

--- a/portable/ThirdParty/XCC/Xtensa/xtensa_vectors.S
+++ b/portable/ThirdParty/XCC/Xtensa/xtensa_vectors.S
@@ -306,6 +306,7 @@
     .global     _xt_panic
     .type       _xt_panic,@function
     .align      4
+    .literal_position
 
 _xt_panic:
     #ifdef XT_SIMULATOR
@@ -386,6 +387,7 @@ Debug Exception.
     .section    .DebugExceptionVector.text, "ax"
     .global     _DebugExceptionVector
     .align      4
+    .literal_position
 
 _DebugExceptionVector:
 
@@ -424,6 +426,7 @@ Double exceptions are not a normal occurrence. They indicate a bug of some kind.
     .section    .DoubleExceptionVector.text, "ax"
     .global     _DoubleExceptionVector
     .align      4
+    .literal_position
 
 _DoubleExceptionVector:
 
@@ -447,6 +450,7 @@ Kernel Exception (including Level 1 Interrupt from kernel mode).
     .section    .KernelExceptionVector.text, "ax"
     .global     _KernelExceptionVector
     .align      4
+    .literal_position
 
 _KernelExceptionVector:
 
@@ -478,6 +482,7 @@ User Exception (including Level 1 Interrupt from user mode).
     .global     _UserExceptionVector
     .type       _UserExceptionVector,@function
     .align      4
+    .literal_position
 
 _UserExceptionVector:
 
@@ -1032,6 +1037,8 @@ _xt_lowint1:
     .global     _Level2Vector
     .type       _Level2Vector,@function
     .align      4
+    .literal_position
+
 _Level2Vector:
     wsr     a0, EXCSAVE_2                   /* preserve a0 */
     call0   _xt_medint2                     /* load interrupt handler */
@@ -1103,6 +1110,8 @@ _xt_medint2_exit:
     .global     _Level3Vector
     .type       _Level3Vector,@function
     .align      4
+    .literal_position
+
 _Level3Vector:
     wsr     a0, EXCSAVE_3                   /* preserve a0 */
     call0   _xt_medint3                     /* load interrupt handler */
@@ -1174,6 +1183,8 @@ _xt_medint3_exit:
     .global     _Level4Vector
     .type       _Level4Vector,@function
     .align      4
+    .literal_position
+
 _Level4Vector:
     wsr     a0, EXCSAVE_4                   /* preserve a0 */
     call0   _xt_medint4                     /* load interrupt handler */
@@ -1244,6 +1255,8 @@ _xt_medint4_exit:
     .global     _Level5Vector
     .type       _Level5Vector,@function
     .align      4
+    .literal_position
+
 _Level5Vector:
     wsr     a0, EXCSAVE_5                   /* preserve a0 */
     call0   _xt_medint5                     /* load interrupt handler */
@@ -1314,6 +1327,8 @@ _xt_medint5_exit:
     .global     _Level6Vector
     .type       _Level6Vector,@function
     .align      4
+    .literal_position
+
 _Level6Vector:
     wsr     a0, EXCSAVE_6                   /* preserve a0 */
     call0   _xt_medint6                     /* load interrupt handler */


### PR DESCRIPTION
Patch submitted by customer on forums here: https://forums.freertos.org/t/cannot-compile-xtensa-port-assembly-with-text-section-literals/14838

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
