### PR TITLE
Fix warnings in posix port

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -325,6 +325,7 @@ portBASE_TYPE xPortSetInterruptMask( void )
 
 void vPortClearInterruptMask( portBASE_TYPE xMask )
 {
+    ( void ) xMask;
 }
 /*-----------------------------------------------------------*/
 
@@ -385,6 +386,8 @@ static void vPortSystemTickHandler( int sig )
     Thread_t * pxThreadToSuspend;
     Thread_t * pxThreadToResume;
 
+    ( void ) sig;
+
 /* uint64_t xExpectedTicks; */
 
     uxCriticalNesting++; /* Signals are blocked in this signal handler. */
@@ -424,6 +427,8 @@ void vPortThreadDying( void * pxTaskToDelete,
                        volatile BaseType_t * pxPendYield )
 {
     Thread_t * pxThread = prvGetThreadFromTask( pxTaskToDelete );
+
+    ( void ) pxPendYield;
 
     pxThread->xDying = pdTRUE;
 }
@@ -526,7 +531,7 @@ static void prvResumeThread( Thread_t * xThreadId )
 
 static void prvSetupSignalsAndSchedulerPolicy( void )
 {
-    struct sigaction sigresume, sigtick;
+    struct sigaction sigtick;
     int iRet;
 
     hMainThread = pthread_self();


### PR DESCRIPTION
Fix warnings in posix port

Description
-----------
Fixes warnings about unused parameters and variables when built with `-Wall -Wextra`.

Test Steps
-----------
Compile a project using this port with `-Wall -Wextra` on either gcc or clang. There will be four warnings:
```
port.c                      326  44 warning  e-f-b    clang [-Wunused-parameter]: Unused parameter 'xMask'
port.c                      383  40 warning  e-f-b    clang [-Wunused-parameter]: Unused parameter 'sig'
port.c                      424  45 warning  e-f-b    clang [-Wunused-parameter]: Unused parameter 'pxPendYield'
port.c                      529  21 warning  e-f-b    clang [-Wunused-variable]: Unused variable 'sigresume'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
