### PR TITLE
Fix array-bounds compiler warning on gcc11+ in list.h

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -290,7 +290,7 @@ typedef struct xLIST
         ( pxConstList )->pxIndex = ( pxConstList )->pxIndex->pxNext;                           \
         if( ( void * ) ( pxConstList )->pxIndex == ( void * ) &( ( pxConstList )->xListEnd ) ) \
         {                                                                                      \
-            ( pxConstList )->pxIndex = ( pxConstList )->pxIndex->pxNext;                       \
+            ( pxConstList )->pxIndex = ( pxConstList )->xListEnd.pxNext;                       \
         }                                                                                      \
         ( pxTCB ) = ( pxConstList )->pxIndex->pvOwner;                                         \
     }


### PR DESCRIPTION
Fix array-bounds compiler warning on gcc11+ in list.h

Description
-----------

listGET_OWNER_OF_NEXT_ENTRY computes `( pxConstList )->pxIndex->pxNext` after verifying that `( pxConstList )->pxIndex` points to `xListEnd`, which due to being a MiniListItem_t, can be shorter than a ListItem_t. Thus, `( pxConstList )->pxIndex` is a `ListItem_t *` that extends past the end of the `List_t` whose `xListEnd` it points to. 

On GCC 11+, this triggers an array-bounds warning. This is fixed by accessing `pxNext` through a `MiniListItem_t` instead.

<del>

listGET_OWNER_OF_NEXT_ENTRY uses uninitialized memory if the passed list is empty (only has the list end marker). While all uses of this macro are nested within a list empty check or are after an assert, this trips up GCC post GCC 11 on O3. Worse yet, with minilist enabled, this macro will dereference a struct offset past the end of the struct when passed an empty list.

Adding this check makes the behavior of the macro on empty list explicit when the only element is xListEnd, and prevents accessing xListEnd->pvOwner (Which is currently NULL where the List_t is zero-initialized; I have not checked if there are cases where it is not).

GCC gives a warning as it catches that the macro does not work with an empty list, but it does not figure that that code path is unreachable. Adding this check or adding more list non-empty checks/asserts directly outside of the macro fixes the issue. With asserts, the issue is only solved when asserts are enabled, so just adding the check is the better solution.

</del>

Test Steps
-----------
Compile tasks.h with GCC 12 (or 11) and with 03 as follows:
```sh
gcc -c tasks.c -I include -I ${KERNEL_CONFIG_PATH}/ -I portable/ThirdParty/GCC/Posix/ -Wall -Wextra -Werror -O3
```

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS/issues/858

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
