### PR TITLE
Add atomic flag for 16-bit ticks PIC24

### DIFF
--- a/portable/MPLAB/PIC24_dsPIC/portmacro.h
+++ b/portable/MPLAB/PIC24_dsPIC/portmacro.h
@@ -59,6 +59,9 @@ typedef unsigned short UBaseType_t;
 #if( configUSE_16_BIT_TICKS == 1 )
 	typedef uint16_t TickType_t;
 	#define portMAX_DELAY ( TickType_t ) 0xffff
+/* 16-bit tick type on a 16-bit architecture, so reads of the tick count do
+ * not need to be guarded with a critical section. */
+	#define portTICK_TYPE_IS_ATOMIC 1
 #else
 	typedef uint32_t TickType_t;
 	#define portMAX_DELAY ( TickType_t ) 0xffffffffUL


### PR DESCRIPTION
Add atomic flag for 16-bit ticks

Description
-----------
This change allows the PIC24 family of
16 bit processors to read the tick count
without a critical section when the tick
count is also 16 bits.

Test Steps
-----------

Related Issue
-----------
Inspired from discussion - https://forums.freertos.org/t/xtaskgettickcount-with-critical-section-on-16-bit-mcu/14860/5


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
