### PR TITLE
LTS Updates

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -2533,7 +2533,6 @@ vportgetheapstats
 vportinitialiseblocks
 vportisrstartfirststask
 vportraisebasepri
-vportresetprivilege
 vportsetmpuregistersetone
 vportsetuptimerinterrupt
 vportstartfirststask
@@ -2852,7 +2851,6 @@ xperiod
 xportgetcoreid
 xportgetfreeheapsize
 xportinstallinterrupthandler
-xportraiseprivilege
 xportregistercinterrupthandler
 xportregisterdump
 xportstartfirsttask

--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,30 @@
 Documentation and download available at https://www.FreeRTOS.org/
 
+Changes between FreeRTOS V10.4.3 LTS Patch 2 and FreeRTOS V10.4.3 LTS Patch 3 released September 16 2022
+
+	+ ARMv7-M and ARMv8-M MPU ports: It is possible for a third party that
+	  already independently gained the ability to execute injected code to
+	  read from or write to arbitrary addresses by passing a negative argument
+	  as the xIndex parameter to pvTaskGetThreadLocalStoragePointer() or
+	  vTaskSetThreadLocalStoragePointer respectively.
+	  We thank Certibit Consulting, LLC for reporting this issue.
+	+ ARMv7-M and ARMv8-M MPU ports: It is possible for an unprivileged task to
+	  invoke any function with privilege by passing it as a parameter to
+	  MPU_xTaskCreate, MPU_xTaskCreateStatic, MPU_xTimerCreate,
+	  MPU_xTimerCreateStatic, or MPU_xTimerPendFunctionCall.
+	  We thank Huazhong University of Science and Technology for reporting this issue.
+	+ ARMv7-M and ARMv8-M ports: It is possible for a third party that has
+	  already independently gained the ability to execute injected code to
+	  achieve further privilege escalation by branching directly inside a
+	  FreeRTOS MPU API wrapper function with a manually crafted stack frame.
+	  We thank Certibit Consulting, LLC, Huazhong University of Science and
+	  Technology and the SecLab team at Northeastern University for reporting
+	  this issue.
+	+ ARMv7-M MPU ports: It is possible to configure overlapping memory
+	  protection unit (MPU) regions such that an unprivileged task can access
+	  privileged data.
+	  We thank the SecLab team at Northeastern University for reporting this issue.
+
 Changes between FreeRTOS V10.4.3 LTS Patch 1 and FreeRTOS V10.4.3 LTS Patch 2 released November 12 2021
 
 	+ ARMv7-M and ARMv8-M MPU ports – prevent non-kernel code from calling the

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -117,13 +117,10 @@
         #endif
 
 /* Map standard timer.h API functions to the MPU equivalents. */
-        #define xTimerCreate                           MPU_xTimerCreate
-        #define xTimerCreateStatic                     MPU_xTimerCreateStatic
         #define pvTimerGetTimerID                      MPU_pvTimerGetTimerID
         #define vTimerSetTimerID                       MPU_vTimerSetTimerID
         #define xTimerIsTimerActive                    MPU_xTimerIsTimerActive
         #define xTimerGetTimerDaemonTaskHandle         MPU_xTimerGetTimerDaemonTaskHandle
-        #define xTimerPendFunctionCall                 MPU_xTimerPendFunctionCall
         #define pcTimerGetName                         MPU_pcTimerGetName
         #define vTimerSetReloadMode                    MPU_vTimerSetReloadMode
         #define uxTimerGetReloadMode                   MPU_uxTimerGetReloadMode

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -170,36 +170,6 @@
         #define PRIVILEGED_DATA         __attribute__( ( section( "privileged_data" ) ) )
         #define FREERTOS_SYSTEM_CALL    __attribute__( ( section( "freertos_system_calls" ) ) )
 
-        /**
-         * @brief Calls the port specific code to raise the privilege.
-         *
-         * Sets xRunningPrivileged to pdFALSE if privilege was raised, else sets
-         * it to pdTRUE.
-         */
-        #define xPortRaisePrivilege( xRunningPrivileged )                      \
-        {                                                                      \
-            /* Check whether the processor is already privileged. */           \
-            xRunningPrivileged = portIS_PRIVILEGED();                          \
-                                                                               \
-            /* If the processor is not already privileged, raise privilege. */ \
-            if( xRunningPrivileged == pdFALSE )                                \
-            {                                                                  \
-                portRAISE_PRIVILEGE();                                         \
-            }                                                                  \
-        }
-
-        /**
-         * @brief If xRunningPrivileged is not pdTRUE, calls the port specific
-         * code to reset the privilege, otherwise does nothing.
-         */
-        #define vPortResetPrivilege( xRunningPrivileged )   \
-        {                                                   \
-            if( xRunningPrivileged == pdFALSE )             \
-            {                                               \
-                portRESET_PRIVILEGE();                      \
-            }                                               \
-        }
-
     #endif /* MPU_WRAPPERS_INCLUDED_FROM_API_FILE */
 
 #else /* portUSING_MPU_WRAPPERS */

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -61,6 +61,9 @@
             portRAISE_PRIVILEGE();
             portMEMORY_BARRIER();
 
+            uxPriority = uxPriority & ~( portPRIVILEGE_BIT );
+            portMEMORY_BARRIER();
+
             xReturn = xTaskCreate( pvTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
             portMEMORY_BARRIER();
 
@@ -91,6 +94,9 @@
         if( portIS_PRIVILEGED() == pdFALSE )
         {
             portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            uxPriority = uxPriority & ~( portPRIVILEGE_BIT );
             portMEMORY_BARRIER();
 
             xReturn = xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
@@ -1678,67 +1684,6 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
 }
 /*-----------------------------------------------------------*/
 
-#if ( ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) && ( configUSE_TIMERS == 1 ) )
-    TimerHandle_t MPU_xTimerCreate( const char * const pcTimerName,
-                                    const TickType_t xTimerPeriodInTicks,
-                                    const UBaseType_t uxAutoReload,
-                                    void * const pvTimerID,
-                                    TimerCallbackFunction_t pxCallbackFunction ) /* FREERTOS_SYSTEM_CALL */
-    {
-        TimerHandle_t xReturn;
-
-        if( portIS_PRIVILEGED() == pdFALSE )
-        {
-            portRAISE_PRIVILEGE();
-            portMEMORY_BARRIER();
-
-            xReturn = xTimerCreate( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction );
-            portMEMORY_BARRIER();
-
-            portRESET_PRIVILEGE();
-            portMEMORY_BARRIER();
-        }
-        else
-        {
-            xReturn = xTimerCreate( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction );
-        }
-
-        return xReturn;
-    }
-#endif /* if ( ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) && ( configUSE_TIMERS == 1 ) ) */
-/*-----------------------------------------------------------*/
-
-#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configUSE_TIMERS == 1 ) )
-    TimerHandle_t MPU_xTimerCreateStatic( const char * const pcTimerName,
-                                          const TickType_t xTimerPeriodInTicks,
-                                          const UBaseType_t uxAutoReload,
-                                          void * const pvTimerID,
-                                          TimerCallbackFunction_t pxCallbackFunction,
-                                          StaticTimer_t * pxTimerBuffer ) /* FREERTOS_SYSTEM_CALL */
-    {
-        TimerHandle_t xReturn;
-
-        if( portIS_PRIVILEGED() == pdFALSE )
-        {
-            portRAISE_PRIVILEGE();
-            portMEMORY_BARRIER();
-
-            xReturn = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
-            portMEMORY_BARRIER();
-
-            portRESET_PRIVILEGE();
-            portMEMORY_BARRIER();
-        }
-        else
-        {
-            xReturn = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
-        }
-
-        return xReturn;
-    }
-#endif /* if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configUSE_TIMERS == 1 ) ) */
-/*-----------------------------------------------------------*/
-
 #if ( configUSE_TIMERS == 1 )
     void * MPU_pvTimerGetTimerID( const TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
@@ -1838,35 +1783,6 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
         return xReturn;
     }
 #endif /* if ( configUSE_TIMERS == 1 ) */
-/*-----------------------------------------------------------*/
-
-#if ( ( INCLUDE_xTimerPendFunctionCall == 1 ) && ( configUSE_TIMERS == 1 ) )
-    BaseType_t MPU_xTimerPendFunctionCall( PendedFunction_t xFunctionToPend,
-                                           void * pvParameter1,
-                                           uint32_t ulParameter2,
-                                           TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
-    {
-        BaseType_t xReturn;
-
-        if( portIS_PRIVILEGED() == pdFALSE )
-        {
-            portRAISE_PRIVILEGE();
-            portMEMORY_BARRIER();
-
-            xReturn = xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
-            portMEMORY_BARRIER();
-
-            portRESET_PRIVILEGE();
-            portMEMORY_BARRIER();
-        }
-        else
-        {
-            xReturn = xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
-        }
-
-        return xReturn;
-    }
-#endif /* if ( ( INCLUDE_xTimerPendFunctionCall == 1 ) && ( configUSE_TIMERS == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TIMERS == 1 )

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -54,11 +54,23 @@
                                 UBaseType_t uxPriority,
                                 TaskHandle_t * pxCreatedTask ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskCreate( pvTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskCreate( pvTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskCreate( pvTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
+        }
 
         return xReturn;
     }
@@ -75,11 +87,22 @@
                                         StaticTask_t * const pxTaskBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
+        }
 
         return xReturn;
     }
@@ -89,24 +112,46 @@
 #if ( INCLUDE_vTaskDelete == 1 )
     void MPU_vTaskDelete( TaskHandle_t pxTaskToDelete ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskDelete( pxTaskToDelete );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskDelete( pxTaskToDelete );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskDelete( pxTaskToDelete );
+        }
     }
