### PR TITLE
RISC-V: Add support for RV32E extension in GCC port

### DIFF
--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -98,35 +98,35 @@ definitions. */
 /*-----------------------------------------------------------*/
 
 .macro portUPDATE_MTIMER_COMPARE_REGISTER
-    load_x t0, pullMachineTimerCompareRegister  /* Load address of compare register into t0. */
-    load_x t1, pullNextTime                     /* Load the address of ullNextTime into t1. */
+    load_x a0, pullMachineTimerCompareRegister  /* Load address of compare register into a0. */
+    load_x a1, pullNextTime                     /* Load the address of ullNextTime into a1. */
 
     #if( __riscv_xlen == 32 )
 
         /* Update the 64-bit mtimer compare match value in two 32-bit writes. */
-        li t4, -1
-        lw t2, 0(t1)                /* Load the low word of ullNextTime into t2. */
-        lw t3, 4(t1)                /* Load the high word of ullNextTime into t3. */
-        sw t4, 0(t0)                /* Low word no smaller than old value to start with - will be overwritten below. */
-        sw t3, 4(t0)                /* Store high word of ullNextTime into compare register.  No smaller than new value. */
-        sw t2, 0(t0)                /* Store low word of ullNextTime into compare register. */
+        li a4, -1
+        lw a2, 0(a1)                /* Load the low word of ullNextTime into a2. */
+        lw a3, 4(a1)                /* Load the high word of ullNextTime into a3. */
+        sw a4, 0(a0)                /* Low word no smaller than old value to start with - will be overwritten below. */
+        sw a3, 4(a0)                /* Store high word of ullNextTime into compare register.  No smaller than new value. */
+        sw a2, 0(a0)                /* Store low word of ullNextTime into compare register. */
         lw t0, uxTimerIncrementsForOneTick  /* Load the value of ullTimerIncrementForOneTick into t0 (could this be optimized by storing in an array next to pullNextTime?). */
-        add t4, t0, t2              /* Add the low word of ullNextTime to the timer increments for one tick (assumes timer increment for one tick fits in 32-bits). */
-        sltu t5, t4, t2             /* See if the sum of low words overflowed (what about the zero case?). */
-        add t6, t3, t5              /* Add overflow to high word of ullNextTime. */
-        sw t4, 0(t1)                /* Store new low word of ullNextTime. */
-        sw t6, 4(t1)                /* Store new high word of ullNextTime. */
+        add a4, t0, a2              /* Add the low word of ullNextTime to the timer increments for one tick (assumes timer increment for one tick fits in 32-bits). */
+        sltu t1, a4, a2             /* See if the sum of low words overflowed (what about the zero case?). */
+        add t2, a3, t1              /* Add overflow to high word of ullNextTime. */
+        sw a4, 0(a1)                /* Store new low word of ullNextTime. */
+        sw t2, 4(a1)                /* Store new high word of ullNextTime. */
 
     #endif /* __riscv_xlen == 32 */
 
     #if( __riscv_xlen == 64 )
 
         /* Update the 64-bit mtimer compare match value. */
-        ld t2, 0(t1)                /* Load ullNextTime into t2. */
-        sd t2, 0(t0)                /* Store ullNextTime into compare register. */
+        ld t2, 0(a1)                /* Load ullNextTime into t2. */
+        sd t2, 0(a0)                /* Store ullNextTime into compare register. */
         ld t0, uxTimerIncrementsForOneTick  /* Load the value of ullTimerIncrementForOneTick into t0 (could this be optimized by storing in an array next to pullNextTime?). */
         add t4, t0, t2              /* Add ullNextTime to the timer increments for one tick. */
-        sd t4, 0(t1)                /* Store ullNextTime. */
+        sd t4, 0(a1)                /* Store ullNextTime. */
 
     #endif /* __riscv_xlen == 64 */
     .endm
@@ -206,7 +206,12 @@ pxPortInitialiseStack:
     store_x t0, 0(a0)                   /* mstatus onto the stack. */
     addi a0, a0, -portWORD_SIZE         /* Space for critical nesting count. */
     store_x x0, 0(a0)                   /* Critical nesting count starts at 0 for every task. */
+
+#ifdef __riscv_32e
+    addi a0, a0, -(6 * portWORD_SIZE)   /* Space for registers x11-x15. */
+#else
     addi a0, a0, -(22 * portWORD_SIZE)  /* Space for registers x11-x31. */
+#endif
     store_x a2, 0(a0)                   /* Task parameters (pvParameters parameter) goes into register X10/a0 on the stack. */
     addi a0, a0, -(6 * portWORD_SIZE)   /* Space for registers x5-x9. */
     load_x t0, xTaskReturnAddress
@@ -241,6 +246,7 @@ xPortStartFirstTask:
     load_x  x13, 10 * portWORD_SIZE( sp )   /* a3 */
     load_x  x14, 11 * portWORD_SIZE( sp )   /* a4 */
     load_x  x15, 12 * portWORD_SIZE( sp )   /* a5 */
+#ifndef __riscv_32e
     load_x  x16, 13 * portWORD_SIZE( sp )   /* a6 */
     load_x  x17, 14 * portWORD_SIZE( sp )   /* a7 */
     load_x  x18, 15 * portWORD_SIZE( sp )   /* s2 */
@@ -257,12 +263,13 @@ xPortStartFirstTask:
     load_x  x29, 26 * portWORD_SIZE( sp )   /* t4 */
     load_x  x30, 27 * portWORD_SIZE( sp )   /* t5 */
     load_x  x31, 28 * portWORD_SIZE( sp )   /* t6 */
+#endif
 
-    load_x  x5, 29 * portWORD_SIZE( sp )    /* Obtain xCriticalNesting value for this task from task's stack. */
+    load_x  x5, portCRITICAL_NESTING_OFFSET * portWORD_SIZE( sp )    /* Obtain xCriticalNesting value for this task from task's stack. */
     load_x  x6, pxCriticalNesting           /* Load the address of xCriticalNesting into x6. */
     store_x x5, 0( x6 )                     /* Restore the critical nesting value for this task. */
 
-    load_x  x5, 30 * portWORD_SIZE( sp )    /* Initial mstatus into x5 (t0). */
+    load_x  x5, portMSTATUS_OFFSET * portWORD_SIZE( sp )    /* Initial mstatus into x5 (t0). */
     addi    x5, x5, 0x08                    /* Set MIE bit so the first task starts with interrupts enabled - required as returns with ret not eret. */
     csrrw   x0, mstatus, x5                 /* Interrupts enabled from here! */
 

--- a/portable/GCC/RISC-V/portmacro.h
+++ b/portable/GCC/RISC-V/portmacro.h
@@ -80,7 +80,11 @@ typedef portUBASE_TYPE TickType_t;
 /* Architecture specifics. */
 #define portSTACK_GROWTH            ( -1 )
 #define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portBYTE_ALIGNMENT          16
+#ifdef __riscv_32e
+    #define portBYTE_ALIGNMENT      8   /* RV32E uses RISC-V EABI with reduced stack alignment requirements */
+#else
+    #define portBYTE_ALIGNMENT      16
+#endif
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */


### PR DESCRIPTION
Add support for RV32E extension in RISC-V GCC port

Description
-----------
RV32E (E for embedded) processors only have 16 registers instead of the 32 a regular RV32 core has. This change allows running FreeRTOS on such cores, by not touching registers `x16`-`x31` when FreeRTOS is built for RV32E.

Test Steps
-----------
Compile the code for RV32E core with EABI. (e.g. `gcc -march=rv32e -mabi=ilp32e` ). The code can be then run also on a regular RV32 core.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
