### PR TITLE
RP2040: Use indirect reference for pxCurrentTCB

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -206,7 +206,7 @@ void vPortStartFirstTask( void )
 {
     __asm volatile (
         "   .syntax unified             \n"
-        "   ldr  r2, =pxCurrentTCB      \n"/* Obtain location of pxCurrentTCB. */
+        "   ldr  r2, pxCurrentTCBConst1 \n"/* Obtain location of pxCurrentTCB. */
         "   ldr  r3, [r2]               \n"
         "   ldr  r0, [r3]               \n"/* The first item in pxCurrentTCB is the task top of stack. */
         "   adds r0, #32                \n"/* Discard everything up to r0. */
@@ -220,6 +220,8 @@ void vPortStartFirstTask( void )
         "   pop  {r2}                   \n"/* Pop and discard XPSR. */
         "   cpsie i                     \n"/* The first task has its context and interrupts can be enabled. */
         "   bx   r3                     \n"/* Finally, jump to the user defined task code. */
+	"   .align 4                       \n"
+	"pxCurrentTCBConst1: .word pxCurrentTCB\n"
     );
 }
 /*-----------------------------------------------------------*/
@@ -380,7 +382,7 @@ void xPortPendSVHandler( void )
         "   .syntax unified                     \n"
         "   mrs r0, psp                         \n"
         "                                       \n"
-        "   ldr r3, =pxCurrentTCB               \n"/* Get the location of the current TCB. */
+        "   ldr r3, pxCurrentTCBConst2          \n"/* Get the location of the current TCB. */
         "   ldr r2, [r3]                        \n"
         "                                       \n"
         "   subs r0, r0, #32                    \n"/* Make space for the remaining low registers. */
@@ -450,6 +452,8 @@ void xPortPendSVHandler( void )
         "   ldmia r0!, {r4-r7}                  \n"/* Pop low registers.  */
         "                                       \n"
         "   bx r3                               \n"
+	"   .align 4                            \n"
+	"pxCurrentTCBConst2: .word pxCurrentTCB \n"
     );
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
This prevents generating a too-large offset and follows the pattern used in other ports, for example [portable/GCC/ARM_CM0/port.c:204](../blob/2dfdfc4ba4d8bb487c8ea6b5428d7d742ce162b8/portable/GCC/ARM_CM0/port.c#L204)

For search engine purposes, this resolves the following error message:
```
/tmp/ccG2Q2Vc.s: Assembler messages:
/tmp/ccG2Q2Vc.s:340: Error: invalid offset, value too big (0x00000630)
/tmp/ccG2Q2Vc.s:671: Error: invalid offset, value too big (0x000004A0)
```

I'm not completely sure why I ran into this issue when presumably this port is generally functional. Maybe something about my build environment?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
