### PR TITLE
Add Cortex M7 r0p1 Errata 837070 workaround to CM4_MPU ports

### DIFF
--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -418,12 +418,12 @@ BaseType_t xPortStartScheduler( void )
 
     /* Errata 837070 workaround must only be enabled on Cortex-M7 r0p0
      * and r0p1 cores. */
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         configASSERT( ( portCPUID == portCORTEX_M7_r0p1_ID ) || ( portCPUID == portCORTEX_M7_r0p0_ID ) );
     #else
         /* When using this port on a Cortex-M7 r0p0 or r0p1 core, define
-         * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in
-         * your FreeRTOSConfig.h. */
+         * configENABLE_ERRATA_837070_WORKAROUND to 1 in your
+         * FreeRTOSConfig.h. */
         configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
         configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
     #endif
@@ -605,13 +605,13 @@ void xPortPendSVHandler( void )
         "										\n"
         "	stmdb sp!, {r0, r3}					\n"
         "	mov r0, %0							\n"
-       #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+       #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
             "	cpsid i							\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         #endif
         "	msr basepri, r0						\n"
         "	dsb									\n"
         "	isb									\n"
-        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
             "	cpsie i							\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         #endif
         "	bl vTaskSwitchContext				\n"

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -70,6 +70,11 @@
 #define portNVIC_SYS_CTRL_STATE_REG               ( *( ( volatile uint32_t * ) 0xe000ed24 ) )
 #define portNVIC_MEM_FAULT_ENABLE                 ( 1UL << 16UL )
 
+/* Constants used to detect a Cortex-M7 r0p1 core, and ensure that a work around is active for errata 837070. */
+#define portCPUID                                 ( *( ( volatile uint32_t * ) 0xE000ed00 ) )
+#define portCORTEX_M7_r0p1_ID                     ( 0x410FC271UL )
+#define portCORTEX_M7_r0p0_ID                     ( 0x410FC270UL )
+
 /* Constants required to access and manipulate the MPU. */
 #define portMPU_TYPE_REG                          ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
 #define portMPU_REGION_BASE_ADDRESS_REG           ( *( ( volatile uint32_t * ) 0xe000ed9C ) )
@@ -410,6 +415,14 @@ BaseType_t xPortStartScheduler( void )
      * https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
     configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) );
 
