### PR TITLE
Generalize Thread Local Storage (TLS) support

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -3090,6 +3090,7 @@ xtimerstartfromisr
 xtimerstop
 xtimerstopfromisr
 xtimertaskhandle
+xtlsblock
 xtos
 xtriggerlevel
 xtriggerlevelbytes

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -71,25 +71,26 @@
 
 /* Required if struct _reent is used. */
 #if ( configUSE_NEWLIB_REENTRANT == 1 )
-    /* Note Newlib support has been included by popular demand, but is not
-     * used by the FreeRTOS maintainers themselves.  FreeRTOS is not
-     * responsible for resulting newlib operation.  User must be familiar with
-     * newlib and must provide system-wide implementations of the necessary
-     * stubs. Be warned that (at the time of writing) the current newlib design
-     * implements a system-wide malloc() that must be provided with locks.
-     *
-     * See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
-     * for additional information. */
+
+/* Note Newlib support has been included by popular demand, but is not
+ * used by the FreeRTOS maintainers themselves.  FreeRTOS is not
+ * responsible for resulting newlib operation.  User must be familiar with
+ * newlib and must provide system-wide implementations of the necessary
+ * stubs. Be warned that (at the time of writing) the current newlib design
+ * implements a system-wide malloc() that must be provided with locks.
+ *
+ * See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+ * for additional information. */
     #include <reent.h>
 
-    #define configUSE_C_RUNTIME_TLS_SUPPORT         1
+    #define configUSE_C_RUNTIME_TLS_SUPPORT    1
 
     #ifndef configTLS_BLOCK_TYPE
-        #define configTLS_BLOCK_TYPE                struct _reent
+        #define configTLS_BLOCK_TYPE           struct _reent
     #endif
 
     #ifndef configINIT_TLS_BLOCK
-        #define configINIT_TLS_BLOCK( xTLSBlock )   _REENT_INIT_PTR( &( xTLSBlock ) )
+        #define configINIT_TLS_BLOCK( xTLSBlock )    _REENT_INIT_PTR( &( xTLSBlock ) )
     #endif
 
     #ifndef configSET_TLS_BLOCK
@@ -97,12 +98,12 @@
     #endif
 
     #ifndef configDEINIT_TLS_BLOCK
-        #define configDEINIT_TLS_BLOCK( xTLSBlock ) _reclaim_reent( &( xTLSBlock ) )
+        #define configDEINIT_TLS_BLOCK( xTLSBlock )    _reclaim_reent( &( xTLSBlock ) )
     #endif
-#endif
+#endif /* if ( configUSE_NEWLIB_REENTRANT == 1 ) */
 
 #ifndef configUSE_C_RUNTIME_TLS_SUPPORT
-    #define configUSE_C_RUNTIME_TLS_SUPPORT     0
+    #define configUSE_C_RUNTIME_TLS_SUPPORT    0
 #endif
 
 #if ( ( configUSE_NEWLIB_REENTRANT == 0 ) && ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
@@ -122,7 +123,7 @@
     #ifndef configDEINIT_TLS_BLOCK
         #error Missing definition:  configDEINIT_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
     #endif
-#endif
+#endif /* if ( ( configUSE_NEWLIB_REENTRANT == 0 ) && ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) ) */
 
 /*
  * Check all the required application specific macros have been defined.

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -71,7 +71,57 @@
 
 /* Required if struct _reent is used. */
 #if ( configUSE_NEWLIB_REENTRANT == 1 )
+    /* Note Newlib support has been included by popular demand, but is not
+     * used by the FreeRTOS maintainers themselves.  FreeRTOS is not
+     * responsible for resulting newlib operation.  User must be familiar with
+     * newlib and must provide system-wide implementations of the necessary
+     * stubs. Be warned that (at the time of writing) the current newlib design
+     * implements a system-wide malloc() that must be provided with locks.
+     *
+     * See the third party link http://www.nadler.com/embedded/newlibAndFreeRTOS.html
+     * for additional information. */
     #include <reent.h>
