### PR TITLE
Change default value of INCLUDE_xTaskGetCurrentTaskHandle

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -254,7 +254,7 @@
 #endif
 
 #ifndef INCLUDE_xTaskGetCurrentTaskHandle
-    #define INCLUDE_xTaskGetCurrentTaskHandle    0
+    #define INCLUDE_xTaskGetCurrentTaskHandle    1
 #endif
 
 #if configUSE_CO_ROUTINES != 0


### PR DESCRIPTION
Set default value of INCLUDE_xTaskGetCurrentTaskHandle to 1.

Description
-----------

The configuration is used to optionally disable the function `xTaskGetCurrentTaskHandle()`. Since the function is required for  stream buffer, message buffer and mutex, setting the configuration default to always enabled. This will cause a small overhead in code size (since the function `xTaskGetCurrentTaskHandle()` is simple and have very few lines of code) and should not cause an overhead in .bss or .data. Most of the linkers should remove the function if its unused within the code.

Test Steps
-----------
None

Related Issue
-----------

This is a follow up of https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/507

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
