### PR TITLE
Update of three badly terminated macro definitions

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -866,9 +866,9 @@ BaseType_t xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
  * return a value.
  */
 #define vTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )                   \
-    {                                                                           \
+    do {                                                                        \
         ( void ) xTaskDelayUntil( ( pxPreviousWakeTime ), ( xTimeIncrement ) ); \
-    }
+    } while(0)
 
 
 /**
@@ -2531,9 +2531,9 @@ void vTaskGenericNotifyGiveFromISR( TaskHandle_t xTaskToNotify,
                                     UBaseType_t uxIndexToNotify,
                                     BaseType_t * pxHigherPriorityTaskWoken ) PRIVILEGED_FUNCTION;
 #define vTaskNotifyGiveFromISR( xTaskToNotify, pxHigherPriorityTaskWoken ) \
-    vTaskGenericNotifyGiveFromISR( ( xTaskToNotify ), ( tskDEFAULT_INDEX_TO_NOTIFY ), ( pxHigherPriorityTaskWoken ) );
+    vTaskGenericNotifyGiveFromISR( ( xTaskToNotify ), ( tskDEFAULT_INDEX_TO_NOTIFY ), ( pxHigherPriorityTaskWoken ) )
 #define vTaskNotifyGiveIndexedFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken ) \
-    vTaskGenericNotifyGiveFromISR( ( xTaskToNotify ), ( uxIndexToNotify ), ( pxHigherPriorityTaskWoken ) );
+    vTaskGenericNotifyGiveFromISR( ( xTaskToNotify ), ( uxIndexToNotify ), ( pxHigherPriorityTaskWoken ) )
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -868,7 +868,7 @@ BaseType_t xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
 #define vTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )                   \
     do {                                                                        \
         ( void ) xTaskDelayUntil( ( pxPreviousWakeTime ), ( xTimeIncrement ) ); \
-    } while(0)
+    } while( 0 )
 
 
 /**


### PR DESCRIPTION

<!--- Title -->

Description
-----------
The following three macros in `task.h` were written in a way that forced to to omit the terminating semicolon when used in a non-block, single statement, `then` part of a if statement:
```
if(condition)
    macro(args, more, args);
else
   /* Any block or statement */
```
Compilers would complain of a syntax error, as the terminating semicolon or the block ending was already part of the macro.
- vTaskDelayUntil() was updated to conform to usual pattern do { ... } while(0), making it into an unterminated statement.
- vTaskNotifyGiveFromISR() and
- vTaskGenericNotifyGiveFromISR() were updated to remove the unneeded terminating semicolons.

I scanned the other files in the include directory for similar patterns and found none.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Attempts to compile any code similar to what described above will no longer fail.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
- This PR addresses issues #553 and #554
- The same issue is present in the `smp`branch and in the latest LTS release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
