### PR TITLE
Add FreeRTOS config directory to include dirs

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/library.cmake
+++ b/portable/ThirdParty/GCC/RP2040/library.cmake
@@ -27,7 +27,8 @@ target_sources(FreeRTOS-Kernel INTERFACE
 )
 
 target_include_directories(FreeRTOS-Kernel INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/include)
+        ${CMAKE_CURRENT_LIST_DIR}/include
+        ${FREERTOS_CONFIG_FILE_DIRECTORY})
 
 target_link_libraries(FreeRTOS-Kernel INTERFACE
         FreeRTOS-Kernel-Core


### PR DESCRIPTION
Description
-----------
This allows the application write to set `FREERTOS_CONFIG_FILE_DIRECTORY` to whichever directory the `FreeRTOSConfig.h` file exists in.

This was reported here - https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/545


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