+
+    #define configUSE_C_RUNTIME_TLS_SUPPORT         1
+
+    #ifndef configTLS_BLOCK_TYPE
+        #define configTLS_BLOCK_TYPE                struct _reent
+    #endif
+
+    #ifndef configINIT_TLS_BLOCK
+        #define configINIT_TLS_BLOCK( xTLSBlock )   _REENT_INIT_PTR( &( xTLSBlock ) )
+    #endif
+
+    #ifndef configSET_TLS_BLOCK
+        #define configSET_TLS_BLOCK( xTLSBlock )    _impure_ptr = &( xTLSBlock )
+    #endif
+
+    #ifndef configDEINIT_TLS_BLOCK
+        #define configDEINIT_TLS_BLOCK( xTLSBlock ) _reclaim_reent( &( xTLSBlock ) )
+    #endif
+#endif
+
+#ifndef configUSE_C_RUNTIME_TLS_SUPPORT
+    #define configUSE_C_RUNTIME_TLS_SUPPORT     0
+#endif
+
+#if ( ( configUSE_NEWLIB_REENTRANT == 0 ) && ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+
+    #ifndef configTLS_BLOCK_TYPE
+        #error Missing definition:  configTLS_BLOCK_TYPE must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+    #endif
+
+    #ifndef configINIT_TLS_BLOCK
+        #error Missing definition:  configINIT_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+    #endif
+
+    #ifndef configSET_TLS_BLOCK
+        #error Missing definition:  configSET_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+    #endif
+
+    #ifndef configDEINIT_TLS_BLOCK
+        #error Missing definition:  configDEINIT_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+    #endif
 #endif
 
 /*
@@ -1223,8 +1273,8 @@ typedef struct xSTATIC_TCB
     #if ( configGENERATE_RUN_TIME_STATS == 1 )
         configRUN_TIME_COUNTER_TYPE ulDummy16;
     #endif
-    #if ( configUSE_NEWLIB_REENTRANT == 1 )
-        struct  _reent xDummy17;
+    #if ( ( configUSE_NEWLIB_REENTRANT == 1 ) || ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) )
+        configTLS_BLOCK_TYPE xDummy17;
     #endif
     #if ( configUSE_TASK_NOTIFICATIONS == 1 )
         uint32_t ulDummy18[ configTASK_NOTIFICATION_ARRAY_ENTRIES ];


### PR DESCRIPTION
Description
-----------
FreeRTOS's Thread Local Storage (TLS) support used variables and functions from newlib, thereby making the TLS support specific to newlib. This commit generalizes the TLS support so that it can be used with other c-runtime libraries also. The default behavior for newlib support is still kept same for backward compatibility.

The application writer would need to set `configUSE_C_RUNTIME_TLS_SUPPORT` to 1 in their FreeRTOSConfig.h and define the following macros to support TLS for a c-runtime library:
1. `configTLS_BLOCK_TYPE` - Type used to define the TLS block in TCB.
2. `configINIT_TLS_BLOCK( xTLSBlock )` - Allocate and initialize memory block for the task's TLS Block.
3. `configSET_TLS_BLOCK( xTLSBlock )` - Switch C-Runtime's TLS Block to point to xTLSBlock.
4. `configDEINIT_TLS_BLOCK( xTLSBlock )` - Free up the memory allocated for the task's TLS Block.

The following is an example to support TLS for picolibc:
```c
 #define configUSE_C_RUNTIME_TLS_SUPPORT        1
 #define configTLS_BLOCK_TYPE                   void*
 #define configINIT_TLS_BLOCK( xTLSBlock )      _init_tls( xTLSBlock )
 #define configSET_TLS_BLOCK( xTLSBlock )       _set_tls( xTLSBlock )
 #define configDEINIT_TLS_BLOCK( xTLSBlock )
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