-#endif
+#endif /* if ( INCLUDE_vTaskDelete == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_xTaskDelayUntil == 1 )
     BaseType_t MPU_xTaskDelayUntil( TickType_t * const pxPreviousWakeTime,
                                     TickType_t xTimeIncrement ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged, xReturn;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
+        }
 
         return xReturn;
     }
@@ -116,11 +161,23 @@
 #if ( INCLUDE_xTaskAbortDelay == 1 )
     BaseType_t MPU_xTaskAbortDelay( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskAbortDelay( xTask );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskAbortDelay( xTask );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskAbortDelay( xTask );
+        }
 
         return xReturn;
     }
@@ -130,24 +187,45 @@
 #if ( INCLUDE_vTaskDelay == 1 )
     void MPU_vTaskDelay( TickType_t xTicksToDelay ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskDelay( xTicksToDelay );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskDelay( xTicksToDelay );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskDelay( xTicksToDelay );
+        }
     }
-#endif
+#endif /* if ( INCLUDE_vTaskDelay == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_uxTaskPriorityGet == 1 )
     UBaseType_t MPU_uxTaskPriorityGet( const TaskHandle_t pxTask ) /* FREERTOS_SYSTEM_CALL */
     {
         UBaseType_t uxReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        uxReturn = uxTaskPriorityGet( pxTask );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            uxReturn = uxTaskPriorityGet( pxTask );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            uxReturn = uxTaskPriorityGet( pxTask );
+        }
 
         return uxReturn;
     }
@@ -158,11 +236,21 @@
     void MPU_vTaskPrioritySet( TaskHandle_t pxTask,
                                UBaseType_t uxNewPriority ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskPrioritySet( pxTask, uxNewPriority );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskPrioritySet( pxTask, uxNewPriority );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskPrioritySet( pxTask, uxNewPriority );
+        }
     }
 #endif /* if ( INCLUDE_vTaskPrioritySet == 1 ) */
 /*-----------------------------------------------------------*/
@@ -171,11 +259,22 @@
     eTaskState MPU_eTaskGetState( TaskHandle_t pxTask ) /* FREERTOS_SYSTEM_CALL */
     {
         eTaskState eReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        eReturn = eTaskGetState( pxTask );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            eReturn = eTaskGetState( pxTask );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            eReturn = eTaskGetState( pxTask );
+        }
 
         return eReturn;
     }
@@ -188,11 +287,21 @@
                            BaseType_t xGetFreeStackSpace,
                            eTaskState eState ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState );
+        }
     }
 #endif /* if ( configUSE_TRACE_FACILITY == 1 ) */
 /*-----------------------------------------------------------*/
@@ -201,11 +310,21 @@
     TaskHandle_t MPU_xTaskGetIdleTaskHandle( void ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGetIdleTaskHandle();
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+            xReturn = xTaskGetIdleTaskHandle();
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGetIdleTaskHandle();
+        }
 
         return xReturn;
     }
@@ -215,44 +334,86 @@
 #if ( INCLUDE_vTaskSuspend == 1 )
     void MPU_vTaskSuspend( TaskHandle_t pxTaskToSuspend ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskSuspend( pxTaskToSuspend );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskSuspend( pxTaskToSuspend );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskSuspend( pxTaskToSuspend );
+        }
     }
-#endif
+#endif /* if ( INCLUDE_vTaskSuspend == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskSuspend == 1 )
     void MPU_vTaskResume( TaskHandle_t pxTaskToResume ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskResume( pxTaskToResume );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskResume( pxTaskToResume );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskResume( pxTaskToResume );
+        }
     }
-#endif
+#endif /* if ( INCLUDE_vTaskSuspend == 1 ) */
 /*-----------------------------------------------------------*/
 
 void MPU_vTaskSuspendAll( void ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged;
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    vTaskSuspendAll();
-    vPortResetPrivilege( xRunningPrivileged );
+        vTaskSuspendAll();
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        vTaskSuspendAll();
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t MPU_xTaskResumeAll( void ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xTaskResumeAll();
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xTaskResumeAll();
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xTaskResumeAll();
+    }
 
     return xReturn;
 }
@@ -261,11 +422,22 @@ BaseType_t MPU_xTaskResumeAll( void ) /* FREERTOS_SYSTEM_CALL */
 TickType_t MPU_xTaskGetTickCount( void ) /* FREERTOS_SYSTEM_CALL */
 {
     TickType_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xTaskGetTickCount();
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xTaskGetTickCount();
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xTaskGetTickCount();
+    }
 
     return xReturn;
 }
@@ -274,11 +446,22 @@ TickType_t MPU_xTaskGetTickCount( void ) /* FREERTOS_SYSTEM_CALL */
 UBaseType_t MPU_uxTaskGetNumberOfTasks( void ) /* FREERTOS_SYSTEM_CALL */
 {
     UBaseType_t uxReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    uxReturn = uxTaskGetNumberOfTasks();
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        uxReturn = uxTaskGetNumberOfTasks();
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        uxReturn = uxTaskGetNumberOfTasks();
+    }
 
     return uxReturn;
 }
@@ -287,11 +470,22 @@ UBaseType_t MPU_uxTaskGetNumberOfTasks( void ) /* FREERTOS_SYSTEM_CALL */
 char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
 {
     char * pcReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    pcReturn = pcTaskGetName( xTaskToQuery );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        pcReturn = pcTaskGetName( xTaskToQuery );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        pcReturn = pcTaskGetName( xTaskToQuery );
+    }
 
     return pcReturn;
 }
@@ -301,11 +495,22 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
     TaskHandle_t MPU_xTaskGetHandle( const char * pcNameToQuery ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGetHandle( pcNameToQuery );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskGetHandle( pcNameToQuery );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGetHandle( pcNameToQuery );
+        }
 
         return xReturn;
     }
@@ -315,36 +520,67 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     void MPU_vTaskList( char * pcWriteBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskList( pcWriteBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskList( pcWriteBuffer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskList( pcWriteBuffer );
+        }
     }
-#endif
+#endif /* if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     void MPU_vTaskGetRunTimeStats( char * pcWriteBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskGetRunTimeStats( pcWriteBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskGetRunTimeStats( pcWriteBuffer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskGetRunTimeStats( pcWriteBuffer );
+        }
     }
-#endif
+#endif /* if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) )
     uint32_t MPU_ulTaskGetIdleRunTimeCounter( void ) /* FREERTOS_SYSTEM_CALL */
     {
         uint32_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = ulTaskGetIdleRunTimeCounter();
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = ulTaskGetIdleRunTimeCounter();
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = ulTaskGetIdleRunTimeCounter();
+        }
 
         return xReturn;
     }
@@ -355,11 +591,21 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
     void MPU_vTaskSetApplicationTaskTag( TaskHandle_t xTask,
                                          TaskHookFunction_t pxTagValue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskSetApplicationTaskTag( xTask, pxTagValue );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskSetApplicationTaskTag( xTask, pxTagValue );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskSetApplicationTaskTag( xTask, pxTagValue );
+        }
     }
 #endif /* if ( configUSE_APPLICATION_TASK_TAG == 1 ) */
 /*-----------------------------------------------------------*/
@@ -368,11 +614,22 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
     TaskHookFunction_t MPU_xTaskGetApplicationTaskTag( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHookFunction_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGetApplicationTaskTag( xTask );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskGetApplicationTaskTag( xTask );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGetApplicationTaskTag( xTask );
+        }
 
         return xReturn;
     }
@@ -384,11 +641,21 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
                                                 BaseType_t xIndex,
                                                 void * pvValue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue );
+        }
     }
 #endif /* if ( configNUM_THREAD_LOCAL_STORAGE_POINTERS != 0 ) */
 /*-----------------------------------------------------------*/
@@ -398,11 +665,22 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
                                                    BaseType_t xIndex ) /* FREERTOS_SYSTEM_CALL */
     {
         void * pvReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        pvReturn = pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            pvReturn = pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            pvReturn = pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex );
+        }
 
         return pvReturn;
     }
@@ -413,11 +691,23 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
     BaseType_t MPU_xTaskCallApplicationTaskHook( TaskHandle_t xTask,
                                                  void * pvParameter ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskCallApplicationTaskHook( xTask, pvParameter );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskCallApplicationTaskHook( xTask, pvParameter );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskCallApplicationTaskHook( xTask, pvParameter );
+        }
 
         return xReturn;
     }
@@ -430,11 +720,22 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
                                           uint32_t * pulTotalRunTime ) /* FREERTOS_SYSTEM_CALL */
     {
         UBaseType_t uxReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        uxReturn = uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            uxReturn = uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            uxReturn = uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
+        }
 
         return uxReturn;
     }
@@ -443,11 +744,23 @@ char * MPU_pcTaskGetName( TaskHandle_t xTaskToQuery ) /* FREERTOS_SYSTEM_CALL */
 
 BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xTaskCatchUpTicks( xTicksToCatchUp );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xTaskCatchUpTicks( xTicksToCatchUp );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xTaskCatchUpTicks( xTicksToCatchUp );
+    }
 
     return xReturn;
 }
@@ -457,11 +770,22 @@ BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTE
     UBaseType_t MPU_uxTaskGetStackHighWaterMark( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
         UBaseType_t uxReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        uxReturn = uxTaskGetStackHighWaterMark( xTask );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            uxReturn = uxTaskGetStackHighWaterMark( xTask );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            uxReturn = uxTaskGetStackHighWaterMark( xTask );
+        }
 
         return uxReturn;
     }
@@ -472,11 +796,22 @@ BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTE
     configSTACK_DEPTH_TYPE MPU_uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) /* FREERTOS_SYSTEM_CALL */
     {
         configSTACK_DEPTH_TYPE uxReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        uxReturn = uxTaskGetStackHighWaterMark2( xTask );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            uxReturn = uxTaskGetStackHighWaterMark2( xTask );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            uxReturn = uxTaskGetStackHighWaterMark2( xTask );
+        }
 
         return uxReturn;
     }
