### PR TITLE
Do not use CMSIS names for interrupt handlers

### DIFF
--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
@@ -225,7 +225,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -409,7 +409,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
@@ -220,7 +220,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -344,7 +344,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
@@ -224,7 +224,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -408,7 +408,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
@@ -219,7 +219,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -333,7 +333,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
@@ -48,8 +48,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 	PUBLIC vPortFreeSecureContext
 
 #if ( configENABLE_FPU == 1 )
@@ -200,7 +200,7 @@ vClearInterruptMask:
 	bx lr
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	ldr r3, =xSecureContext					/* Read the location of xSecureContext i.e. &( xSecureContext ). */
 	ldr r0, [r3]							/* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
 	ldr r3, =pxCurrentTCB					/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
@@ -365,7 +365,7 @@ PendSV_Handler:
 		bx lr
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	movs r0, #4
 	mov r1, lr
 	tst r0, r1

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portasm.s
@@ -43,8 +43,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 
 #if ( configENABLE_FPU == 1 )
 	#error Cortex-M23 does not have a Floating Point Unit (FPU) and therefore configENABLE_FPU must be set to 0.
@@ -187,7 +187,7 @@ vClearInterruptMask:
 	bx lr
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	mrs r0, psp								/* Read PSP in r0. */
 	ldr r2, =pxCurrentTCB					/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
 	ldr r1, [r2]							/* Read pxCurrentTCB. */
@@ -295,7 +295,7 @@ PendSV_Handler:
 #endif /* configENABLE_MPU */
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	movs r0, #4
 	mov r1, lr
 	tst r0, r1

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
@@ -47,8 +47,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 	PUBLIC vPortFreeSecureContext
 /*-----------------------------------------------------------*/
 
@@ -183,7 +183,7 @@ vClearInterruptMask:
 	bx lr									/* Return. */
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	ldr r3, =xSecureContext					/* Read the location of xSecureContext i.e. &( xSecureContext ). */
 	ldr r0, [r3]							/* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
 	ldr r3, =pxCurrentTCB					/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
@@ -332,7 +332,7 @@ PendSV_Handler:
 		bx lr
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	tst lr, #4
 	ite eq
 	mrseq r0, msp

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portasm.s
@@ -43,8 +43,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 /*-----------------------------------------------------------*/
 
 /*---------------- Unprivileged Functions -------------------*/
@@ -169,7 +169,7 @@ vClearInterruptMask:
 	bx lr									/* Return. */
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	mrs r0, psp								/* Read PSP in r0. */
 #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
 	tst lr, #0x10							/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -251,7 +251,7 @@ PendSV_Handler:
 	bx r3
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	tst lr, #4
 	ite eq
 	mrseq r0, msp

--- a/portable/ARMv8M/non_secure/portasm.h
+++ b/portable/ARMv8M/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/GCC/ARM_CM23/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23/non_secure/portasm.c
@@ -225,7 +225,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -409,7 +409,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/GCC/ARM_CM23/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM23/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
@@ -220,7 +220,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -344,7 +344,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -224,7 +224,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -408,7 +408,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/GCC/ARM_CM33/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -219,7 +219,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -333,7 +333,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/GCC/ARM_CM55/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55/non_secure/portasm.c
@@ -224,7 +224,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -408,7 +408,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/GCC/ARM_CM55/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM55/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
@@ -219,7 +219,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 }
 /*-----------------------------------------------------------*/
 
-void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void xPortPendSVHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
@@ -333,7 +333,7 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortSVCHandler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/IAR/ARM_CM23/non_secure/portasm.h
+++ b/portable/IAR/ARM_CM23/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/IAR/ARM_CM23/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM23/non_secure/portasm.s
@@ -48,8 +48,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 	PUBLIC vPortFreeSecureContext
 
 #if ( configENABLE_FPU == 1 )
@@ -200,7 +200,7 @@ vClearInterruptMask:
 	bx lr
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	ldr r3, =xSecureContext					/* Read the location of xSecureContext i.e. &( xSecureContext ). */
 	ldr r0, [r3]							/* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
 	ldr r3, =pxCurrentTCB					/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
@@ -365,7 +365,7 @@ PendSV_Handler:
 		bx lr
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	movs r0, #4
 	mov r1, lr
 	tst r0, r1

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portasm.s
@@ -43,8 +43,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 
 #if ( configENABLE_FPU == 1 )
 	#error Cortex-M23 does not have a Floating Point Unit (FPU) and therefore configENABLE_FPU must be set to 0.
@@ -187,7 +187,7 @@ vClearInterruptMask:
 	bx lr
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	mrs r0, psp								/* Read PSP in r0. */
 	ldr r2, =pxCurrentTCB					/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
 	ldr r1, [r2]							/* Read pxCurrentTCB. */
