### PR TITLE
Fix the exception vector base address deleted in 9efca75

### DIFF
--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -225,6 +225,15 @@ chip_specific_stack_frame:              /* First add any chip specific registers
 /*-----------------------------------------------------------*/
 
 xPortStartFirstTask:
+
+#if( portasmHAS_SIFIVE_CLINT != 0 )
+    /* If there is a clint then interrupts can branch directly to the FreeRTOS
+    trap handler.  Otherwise the interrupt controller will need to be configured
+    outside of this file. */
+    la t0, freertos_risc_v_trap_handler
+    csrw mtvec, t0
+#endif /* portasmHAS_CLILNT */
+
     load_x  sp, pxCurrentTCB            /* Load pxCurrentTCB. */
     load_x  sp, 0( sp )                 /* Read sp from first TCB member. */
 


### PR DESCRIPTION
<!--- Title -->

Description 
-----------
 Fix the exception vector base address deleted in 9efca75
<!--- Describe your changes in detail. -->

Test Steps 
-----------
test with FreeRTOS/Demo/RISC-V-Qemu-virt_GCC
<!-- Describe the steps to reproduce. -->

Related Issue 
-----------
<!-- If any, please provide issue ID. -->
9efca75

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