@@ -487,11 +822,21 @@ BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTE
     TaskHandle_t MPU_xTaskGetCurrentTaskHandle( void ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGetCurrentTaskHandle();
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+            xReturn = xTaskGetCurrentTaskHandle();
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGetCurrentTaskHandle();
+        }
 
         return xReturn;
     }
@@ -501,11 +846,23 @@ BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTE
 #if ( INCLUDE_xTaskGetSchedulerState == 1 )
     BaseType_t MPU_xTaskGetSchedulerState( void ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGetSchedulerState();
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskGetSchedulerState();
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGetSchedulerState();
+        }
 
         return xReturn;
     }
@@ -514,22 +871,44 @@ BaseType_t MPU_xTaskCatchUpTicks( TickType_t xTicksToCatchUp ) /* FREERTOS_SYSTE
 
 void MPU_vTaskSetTimeOutState( TimeOut_t * const pxTimeOut ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged;
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    vTaskSetTimeOutState( pxTimeOut );
-    vPortResetPrivilege( xRunningPrivileged );
+        vTaskSetTimeOutState( pxTimeOut );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        vTaskSetTimeOutState( pxTimeOut );
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                      TickType_t * const pxTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
+    }
 
     return xReturn;
 }
@@ -542,11 +921,23 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                        eNotifyAction eAction,
                                        uint32_t * pulPreviousNotificationValue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
+        }
 
         return xReturn;
     }
@@ -560,11 +951,23 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                            uint32_t * pulNotificationValue,
                                            TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait );
+        }
 
         return xReturn;
     }
@@ -577,11 +980,22 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                           TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
         uint32_t ulReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        ulReturn = ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            ulReturn = ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            ulReturn = ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait );
+        }
 
         return ulReturn;
     }
@@ -592,11 +1006,23 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
     BaseType_t MPU_xTaskGenericNotifyStateClear( TaskHandle_t xTask,
                                                  UBaseType_t uxIndexToClear ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTaskGenericNotifyStateClear( xTask, uxIndexToClear );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTaskGenericNotifyStateClear( xTask, uxIndexToClear );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTaskGenericNotifyStateClear( xTask, uxIndexToClear );
+        }
 
         return xReturn;
     }
@@ -609,11 +1035,22 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                                 uint32_t ulBitsToClear ) /* FREERTOS_SYSTEM_CALL */
     {
         uint32_t ulReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        ulReturn = ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            ulReturn = ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            ulReturn = ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear );
+        }
 
         return ulReturn;
     }
@@ -626,11 +1063,22 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                            uint8_t ucQueueType ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
+        }
 
         return xReturn;
     }
@@ -645,11 +1093,22 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                                  const uint8_t ucQueueType ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType );
+        }
 
         return xReturn;
     }
@@ -659,11 +1118,23 @@ BaseType_t MPU_xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
 BaseType_t MPU_xQueueGenericReset( QueueHandle_t pxQueue,
                                    BaseType_t xNewQueue ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xQueueGenericReset( pxQueue, xNewQueue );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xQueueGenericReset( pxQueue, xNewQueue );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xQueueGenericReset( pxQueue, xNewQueue );
+    }
 
     return xReturn;
 }
@@ -674,11 +1145,23 @@ BaseType_t MPU_xQueueGenericSend( QueueHandle_t xQueue,
                                   TickType_t xTicksToWait,
                                   BaseType_t xCopyPosition ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
+    }
 
     return xReturn;
 }
@@ -687,11 +1170,22 @@ BaseType_t MPU_xQueueGenericSend( QueueHandle_t xQueue,
 UBaseType_t MPU_uxQueueMessagesWaiting( const QueueHandle_t pxQueue ) /* FREERTOS_SYSTEM_CALL */
 {
     UBaseType_t uxReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    uxReturn = uxQueueMessagesWaiting( pxQueue );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        uxReturn = uxQueueMessagesWaiting( pxQueue );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        uxReturn = uxQueueMessagesWaiting( pxQueue );
+    }
 
     return uxReturn;
 }
@@ -700,11 +1194,22 @@ UBaseType_t MPU_uxQueueMessagesWaiting( const QueueHandle_t pxQueue ) /* FREERTO
 UBaseType_t MPU_uxQueueSpacesAvailable( const QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
 {
     UBaseType_t uxReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    uxReturn = uxQueueSpacesAvailable( xQueue );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        uxReturn = uxQueueSpacesAvailable( xQueue );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        uxReturn = uxQueueSpacesAvailable( xQueue );
+    }
 
     return uxReturn;
 }
@@ -714,11 +1219,23 @@ BaseType_t MPU_xQueueReceive( QueueHandle_t pxQueue,
                               void * const pvBuffer,
                               TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xQueueReceive( pxQueue, pvBuffer, xTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xQueueReceive( pxQueue, pvBuffer, xTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xQueueReceive( pxQueue, pvBuffer, xTicksToWait );
+    }
 
     return xReturn;
 }
@@ -728,11 +1245,23 @@ BaseType_t MPU_xQueuePeek( QueueHandle_t xQueue,
                            void * const pvBuffer,
                            TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xQueuePeek( xQueue, pvBuffer, xTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xQueuePeek( xQueue, pvBuffer, xTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xQueuePeek( xQueue, pvBuffer, xTicksToWait );
+    }
 
     return xReturn;
 }
@@ -741,11 +1270,23 @@ BaseType_t MPU_xQueuePeek( QueueHandle_t xQueue,
 BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                     TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xQueueSemaphoreTake( xQueue, xTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xQueueSemaphoreTake( xQueue, xTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xQueueSemaphoreTake( xQueue, xTicksToWait );
+    }
 
     return xReturn;
 }
@@ -755,11 +1296,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     TaskHandle_t MPU_xQueueGetMutexHolder( QueueHandle_t xSemaphore ) /* FREERTOS_SYSTEM_CALL */
     {
         void * xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueGetMutexHolder( xSemaphore );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueGetMutexHolder( xSemaphore );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueGetMutexHolder( xSemaphore );
+        }
 
         return xReturn;
     }
@@ -770,11 +1322,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     QueueHandle_t MPU_xQueueCreateMutex( const uint8_t ucQueueType ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueCreateMutex( ucQueueType );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueCreateMutex( ucQueueType );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueCreateMutex( ucQueueType );
+        }
 
         return xReturn;
     }
@@ -786,11 +1349,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                StaticQueue_t * pxStaticQueue ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueCreateMutexStatic( ucQueueType, pxStaticQueue );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueCreateMutexStatic( ucQueueType, pxStaticQueue );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueCreateMutexStatic( ucQueueType, pxStaticQueue );
+        }
 
         return xReturn;
     }
@@ -802,11 +1376,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                      UBaseType_t uxInitialCount ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueCreateCountingSemaphore( uxCountValue, uxInitialCount );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueCreateCountingSemaphore( uxCountValue, uxInitialCount );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueCreateCountingSemaphore( uxCountValue, uxInitialCount );
+        }
 
         return xReturn;
     }
@@ -820,11 +1405,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                            StaticQueue_t * pxStaticQueue ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue );
+        }
 
         return xReturn;
     }
@@ -835,11 +1431,23 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     BaseType_t MPU_xQueueTakeMutexRecursive( QueueHandle_t xMutex,
                                              TickType_t xBlockTime ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueTakeMutexRecursive( xMutex, xBlockTime );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueTakeMutexRecursive( xMutex, xBlockTime );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueTakeMutexRecursive( xMutex, xBlockTime );
+        }
 
         return xReturn;
     }
@@ -849,11 +1457,23 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
 #if ( configUSE_RECURSIVE_MUTEXES == 1 )
     BaseType_t MPU_xQueueGiveMutexRecursive( QueueHandle_t xMutex ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueGiveMutexRecursive( xMutex );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueGiveMutexRecursive( xMutex );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueGiveMutexRecursive( xMutex );
+        }
 
         return xReturn;
     }
@@ -864,11 +1484,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     QueueSetHandle_t MPU_xQueueCreateSet( UBaseType_t uxEventQueueLength ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueSetHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueCreateSet( uxEventQueueLength );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueCreateSet( uxEventQueueLength );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueCreateSet( uxEventQueueLength );
+        }
 
         return xReturn;
     }
@@ -880,11 +1511,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
                                                     TickType_t xBlockTimeTicks ) /* FREERTOS_SYSTEM_CALL */
     {
         QueueSetMemberHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueSelectFromSet( xQueueSet, xBlockTimeTicks );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueSelectFromSet( xQueueSet, xBlockTimeTicks );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueSelectFromSet( xQueueSet, xBlockTimeTicks );
+        }
 
         return xReturn;
     }
@@ -895,11 +1537,23 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     BaseType_t MPU_xQueueAddToSet( QueueSetMemberHandle_t xQueueOrSemaphore,
                                    QueueSetHandle_t xQueueSet ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
+        }
 
         return xReturn;
     }
@@ -910,11 +1564,23 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     BaseType_t MPU_xQueueRemoveFromSet( QueueSetMemberHandle_t xQueueOrSemaphore,
                                         QueueSetHandle_t xQueueSet ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet );
+        }
 
         return xReturn;
     }
@@ -925,11 +1591,21 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     void MPU_vQueueAddToRegistry( QueueHandle_t xQueue,
                                   const char * pcName ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vQueueAddToRegistry( xQueue, pcName );
-        vPortResetPrivilege( xRunningPrivileged );
+            vQueueAddToRegistry( xQueue, pcName );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vQueueAddToRegistry( xQueue, pcName );
+        }
     }
 #endif /* if configQUEUE_REGISTRY_SIZE > 0 */
 /*-----------------------------------------------------------*/
