### PR TITLE
RP2040: Allow FreeRTOS to be added to the parent CMake project post initialization of the Pico SDK

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/CMakeLists.txt
+++ b/portable/ThirdParty/GCC/RP2040/CMakeLists.txt
@@ -21,20 +21,31 @@ if (NOT TARGET _FreeRTOS_kernel_inclusion_marker)
 
     pico_is_top_level_project(FREERTOS_KERNEL_TOP_LEVEL_PROJECT)
 
-    # The real work gets done in library.cmake which is called at the end of pico_sdk_init
-    list(APPEND PICO_SDK_POST_LIST_FILES ${CMAKE_CURRENT_LIST_DIR}/library.cmake)
-
-    # We need to inject the following header file into ALL SDK files (which we do via the config header)
-    list(APPEND PICO_CONFIG_HEADER_FILES ${CMAKE_CURRENT_LIST_DIR}/include/freertos_sdk_config.h)
-
-    if (FREERTOS_KERNEL_TOP_LEVEL_PROJECT)
-        message("FreeRTOS: initialize SDK since we're the top-level")
-        # Initialize the SDK
-        pico_sdk_init()
+    # if the SDK has already been initialized, then just add our libraries now - this allows
+    # this FreeRTOS port to just be added as a sub-directory or include within another project, rather than
+    # having to include it at the top level before pico_sdk_init()
+    if (TARGET _pico_sdk_inclusion_marker)
+        if (PICO_SDK_VERSION_STRING VERSION_LESS "1.3.2")
+            message(FATAL_ERROR "Require at least Raspberry Pi Pico SDK version 1.3.2 to include FreeRTOS after pico_sdk_init()")
+        endif()
+        include(${CMAKE_CURRENT_LIST_DIR}/library.cmake)
     else()
-        set(PICO_SDK_POST_LIST_FILES ${PICO_SDK_POST_LIST_FILES} PARENT_SCOPE)
-        set(PICO_CONFIG_HEADER_FILES ${PICO_CONFIG_HEADER_FILES} PARENT_SCOPE)
-        set(FREERTOS_KERNEL_PATH ${FREERTOS_KERNEL_PATH} PARENT_SCOPE)
+        # The real work gets done in library.cmake which is called at the end of pico_sdk_init
+        list(APPEND PICO_SDK_POST_LIST_FILES ${CMAKE_CURRENT_LIST_DIR}/library.cmake)
+        if (PICO_SDK_VERSION_STRING VERSION_LESS "1.3.2")
+            # We need to inject the following header file into ALL SDK files (which we do via the config header)
+            list(APPEND PICO_CONFIG_HEADER_FILES ${CMAKE_CURRENT_LIST_DIR}/include/freertos_sdk_config.h)
+        endif()
+
+        if (FREERTOS_KERNEL_TOP_LEVEL_PROJECT)
+            message("FreeRTOS: initialize SDK since we're the top-level")
+            # Initialize the SDK
+            pico_sdk_init()
+        else()
+            set(FREERTOS_KERNEL_PATH ${FREERTOS_KERNEL_PATH} PARENT_SCOPE)
+            set(PICO_CONFIG_HEADER_FILES ${PICO_CONFIG_HEADER_FILES} PARENT_SCOPE)
+            set(PICO_SDK_POST_LIST_FILES ${PICO_SDK_POST_LIST_FILES} PARENT_SCOPE)
+        endif()
     endif()
 endif()
 

--- a/portable/ThirdParty/GCC/RP2040/README.md
+++ b/portable/ThirdParty/GCC/RP2040/README.md
@@ -10,16 +10,28 @@ Note that a FreeRTOS SMP version of this port is also available in the FreeRTOS-
 
 ## Using this port
 
-Copy [FreeRTOS-Kernel-import.cmake](FreeRTOS-Kernel-import.cmake) into your project, and
-add:
+You can copy [FreeRTOS-Kernel-import.cmake](FreeRTOS-Kernel-import.cmake) into your project, and
+add the following in your `CMakeLists.txt`:
 
 ```cmake
 import(FreeRTOS_Kernel_import.cmake)
 ```
 
-below the usual import of `pico_sdk_import.cmake`
+This will locate the FreeRTOS kernel if it is a direct sub-module of your project, or if you provide the 
+`FREERTOS_KERNEL_PATH` variable in your environment or via `-DFREERTOS_KERNEL_PATH=/path/to/FreeRTOS-Kernel` on the CMake command line.
 
-This will find the FreeRTOS kernel if it is a direct sub-module of your project, or if you provide the `FREERTOS_KERNEL_PATH` variable in your environment or via `-DFREERTOS_KERNEL_PATH=/path/to/FreeRTOS-Kernel` on the CMake command line.
+**NOTE:** If you are using version 1.3.1 or older of the Raspberry Pi Pico SDK then this line must appear before the 
+`pico_sdk_init()` and will cause FreeRTOS to be included/required in all RP2040 targets in your project. After this SDK 
+version, you can include the FreeRTOS-Kernel support later in your CMake build (possibly in a subdirectory) and the 
+FreeRTOS-Kernel support will only apply to those targets which explicitly include FreeRTOS support.
+
+As an alternative to the `import` statement above, you can just add this directory directly via thw following (with 
+the same placement restrictions related to the Raspberry Pi Pico SDK version above): 
+
+```cmake
+add_subdirectory(path/to/this/directory FreeRTOS-Kernel)
+```
+
 
 ## Advanced Configuration
 

--- a/portable/ThirdParty/GCC/RP2040/library.cmake
+++ b/portable/ThirdParty/GCC/RP2040/library.cmake
@@ -16,6 +16,11 @@ target_sources(FreeRTOS-Kernel-Core INTERFACE
         )
 target_include_directories(FreeRTOS-Kernel-Core INTERFACE ${FREERTOS_KERNEL_PATH}/include)
 
+if (PICO_SDK_VERSION_STRING VERSION_GREATER_EQUAL "1.3.2")
+    target_compile_definitions(FreeRTOS-Kernel-Core INTERFACE
+            PICO_CONFIG_RTOS_ADAPTER_HEADER=${CMAKE_CURRENT_LIST_DIR}/include/freertos_sdk_config.h)
+endif()
+
 add_library(FreeRTOS-Kernel INTERFACE)
 target_sources(FreeRTOS-Kernel INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/port.c


### PR DESCRIPTION
Including FreeRTOS in the top level CMakeLists.txt is not always convenient, so this change allows
FreeRTOS_Kernel_import.cmake or just the CMakeLists.txt to be included wherever in the user's project.