### PR TITLE
Add .syntax unified to GCC assembly functions

### DIFF
--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
@@ -137,6 +137,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	tst r0, r1										\n"/* Perform r0 & r1 (bitwise AND) and update the conditions flag. */
@@ -157,6 +159,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* Read the CONTROL register. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	bics r0, r1										\n"/* Clear the bit 0. */
@@ -171,6 +175,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	orrs r0, r1										\n"/* r0 = r0 | r1. */
@@ -185,6 +191,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -206,6 +214,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, PRIMASK									\n"
         "	cpsid i											\n"
         "	bx lr											\n"
@@ -218,6 +228,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr PRIMASK, r0									\n"
         "	bx lr											\n"
         ::: "memory"
@@ -413,6 +425,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	movs r0, #4										\n"
         "	mov r1, lr										\n"
         "	tst r0, r1										\n"
@@ -435,6 +449,8 @@ void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	svc %0											\n"/* Secure context is allocated in the supervisor call. */
         "	bx lr											\n"/* Return. */
         ::"i" ( portSVC_ALLOCATE_SECURE_CONTEXT ) : "memory"
@@ -446,6 +462,8 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r2, [r0]									\n"/* The first item in the TCB is the top of the stack. */
         "	ldr r1, [r2]									\n"/* The first item on the stack is the task's xSecureContext. */
         "	cmp r1, #0										\n"/* Raise svc if task's xSecureContext is not NULL. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
@@ -132,6 +132,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	tst r0, r1										\n"/* Perform r0 & r1 (bitwise AND) and update the conditions flag. */
@@ -152,6 +154,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs  r0, control								\n"/* Read the CONTROL register. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	bics r0, r1										\n"/* Clear the bit 0. */
@@ -166,6 +170,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	orrs r0, r1										\n"/* r0 = r0 | r1. */
@@ -180,6 +186,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -201,6 +209,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, PRIMASK									\n"
         "	cpsid i											\n"
         "	bx lr											\n"
@@ -213,6 +223,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr PRIMASK, r0									\n"
         "	bx lr											\n"
         ::: "memory"
@@ -348,6 +360,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	movs r0, #4										\n"
         "	mov r1, lr										\n"
         "	tst r0, r1										\n"

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
@@ -135,6 +135,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
         "	ite ne											\n"
@@ -152,6 +154,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* Read the CONTROL register. */
         "	bic r0, #1										\n"/* Clear the bit 0. */
         "	msr control, r0									\n"/* Write back the new CONTROL value. */
@@ -165,6 +169,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	orr r0, #1										\n"/* r0 = r0 | 1. */
         "	msr control, r0									\n"/* CONTROL = r0. */
@@ -178,6 +184,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -200,6 +208,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
         "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
         "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
@@ -215,6 +225,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr basepri, r0									\n"/* basepri = ulMask. */
         "	dsb												\n"
         "	isb												\n"
@@ -412,6 +424,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	tst lr, #4										\n"
         "	ite eq											\n"
         "	mrseq r0, msp									\n"
@@ -429,6 +443,8 @@ void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	svc %0											\n"/* Secure context is allocated in the supervisor call. */
         "	bx lr											\n"/* Return. */
         ::"i" ( portSVC_ALLOCATE_SECURE_CONTEXT ) : "memory"
@@ -440,6 +456,8 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r2, [r0]									\n"/* The first item in the TCB is the top of the stack. */
         "	ldr r1, [r2]									\n"/* The first item on the stack is the task's xSecureContext. */
         "	cmp r1, #0										\n"/* Raise svc if task's xSecureContext is not NULL. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
@@ -130,6 +130,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
         "	ite ne											\n"
@@ -147,6 +149,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs  r0, control								\n"/* Read the CONTROL register. */
         "	bic r0, #1										\n"/* Clear the bit 0. */
         "	msr  control, r0								\n"/* Write back the new CONTROL value. */
@@ -160,6 +164,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	orr r0, #1										\n"/* r0 = r0 | 1. */
         "	msr control, r0									\n"/* CONTROL = r0. */
@@ -173,6 +179,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -195,6 +203,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
         "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
         "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