@@ -295,7 +295,7 @@ PendSV_Handler:
 #endif /* configENABLE_MPU */
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	movs r0, #4
 	mov r1, lr
 	tst r0, r1

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/IAR/ARM_CM33/non_secure/portasm.h
+++ b/portable/IAR/ARM_CM33/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/IAR/ARM_CM33/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM33/non_secure/portasm.s
@@ -47,8 +47,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 	PUBLIC vPortFreeSecureContext
 /*-----------------------------------------------------------*/
 
@@ -183,7 +183,7 @@ vClearInterruptMask:
 	bx lr									/* Return. */
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	ldr r3, =xSecureContext					/* Read the location of xSecureContext i.e. &( xSecureContext ). */
 	ldr r0, [r3]							/* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
 	ldr r3, =pxCurrentTCB					/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
@@ -332,7 +332,7 @@ PendSV_Handler:
 		bx lr
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	tst lr, #4
 	ite eq
 	mrseq r0, msp

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portasm.s
@@ -43,8 +43,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 /*-----------------------------------------------------------*/
 
 /*---------------- Unprivileged Functions -------------------*/
@@ -169,7 +169,7 @@ vClearInterruptMask:
 	bx lr									/* Return. */
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	mrs r0, psp								/* Read PSP in r0. */
 #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
 	tst lr, #0x10							/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -251,7 +251,7 @@ PendSV_Handler:
 	bx r3
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	tst lr, #4
 	ite eq
 	mrseq r0, msp

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/IAR/ARM_CM55/non_secure/portasm.h
+++ b/portable/IAR/ARM_CM55/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/IAR/ARM_CM55/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM55/non_secure/portasm.s
@@ -47,8 +47,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 	PUBLIC vPortFreeSecureContext
 /*-----------------------------------------------------------*/
 
@@ -183,7 +183,7 @@ vClearInterruptMask:
 	bx lr									/* Return. */
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	ldr r3, =xSecureContext					/* Read the location of xSecureContext i.e. &( xSecureContext ). */
 	ldr r0, [r3]							/* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
 	ldr r3, =pxCurrentTCB					/* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
@@ -332,7 +332,7 @@ PendSV_Handler:
 		bx lr
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	tst lr, #4
 	ite eq
 	mrseq r0, msp

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -339,7 +339,7 @@ void vPortExitCritical( void ) PRIVILEGED_FUNCTION;
 /**
  * @brief SysTick handler.
  */
-void SysTick_Handler( void ) PRIVILEGED_FUNCTION;
+void xPortSysTickHandler( void ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief C part of SVC handler.
@@ -751,7 +751,7 @@ void vPortExitCritical( void ) /* PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
+void xPortSysTickHandler( void ) /* PRIVILEGED_FUNCTION */
 {
     uint32_t ulPreviousMask;
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portasm.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portasm.h
@@ -89,12 +89,12 @@ void vClearInterruptMask( uint32_t ulMask ) __attribute__( ( naked ) ) PRIVILEGE
 /**
  * @brief PendSV Exception handler.
  */
-void PendSV_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void xPortPendSVHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief SVC Handler.
  */
-void SVC_Handler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
+void vPortSVCHandler( void ) __attribute__( ( naked ) ) PRIVILEGED_FUNCTION;
 
 /**
  * @brief Allocate a Secure context for the calling task.

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portasm.s
@@ -43,8 +43,8 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
 	PUBLIC vStartFirstTask
 	PUBLIC ulSetInterruptMask
 	PUBLIC vClearInterruptMask
-	PUBLIC PendSV_Handler
-	PUBLIC SVC_Handler
+	PUBLIC xPortPendSVHandler
+	PUBLIC vPortSVCHandler
 /*-----------------------------------------------------------*/
 
 /*---------------- Unprivileged Functions -------------------*/
@@ -169,7 +169,7 @@ vClearInterruptMask:
 	bx lr									/* Return. */
 /*-----------------------------------------------------------*/
 
-PendSV_Handler:
+xPortPendSVHandler:
 	mrs r0, psp								/* Read PSP in r0. */
 #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
 	tst lr, #0x10							/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -251,7 +251,7 @@ PendSV_Handler:
 	bx r3
 /*-----------------------------------------------------------*/
 
-SVC_Handler:
+vPortSVCHandler:
 	tst lr, #4
 	ite eq
 	mrseq r0, msp


### PR DESCRIPTION
Description
-----------
We use the following 3 interrupt handlers in the port layer:

1. PendSV Handler
2. SVC Handler
3. SysTick Handler

Earlier we were using CMSIS names for these handlers which made it difficult for the application writer to use an alternate handler with the same CMSIS name. This commit changes the names of these handlers to FreeRTOS specific ones, same as v7-M ports. The application writer will need to map them to the CMSIS names, if needed, in their `FreeRTOSConfig.h`:

```c
 #define xPortPendSVHandler         PendSV_Handler
 #define vPortSVCHandler            SVC_Handler
 #define xPortSysTickHandler        SysTick_Handler
```

It was reported here - https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/511

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