@@ -937,11 +1613,21 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
 #if configQUEUE_REGISTRY_SIZE > 0
     void MPU_vQueueUnregisterQueue( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vQueueUnregisterQueue( xQueue );
-        vPortResetPrivilege( xRunningPrivileged );
+            vQueueUnregisterQueue( xQueue );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vQueueUnregisterQueue( xQueue );
+        }
     }
 #endif /* if configQUEUE_REGISTRY_SIZE > 0 */
 /*-----------------------------------------------------------*/
@@ -950,11 +1636,22 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
     const char * MPU_pcQueueGetName( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     {
         const char * pcReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        pcReturn = pcQueueGetName( xQueue );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            pcReturn = pcQueueGetName( xQueue );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            pcReturn = pcQueueGetName( xQueue );
+        }
 
         return pcReturn;
     }
@@ -963,11 +1660,21 @@ BaseType_t MPU_xQueueSemaphoreTake( QueueHandle_t xQueue,
 
 void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged;
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    vQueueDelete( xQueue );
-    vPortResetPrivilege( xRunningPrivileged );
+        vQueueDelete( xQueue );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        vQueueDelete( xQueue );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -979,11 +1686,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                     TimerCallbackFunction_t pxCallbackFunction ) /* FREERTOS_SYSTEM_CALL */
     {
         TimerHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerCreate( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerCreate( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerCreate( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction );
+        }
 
         return xReturn;
     }
@@ -999,11 +1717,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                           StaticTimer_t * pxTimerBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         TimerHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
+        }
 
         return xReturn;
     }
@@ -1014,11 +1743,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     void * MPU_pvTimerGetTimerID( const TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         void * pvReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        pvReturn = pvTimerGetTimerID( xTimer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            pvReturn = pvTimerGetTimerID( xTimer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            pvReturn = pvTimerGetTimerID( xTimer );
+        }
 
         return pvReturn;
     }
@@ -1029,11 +1769,21 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     void MPU_vTimerSetTimerID( TimerHandle_t xTimer,
                                void * pvNewID ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTimerSetTimerID( xTimer, pvNewID );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTimerSetTimerID( xTimer, pvNewID );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTimerSetTimerID( xTimer, pvNewID );
+        }
     }
 #endif /* if ( configUSE_TIMERS == 1 ) */
 /*-----------------------------------------------------------*/
@@ -1041,11 +1791,23 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
 #if ( configUSE_TIMERS == 1 )
     BaseType_t MPU_xTimerIsTimerActive( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerIsTimerActive( xTimer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerIsTimerActive( xTimer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerIsTimerActive( xTimer );
+        }
 
         return xReturn;
     }
@@ -1056,11 +1818,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* FREERTOS_SYSTEM_CALL */
     {
         TaskHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerGetTimerDaemonTaskHandle();
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerGetTimerDaemonTaskHandle();
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerGetTimerDaemonTaskHandle();
+        }
 
         return xReturn;
     }
@@ -1073,11 +1846,23 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                            uint32_t ulParameter2,
                                            TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xReturn, xRunningPrivileged;
+        BaseType_t xReturn;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
+        }
 
         return xReturn;
     }
@@ -1088,11 +1873,21 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
                                   const UBaseType_t uxAutoReload ) /* FREERTOS_SYSTEM_CALL */
     {
-        BaseType_t xRunningPrivileged;
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        vTimerSetReloadMode( xTimer, uxAutoReload );
-        vPortResetPrivilege( xRunningPrivileged );
+            vTimerSetReloadMode( xTimer, uxAutoReload );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            vTimerSetReloadMode( xTimer, uxAutoReload );
+        }
     }
 #endif /* if ( configUSE_TIMERS == 1 ) */
 /*-----------------------------------------------------------*/
@@ -1101,11 +1896,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     UBaseType_t MPU_uxTimerGetReloadMode( TimerHandle_t xTimer )
     {
         UBaseType_t uxReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        uxReturn = uxTimerGetReloadMode( xTimer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            uxReturn = uxTimerGetReloadMode( xTimer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            uxReturn = uxTimerGetReloadMode( xTimer );
+        }
 
         return uxReturn;
     }
@@ -1116,11 +1922,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     const char * MPU_pcTimerGetName( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         const char * pcReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        pcReturn = pcTimerGetName( xTimer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            pcReturn = pcTimerGetName( xTimer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            pcReturn = pcTimerGetName( xTimer );
+        }
 
         return pcReturn;
     }
@@ -1131,11 +1948,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     TickType_t MPU_xTimerGetPeriod( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         TickType_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerGetPeriod( xTimer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerGetPeriod( xTimer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerGetPeriod( xTimer );
+        }
 
         return xReturn;
     }
@@ -1146,11 +1974,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     TickType_t MPU_xTimerGetExpiryTime( TimerHandle_t xTimer ) /* FREERTOS_SYSTEM_CALL */
     {
         TickType_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerGetExpiryTime( xTimer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerGetExpiryTime( xTimer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerGetExpiryTime( xTimer );
+        }
 
         return xReturn;
     }
@@ -1165,11 +2004,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
                                          const TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
     {
         BaseType_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xTimerGenericCommand( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xTimerGenericCommand( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xTimerGenericCommand( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+        }
 
         return xReturn;
     }
@@ -1180,11 +2030,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     EventGroupHandle_t MPU_xEventGroupCreate( void ) /* FREERTOS_SYSTEM_CALL */
     {
         EventGroupHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xEventGroupCreate();
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xEventGroupCreate();
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xEventGroupCreate();
+        }
 
         return xReturn;
     }
@@ -1195,11 +2056,22 @@ void MPU_vQueueDelete( QueueHandle_t xQueue ) /* FREERTOS_SYSTEM_CALL */
     EventGroupHandle_t MPU_xEventGroupCreateStatic( StaticEventGroup_t * pxEventGroupBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         EventGroupHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xEventGroupCreateStatic( pxEventGroupBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xEventGroupCreateStatic( pxEventGroupBuffer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xEventGroupCreateStatic( pxEventGroupBuffer );
+        }
 
         return xReturn;
     }
@@ -1213,11 +2085,22 @@ EventBits_t MPU_xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                      TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait );
+    }
 
     return xReturn;
 }
@@ -1227,11 +2110,22 @@ EventBits_t MPU_xEventGroupClearBits( EventGroupHandle_t xEventGroup,
                                       const EventBits_t uxBitsToClear ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xEventGroupClearBits( xEventGroup, uxBitsToClear );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xEventGroupClearBits( xEventGroup, uxBitsToClear );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xEventGroupClearBits( xEventGroup, uxBitsToClear );
+    }
 
     return xReturn;
 }
@@ -1241,11 +2135,22 @@ EventBits_t MPU_xEventGroupSetBits( EventGroupHandle_t xEventGroup,
                                     const EventBits_t uxBitsToSet ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xEventGroupSetBits( xEventGroup, uxBitsToSet );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xEventGroupSetBits( xEventGroup, uxBitsToSet );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xEventGroupSetBits( xEventGroup, uxBitsToSet );
+    }
 
     return xReturn;
 }
@@ -1257,11 +2162,22 @@ EventBits_t MPU_xEventGroupSync( EventGroupHandle_t xEventGroup,
                                  TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     EventBits_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
+    }
 
     return xReturn;
 }
@@ -1269,11 +2185,21 @@ EventBits_t MPU_xEventGroupSync( EventGroupHandle_t xEventGroup,
 
 void MPU_vEventGroupDelete( EventGroupHandle_t xEventGroup ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged;
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    vEventGroupDelete( xEventGroup );
-    vPortResetPrivilege( xRunningPrivileged );
+        vEventGroupDelete( xEventGroup );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        vEventGroupDelete( xEventGroup );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -1283,11 +2209,22 @@ size_t MPU_xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
                               TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
+    }
 
     return xReturn;
 }
@@ -1296,11 +2233,22 @@ size_t MPU_xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
 size_t MPU_xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferNextMessageLengthBytes( xStreamBuffer );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferNextMessageLengthBytes( xStreamBuffer );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferNextMessageLengthBytes( xStreamBuffer );
+    }
 
     return xReturn;
 }
@@ -1312,11 +2260,22 @@ size_t MPU_xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
                                  TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
+    }
 
     return xReturn;
 }
@@ -1324,21 +2283,43 @@ size_t MPU_xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
 
 void MPU_vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xRunningPrivileged;
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    vStreamBufferDelete( xStreamBuffer );
-    vPortResetPrivilege( xRunningPrivileged );
+        vStreamBufferDelete( xStreamBuffer );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        vStreamBufferDelete( xStreamBuffer );
+    }
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t MPU_xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferIsFull( xStreamBuffer );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferIsFull( xStreamBuffer );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferIsFull( xStreamBuffer );
+    }
 
     return xReturn;
 }