@@ -210,6 +220,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr basepri, r0									\n"/* basepri = ulMask. */
         "	dsb												\n"
         "	isb												\n"
@@ -337,6 +349,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	tst lr, #4										\n"
         "	ite eq											\n"
         "	mrseq r0, msp									\n"

--- a/portable/GCC/ARM_CM23/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23/non_secure/portasm.c
@@ -137,6 +137,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	tst r0, r1										\n"/* Perform r0 & r1 (bitwise AND) and update the conditions flag. */
@@ -157,6 +159,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* Read the CONTROL register. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	bics r0, r1										\n"/* Clear the bit 0. */
@@ -171,6 +175,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	orrs r0, r1										\n"/* r0 = r0 | r1. */
@@ -185,6 +191,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -206,6 +214,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, PRIMASK									\n"
         "	cpsid i											\n"
         "	bx lr											\n"
@@ -218,6 +228,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr PRIMASK, r0									\n"
         "	bx lr											\n"
         ::: "memory"
@@ -413,6 +425,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	movs r0, #4										\n"
         "	mov r1, lr										\n"
         "	tst r0, r1										\n"
@@ -435,6 +449,8 @@ void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	svc %0											\n"/* Secure context is allocated in the supervisor call. */
         "	bx lr											\n"/* Return. */
         ::"i" ( portSVC_ALLOCATE_SECURE_CONTEXT ) : "memory"
@@ -446,6 +462,8 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r2, [r0]									\n"/* The first item in the TCB is the top of the stack. */
         "	ldr r1, [r2]									\n"/* The first item on the stack is the task's xSecureContext. */
         "	cmp r1, #0										\n"/* Raise svc if task's xSecureContext is not NULL. */

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
@@ -132,6 +132,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	tst r0, r1										\n"/* Perform r0 & r1 (bitwise AND) and update the conditions flag. */
@@ -152,6 +154,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs  r0, control								\n"/* Read the CONTROL register. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	bics r0, r1										\n"/* Clear the bit 0. */
@@ -166,6 +170,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	movs r1, #1										\n"/* r1 = 1. */
         "	orrs r0, r1										\n"/* r0 = r0 | r1. */
@@ -180,6 +186,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -201,6 +209,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, PRIMASK									\n"
         "	cpsid i											\n"
         "	bx lr											\n"
@@ -213,6 +223,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr PRIMASK, r0									\n"
         "	bx lr											\n"
         ::: "memory"
@@ -348,6 +360,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	movs r0, #4										\n"
         "	mov r1, lr										\n"
         "	tst r0, r1										\n"

--- a/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -135,6 +135,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
         "	ite ne											\n"
@@ -152,6 +154,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* Read the CONTROL register. */
         "	bic r0, #1										\n"/* Clear the bit 0. */
         "	msr control, r0									\n"/* Write back the new CONTROL value. */
@@ -165,6 +169,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	orr r0, #1										\n"/* r0 = r0 | 1. */
         "	msr control, r0									\n"/* CONTROL = r0. */
@@ -178,6 +184,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -200,6 +208,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
         "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
         "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
@@ -215,6 +225,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr basepri, r0									\n"/* basepri = ulMask. */
         "	dsb												\n"
         "	isb												\n"
@@ -412,6 +424,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	tst lr, #4										\n"
         "	ite eq											\n"
         "	mrseq r0, msp									\n"
@@ -429,6 +443,8 @@ void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	svc %0											\n"/* Secure context is allocated in the supervisor call. */
         "	bx lr											\n"/* Return. */
         ::"i" ( portSVC_ALLOCATE_SECURE_CONTEXT ) : "memory"
@@ -440,6 +456,8 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r2, [r0]									\n"/* The first item in the TCB is the top of the stack. */
         "	ldr r1, [r2]									\n"/* The first item on the stack is the task's xSecureContext. */
         "	cmp r1, #0										\n"/* Raise svc if task's xSecureContext is not NULL. */

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -130,6 +130,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
         "	ite ne											\n"
@@ -147,6 +149,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs  r0, control								\n"/* Read the CONTROL register. */
         "	bic r0, #1										\n"/* Clear the bit 0. */
         "	msr  control, r0								\n"/* Write back the new CONTROL value. */
