### PR TITLE
Added a check wherein a mutex is given only by the owner

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -283,6 +283,10 @@
     #define configUSE_MUTEXES    0
 #endif
 
+#ifndef configCHECK_MUTEX_GIVEN_BY_OWNER
+    #define configCHECK_MUTEX_GIVEN_BY_OWNER    0
+#endif
+
 #ifndef configUSE_TIMERS
     #define configUSE_TIMERS    0
 #endif

--- a/queue.c
+++ b/queue.c
@@ -850,11 +850,11 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
     }
     #endif
 
-#if ( configUSE_MUTEXES == 1 && configCHECK_MUTEX_GIVEN_BY_OWNER == 1 )
-    configASSERT( pxQueue->uxQueueType != queueQUEUE_IS_MUTEX
-                 || pxQueue->u.xSemaphore.xMutexHolder == NULL
-                 || pxQueue->u.xSemaphore.xMutexHolder == xTaskGetCurrentTaskHandle() );
-#endif
+    #if ( configUSE_MUTEXES == 1 && configCHECK_MUTEX_GIVEN_BY_OWNER == 1 )
+        configASSERT( pxQueue->uxQueueType != queueQUEUE_IS_MUTEX ||
+                      pxQueue->u.xSemaphore.xMutexHolder == NULL ||
+                      pxQueue->u.xSemaphore.xMutexHolder == xTaskGetCurrentTaskHandle() );
+    #endif
 
     /*lint -save -e904 This function relaxes the coding standard somewhat to
      * allow return statements within the function itself.  This is done in the

--- a/queue.c
+++ b/queue.c
@@ -850,7 +850,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
     }
     #endif
 
-#if ( configUSE_MUTEXES == 1 && configCHECK_MUTEX_GIVEN_BY_OWNER == 1)
+#if ( configUSE_MUTEXES == 1 && configCHECK_MUTEX_GIVEN_BY_OWNER == 1 )
     configASSERT( pxQueue->uxQueueType != queueQUEUE_IS_MUTEX
                  || pxQueue->u.xSemaphore.xMutexHolder == NULL
                  || pxQueue->u.xSemaphore.xMutexHolder == xTaskGetCurrentTaskHandle() );

--- a/queue.c
+++ b/queue.c
@@ -850,6 +850,12 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
     }
     #endif
 
+#if ( configUSE_MUTEXES == 1 && configCHECK_MUTEX_GIVEN_BY_OWNER == 1)
+    configASSERT( pxQueue->uxQueueType != queueQUEUE_IS_MUTEX
+                 || pxQueue->u.xSemaphore.xMutexHolder == NULL
+                 || pxQueue->u.xSemaphore.xMutexHolder == xTaskGetCurrentTaskHandle() );
+#endif
+
     /*lint -save -e904 This function relaxes the coding standard somewhat to
      * allow return statements within the function itself.  This is done in the
      * interest of execution time efficiency. */


### PR DESCRIPTION
Mutex type semaphores should be aquired and released by the same task. This commit adds an assertion check in xQueueGenericSend wherein the assertion will fail if a mutex is not given by the owner of the mutex.

Signed-off-by: Sudeep Mohanty <sudp.mohanty@gmail.com>



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
