### PR TITLE
Remove critical section in xTaskGetSchedulerState

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -5038,18 +5038,14 @@ static void prvResetNextTaskUnblockTime( void )
         }
         else
         {
-            taskENTER_CRITICAL();
+            if( uxSchedulerSuspended == ( UBaseType_t ) pdFALSE )
             {
-                if( uxSchedulerSuspended == ( UBaseType_t ) pdFALSE )
-                {
-                    xReturn = taskSCHEDULER_RUNNING;
-                }
-                else
-                {
-                    xReturn = taskSCHEDULER_SUSPENDED;
-                }
+                xReturn = taskSCHEDULER_RUNNING;
             }
-            taskEXIT_CRITICAL();
+            else
+            {
+                xReturn = taskSCHEDULER_SUSPENDED;
+            }
         }
 
         return xReturn;


### PR DESCRIPTION
Remove critical section in xTaskGetSchedulerState()

Description
-----------
<!--- Describe your changes in detail. -->
This PR is related to issue #515. 

xTaskGetSchedulerState() is called after vTaskStartScheduler() set xSchedulerRunning to pdTRUE but before the core calls vPortStartFirstTask() to switch in first FreeRTOS task and enable interrupt. Since vPortStartFirstTask() is not called, the core is not able to handle yield request. xTaskGetSchedulerState() function tries to enter the critical section after scheduler started. There will be an [assertion](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/8128208bdee1f997f83cae631b861f36aeea9b1f/tasks.c#L671) if the core is not able to handle yield request when entering the critical section.

A solution is to remove the critical section in vTaskStartScheduler() for the following reason:
* If the core is in critical section or suspends the scheduler, the critical section protection is not necessary.
* If the scheduler is suspended by other core, the core calls xTaskGetSchedulerState() always get **taskSCHEDULER_RUNNING** due to task spinlock is also required to enter critical section. To get the correct current scheduler state without being blocking, the critical section in xTaskGetSchedulerState() should be removed.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
With RP2040 port, the problem can be reproduced with the following condition:
* Core 0 creates task to request Core 1 to yield ( create task with core affinity or create two equal priority tasks can do )
* Core 1 insert the following code before switched in the first task at this[ line ](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/8128208bdee1f997f83cae631b861f36aeea9b1f/portable/ThirdParty/GCC/RP2040/port.c#L301)
```
if( portGET_CORE_ID() == 1 )
{
    while( xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED );
}
```
Before the fix, there will be assertion.
```
assertion "pxThisTCB->xTaskRunState != ( TaskRunning_t ) ( -2 )" failed: file "FreeRTOS/FreeRTOS/Source/tasks.c", line 707, function: prvCheckForRunStateChange
```
After the fix, there won't be assertion.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
