### PR TITLE
cTaskWokenByPost -> xTaskWokenByReceive

### DIFF
--- a/include/queue.h
+++ b/include/queue.h
@@ -1400,12 +1400,12 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
  *      vOutputCharacter( cRxedChar );
  *
  *      // If removing the character from the queue woke the task that was
- *      // posting onto the queue cTaskWokenByReceive will have been set to
+ *      // posting onto the queue xTaskWokenByReceive will have been set to
  *      // pdTRUE.  No matter how many times this loop iterates only one
  *      // task will be woken.
  *  }
  *
- *  if( cTaskWokenByReceive != ( char ) pdFALSE;
+ *  if( xTaskWokenByReceive != ( char ) pdFALSE;
  *  {
  *      taskYIELD ();
  *  }

--- a/include/queue.h
+++ b/include/queue.h
@@ -1405,7 +1405,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
  *      // task will be woken.
  *  }
  *
- *  if( cTaskWokenByPost != ( char ) pdFALSE;
+ *  if( cTaskWokenByReceive != ( char ) pdFALSE;
  *  {
  *      taskYIELD ();
  *  }


### PR DESCRIPTION
Typo in Documentation

Description
-----------
Replaced cTaskWokenByPost with cTaskWokenByReceive.

Test Steps
-----------
Typo in Doc - read it ;)

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
