### PR TITLE
Add support for MISRA rule 8.13

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -84,8 +84,8 @@
  * \ingroup Tasks
  */
 struct tskTaskControlBlock; /* The old naming convention is used to prevent breaking kernel aware debuggers. */
-typedef struct tskTaskControlBlock * TaskHandle_t;
-typedef struct tskTaskControlBlock * const ConstTaskHandle_t;
+typedef struct tskTaskControlBlock           * TaskHandle_t;
+typedef struct tskTaskControlBlock * const   ConstTaskHandle_t;
 
 /*
  * Defines the prototype to which the application task hook function must

--- a/include/task.h
+++ b/include/task.h
@@ -85,6 +85,7 @@
  */
 struct tskTaskControlBlock; /* The old naming convention is used to prevent breaking kernel aware debuggers. */
 typedef struct tskTaskControlBlock * TaskHandle_t;
+typedef struct tskTaskControlBlock * const ConstTaskHandle_t;
 
 /*
  * Defines the prototype to which the application task hook function must


### PR DESCRIPTION
Add support for MISRA rule 8.13

Description
-----------
Add support for MISRA rule 8.13
MISRA rule  8.13, likes non changeable memory to be pointed by constant pointers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
