### PR TITLE
portable-RP2040: Fix typo in README.md

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/README.md
+++ b/portable/ThirdParty/GCC/RP2040/README.md
@@ -14,7 +14,7 @@ You can copy [FreeRTOS-Kernel-import.cmake](FreeRTOS-Kernel-import.cmake) into y
 add the following in your `CMakeLists.txt`:
 
 ```cmake
-import(FreeRTOS_Kernel_import.cmake)
+include(FreeRTOS_Kernel_import.cmake)
 ```
 
 This will locate the FreeRTOS kernel if it is a direct sub-module of your project, or if you provide the 


### PR DESCRIPTION
Fix typo in RP2040 port README.md

Description
-----------
Replace "import" with "include" in the RP2040 Readme.md cmake code sample.

Related Issue
-----------
#557 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