@@ -1346,11 +2327,23 @@ BaseType_t MPU_xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer ) /* FREE
 
 BaseType_t MPU_xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferIsEmpty( xStreamBuffer );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferIsEmpty( xStreamBuffer );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferIsEmpty( xStreamBuffer );
+    }
 
     return xReturn;
 }
@@ -1358,11 +2351,23 @@ BaseType_t MPU_xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer ) /* FRE
 
 BaseType_t MPU_xStreamBufferReset( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferReset( xStreamBuffer );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferReset( xStreamBuffer );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferReset( xStreamBuffer );
+    }
 
     return xReturn;
 }
@@ -1371,11 +2376,21 @@ BaseType_t MPU_xStreamBufferReset( StreamBufferHandle_t xStreamBuffer ) /* FREER
 size_t MPU_xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferSpacesAvailable( xStreamBuffer );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+        xReturn = xStreamBufferSpacesAvailable( xStreamBuffer );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferSpacesAvailable( xStreamBuffer );
+    }
 
     return xReturn;
 }
@@ -1384,11 +2399,22 @@ size_t MPU_xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer ) /*
 size_t MPU_xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
 {
     size_t xReturn;
-    BaseType_t xRunningPrivileged;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferBytesAvailable( xStreamBuffer );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferBytesAvailable( xStreamBuffer );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferBytesAvailable( xStreamBuffer );
+    }
 
     return xReturn;
 }
@@ -1397,11 +2423,23 @@ size_t MPU_xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer ) /* 
 BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
                                              size_t xTriggerLevel ) /* FREERTOS_SYSTEM_CALL */
 {
-    BaseType_t xReturn, xRunningPrivileged;
+    BaseType_t xReturn;
 
-    xPortRaisePrivilege( xRunningPrivileged );
-    xReturn = xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
-    vPortResetPrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
+
+        xReturn = xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        xReturn = xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
+    }
 
     return xReturn;
 }
@@ -1413,11 +2451,22 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
                                                          BaseType_t xIsMessageBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         StreamBufferHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer );
+        }
 
         return xReturn;
     }
@@ -1432,11 +2481,22 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
                                                                StaticStreamBuffer_t * const pxStaticStreamBuffer ) /* FREERTOS_SYSTEM_CALL */
     {
         StreamBufferHandle_t xReturn;
-        BaseType_t xRunningPrivileged;
 
-        xPortRaisePrivilege( xRunningPrivileged );
-        xReturn = xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer );
-        vPortResetPrivilege( xRunningPrivileged );
+        if( portIS_PRIVILEGED() == pdFALSE )
+        {
+            portRAISE_PRIVILEGE();
+            portMEMORY_BARRIER();
+
+            xReturn = xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer );
+            portMEMORY_BARRIER();
+
+            portRESET_PRIVILEGE();
+            portMEMORY_BARRIER();
+        }
+        else
+        {
+            xReturn = xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer );
+        }
 
         return xReturn;
     }
@@ -1452,11 +2512,21 @@ BaseType_t MPU_xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
  * void MPU_FunctionName( [parameters ] ) FREERTOS_SYSTEM_CALL;
  * void MPU_FunctionName( [parameters ] )
  * {
- * BaseType_t xRunningPrivileged;
+ *      if( portIS_PRIVILEGED() == pdFALSE )
+ *      {
+ *          portRAISE_PRIVILEGE();
+ *          portMEMORY_BARRIER();
  *
- * xPortRaisePrivilege( xRunningPrivileged );
- * FunctionName( [parameters ] );
- * vPortResetPrivilege( xRunningPrivileged );
+ *          FunctionName( [parameters ] );
+ *          portMEMORY_BARRIER();
+ *
+ *          portRESET_PRIVILEGE();
+ *          portMEMORY_BARRIER();
+ *      }
+ *      else
+ *      {
+ *          FunctionName( [parameters ] );
+ *      }
  * }
  */
 

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -478,30 +478,55 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    portDISABLE_INTERRUPTS();
-    uxCriticalNesting++;
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
-
-    configASSERT( uxCriticalNesting );
-    uxCriticalNesting--;
-
-    if( uxCriticalNesting == 0 )
+    if( portIS_PRIVILEGED() == pdFALSE )
     {
-        portENABLE_INTERRUPTS();
-    }
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -637,6 +637,7 @@ static void prvSetupMPU( void )
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
                                        ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+                                       ( portMPU_REGION_EXECUTE_NEVER ) |
                                        prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
                                        ( portMPU_REGION_ENABLE );
 
@@ -736,6 +737,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
             ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
+            ( portMPU_REGION_EXECUTE_NEVER ) |
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
@@ -761,7 +763,8 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 ( portSTACK_REGION ); /* Region number. */
 
             xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
-                ( portMPU_REGION_READ_WRITE ) | /* Read and write. */
+                ( portMPU_REGION_READ_WRITE ) |
+                ( portMPU_REGION_EXECUTE_NEVER ) |
                 ( prvGetMPURegionSizeSetting( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) ) |
                 ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
                 ( portMPU_REGION_ENABLE );

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -731,7 +731,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
         xMPUSettings->xRegion[ 0 ].ulRegionBaseAddress =
             ( ( uint32_t ) __SRAM_segment_start__ ) | /* Base address. */
             ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION );
+            ( portSTACK_REGION ); /* Region number. */
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
@@ -739,23 +739,10 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
-        /* Re-instate the privileged only RAM region as xRegion[ 0 ] will have
-         * just removed the privileged only parameters. */
-        xMPUSettings->xRegion[ 1 ].ulRegionBaseAddress =
-            ( ( uint32_t ) __privileged_data_start__ ) | /* Base address. */
-            ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION + 1 );
-
-        xMPUSettings->xRegion[ 1 ].ulRegionAttribute =
-            ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-            ( portMPU_REGION_CACHEABLE_BUFFERABLE ) |
-            prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
-            ( portMPU_REGION_ENABLE );
-
-        /* Invalidate all other regions. */
-        for( ul = 2; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        /* Invalidate user configurable regions. */
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
-            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
             xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
         }
     }
@@ -782,7 +769,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         lIndex = 0;
 
-        for( ul = 1; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
             if( ( xRegions[ lIndex ] ).ulLengthInBytes > 0UL )
             {
@@ -792,7 +779,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 xMPUSettings->xRegion[ ul ].ulRegionBaseAddress =
                     ( ( uint32_t ) xRegions[ lIndex ].pvBaseAddress ) |
                     ( portMPU_REGION_VALID ) |
-                    ( portSTACK_REGION + ul ); /* Region number. */
+                    ( ul - 1UL ); /* Region number. */
 
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute =
                     ( prvGetMPURegionSizeSetting( xRegions[ lIndex ].ulLengthInBytes ) ) |
@@ -802,7 +789,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             else
             {
                 /* Invalidate the region. */
-                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
             }
 

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -81,15 +81,15 @@
     #define portMPU_REGION_CACHEABLE_BUFFERABLE                      ( 0x07UL << 16UL )
     #define portMPU_REGION_EXECUTE_NEVER                             ( 0x01UL << 28UL )
 
-    #define portUNPRIVILEGED_FLASH_REGION                            ( 0UL )
-    #define portPRIVILEGED_FLASH_REGION                              ( 1UL )
-    #define portPRIVILEGED_RAM_REGION                                ( 2UL )
     #define portGENERAL_PERIPHERALS_REGION                           ( 3UL )
     #define portSTACK_REGION                                         ( 4UL )
-    #define portFIRST_CONFIGURABLE_REGION                            ( 5UL )
-    #define portLAST_CONFIGURABLE_REGION                             ( 7UL )
+    #define portUNPRIVILEGED_FLASH_REGION                            ( 5UL )
+    #define portPRIVILEGED_FLASH_REGION                              ( 6UL )
+    #define portPRIVILEGED_RAM_REGION                                ( 7UL )
+    #define portFIRST_CONFIGURABLE_REGION                            ( 0UL )
+    #define portLAST_CONFIGURABLE_REGION                             ( 2UL )
     #define portNUM_CONFIGURABLE_REGIONS                             ( ( portLAST_CONFIGURABLE_REGION - portFIRST_CONFIGURABLE_REGION ) + 1 )
-    #define portTOTAL_NUM_REGIONS                                    ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus one to make space for the stack region. */
+    #define portTOTAL_NUM_REGIONS_IN_TCB                             ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus one to make space for the stack region. */
 
     #define portSWITCH_TO_USER_MODE()    __asm volatile ( " mrs r0, control \n orr r0, #1 \n msr control, r0 " ::: "r0", "memory" )
 
@@ -102,7 +102,7 @@
 /* Plus 1 to create space for the stack region. */
     typedef struct MPU_SETTINGS
     {
-        xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS ];
+        xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS_IN_TCB ];
     } xMPU_SETTINGS;
 
 /* Architecture specifics. */

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -514,30 +514,55 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    portDISABLE_INTERRUPTS();
-    uxCriticalNesting++;
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
-
-    configASSERT( uxCriticalNesting );
-    uxCriticalNesting--;
-
-    if( uxCriticalNesting == 0 )
+    if( portIS_PRIVILEGED() == pdFALSE )
     {
-        portENABLE_INTERRUPTS();
-    }
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -723,6 +723,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_RAM_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
+                                       ( portMPU_REGION_EXECUTE_NEVER ) |
                                        ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
                                        ( portMPU_REGION_ENABLE );
@@ -834,6 +835,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
+            ( portMPU_REGION_EXECUTE_NEVER ) |
             ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
@@ -860,7 +862,8 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 ( portSTACK_REGION ); /* Region number. */
 
             xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
-                ( portMPU_REGION_READ_WRITE ) | /* Read and write. */
+                ( portMPU_REGION_READ_WRITE ) |
+                ( portMPU_REGION_EXECUTE_NEVER ) |
                 ( prvGetMPURegionSizeSetting( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) ) |
                 ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                 ( portMPU_REGION_ENABLE );

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -68,7 +68,7 @@
 #define portMPU_REGION_BASE_ADDRESS_REG           ( *( ( volatile uint32_t * ) 0xe000ed9C ) )
 #define portMPU_REGION_ATTRIBUTE_REG              ( *( ( volatile uint32_t * ) 0xe000edA0 ) )
 #define portMPU_CTRL_REG                          ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portEXPECTED_MPU_TYPE_VALUE               ( portTOTAL_NUM_REGIONS << 8UL )
+#define portEXPECTED_MPU_TYPE_VALUE               ( configTOTAL_MPU_REGIONS << 8UL )
 #define portMPU_ENABLE                            ( 0x01UL )
 #define portMPU_BACKGROUND_ENABLE                 ( 1UL << 2UL )
 #define portPRIVILEGED_EXECUTION_START_ADDRESS    ( 0UL )
