### PR TITLE
Add Newlib dynamic reentrancy

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -72,6 +72,14 @@
     #include <reent.h>
 #endif
 
+#ifdef configNEWLIB_REENTRANT_IS_DYNAMIC
+    #if ( configUSE_NEWLIB_REENTRANT != 1 )
+        #error configUSE_NEWLIB_REENTRANT must be defined to 1 to enable configNEWLIB_REENTRANT_IS_DYNAMIC
+    #endif
+#else /* configNEWLIB_REENTRANT_IS_DYNAMIC */
+    #define configNEWLIB_REENTRANT_IS_DYNAMIC   0
+#endif /* configNEWLIB_REENTRANT_IS_DYNAMIC */
+
 /*
  * Check all the required application specific macros have been defined.
  * These macros are application specific and (as downloaded) are defined

--- a/tasks.c
+++ b/tasks.c
@@ -2854,15 +2854,18 @@ void vTaskStartScheduler( void )
          * starts to run. */
         portDISABLE_INTERRUPTS();
 
-        #if ( configUSE_NEWLIB_REENTRANT == 1 )
+        #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) && ( configNEWLIB_REENTRANT_IS_DYNAMIC == 0 ) )
             {
                 /* Switch Newlib's _impure_ptr variable to point to the _reent
                  * structure specific to the task that will run first.
                  * See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
-                 * for additional information. */
+                 * for additional information.
+                 *
+                 * Note: Updating the _impure_ptr is not required when Newlib is compiled with
+                 * __DYNAMIC_REENT__ enabled. The port should provide __getreent() instead. */
                 _impure_ptr = &( pxCurrentTCB->xNewLib_reent );
             }
-        #endif /* configUSE_NEWLIB_REENTRANT */
+        #endif /* ( configUSE_NEWLIB_REENTRANT == 1 ) && ( configNEWLIB_REENTRANT_IS_DYNAMIC == 0 ) */
 
         xNextTaskUnblockTime = portMAX_DELAY;
         xSchedulerRunning = pdTRUE;
@@ -3945,15 +3948,18 @@ void vTaskSwitchContext( BaseType_t xCoreID )
                 }
             #endif
 
-            #if ( configUSE_NEWLIB_REENTRANT == 1 )
+            #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) && ( configNEWLIB_REENTRANT_IS_DYNAMIC == 0 ) )
                 {
                     /* Switch Newlib's _impure_ptr variable to point to the _reent
                      * structure specific to this task.
                      * See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
-                     * for additional information. */
+                     * for additional information.
+                     *
+                     * Note: Updating the _impure_ptr is not required when Newlib is compiled with
+                     * __DYNAMIC_REENT__ enabled. The the port should provide __getreent() instead. */
                     _impure_ptr = &( pxCurrentTCB->xNewLib_reent );
                 }
-            #endif /* configUSE_NEWLIB_REENTRANT */
+            #endif /* ( configUSE_NEWLIB_REENTRANT == 1 ) && ( configNEWLIB_REENTRANT_IS_DYNAMIC == 0 ) */
         }
     }
     portRELEASE_ISR_LOCK();


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Currently, when `configUSE_NEWLIB_REENTRANT` is enabled, FreeRTOS will update Newlibs `_impure_ptr` on every context switch to point to the current task's `reent` struct. However, this behavior is no longer valid for SMP due to the fact that two or more cores can switch contexts, thus leading to a corrupted `_impure_ptr` (i.e., multiple cores cannot share the same `_impure_ptr`.

Newlib provides a `__DYNAMIC_REENT__` feature where all newlib functions will call a `__getreent()` function to get the required reentrancy structure instead of referring to the `_impure_ptr`. In case of FreeRTOS, it should just return the current core's current task's `reent` struct.

This commit adds the following changes:

- A `configNEWLIB_REENTRANT_IS_DYNAMIC` option to enable Newlib dynamic reentrancy support in FreeRTOS SMP
- `_impure_ptr` is no longer modified by FreeRTOS when `configNEWLIB_REENTRANT_IS_DYNAMIC` is enabled
- Port should provide their own `__getreent()` (probably somewhere in `freertos_tasks_c_additions.h`. The function could look something like the following:

```c
/**
 * @brief Get reentrancy structure of the current task
 *
 * - This funciton is required by newlib (when __DYNAMIC_REENT__ is enabled)
 * - It will return a pointer to the current task's reent struct
 * - If FreeRTOS is not running, it will return the global reent struct
 *
 * @return Pointer to a the (current taks's)/(global) reent struct
 */
struct _reent* __getreent(void) {
    // No lock needed because if this changes, we won't be running anymore.
    TCB_t *pxCurTask = xTaskGetCurrentTaskHandle();
    if (pxCurTask == NULL) {
        // No task running. Return global struct.
        return _GLOBAL_REENT;
    } else {
        // We have a task; return its reentrant struct.
        return &pxCurTask->xNewLib_reent;
    }
}
```