### PR TITLE
Update prvYieldCore() compile warning for single core targets

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -703,11 +703,13 @@ static void prvYieldCore( BaseType_t xCoreID )
         {
             xYieldPendings[ xCoreID ] = pdTRUE;
         }
-        else
-        {
-            portYIELD_CORE( xCoreID );
-            pxCurrentTCBs[ xCoreID ]->xTaskRunState = taskTASK_YIELDING;
-        }
+        #if ( configNUM_CORES > 1 )
+            else
+            {
+                portYIELD_CORE( xCoreID );
+                pxCurrentTCBs[ xCoreID ]->xTaskRunState = taskTASK_YIELDING;
+            }
+        #endif
     }
 }
 


### PR DESCRIPTION
Description
-----------
When configNUM_CORES is 1, `prvYieldCore()` generates an array subscript
outofbound error (`-Warray-bounds`) when compiled with GCC with space
optimization enabled (-Os).

This commit updates the code flow in `prvYieldCore()` to compile out
the part where yield is needed on the other core which is unnecessary
for single-core targets.

Test Steps
-----------
To generate the warning, compile FreeRTOS smp branch with GCC and -Os optimization enabled.

```
warning: array subscript [0, 0] is outside array bounds of 'TCB_t * volatile[1]' {aka 'struct tskTaskControlBlock * volatile[1]'} [-Warray-bounds]
  716 |             pxCurrentTCBs[ xCoreID ]->xTaskRunState = taskTASK_YIELDING;
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
