### PR TITLE
Implement MicroBlazeV9 stack protection

### DIFF
--- a/portable/GCC/MicroBlazeV9/port.c
+++ b/portable/GCC/MicroBlazeV9/port.c
@@ -127,7 +127,7 @@ extern void _start1( void );
 	pxTopOfStack--;
 
 	#if ( portHAS_STACK_OVERFLOW_CHECKING == 1 )
-		/* Store the stack limits (on the stack, ironically) */
+		/* Store the stack limits. */
 		*pxTopOfStack = (StackType_t) (pxTopOfStack + 3);
 		pxTopOfStack--;
 		*pxTopOfStack = (StackType_t) pxEndOfStack;
@@ -360,15 +360,7 @@ int32_t lReturn;
 
 	if( lReturn == pdPASS )
 	{
-		if( pxHandler )
-		{
-			lReturn = XIntc_Connect( &xInterruptControllerInstance, ucInterruptID, pxHandler, pvCallBackRef );
-		}
-		else
-		{
-			XIntc_Disconnect( &xInterruptControllerInstance, ucInterruptID );
-			lReturn = XST_SUCCESS;
-		}
+		lReturn = XIntc_Connect( &xInterruptControllerInstance, ucInterruptID, pxHandler, pvCallBackRef );
 	}
 
 	if( lReturn == XST_SUCCESS )

--- a/portable/GCC/MicroBlazeV9/port.c
+++ b/portable/GCC/MicroBlazeV9/port.c
@@ -105,7 +105,11 @@ static XIntc xInterruptControllerInstance;
  *
  * See the portable.h header file.
  */
