### PR TITLE
Add vPortRemoveInterruptHandler API

### DIFF
--- a/portable/GCC/MicroBlazeV9/port.c
+++ b/portable/GCC/MicroBlazeV9/port.c
@@ -374,6 +374,26 @@ int32_t lReturn;
 }
 /*-----------------------------------------------------------*/
 
+BaseType_t xPortRemoveInterruptHandler( uint8_t ucInterruptID )
+{
+int32_t lReturn;
+
+	/* An API function is provided to remove an interrupt handler because the
+	interrupt controller instance variable is private to this file. */
+
+	lReturn = prvEnsureInterruptControllerIsInitialised();
+
+	if( lReturn == pdPASS )
+	{
+		XIntc_Disconnect( &xInterruptControllerInstance, ucInterruptID );
+	}
+
+	configASSERT( lReturn == pdPASS );
+
+	return lReturn;
+}
+/*-----------------------------------------------------------*/
+
 static int32_t prvEnsureInterruptControllerIsInitialised( void )
 {
 static int32_t lInterruptControllerInitialised = pdFALSE;

--- a/portable/GCC/MicroBlazeV9/port.c
+++ b/portable/GCC/MicroBlazeV9/port.c
@@ -327,7 +327,7 @@ int32_t lReturn;
 		portEXIT_CRITICAL();
 	}
 
-	configASSERT( lReturn );
+	configASSERT( lReturn == pdPASS );
 }
 /*-----------------------------------------------------------*/
 
@@ -345,7 +345,7 @@ int32_t lReturn;
 		XIntc_Disable( &xInterruptControllerInstance, ucInterruptID );
 	}
 
-	configASSERT( lReturn );
+	configASSERT( lReturn == pdPASS );
 }
 /*-----------------------------------------------------------*/
 
@@ -374,7 +374,7 @@ int32_t lReturn;
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xPortRemoveInterruptHandler( uint8_t ucInterruptID )
+void vPortRemoveInterruptHandler( uint8_t ucInterruptID )
 {
 int32_t lReturn;
 
@@ -389,8 +389,6 @@ int32_t lReturn;
 	}
 
 	configASSERT( lReturn == pdPASS );
-
-	return lReturn;
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
This API is added to the MicroBlazeV9 port. It enables the application writer to remove an interrupt handler.

This was originally contributed in this PR - https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/523

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
