### PR TITLE
Correct spelling mistake in header files

### DIFF
--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -38,7 +38,7 @@
 #ifndef MPU_PROTOTYPES_H
 #define MPU_PROTOTYPES_H
 
-/* MPU versions of tasks.h API functions. */
+/* MPU versions of task.h API functions. */
 BaseType_t MPU_xTaskCreate( TaskFunction_t pxTaskCode,
                             const char * const pcName,
                             const uint16_t usStackDepth,

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -46,7 +46,7 @@
  * privileges.
  */
 
-/* Map standard tasks.h API functions to the MPU equivalents. */
+/* Map standard task.h API functions to the MPU equivalents. */
         #define xTaskCreate                            MPU_xTaskCreate
         #define xTaskCreateStatic                      MPU_xTaskCreateStatic
         #define vTaskDelete                            MPU_vTaskDelete


### PR DESCRIPTION
Correct spelling mistake in mpu_wrappers.h and mpu_prototypes.h.

Description
-----------
tasks.h doesn't exist.

Test Steps
-----------
N/A

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
