### PR TITLE
Posix: Remove unused signal set variable from port

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -93,7 +93,6 @@ static inline Thread_t * prvGetThreadFromTask( TaskHandle_t xTask )
 /*-----------------------------------------------------------*/
 
 static pthread_once_t hSigSetupThread = PTHREAD_ONCE_INIT;
-static sigset_t xResumeSignals;
 static sigset_t xAllSignals;
 static sigset_t xSchedulerOriginalSignalMask;
 static pthread_t hMainThread = ( pthread_t ) NULL;
@@ -527,8 +526,6 @@ static void prvSetupSignalsAndSchedulerPolicy( void )
     hMainThread = pthread_self();
 
     /* Initialise common signal masks. */
-    sigemptyset( &xResumeSignals );
-    sigaddset( &xResumeSignals, SIG_RESUME );
     sigfillset( &xAllSignals );
 
     /* Don't block SIGINT so this can be used to break into GDB while


### PR DESCRIPTION
# Remove Unused signal set from POSIX `port.c`.

I noticed that a static variable `xResumeSignals` is prepared by the signal functions (`sigemptyset` and `sigaddset`)  but never used. I built the POSIX full demo example with this change and it still worked. Since it's a static variable and never used, I think it can be removed to improve code clarity. As far as I can see, the two aforementioned functions have no side effects besides changing the passed signal set. Please let me know if my assumptions are incorrect or if I'm missing something.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