+#if ( portHAS_STACK_OVERFLOW_CHECKING == 1 )
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, StackType_t *pxEndOfStack, TaskFunction_t pxCode, void *pvParameters )
+#else
 StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+#endif
 {
 extern void *_SDA2_BASE_, *_SDA_BASE_;
 const uint32_t ulR2 = ( uint32_t ) &_SDA2_BASE_;
@@ -121,6 +125,14 @@ extern void _start1( void );
 	pxTopOfStack--;
 	*pxTopOfStack = ( StackType_t ) 0x00000000;
 	pxTopOfStack--;
+
+	#if ( portHAS_STACK_OVERFLOW_CHECKING == 1 )
+		/* Store the stack limits (on the stack, ironically) */
+		*pxTopOfStack = (StackType_t) (pxTopOfStack + 3);
+		pxTopOfStack--;
+		*pxTopOfStack = (StackType_t) pxEndOfStack;
+		pxTopOfStack--;
+	#endif
 
 	#if( XPAR_MICROBLAZE_USE_FPU != 0 )
 		/* The FSR value placed in the initial task context is just 0. */

--- a/portable/GCC/MicroBlazeV9/port.c
+++ b/portable/GCC/MicroBlazeV9/port.c
@@ -360,7 +360,15 @@ int32_t lReturn;
 
 	if( lReturn == pdPASS )
 	{
-		lReturn = XIntc_Connect( &xInterruptControllerInstance, ucInterruptID, pxHandler, pvCallBackRef );
+		if( pxHandler )
+		{
+			lReturn = XIntc_Connect( &xInterruptControllerInstance, ucInterruptID, pxHandler, pvCallBackRef );
+		}
+		else
+		{
+			XIntc_Disconnect( &xInterruptControllerInstance, ucInterruptID );
+			lReturn = XST_SUCCESS;
+		}
 	}
 
 	if( lReturn == XST_SUCCESS )

--- a/portable/GCC/MicroBlazeV9/portasm.S
+++ b/portable/GCC/MicroBlazeV9/portasm.S
@@ -179,7 +179,9 @@
 	lw	r1, r0, r18
 
 #if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
-	/* Restore the stack limits -- must not load from r1! */
+	/* Restore the stack limits -- must not load from r1 (Stack Pointer)
+	because if the address of load or store instruction is out of range,
+	it will trigger Stack Protection Violation exception. */
 	or	r18, r0, r1
 	lwi	r12, r18, portSLR_OFFSET
 	mts	rslr, r12

--- a/portable/GCC/MicroBlazeV9/portasm.S
+++ b/portable/GCC/MicroBlazeV9/portasm.S
@@ -33,16 +33,6 @@
 #include "microblaze_exceptions_g.h"
 #include "xparameters.h"
 
-/* The context is oversized to allow functions called from the ISR to write
-back into the caller stack. */
-#if( XPAR_MICROBLAZE_USE_FPU != 0 )
-	#define portCONTEXT_SIZE 136
-	#define portMINUS_CONTEXT_SIZE -136
-#else
-	#define portCONTEXT_SIZE 132
-	#define portMINUS_CONTEXT_SIZE -132
-#endif
-
 /* Offsets from the stack pointer at which saved registers are placed. */
 #define portR31_OFFSET	4
 #define portR30_OFFSET	8
@@ -76,7 +66,31 @@ back into the caller stack. */
 #define portR2_OFFSET	120
 #define portCRITICAL_NESTING_OFFSET 124
 #define portMSR_OFFSET 128
-#define portFSR_OFFSET 132
+
+#if( XPAR_MICROBLAZE_USE_FPU != 0 )
+	#define portFSR_OFFSET 132
+	#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+		#define portSLR_OFFSET 136
+		#define portSHR_OFFSET 140
+
+		#define portCONTEXT_SIZE 144
+		#define portMINUS_CONTEXT_SIZE -144
+	#else
+		#define portCONTEXT_SIZE 136
+		#define portMINUS_CONTEXT_SIZE -136
+	#endif
+#else
+	#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+		#define portSLR_OFFSET 132
+		#define portSHR_OFFSET 136
+
+		#define portCONTEXT_SIZE 140
+		#define portMINUS_CONTEXT_SIZE -140
+	#else
+		#define portCONTEXT_SIZE 132
+		#define portMINUS_CONTEXT_SIZE -132
+	#endif
+#endif
 
 	.extern pxCurrentTCB
 	.extern XIntc_DeviceInterruptHandler
@@ -144,6 +158,14 @@ back into the caller stack. */
 		swi r18, r1, portFSR_OFFSET
 	#endif
 
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+	/* Save the stack limits */
+	mfs r18, rslr
+	swi r18, r1, portSLR_OFFSET
+	mfs r18, rshr
+	swi r18, r1, portSHR_OFFSET
+#endif
+
 	/* Save the top of stack value to the TCB. */
 	lwi r3, r0, pxCurrentTCB
 	sw	r1, r0, r3
@@ -155,6 +177,15 @@ back into the caller stack. */
 	/* Load the top of stack value from the TCB. */
 	lwi r18, r0, pxCurrentTCB
 	lw	r1, r0, r18
+
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+	/* Restore the stack limits -- must not load from r1! */
+	or	r18, r0, r1
+	lwi	r12, r18, portSLR_OFFSET
+	mts	rslr, r12
+	lwi	r12, r18, portSHR_OFFSET
+	mts	rshr, r12
+#endif
 
 	/* Restore the general registers. */
 	lwi r31, r1, portR31_OFFSET
@@ -252,6 +283,13 @@ _interrupt_handler:
 	/* Switch to the ISR stack. */
 	lwi r1, r0, pulISRStack
 
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+	ori r18, r0, _stack_end
+	mts rslr, r18
+	ori r18, r0, _stack
+	mts rshr, r18
+#endif
+
 	/* The parameter to the interrupt handler. */
 	ori r5, r0, configINTERRUPT_CONTROLLER_TO_USE
 
@@ -295,6 +333,13 @@ VPortYieldASM:
 
 	/* Switch to use the ISR stack. */
 	lwi r1, r0, pulISRStack
+
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+	ori r18, r0, _stack_end
+	mts rslr, r18
+	ori r18, r0, _stack
+	mts rshr, r18
+#endif
 
 	/* Select the next task to execute. */
 	bralid r15, vTaskSwitchContext

--- a/portable/GCC/MicroBlazeV9/portmacro.h
+++ b/portable/GCC/MicroBlazeV9/portmacro.h
@@ -152,6 +152,11 @@ extern volatile uint32_t ulTaskSwitchRequested;
 #define portNOP()					asm volatile ( "NOP" )
 /*-----------------------------------------------------------*/
 
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+#define portHAS_STACK_OVERFLOW_CHECKING	1
+#endif
+/*-----------------------------------------------------------*/
+
 /* Task function macros as described on the FreeRTOS.org WEB site. */
 #define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
 #define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This enables support for hardware-level stack protection on MicroBlazeV9.  There's no inherent reason why it shouldn't also work on older MicroBlaze as well, but this is the only one I tested this specific implementation with.  (I have previously tested similar code on V8, though, so I know it at least can work on that.)

Test Steps
-----------
1. On a Xilinx 7-series FPGA, configure a MicroBlaze core with the stack protection exception enabled.
2. Configure FreeRTOS with `configCHECK_FOR_STACK_OVERFLOW = 0` (optional; it will also work with it enabled, but it's not needed)
3. During normal operation, everything runs normally (which is **not** the case if you enable the exception without using this code).
4. If any task exceeds its stack limits, the CPU will immediately raise an exception without needing FreeRTOS to catch it after the fact during a task switch.

(As an aside, it looks like the version of FreeRTOS that Xilinx include with Vivado also includes support for 64-bit CPUs, which appears to be missing in this repository.  You might want to hassle them to contribute it upstream.)

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
