### PR TITLE
Fix NULL pointer dereference in vPortGetHeapStats

### DIFF
--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -494,7 +494,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
          * is initialised automatically when the first allocation is made. */
         if( pxBlock != NULL )
         {
-            do
+            while( pxBlock != pxEnd )
             {
                 /* Increment the number of blocks and record the largest block seen
                  * so far. */
@@ -513,7 +513,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
                 /* Move to the next block in the chain until the last block is
                  * reached. */
                 pxBlock = pxBlock->pxNextFreeBlock;
-            } while( pxBlock != pxEnd );
+            }
         }
     }
     ( void ) xTaskResumeAll();

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -544,7 +544,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
          * is initialised automatically when the first allocation is made. */
         if( pxBlock != NULL )
         {
-            do
+            while( pxBlock != pxEnd )
             {
                 /* Increment the number of blocks and record the largest block seen
                  * so far. */
@@ -569,7 +569,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
                 /* Move to the next block in the chain until the last block is
                  * reached. */
                 pxBlock = pxBlock->pxNextFreeBlock;
-            } while( pxBlock != pxEnd );
+            }
         }
     }
     ( void ) xTaskResumeAll();


### PR DESCRIPTION
Description
-----------
When the heap is exhausted (no free block), start and end markers are the only blocks present in the free block list:

```
     +---------------+     +-----------> NULL
     |               |     |
     |               V     |
+ ----- +            + ----- +
|   |   |            |   |   |
|   |   |            |   |   |
+ ----- +            + ----- +
  xStart               pxEnd
```

The code block which traverses the list of free blocks to calculate heap stats used a `do..while` loop that moved past the end marker when the heap had no free block resulting in a `NULL` pointer dereference. This commit changes the `do..while` loop to `while` loop thereby ensuring that we never move past the end marker.

This was reported here - https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/534

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