@@ -160,6 +164,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	orr r0, #1										\n"/* r0 = r0 | 1. */
         "	msr control, r0									\n"/* CONTROL = r0. */
@@ -173,6 +179,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -195,6 +203,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
         "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
         "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
@@ -210,6 +220,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr basepri, r0									\n"/* basepri = ulMask. */
         "	dsb												\n"
         "	isb												\n"
@@ -337,6 +349,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	tst lr, #4										\n"
         "	ite eq											\n"
         "	mrseq r0, msp									\n"

--- a/portable/GCC/ARM_CM55/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55/non_secure/portasm.c
@@ -135,6 +135,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
         "	ite ne											\n"
@@ -152,6 +154,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* Read the CONTROL register. */
         "	bic r0, #1										\n"/* Clear the bit 0. */
         "	msr control, r0									\n"/* Write back the new CONTROL value. */
@@ -165,6 +169,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	orr r0, #1										\n"/* r0 = r0 | 1. */
         "	msr control, r0									\n"/* CONTROL = r0. */
@@ -178,6 +184,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -200,6 +208,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
         "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
         "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
@@ -215,6 +225,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr basepri, r0									\n"/* basepri = ulMask. */
         "	dsb												\n"
         "	isb												\n"
@@ -412,6 +424,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	tst lr, #4										\n"
         "	ite eq											\n"
         "	mrseq r0, msp									\n"
@@ -429,6 +443,8 @@ void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	svc %0											\n"/* Secure context is allocated in the supervisor call. */
         "	bx lr											\n"/* Return. */
         ::"i" ( portSVC_ALLOCATE_SECURE_CONTEXT ) : "memory"
@@ -440,6 +456,8 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r2, [r0]									\n"/* The first item in the TCB is the top of the stack. */
         "	ldr r1, [r2]									\n"/* The first item on the stack is the task's xSecureContext. */
         "	cmp r1, #0										\n"/* Raise svc if task's xSecureContext is not NULL. */

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
@@ -130,6 +130,8 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	tst r0, #1										\n"/* Perform r0 & 1 (bitwise AND) and update the conditions flag. */
         "	ite ne											\n"
@@ -147,6 +149,8 @@ void vRaisePrivilege( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs  r0, control								\n"/* Read the CONTROL register. */
         "	bic r0, #1										\n"/* Clear the bit 0. */
         "	msr  control, r0								\n"/* Write back the new CONTROL value. */
@@ -160,6 +164,8 @@ void vResetPrivilege( void ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, control									\n"/* r0 = CONTROL. */
         "	orr r0, #1										\n"/* r0 = r0 | 1. */
         "	msr control, r0									\n"/* CONTROL = r0. */
@@ -173,6 +179,8 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	ldr r0, xVTORConst								\n"/* Use the NVIC offset register to locate the stack. */
         "	ldr r0, [r0]									\n"/* Read the VTOR register which gives the address of vector table. */
         "	ldr r0, [r0]									\n"/* The first entry in vector table is stack pointer. */
@@ -195,6 +203,8 @@ uint32_t ulSetInterruptMask( void ) /* __attribute__(( naked )) PRIVILEGED_FUNCT
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	mrs r0, basepri									\n"/* r0 = basepri. Return original basepri value. */
         "	mov r1, %0										\n"/* r1 = configMAX_SYSCALL_INTERRUPT_PRIORITY. */
         "	msr basepri, r1									\n"/* Disable interrupts upto configMAX_SYSCALL_INTERRUPT_PRIORITY. */
@@ -210,6 +220,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	msr basepri, r0									\n"/* basepri = ulMask. */
         "	dsb												\n"
         "	isb												\n"
@@ -337,6 +349,8 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (
+        "	.syntax unified									\n"
+        "													\n"
         "	tst lr, #4										\n"
         "	ite eq											\n"
         "	mrseq r0, msp									\n"


### PR DESCRIPTION
Description
-----------
This fixes the compilation issue with XC32 compiler.

It was reported here - https://forums.freertos.org/t/xc32-v4-00-error-with-building-freertos-portasm-c/14357/4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