+    #if !defined( configTARGET_ARM_CM7_r0p0 ) && !defined( configTARGET_ARM_CM7_r0p1 )
+        /* Cortex M7 r0p0 and r0p1 require a workaround for ARN errata 837070.
+         * When using a Cortex-M7 r0p0 or r0p1 target, define configTARGET_ARM_CM7_r0p0
+         * or configTARGET_ARM_CM7_r0p1 in your FreeRTOSConfig.h */
+        configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
+        configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
+    #endif /* !configTARGET_ARM_CM7_r0p1 && !configTARGET_ARM_CM7_r0p0 */
+
     #if ( configASSERT_DEFINED == 1 )
         {
             volatile uint32_t ulOriginalPriority;
@@ -587,9 +600,15 @@ void xPortPendSVHandler( void )
         "										\n"
         "	stmdb sp!, {r0, r3}					\n"
         "	mov r0, %0							\n"
+        #if defined( configTARGET_ARM_CM7_r0p0 ) || defined( configTARGET_ARM_CM7_r0p1 )
+            "	cpsid i						    \n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+        #endif /* configTARGET_ARM_CM7_r0p0 || configTARGET_ARM_CM7_r0p1 */
         "	msr basepri, r0						\n"
         "	dsb									\n"
         "	isb									\n"
+        #if defined( configTARGET_ARM_CM7_r0p0 ) || defined( configTARGET_ARM_CM7_r0p1 )
+            "	cpsie i							\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+        #endif /* configTARGET_ARM_CM7_r0p0 || configTARGET_ARM_CM7_r0p1 */
         "	bl vTaskSwitchContext				\n"
         "	mov r0, #0							\n"
         "	msr basepri, r0						\n"

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -72,13 +72,6 @@ typedef unsigned long    UBaseType_t;
     #define portTICK_TYPE_IS_ATOMIC    1
 #endif
 
-/* Cortex-M7 r0p0 and r0p1 cores require a workaround for ARM errata 837070.
- * When using this port on a Cortex-M7 r0p0 or r0p1 core, define
- * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in your
- * FreeRTOSConfig.h. */
-#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
-    #define portENABLE_ERRATA_837070_WORKAROUND       1
-#endif
 /*-----------------------------------------------------------*/
 
 /* MPU specific constants. */
@@ -355,13 +348,13 @@ portFORCE_INLINE static void vPortRaiseBASEPRI( void )
     __asm volatile
     (
         "	mov %0, %1												\n"
-        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
             "	cpsid i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         #endif
         "	msr basepri, %0											\n"
         "	isb														\n"
         "	dsb														\n"
-        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
             "	cpsie i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         #endif
         : "=r" ( ulNewBASEPRI ) : "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
@@ -378,13 +371,13 @@ portFORCE_INLINE static uint32_t ulPortRaiseBASEPRI( void )
     (
         "	mrs %0, basepri											\n"
         "	mov %1, %2												\n"
-        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
             "	cpsid i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         #endif
         "	msr basepri, %1											\n"
         "	isb														\n"
         "	dsb														\n"
-        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
             "	cpsie i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         #endif
         : "=r" ( ulOriginalBASEPRI ), "=r" ( ulNewBASEPRI ) : "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -71,6 +71,14 @@ typedef unsigned long    UBaseType_t;
  * not need to be guarded with a critical section. */
     #define portTICK_TYPE_IS_ATOMIC    1
 #endif
+
+/* Cortex-M7 r0p0 and r0p1 cores require a workaround for ARM errata 837070.
+ * When using this port on a Cortex-M7 r0p0 or r0p1 core, define
+ * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in your
+ * FreeRTOSConfig.h. */
+#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
+    #define portENABLE_ERRATA_837070_WORKAROUND       1
+#endif
 /*-----------------------------------------------------------*/
 
 /* MPU specific constants. */
@@ -346,10 +354,16 @@ portFORCE_INLINE static void vPortRaiseBASEPRI( void )
 
     __asm volatile
     (
-        "	mov %0, %1												\n"\
-        "	msr basepri, %0											\n"\
-        "	isb														\n"\
-        "	dsb														\n"\
+        "	mov %0, %1												\n"
+        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+            "	cpsid i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+        #endif
+        "	msr basepri, %0											\n"
+        "	isb														\n"
+        "	dsb														\n"
+        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+            "	cpsie i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+        #endif
         : "=r" ( ulNewBASEPRI ) : "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
     );
 }
@@ -362,11 +376,17 @@ portFORCE_INLINE static uint32_t ulPortRaiseBASEPRI( void )
 
     __asm volatile
     (
-        "	mrs %0, basepri											\n"\
-        "	mov %1, %2												\n"\
-        "	msr basepri, %1											\n"\
-        "	isb														\n"\
-        "	dsb														\n"\
+        "	mrs %0, basepri											\n"
+        "	mov %1, %2												\n"
+        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+            "	cpsid i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+        #endif
+        "	msr basepri, %1											\n"
+        "	isb														\n"
+        "	dsb														\n"
+        #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+            "	cpsie i												\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+        #endif
         : "=r" ( ulOriginalBASEPRI ), "=r" ( ulNewBASEPRI ) : "i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) : "memory"
     );
 

--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -445,11 +445,11 @@ void xPortPendSVHandler( void )
         "										\n"
         "	stmdb sp!, {r0, r3}					\n"
         "	mov r0, %0 							\n"
-        "	cpsid i								\n"/* Errata workaround. */
+        "	cpsid i								\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         "	msr basepri, r0						\n"
         "	dsb									\n"
         "	isb									\n"
-        "	cpsie i								\n"/* Errata workaround. */
+        "	cpsie i								\n"/* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
         "	bl vTaskSwitchContext				\n"
         "	mov r0, #0							\n"
         "	msr basepri, r0						\n"

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -98,8 +98,8 @@
 #define portNVIC_PENDSVCLEAR_BIT                  ( 1UL << 27UL )
 #define portNVIC_PEND_SYSTICK_CLEAR_BIT           ( 1UL << 25UL )
 
-/* Constants used to detect a Cortex-M7 r0p1 core, which should use the ARM_CM7
- * r0p1 port. */
+/* Constants used to detect Cortex-M7 r0p0 and r0p1 cores, and ensure
+ * that a work around is active for errata 837070. */
 #define portCPUID                                 ( *( ( volatile uint32_t * ) 0xE000ed00 ) )
 #define portCORTEX_M7_r0p1_ID                     ( 0x410FC271UL )
 #define portCORTEX_M7_r0p0_ID                     ( 0x410FC270UL )
@@ -350,11 +350,17 @@ BaseType_t xPortStartScheduler( void )
      * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
     configASSERT( configMAX_SYSCALL_INTERRUPT_PRIORITY );
 
-    /* This port can be used on all revisions of the Cortex-M7 core other than
-     * the r0p1 parts.  r0p1 parts should use the port from the
-     * /source/portable/GCC/ARM_CM7/r0p1 directory. */
-    configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
-    configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
+    /* Errata 837070 workaround must only be enabled on Cortex-M7 r0p0
+     * and r0p1 cores. */
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        configASSERT( ( portCPUID == portCORTEX_M7_r0p1_ID ) || ( portCPUID == portCORTEX_M7_r0p0_ID ) );
+    #else
+        /* When using this port on a Cortex-M7 r0p0 or r0p1 core, define
+         * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in
+         * your FreeRTOSConfig.h. */
+        configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
+        configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
+    #endif
 
     #if ( configASSERT_DEFINED == 1 )
         {

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -352,12 +352,12 @@ BaseType_t xPortStartScheduler( void )
 
     /* Errata 837070 workaround must only be enabled on Cortex-M7 r0p0
      * and r0p1 cores. */
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         configASSERT( ( portCPUID == portCORTEX_M7_r0p1_ID ) || ( portCPUID == portCORTEX_M7_r0p0_ID ) );
     #else
         /* When using this port on a Cortex-M7 r0p0 or r0p1 core, define
-         * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in
-         * your FreeRTOSConfig.h. */
+         * configENABLE_ERRATA_837070_WORKAROUND to 1 in your
+         * FreeRTOSConfig.h. */
         configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
         configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
     #endif

--- a/portable/IAR/ARM_CM4F_MPU/portasm.s
+++ b/portable/IAR/ARM_CM4F_MPU/portasm.s
@@ -70,9 +70,15 @@ xPortPendSVHandler:
 
 	stmdb sp!, {r0, r3}
 	mov r0, #configMAX_SYSCALL_INTERRUPT_PRIORITY
+	#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
+		cpsid i /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+	#endif
 	msr basepri, r0
 	dsb
 	isb
+	#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
+		cpsie i /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+	#endif
 	bl vTaskSwitchContext
 	mov r0, #0
 	msr basepri, r0

--- a/portable/IAR/ARM_CM4F_MPU/portasm.s
+++ b/portable/IAR/ARM_CM4F_MPU/portasm.s
@@ -70,13 +70,13 @@ xPortPendSVHandler:
 
 	stmdb sp!, {r0, r3}
 	mov r0, #configMAX_SYSCALL_INTERRUPT_PRIORITY
-	#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
+	#if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
 		cpsid i /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
 	#endif
 	msr basepri, r0
 	dsb
 	isb
-	#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
+	#if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
 		cpsie i /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
 	#endif
 	bl vTaskSwitchContext

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -74,13 +74,6 @@ typedef unsigned long    UBaseType_t;
     #define portTICK_TYPE_IS_ATOMIC    1
 #endif
 
-/* Cortex-M7 r0p0 and r0p1 cores require a workaround for ARM errata 837070.
- * When using this port on a Cortex-M7 r0p0 or r0p1 core, define
- * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in your
- * FreeRTOSConfig.h. */
-#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
-    #define portENABLE_ERRATA_837070_WORKAROUND       1
-#endif
 /*-----------------------------------------------------------*/
 
 /* MPU specific constants. */
@@ -261,7 +254,7 @@ typedef struct MPU_SETTINGS
 extern void vPortEnterCritical( void );
 extern void vPortExitCritical( void );
 
-#if( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+#if( configENABLE_ERRATA_837070_WORKAROUND == 1 )
     #define portDISABLE_INTERRUPTS()                               \
         {                                                          \
             __disable_interrupt();                                 \

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -59,7 +59,8 @@
 #define portNVIC_SYS_CTRL_STATE_REG               ( *( ( volatile uint32_t * ) 0xe000ed24 ) )
 #define portNVIC_MEM_FAULT_ENABLE                 ( 1UL << 16UL )
 
-/* Constants used to detect a Cortex-M7 r0p1 core, which should use the ARM_CM7 r0p1 port. */
+/* Constants used to detect Cortex-M7 r0p0 and r0p1 cores, and ensure
+ * that a work around is active for errata 837070. */
 #define portCPUID                                 ( *( ( volatile uint32_t * ) 0xE000ed00 ) )
 #define portCORTEX_M7_r0p1_ID                     ( 0x410FC271UL )
 #define portCORTEX_M7_r0p0_ID                     ( 0x410FC270UL )
@@ -405,13 +406,17 @@ BaseType_t xPortStartScheduler( void )
      * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
     configASSERT( configMAX_SYSCALL_INTERRUPT_PRIORITY );
 
-    #if !defined( configTARGET_ARM_CM7_r0p0 ) && !defined( configTARGET_ARM_CM7_r0p1 )
-        /* Cortex M7 r0p0 and r0p1 require a workaround for ARN errata 837070.
-         * When using a Cortex-M7 r0p0 or r0p1 target, define configTARGET_ARM_CM7_r0p0
-         * or configTARGET_ARM_CM7_r0p1 in your FreeRTOSConfig.h */
+    /* Errata 837070 workaround must only be enabled on Cortex-M7 r0p0
+     * and r0p1 cores. */
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        configASSERT( ( portCPUID == portCORTEX_M7_r0p1_ID ) || ( portCPUID == portCORTEX_M7_r0p0_ID ) );
+    #else
+        /* When using this port on a Cortex-M7 r0p0 or r0p1 core, define
+         * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in
+         * your FreeRTOSConfig.h. */
         configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
         configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
-    #endif /* !configTARGET_ARM_CM7_r0p1 && !configTARGET_ARM_CM7_r0p0 */
+    #endif
 
     #if ( configASSERT_DEFINED == 1 )
         {
@@ -604,15 +609,15 @@ __asm void xPortPendSVHandler( void )
 
     stmdb sp !, { r0, r3 }
     mov r0, # configMAX_SYSCALL_INTERRUPT_PRIORITY
-    #if defined( configTARGET_ARM_CM7_r0p0 ) || defined( configTARGET_ARM_CM7_r0p1 )
-        cpsid i		        /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
-    #endif /* configTARGET_ARM_CM7_r0p0 || configTARGET_ARM_CM7_r0p1 */
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        cpsid i             /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+    #endif
     msr basepri, r0
     dsb
     isb
-    #if defined( configTARGET_ARM_CM7_r0p0 ) || defined( configTARGET_ARM_CM7_r0p1 )
-        cpsie i			    /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
-    #endif /* configTARGET_ARM_CM7_r0p0 || configTARGET_ARM_CM7_r0p1 */
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        cpsie i             /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+    #endif
     bl vTaskSwitchContext
     mov r0, #0
     msr basepri, r0

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -59,6 +59,11 @@
 #define portNVIC_SYS_CTRL_STATE_REG               ( *( ( volatile uint32_t * ) 0xe000ed24 ) )
 #define portNVIC_MEM_FAULT_ENABLE                 ( 1UL << 16UL )
 
+/* Constants used to detect a Cortex-M7 r0p1 core, which should use the ARM_CM7 r0p1 port. */
+#define portCPUID                                 ( *( ( volatile uint32_t * ) 0xE000ed00 ) )
+#define portCORTEX_M7_r0p1_ID                     ( 0x410FC271UL )
+#define portCORTEX_M7_r0p0_ID                     ( 0x410FC270UL )
+
 /* Constants required to access and manipulate the MPU. */
 #define portMPU_TYPE_REG                          ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
 #define portMPU_REGION_BASE_ADDRESS_REG           ( *( ( volatile uint32_t * ) 0xe000ed9C ) )
@@ -400,6 +405,14 @@ BaseType_t xPortStartScheduler( void )
      * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
     configASSERT( configMAX_SYSCALL_INTERRUPT_PRIORITY );
 
+    #if !defined( configTARGET_ARM_CM7_r0p0 ) && !defined( configTARGET_ARM_CM7_r0p1 )
+        /* Cortex M7 r0p0 and r0p1 require a workaround for ARN errata 837070.
+         * When using a Cortex-M7 r0p0 or r0p1 target, define configTARGET_ARM_CM7_r0p0
+         * or configTARGET_ARM_CM7_r0p1 in your FreeRTOSConfig.h */
+        configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
+        configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
+    #endif /* !configTARGET_ARM_CM7_r0p1 && !configTARGET_ARM_CM7_r0p0 */
+
     #if ( configASSERT_DEFINED == 1 )
         {
             volatile uint32_t ulOriginalPriority;
@@ -591,9 +604,15 @@ __asm void xPortPendSVHandler( void )
 
     stmdb sp !, { r0, r3 }
     mov r0, # configMAX_SYSCALL_INTERRUPT_PRIORITY
+    #if defined( configTARGET_ARM_CM7_r0p0 ) || defined( configTARGET_ARM_CM7_r0p1 )
+        cpsid i		        /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+    #endif /* configTARGET_ARM_CM7_r0p0 || configTARGET_ARM_CM7_r0p1 */
     msr basepri, r0
     dsb
     isb
+    #if defined( configTARGET_ARM_CM7_r0p0 ) || defined( configTARGET_ARM_CM7_r0p1 )
+        cpsie i			    /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
+    #endif /* configTARGET_ARM_CM7_r0p0 || configTARGET_ARM_CM7_r0p1 */
     bl vTaskSwitchContext
     mov r0, #0
     msr basepri, r0

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -408,12 +408,12 @@ BaseType_t xPortStartScheduler( void )
 
     /* Errata 837070 workaround must only be enabled on Cortex-M7 r0p0
      * and r0p1 cores. */
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         configASSERT( ( portCPUID == portCORTEX_M7_r0p1_ID ) || ( portCPUID == portCORTEX_M7_r0p0_ID ) );
     #else
         /* When using this port on a Cortex-M7 r0p0 or r0p1 core, define
-         * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in
-         * your FreeRTOSConfig.h. */
+         * configENABLE_ERRATA_837070_WORKAROUND to 1 in your
+         * FreeRTOSConfig.h. */
         configASSERT( portCPUID != portCORTEX_M7_r0p1_ID );
         configASSERT( portCPUID != portCORTEX_M7_r0p0_ID );
     #endif
@@ -609,13 +609,13 @@ __asm void xPortPendSVHandler( void )
 
     stmdb sp !, { r0, r3 }
     mov r0, # configMAX_SYSCALL_INTERRUPT_PRIORITY
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         cpsid i             /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
     #endif
     msr basepri, r0
     dsb
     isb
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         cpsie i             /* ARM Cortex-M7 r0p1 Errata 837070 workaround. */
     #endif
     bl vTaskSwitchContext

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -70,6 +70,14 @@ typedef unsigned long    UBaseType_t;
  * not need to be guarded with a critical section. */
     #define portTICK_TYPE_IS_ATOMIC    1
 #endif
+
+/* Cortex-M7 r0p0 and r0p1 cores require a workaround for ARM errata 837070.
+ * When using this port on a Cortex-M7 r0p0 or r0p1 core, define
+ * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in your
+ * FreeRTOSConfig.h. */
+#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
+    #define portENABLE_ERRATA_837070_WORKAROUND       1
+#endif
 /*-----------------------------------------------------------*/
 
 /* MPU specific constants. */
@@ -334,9 +342,15 @@ static portFORCE_INLINE void vPortRaiseBASEPRI( void )
         /* Set BASEPRI to the max syscall priority to effect a critical
          * section. */
 /* *INDENT-OFF* */
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        cpsid i
+    #endif
         msr basepri, ulNewBASEPRI
         dsb
         isb
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        cpsie i
+    #endif
 /* *INDENT-ON* */
     }
 }
@@ -366,9 +380,15 @@ static portFORCE_INLINE uint32_t ulPortRaiseBASEPRI( void )
          * section. */
 /* *INDENT-OFF* */
         mrs ulReturn, basepri
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        cpsid i
+    #endif
         msr basepri, ulNewBASEPRI
         dsb
         isb
+    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+        cpsie i
+    #endif
 /* *INDENT-ON* */
     }
 

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -71,13 +71,6 @@ typedef unsigned long    UBaseType_t;
     #define portTICK_TYPE_IS_ATOMIC    1
 #endif
 
-/* Cortex-M7 r0p0 and r0p1 cores require a workaround for ARM errata 837070.
- * When using this port on a Cortex-M7 r0p0 or r0p1 core, define
- * configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 to 1 in your
- * FreeRTOSConfig.h. */
-#if ( ( configTARGET_ARM_CM7_r0p0 == 1 ) || ( configTARGET_ARM_CM7_r0p1 == 1 ) )
-    #define portENABLE_ERRATA_837070_WORKAROUND       1
-#endif
 /*-----------------------------------------------------------*/
 
 /* MPU specific constants. */
@@ -342,13 +335,13 @@ static portFORCE_INLINE void vPortRaiseBASEPRI( void )
         /* Set BASEPRI to the max syscall priority to effect a critical
          * section. */
 /* *INDENT-OFF* */
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         cpsid i
     #endif
         msr basepri, ulNewBASEPRI
         dsb
         isb
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         cpsie i
     #endif
 /* *INDENT-ON* */
@@ -380,13 +373,13 @@ static portFORCE_INLINE uint32_t ulPortRaiseBASEPRI( void )
          * section. */
 /* *INDENT-OFF* */
         mrs ulReturn, basepri
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         cpsid i
     #endif
         msr basepri, ulNewBASEPRI
         dsb
         isb
-    #if ( portENABLE_ERRATA_837070_WORKAROUND == 1 )
+    #if ( configENABLE_ERRATA_837070_WORKAROUND == 1 )
         cpsie i
     #endif
 /* *INDENT-ON* */


### PR DESCRIPTION
Description
-----------
Add ARM Cortex M7 r0p0 / r0p1 Errata 837070 workaround to CM4 MPU ports.

Add a runtime assertion when running on a cortex M7 r0p0 or r0p1 and the workaround is not enabled.

Optionally, enable the errata workaround by defining configTARGET_ARM_CM7_r0p0 or configTARGET_ARM_CM7_r0p1 in FreeRTOSConfig.h.

Related Issue
-----------
FreeRTOS Forum Topic: https://forums.freertos.org/t/freertos-mpu-support-in-arm-cortex-m7/15306/3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