@@ -359,12 +359,12 @@ static void prvRestoreContextOfFirstTask( void )
         "	ldmia r1!, {r4-r11}				\n"/* Read 4 sets of MPU registers [MPU Region # 4 - 7]. */
         "	stmia r2, {r4-r11}				\n"/* Write 4 sets of MPU registers [MPU Region # 4 - 7]. */
         "									\n"
-        #if ( portTOTAL_NUM_REGIONS == 16 )
+        #if ( configTOTAL_MPU_REGIONS == 16 )
             "	ldmia r1!, {r4-r11}				\n"/* Read 4 sets of MPU registers [MPU Region # 8 - 11]. */
             "	stmia r2, {r4-r11}				\n"/* Write 4 sets of MPU registers. [MPU Region # 8 - 11]. */
             "	ldmia r1!, {r4-r11}				\n"/* Read 4 sets of MPU registers [MPU Region # 12 - 15]. */
             "	stmia r2, {r4-r11}				\n"/* Write 4 sets of MPU registers. [MPU Region # 12 - 15]. */
-        #endif /* portTOTAL_NUM_REGIONS == 16. */
+        #endif /* configTOTAL_MPU_REGIONS == 16. */
         "									\n"
         "	ldr r2, =0xe000ed94				\n"/* MPU_CTRL register. */
         "	ldr r3, [r2]					\n"/* Read the value of MPU_CTRL. */
@@ -585,12 +585,12 @@ void xPortPendSVHandler( void )
         "	ldmia r1!, {r4-r11}					\n"/* Read 4 sets of MPU registers [MPU Region # 4 - 7]. */
         "	stmia r2, {r4-r11}					\n"/* Write 4 sets of MPU registers [MPU Region # 4 - 7]. */
         "										\n"
-        #if ( portTOTAL_NUM_REGIONS == 16 )
+        #if ( configTOTAL_MPU_REGIONS == 16 )
             "	ldmia r1!, {r4-r11}					\n"/* Read 4 sets of MPU registers [MPU Region # 8 - 11]. */
             "	stmia r2, {r4-r11}					\n"/* Write 4 sets of MPU registers. [MPU Region # 8 - 11]. */
             "	ldmia r1!, {r4-r11}					\n"/* Read 4 sets of MPU registers [MPU Region # 12 - 15]. */
             "	stmia r2, {r4-r11}					\n"/* Write 4 sets of MPU registers. [MPU Region # 12 - 15]. */
-        #endif /* portTOTAL_NUM_REGIONS == 16. */
+        #endif /* configTOTAL_MPU_REGIONS == 16. */
         "										\n"
         "	ldr r2, =0xe000ed94					\n"/* MPU_CTRL register. */
         "	ldr r3, [r2]						\n"/* Read the value of MPU_CTRL. */
@@ -687,7 +687,7 @@ static void prvSetupMPU( void )
     #endif /* if defined( __ARMCC_VERSION ) */
 
     /* The only permitted number of regions are 8 or 16. */
-    configASSERT( ( portTOTAL_NUM_REGIONS == 8 ) || ( portTOTAL_NUM_REGIONS == 16 ) );
+    configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
 
     /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
     configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
@@ -830,7 +830,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
         xMPUSettings->xRegion[ 0 ].ulRegionBaseAddress =
             ( ( uint32_t ) __SRAM_segment_start__ ) | /* Base address. */
             ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION );
+            ( portSTACK_REGION ); /* Region number. */
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
@@ -838,23 +838,10 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
-        /* Re-instate the privileged only RAM region as xRegion[ 0 ] will have
-         * just removed the privileged only parameters. */
-        xMPUSettings->xRegion[ 1 ].ulRegionBaseAddress =
-            ( ( uint32_t ) __privileged_data_start__ ) | /* Base address. */
-            ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION + 1 );
-
-        xMPUSettings->xRegion[ 1 ].ulRegionAttribute =
-            ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
-            prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
-            ( portMPU_REGION_ENABLE );
-
-        /* Invalidate all other regions. */
-        for( ul = 2; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        /* Invalidate user configurable regions. */
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
-            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
             xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
         }
     }
@@ -881,7 +868,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         lIndex = 0;
 
-        for( ul = 1; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
             if( ( xRegions[ lIndex ] ).ulLengthInBytes > 0UL )
             {
@@ -891,7 +878,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 xMPUSettings->xRegion[ ul ].ulRegionBaseAddress =
                     ( ( uint32_t ) xRegions[ lIndex ].pvBaseAddress ) |
                     ( portMPU_REGION_VALID ) |
-                    ( portSTACK_REGION + ul ); /* Region number. */
+                    ( ul - 1UL ); /* Region number. */
 
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute =
                     ( prvGetMPURegionSizeSetting( xRegions[ lIndex ].ulLengthInBytes ) ) |
@@ -901,7 +888,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             else
             {
                 /* Invalidate the region. */
-                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
             }
 

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -170,15 +170,15 @@ typedef unsigned long    UBaseType_t;
     #define configTEX_S_C_B_SRAM          ( 0x07UL )
 #endif
 
-#define portUNPRIVILEGED_FLASH_REGION     ( 0UL )
-#define portPRIVILEGED_FLASH_REGION       ( 1UL )
-#define portPRIVILEGED_RAM_REGION         ( 2UL )
-#define portGENERAL_PERIPHERALS_REGION    ( 3UL )
-#define portSTACK_REGION                  ( 4UL )
-#define portFIRST_CONFIGURABLE_REGION     ( 5UL )
-#define portTOTAL_NUM_REGIONS             ( configTOTAL_MPU_REGIONS )
-#define portNUM_CONFIGURABLE_REGIONS      ( portTOTAL_NUM_REGIONS - portFIRST_CONFIGURABLE_REGION )
-#define portLAST_CONFIGURABLE_REGION      ( portTOTAL_NUM_REGIONS - 1 )
+#define portGENERAL_PERIPHERALS_REGION    ( configTOTAL_MPU_REGIONS - 5UL )
+#define portSTACK_REGION                  ( configTOTAL_MPU_REGIONS - 4UL )
+#define portUNPRIVILEGED_FLASH_REGION     ( configTOTAL_MPU_REGIONS - 3UL )
+#define portPRIVILEGED_FLASH_REGION       ( configTOTAL_MPU_REGIONS - 2UL )
+#define portPRIVILEGED_RAM_REGION         ( configTOTAL_MPU_REGIONS - 1UL )
+#define portFIRST_CONFIGURABLE_REGION     ( 0UL )
+#define portLAST_CONFIGURABLE_REGION      ( configTOTAL_MPU_REGIONS - 6UL )
+#define portNUM_CONFIGURABLE_REGIONS      ( configTOTAL_MPU_REGIONS - 5UL )
+#define portTOTAL_NUM_REGIONS_IN_TCB      ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus 1 to create space for the stack region. */
 
 #define portSWITCH_TO_USER_MODE()    __asm volatile ( " mrs r0, control \n orr r0, #1 \n msr control, r0 " ::: "r0", "memory" )
 
@@ -188,10 +188,9 @@ typedef struct MPU_REGION_REGISTERS
     uint32_t ulRegionAttribute;
 } xMPU_REGION_REGISTERS;
 
-/* Plus 1 to create space for the stack region. */
 typedef struct MPU_SETTINGS
 {
-    xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS ];
+    xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS_IN_TCB ];
 } xMPU_SETTINGS;
 
 /* Architecture specifics. */

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -562,6 +562,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_RAM_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
+                                       ( portMPU_REGION_EXECUTE_NEVER ) |
                                        ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
                                        ( portMPU_REGION_ENABLE );
@@ -631,6 +632,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
+            ( portMPU_REGION_EXECUTE_NEVER ) |
             ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
@@ -657,7 +659,8 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 ( portSTACK_REGION ); /* Region number. */
 
             xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
-                ( portMPU_REGION_READ_WRITE ) | /* Read and write. */
+                ( portMPU_REGION_READ_WRITE ) |
+                ( portMPU_REGION_EXECUTE_NEVER ) |
                 ( prvGetMPURegionSizeSetting( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) ) |
                 ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                 ( portMPU_REGION_ENABLE );

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -75,7 +75,7 @@
 #define portMPU_REGION_BASE_ADDRESS_REG           ( *( ( volatile uint32_t * ) 0xe000ed9C ) )
 #define portMPU_REGION_ATTRIBUTE_REG              ( *( ( volatile uint32_t * ) 0xe000edA0 ) )
 #define portMPU_CTRL_REG                          ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portEXPECTED_MPU_TYPE_VALUE               ( portTOTAL_NUM_REGIONS << 8UL )
+#define portEXPECTED_MPU_TYPE_VALUE               ( configTOTAL_MPU_REGIONS << 8UL )
 #define portMPU_ENABLE                            ( 0x01UL )
 #define portMPU_BACKGROUND_ENABLE                 ( 1UL << 2UL )
 #define portPRIVILEGED_EXECUTION_START_ADDRESS    ( 0UL )
@@ -526,7 +526,7 @@ static void prvSetupMPU( void )
     extern uint32_t __privileged_data_end__[];
 
     /* The only permitted number of regions are 8 or 16. */
-    configASSERT( ( portTOTAL_NUM_REGIONS == 8 ) || ( portTOTAL_NUM_REGIONS == 16 ) );
+    configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
 
     /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
     configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
@@ -627,7 +627,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
         xMPUSettings->xRegion[ 0 ].ulRegionBaseAddress =
             ( ( uint32_t ) __SRAM_segment_start__ ) | /* Base address. */
             ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION );
