### PR TITLE
Removed the 'configASSERT( xInheritanceOccurred == pdFALSE )' assertion from xQueueSemaphoreTake

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -1604,15 +1604,6 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
             {
                 if( xTicksToWait == ( TickType_t ) 0 )
                 {
-                    /* For inheritance to have occurred there must have been an
-                     * initial timeout, and an adjusted timeout cannot become 0, as
-                     * if it were 0 the function would have exited. */
-                    #if ( configUSE_MUTEXES == 1 )
-                    {
-                        configASSERT( xInheritanceOccurred == pdFALSE );
-                    }
-                    #endif /* configUSE_MUTEXES */
-
                     /* The semaphore count was 0 and no block time is specified
                      * (or the block time has expired) so exit now. */
                     taskEXIT_CRITICAL();


### PR DESCRIPTION
Removed the 'configASSERT( xInheritanceOccurred == pdFALSE )' assertion from xQueueSemaphoreTake as the reasoning behind it is wrong; it can trigger on wrongly on highly-contested semaphores on multicore systems. See [the forum](https://forums.freertos.org/t/15967) for details.