### PR TITLE
RP2040: Remove incorrect assertion

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -742,9 +742,6 @@ __attribute__( ( weak ) ) void vPortSetupTimerInterrupt( void )
             ulYieldSpinLockSaveValue = ulSave;
             xEventGroupWaitBits( xEventGroup, prvGetEventGroupBit(pxLock->spin_lock),
                                  pdTRUE, pdFALSE, portMAX_DELAY);
-            /* sanity check that interrupts were disabled, then re-enabled during the call, which will have
-             * taken care of the yield */
-            configASSERT( pxYieldSpinLock == NULL);
         }
     }
 


### PR DESCRIPTION
After the xEventGroupWaitBits in vProtLockInternalSpinUnlockWithWait there was an assertion about
pxYiledSpinLock being NULL, however when xEventGroupWaitBits returns, IRQs have been re-enabled
and so it is no longer safe to assert on the state which was protected by IRQs being disabled.

I spotted this once during a long running test, and made a simple extreme test app to repro the problem. 