+            ( portSTACK_REGION ); /* Region number. */
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
@@ -635,23 +635,10 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
-        /* Re-instate the privileged only RAM region as xRegion[ 0 ] will have
-         * just removed the privileged only parameters. */
-        xMPUSettings->xRegion[ 1 ].ulRegionBaseAddress =
-            ( ( uint32_t ) __privileged_data_start__ ) | /* Base address. */
-            ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION + 1 );
-
-        xMPUSettings->xRegion[ 1 ].ulRegionAttribute =
-            ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
-            prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
-            ( portMPU_REGION_ENABLE );
-
-        /* Invalidate all other regions. */
-        for( ul = 2; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        /* Invalidate user configurable regions. */
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
-            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
             xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
         }
     }
@@ -678,7 +665,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         lIndex = 0;
 
-        for( ul = 1; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
             if( ( xRegions[ lIndex ] ).ulLengthInBytes > 0UL )
             {
@@ -688,7 +675,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 xMPUSettings->xRegion[ ul ].ulRegionBaseAddress =
                     ( ( uint32_t ) xRegions[ lIndex ].pvBaseAddress ) |
                     ( portMPU_REGION_VALID ) |
-                    ( portSTACK_REGION + ul ); /* Region number. */
+                    ( ul - 1UL ); /* Region number. */
 
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute =
                     ( prvGetMPURegionSizeSetting( xRegions[ lIndex ].ulLengthInBytes ) ) |
@@ -698,7 +685,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             else
             {
                 /* Invalidate the region. */
-                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
             }
 

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -442,41 +442,73 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
-
-    portDISABLE_INTERRUPTS();
-    uxCriticalNesting++;
-
-    /* This is not the interrupt safe version of the enter critical function so
-     * assert() if it is being called from an interrupt context.  Only API
-     * functions that end in "FromISR" can be used in an interrupt.  Only assert if
-     * the critical nesting count is 1 to protect against recursive calls if the
-     * assert function also uses a critical section. */
-    if( uxCriticalNesting == 1 )
+    if( portIS_PRIVILEGED() == pdFALSE )
     {
-        configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
-    }
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+        /* This is not the interrupt safe version of the enter critical function so
+         * assert() if it is being called from an interrupt context.  Only API
+         * functions that end in "FromISR" can be used in an interrupt.  Only assert if
+         * the critical nesting count is 1 to protect against recursive calls if the
+         * assert function also uses a critical section. */
+        if( uxCriticalNesting == 1 )
+        {
+            configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
+        }
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+        /* This is not the interrupt safe version of the enter critical function so
+         * assert() if it is being called from an interrupt context.  Only API
+         * functions that end in "FromISR" can be used in an interrupt.  Only assert if
+         * the critical nesting count is 1 to protect against recursive calls if the
+         * assert function also uses a critical section. */
+        if( uxCriticalNesting == 1 )
+        {
+            configASSERT( ( portNVIC_INT_CTRL_REG & portVECTACTIVE_MASK ) == 0 );
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
-
-    configASSERT( uxCriticalNesting );
-
-    uxCriticalNesting--;
-
-    if( uxCriticalNesting == 0 )
+    if( portIS_PRIVILEGED() == pdFALSE )
     {
-        portENABLE_INTERRUPTS();
-    }
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -172,15 +172,15 @@ typedef unsigned long    UBaseType_t;
     #define configTEX_S_C_B_SRAM          ( 0x07UL )
 #endif
 
-#define portUNPRIVILEGED_FLASH_REGION     ( 0UL )
-#define portPRIVILEGED_FLASH_REGION       ( 1UL )
-#define portPRIVILEGED_RAM_REGION         ( 2UL )
-#define portGENERAL_PERIPHERALS_REGION    ( 3UL )
-#define portSTACK_REGION                  ( 4UL )
-#define portFIRST_CONFIGURABLE_REGION     ( 5UL )
-#define portTOTAL_NUM_REGIONS             ( configTOTAL_MPU_REGIONS )
-#define portNUM_CONFIGURABLE_REGIONS      ( portTOTAL_NUM_REGIONS - portFIRST_CONFIGURABLE_REGION )
-#define portLAST_CONFIGURABLE_REGION      ( portTOTAL_NUM_REGIONS - 1UL )
+#define portGENERAL_PERIPHERALS_REGION    ( configTOTAL_MPU_REGIONS - 5UL )
+#define portSTACK_REGION                  ( configTOTAL_MPU_REGIONS - 4UL )
+#define portUNPRIVILEGED_FLASH_REGION     ( configTOTAL_MPU_REGIONS - 3UL )
+#define portPRIVILEGED_FLASH_REGION       ( configTOTAL_MPU_REGIONS - 2UL )
+#define portPRIVILEGED_RAM_REGION         ( configTOTAL_MPU_REGIONS - 1UL )
+#define portFIRST_CONFIGURABLE_REGION     ( 0UL )
+#define portLAST_CONFIGURABLE_REGION      ( configTOTAL_MPU_REGIONS - 6UL )
+#define portNUM_CONFIGURABLE_REGIONS      ( configTOTAL_MPU_REGIONS - 5UL )
+#define portTOTAL_NUM_REGIONS_IN_TCB      ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus 1 to create space for the stack region. */
 
 #define portSWITCH_TO_USER_MODE()    __asm volatile ( " mrs r0, control \n orr r0, r0, #1 \n msr control, r0 " ::: "r0", "memory" )
 
@@ -190,10 +190,9 @@ typedef struct MPU_REGION_REGISTERS
     uint32_t ulRegionAttribute;
 } xMPU_REGION_REGISTERS;
 
-/* Plus 1 to create space for the stack region. */
 typedef struct MPU_SETTINGS
 {
-    xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS ];
+    xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS_IN_TCB ];
 } xMPU_SETTINGS;
 
 /* Architecture specifics. */

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -517,30 +517,55 @@ void vPortEndScheduler( void )
 
 void vPortEnterCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
+    if( portIS_PRIVILEGED() == pdFALSE )
+    {
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    portDISABLE_INTERRUPTS();
-    uxCriticalNesting++;
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        portDISABLE_INTERRUPTS();
+        uxCriticalNesting++;
+    }
 }
 /*-----------------------------------------------------------*/
 
 void vPortExitCritical( void )
 {
-    BaseType_t xRunningPrivileged;
-    xPortRaisePrivilege( xRunningPrivileged );
-
-    configASSERT( uxCriticalNesting );
-    uxCriticalNesting--;
-
-    if( uxCriticalNesting == 0 )
+    if( portIS_PRIVILEGED() == pdFALSE )
     {
-        portENABLE_INTERRUPTS();
-    }
+        portRAISE_PRIVILEGE();
+        portMEMORY_BARRIER();
 
-    vPortResetPrivilege( xRunningPrivileged );
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+        portMEMORY_BARRIER();
+
+        portRESET_PRIVILEGE();
+        portMEMORY_BARRIER();
+    }
+    else
+    {
+        configASSERT( uxCriticalNesting );
+        uxCriticalNesting--;
+
+        if( uxCriticalNesting == 0 )
+        {
+            portENABLE_INTERRUPTS();
+        }
+    }
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -726,6 +726,7 @@ static void prvSetupMPU( void )
                                           ( portPRIVILEGED_RAM_REGION );
 
         portMPU_REGION_ATTRIBUTE_REG = ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
+                                       ( portMPU_REGION_EXECUTE_NEVER ) |
                                        ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                                        prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
                                        ( portMPU_REGION_ENABLE );
@@ -825,6 +826,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
+            ( portMPU_REGION_EXECUTE_NEVER ) |
             ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
@@ -851,7 +853,8 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 ( portSTACK_REGION ); /* Region number. */
 
             xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
-                ( portMPU_REGION_READ_WRITE ) | /* Read and write. */
+                ( portMPU_REGION_READ_WRITE ) |
+                ( portMPU_REGION_EXECUTE_NEVER ) |
                 ( prvGetMPURegionSizeSetting( ulStackDepth * ( uint32_t ) sizeof( StackType_t ) ) ) |
                 ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
                 ( portMPU_REGION_ENABLE );

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -57,7 +57,7 @@
 #define portMPU_REGION_BASE_ADDRESS_REG           ( *( ( volatile uint32_t * ) 0xe000ed9C ) )
 #define portMPU_REGION_ATTRIBUTE_REG              ( *( ( volatile uint32_t * ) 0xe000edA0 ) )
 #define portMPU_CTRL_REG                          ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portEXPECTED_MPU_TYPE_VALUE               ( portTOTAL_NUM_REGIONS << 8UL )
+#define portEXPECTED_MPU_TYPE_VALUE               ( configTOTAL_MPU_REGIONS << 8UL )
 #define portMPU_ENABLE                            ( 0x01UL )
 #define portMPU_BACKGROUND_ENABLE                 ( 1UL << 2UL )
 #define portPRIVILEGED_EXECUTION_START_ADDRESS    ( 0UL )
@@ -352,12 +352,12 @@ __asm void prvRestoreContextOfFirstTask( void )
     ldmia r1 !, { r4 - r11 } /* Read 4 sets of MPU registers [MPU Region # 4 - 7]. */
     stmia r2, { r4 - r11 }  /* Write 4 sets of MPU registers [MPU Region # 4 - 7]. */
 
-    #if ( portTOTAL_NUM_REGIONS == 16 )
+    #if ( configTOTAL_MPU_REGIONS == 16 )
         ldmia r1 !, { r4 - r11 } /* Read 4 sets of MPU registers [MPU Region # 8 - 11]. */
         stmia r2, { r4 - r11 } /* Write 4 sets of MPU registers. [MPU Region # 8 - 11]. */
         ldmia r1 !, { r4 - r11 } /* Read 4 sets of MPU registers [MPU Region # 12 - 15]. */
         stmia r2, { r4 - r11 }  /* Write 4 sets of MPU registers. [MPU Region # 12 - 15]. */
