### PR TITLE
Add support for retrieving a task's uxCoreAffinityMask with the vTaskGetInfo() API

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -153,6 +153,9 @@ typedef struct xTASK_STATUS
     uint32_t ulRunTimeCounter;                       /* The total run time allocated to the task so far, as defined by the run time stats clock.  See https://www.FreeRTOS.org/rtos-run-time-stats.html.  Only valid when configGENERATE_RUN_TIME_STATS is defined as 1 in FreeRTOSConfig.h. */
     StackType_t * pxStackBase;                       /* Points to the lowest address of the task's stack area. */
     configSTACK_DEPTH_TYPE usStackHighWaterMark;     /* The minimum amount of stack space that has remained for the task since the task was created.  The closer this value is to zero the closer the task has come to overflowing its stack. */
+#if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
+    UBaseType_t uxCoreAffinityMask;                  /* The core affinity mask for the task */
+#endif
 } TaskStatus_t;
 
 /* Possible return values for eTaskConfirmSleepModeStatus(). */

--- a/include/task.h
+++ b/include/task.h
@@ -153,7 +153,7 @@ typedef struct xTASK_STATUS
     uint32_t ulRunTimeCounter;                       /* The total run time allocated to the task so far, as defined by the run time stats clock.  See https://www.FreeRTOS.org/rtos-run-time-stats.html.  Only valid when configGENERATE_RUN_TIME_STATS is defined as 1 in FreeRTOSConfig.h. */
     StackType_t * pxStackBase;                       /* Points to the lowest address of the task's stack area. */
     configSTACK_DEPTH_TYPE usStackHighWaterMark;     /* The minimum amount of stack space that has remained for the task since the task was created.  The closer this value is to zero the closer the task has come to overflowing its stack. */
-#if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
+#if ( ( configUSE_CORE_AFFINITY == 1 ) && ( configNUM_CORES > 1 ) )
     UBaseType_t uxCoreAffinityMask;                  /* The core affinity mask for the task */
 #endif
 } TaskStatus_t;

--- a/tasks.c
+++ b/tasks.c
@@ -4708,7 +4708,7 @@ static void prvCheckTasksWaitingTermination( void )
         pxTaskStatus->pxStackBase = pxTCB->pxStack;
         pxTaskStatus->xTaskNumber = pxTCB->uxTCBNumber;
 
-        #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
+        #if ( ( configUSE_CORE_AFFINITY == 1 ) && ( configNUM_CORES > 1 ) )
             {
                 pxTaskStatus->uxCoreAffinityMask = pxTCB->uxCoreAffinityMask;
             }

--- a/tasks.c
+++ b/tasks.c
@@ -4708,6 +4708,12 @@ static void prvCheckTasksWaitingTermination( void )
         pxTaskStatus->pxStackBase = pxTCB->pxStack;
         pxTaskStatus->xTaskNumber = pxTCB->uxTCBNumber;
 
+        #if ( configUSE_CORE_AFFINITY == 1 && configNUM_CORES > 1 )
+            {
+                pxTaskStatus->uxCoreAffinityMask = pxTCB->uxCoreAffinityMask;
+            }
+        #endif
+
         #if ( configUSE_MUTEXES == 1 )
             {
                 pxTaskStatus->uxBasePriority = pxTCB->uxBasePriority;


### PR DESCRIPTION
This commit adds support for retrieving the task's core affinity mask when SMP is used for more than 1 cores and configUSE_CORE_AFFINITY is enabled.

Signed-off-by: Sudeep Mohanty <sudp.mohanty@gmail.com>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
