### PR TITLE
Ensure that xTaskGetCurrentTaskHandle is included

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -44,6 +44,10 @@
     #error configUSE_TASK_NOTIFICATIONS must be set to 1 to build stream_buffer.c
 #endif
 
+#if ( INCLUDE_xTaskGetCurrentTaskHandle != 1 )
+    #error INCLUDE_xTaskGetCurrentTaskHandle must be set to 1 to build stream_buffer.c
+#endif
+
 /* Lint e961, e9021 and e750 are suppressed as a MISRA exception justified
  * because the MPU ports require MPU_WRAPPERS_INCLUDED_FROM_API_FILE to be defined
  * for the header files above, but not in this file, in order to generate the


### PR DESCRIPTION
Description
-----------
This PR adds a check that `INCLUDE_xTaskGetCurrentTaskHandle` is set to `1`. A compile time error message is produced if it is not set to `1`. This is needed because stream_buffer.c uses `xTaskGetCurrentTaskHandle`.

This was reported here - https://forums.freertos.org/t/xstreambufferreceive-include-xtaskgetcur/15283


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