-    #endif /* portTOTAL_NUM_REGIONS == 16. */
+    #endif /* configTOTAL_MPU_REGIONS == 16. */
 
     ldr r2, =0xe000ed94     /* MPU_CTRL register. */
     ldr r3, [ r2 ] /* Read the value of MPU_CTRL. */
@@ -590,12 +590,12 @@ __asm void xPortPendSVHandler( void )
     ldmia r1 !, { r4 - r11 } /* Read 4 sets of MPU registers [MPU Region # 4 - 7]. */
     stmia r2, { r4 - r11 }   /* Write 4 sets of MPU registers [MPU Region # 4 - 7]. */
 
-    #if ( portTOTAL_NUM_REGIONS == 16 )
+    #if ( configTOTAL_MPU_REGIONS == 16 )
         ldmia r1 !, { r4 - r11 } /* Read 4 sets of MPU registers [MPU Region # 8 - 11]. */
         stmia r2, { r4 - r11 }  /* Write 4 sets of MPU registers. [MPU Region # 8 - 11]. */
         ldmia r1 !, { r4 - r11 } /* Read 4 sets of MPU registers [MPU Region # 12 - 15]. */
         stmia r2, { r4 - r11 } /* Write 4 sets of MPU registers. [MPU Region # 12 - 15]. */
-    #endif /* portTOTAL_NUM_REGIONS == 16. */
+    #endif /* configTOTAL_MPU_REGIONS == 16. */
 
     ldr r2, =0xe000ed94     /* MPU_CTRL register. */
     ldr r3, [ r2 ] /* Read the value of MPU_CTRL. */
@@ -690,7 +690,7 @@ static void prvSetupMPU( void )
     extern uint32_t __privileged_data_end__;
 
     /* The only permitted number of regions are 8 or 16. */
-    configASSERT( ( portTOTAL_NUM_REGIONS == 8 ) || ( portTOTAL_NUM_REGIONS == 16 ) );
+    configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
 
     /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
     configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
@@ -821,7 +821,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
         xMPUSettings->xRegion[ 0 ].ulRegionBaseAddress =
             ( ( uint32_t ) __SRAM_segment_start__ ) | /* Base address. */
             ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION );
+            ( portSTACK_REGION ); /* Region number. */
 
         xMPUSettings->xRegion[ 0 ].ulRegionAttribute =
             ( portMPU_REGION_READ_WRITE ) |
@@ -829,23 +829,10 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             ( prvGetMPURegionSizeSetting( ( uint32_t ) __SRAM_segment_end__ - ( uint32_t ) __SRAM_segment_start__ ) ) |
             ( portMPU_REGION_ENABLE );
 
-        /* Re-instate the privileged only RAM region as xRegion[ 0 ] will have
-         * just removed the privileged only parameters. */
-        xMPUSettings->xRegion[ 1 ].ulRegionBaseAddress =
-            ( ( uint32_t ) __privileged_data_start__ ) | /* Base address. */
-            ( portMPU_REGION_VALID ) |
-            ( portSTACK_REGION + 1 );
-
-        xMPUSettings->xRegion[ 1 ].ulRegionAttribute =
-            ( portMPU_REGION_PRIVILEGED_READ_WRITE ) |
-            ( ( configTEX_S_C_B_SRAM & portMPU_RASR_TEX_S_C_B_MASK ) << portMPU_RASR_TEX_S_C_B_LOCATION ) |
-            prvGetMPURegionSizeSetting( ( uint32_t ) __privileged_data_end__ - ( uint32_t ) __privileged_data_start__ ) |
-            ( portMPU_REGION_ENABLE );
-
-        /* Invalidate all other regions. */
-        for( ul = 2; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        /* Invalidate user configurable regions. */
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
-            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+            xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
             xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
         }
     }
@@ -872,7 +859,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
 
         lIndex = 0;
 
-        for( ul = 1; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
+        for( ul = 1UL; ul <= portNUM_CONFIGURABLE_REGIONS; ul++ )
         {
             if( ( xRegions[ lIndex ] ).ulLengthInBytes > 0UL )
             {
@@ -882,7 +869,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                 xMPUSettings->xRegion[ ul ].ulRegionBaseAddress =
                     ( ( uint32_t ) xRegions[ lIndex ].pvBaseAddress ) |
                     ( portMPU_REGION_VALID ) |
-                    ( portSTACK_REGION + ul ); /* Region number. */
+                    ( ul - 1UL ); /* Region number. */
 
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute =
                     ( prvGetMPURegionSizeSetting( xRegions[ lIndex ].ulLengthInBytes ) ) |
@@ -892,7 +879,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             else
             {
                 /* Invalidate the region. */
-                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( portSTACK_REGION + ul ) | portMPU_REGION_VALID;
+                xMPUSettings->xRegion[ ul ].ulRegionBaseAddress = ( ( ul - 1UL ) | portMPU_REGION_VALID );
                 xMPUSettings->xRegion[ ul ].ulRegionAttribute = 0UL;
             }
 

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -169,15 +169,15 @@ typedef unsigned long    UBaseType_t;
     #define configTEX_S_C_B_SRAM          ( 0x07UL )
 #endif
 
-#define portUNPRIVILEGED_FLASH_REGION     ( 0UL )
-#define portPRIVILEGED_FLASH_REGION       ( 1UL )
-#define portPRIVILEGED_RAM_REGION         ( 2UL )
-#define portGENERAL_PERIPHERALS_REGION    ( 3UL )
-#define portSTACK_REGION                  ( 4UL )
-#define portFIRST_CONFIGURABLE_REGION     ( 5UL )
-#define portTOTAL_NUM_REGIONS             ( configTOTAL_MPU_REGIONS )
-#define portNUM_CONFIGURABLE_REGIONS      ( portTOTAL_NUM_REGIONS - portFIRST_CONFIGURABLE_REGION )
-#define portLAST_CONFIGURABLE_REGION      ( portTOTAL_NUM_REGIONS - 1 )
+#define portGENERAL_PERIPHERALS_REGION    ( configTOTAL_MPU_REGIONS - 5UL )
+#define portSTACK_REGION                  ( configTOTAL_MPU_REGIONS - 4UL )
+#define portUNPRIVILEGED_FLASH_REGION     ( configTOTAL_MPU_REGIONS - 3UL )
+#define portPRIVILEGED_FLASH_REGION       ( configTOTAL_MPU_REGIONS - 2UL )
+#define portPRIVILEGED_RAM_REGION         ( configTOTAL_MPU_REGIONS - 1UL )
+#define portFIRST_CONFIGURABLE_REGION     ( 0UL )
+#define portLAST_CONFIGURABLE_REGION      ( configTOTAL_MPU_REGIONS - 6UL )
+#define portNUM_CONFIGURABLE_REGIONS      ( configTOTAL_MPU_REGIONS - 5UL )
+#define portTOTAL_NUM_REGIONS_IN_TCB      ( portNUM_CONFIGURABLE_REGIONS + 1 ) /* Plus 1 to create space for the stack region. */
 
 void vPortSwitchToUserMode( void );
 #define portSWITCH_TO_USER_MODE()    vPortSwitchToUserMode()
@@ -188,10 +188,9 @@ typedef struct MPU_REGION_REGISTERS
     uint32_t ulRegionAttribute;
 } xMPU_REGION_REGISTERS;
 
-/* Plus 1 to create space for the stack region. */
 typedef struct MPU_SETTINGS
 {
-    xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS ];
+    xMPU_REGION_REGISTERS xRegion[ portTOTAL_NUM_REGIONS_IN_TCB ];
 } xMPU_SETTINGS;
 
 /* Architecture specifics. */

--- a/tasks.c
+++ b/tasks.c
@@ -3600,7 +3600,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     {
         TCB_t * pxTCB;
 
-        if( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS )
+        if( ( xIndex >= 0 ) &&
+            ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
         {
             pxTCB = prvGetTCBFromHandle( xTaskToSet );
             configASSERT( pxTCB != NULL );
@@ -3619,7 +3620,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
         void * pvReturn = NULL;
         TCB_t * pxTCB;
 
-        if( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS )
+        if( ( xIndex >= 0 ) &&
+            ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
         {
             pxTCB = prvGetTCBFromHandle( xTaskToQuery );
             pvReturn = pxTCB->pvThreadLocalStoragePointers[ xIndex ];


### PR DESCRIPTION
Description
-----------
This PR address the following issues:

1. **ARMv7-M and ARMv8-M MPU ports**: It is possible for a third party that already independently gained the ability to execute injected code to read from or write to arbitrary addresses by passing a negative argument as the `xIndex` parameter to `pvTaskGetThreadLocalStoragePointer()` or `vTaskSetThreadLocalStoragePointer()` respectively. We thank Certibit Consulting, LLC for reporting this issue.
2. **ARMv7-M and ARMv8-M MPU ports**: It is possible for an unprivileged task to invoke any function with privilege by passing it as a parameter to `MPU_xTaskCreate`, `MPU_xTaskCreateStatic`, `MPU_xTimerCreate`, `MPU_xTimerCreateStatic`, or `MPU_xTimerPendFunctionCall`. We thank Huazhong University of Science and Technology for reporting this issue.
3. **ARMv7-M and ARMv8-M MPU ports**: It is possible for a third party that has already independently gained the ability to execute injected code to achieve further privilege escalation by branching directly inside a FreeRTOS MPU API wrapper function with a manually crafted stack frame. We thank Certibit Consulting, LLC, Huazhong University of Science and Technology and the SecLab team at Northeastern University for reporting this issue.
4. **ARMv7-M MPU ports**: It is possible to configure overlapping memory protection unit (MPU) regions such that an unprivileged task can access privileged data. We thank the SecLab team at Northeastern University for reporting this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
