### PR TITLE
Add support for the configUSE_TASK_FPU_SUPPORT constant in the GCC/ARM_CR5 port

### DIFF
--- a/portable/GCC/ARM_CR5/port.c
+++ b/portable/GCC/ARM_CR5/port.c
@@ -444,17 +444,19 @@ void FreeRTOS_Tick_Handler( void )
 }
 /*-----------------------------------------------------------*/
 
-void vPortTaskUsesFPU( void )
-{
-    uint32_t ulInitialFPSCR = 0;
+#if( configUSE_TASK_FPU_SUPPORT != 2 )
+    void vPortTaskUsesFPU( void )
+    {
+        uint32_t ulInitialFPSCR = 0;
 
-    /* A task is registering the fact that it needs an FPU context.  Set the
-     * FPU flag (which is saved as part of the task context). */
-    ulPortTaskHasFPUContext = pdTRUE;
+        /* A task is registering the fact that it needs an FPU context.  Set the
+         * FPU flag (which is saved as part of the task context). */
+        ulPortTaskHasFPUContext = pdTRUE;
 
-    /* Initialise the floating point status register. */
-    __asm volatile ( "FMXR 	FPSCR, %0" ::"r" ( ulInitialFPSCR ) : "memory" );
-}
+        /* Initialise the floating point status register. */
+        __asm volatile ( "FMXR 	FPSCR, %0" ::"r" ( ulInitialFPSCR ) : "memory" );
+    }
+#endif /* configUSE_TASK_FPU_SUPPORT */
 /*-----------------------------------------------------------*/
 
 void vPortClearInterruptMask( uint32_t ulNewMaskValue )

--- a/portable/GCC/ARM_CR5/port.c
+++ b/portable/GCC/ARM_CR5/port.c
@@ -311,7 +311,7 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         ulPortTaskHasFPUContext = pdTRUE;
     }
     #else
-
+    {
         #error Invalid configUSE_TASK_FPU_SUPPORT setting - configUSE_TASK_FPU_SUPPORT must be set to 1, 2, or left undefined.
     }
     #endif /* configUSE_TASK_FPU_SUPPORT */
@@ -506,6 +506,7 @@ void FreeRTOS_Tick_Handler( void )
 /*-----------------------------------------------------------*/
 
 #if( configUSE_TASK_FPU_SUPPORT != 2 )
+
     void vPortTaskUsesFPU( void )
     {
         uint32_t ulInitialFPSCR = 0;
@@ -517,6 +518,7 @@ void FreeRTOS_Tick_Handler( void )
         /* Initialise the floating point status register. */
         __asm volatile ( "FMXR 	FPSCR, %0" ::"r" ( ulInitialFPSCR ) : "memory" );
     }
+
 #endif /* configUSE_TASK_FPU_SUPPORT */
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CR5/port.c
+++ b/portable/GCC/ARM_CR5/port.c
@@ -149,8 +149,17 @@
     #define portTASK_RETURN_ADDRESS    prvTaskExitError
 #endif
 
-/* The space on the stack required to hold the FPU registers.  This is 16 64-bit
-registers, plus a 32-bit status register. */
+/*
+ * The space on the stack required to hold the FPU registers.
+ *
+ * The ARM Cortex R5 processor implements the VFPv3-D16 FPU
+ * architecture. This includes only 16 double-precision registers,
+ * instead of 32 as is in VFPv3. The register bank can be viewed
+ * either as sixteen 64-bit double-word registers (D0-D15) or
+ * thirty-two 32-bit single-word registers (S0-S31), in both cases
+ * the size of the bank remains the same. The FPU has also a 32-bit
+ * status register.
+ */
 #define portFPU_REGISTER_WORDS    ( ( 16 * 2 ) + 1 )
 
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CR5/port.c
+++ b/portable/GCC/ARM_CR5/port.c
@@ -166,6 +166,27 @@ extern void vPortRestoreTaskContext( void );
  */
 static void prvTaskExitError( void );
 
+/*
+ * If the application provides an implementation of vApplicationIRQHandler(),
+ * then it will get called directly without saving the FPU registers on
+ * interrupt entry, and this weak implementation of
+ * vApplicationFPUSafeIRQHandler() is just provided to remove linkage errors -
+ * it should never actually get called so its implementation contains a
+ * call to configASSERT() that will always fail.
+ *
+ * If the application provides its own implementation of
+ * vApplicationFPUSafeIRQHandler() then the implementation of
+ * vApplicationIRQHandler() provided in portASM.S will save the FPU registers
+ * before calling it.
+ *
+ * Therefore, if the application writer wants FPU registers to be saved on
+ * interrupt entry their IRQ handler must be called
+ * vApplicationFPUSafeIRQHandler(), and if the application writer does not want
+ * FPU registers to be saved on interrupt entry their IRQ handler must be
+ * called vApplicationIRQHandler().
+ */
+void vApplicationFPUSafeIRQHandler( uint32_t ulICCIAR ) __attribute__((weak) );
+
 /*-----------------------------------------------------------*/
 
 /* A variable is used to keep track of the critical section nesting.  This
@@ -304,6 +325,13 @@ static void prvTaskExitError( void )
     for( ; ; )
     {
     }
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationFPUSafeIRQHandler( uint32_t ulICCIAR )
+{
+    ( void ) ulICCIAR;
+    configASSERT( ( volatile void * ) NULL );
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CR5/portASM.S
+++ b/portable/GCC/ARM_CR5/portASM.S
@@ -262,6 +262,44 @@ switch_before_exit:
 	next. */
 	portRESTORE_CONTEXT
 
+/******************************************************************************
+ * If the application provides an implementation of vApplicationIRQHandler(),
+ * then it will get called directly without saving the FPU registers on
+ * interrupt entry, and this weak implementation of
+ * vApplicationIRQHandler() will not get called.
+ *
+ * If the application provides its own implementation of
+ * vApplicationFPUSafeIRQHandler() then this implementation of
+ * vApplicationIRQHandler() will be called, save the FPU registers, and then
+ * call vApplicationFPUSafeIRQHandler().
+ *
+ * Therefore, if the application writer wants FPU registers to be saved on
+ * interrupt entry their IRQ handler must be called
+ * vApplicationFPUSafeIRQHandler(), and if the application writer does not want
+ * FPU registers to be saved on interrupt entry their IRQ handler must be
+ * called vApplicationIRQHandler().
+ *****************************************************************************/
+
+.align 4
+.weak vApplicationIRQHandler
+.type vApplicationIRQHandler, %function
+vApplicationIRQHandler:
+	PUSH	{LR}
+	FMRX	R1,  FPSCR
+	VPUSH	{D0-D15}
+	/* VPUSH {D16-D31} */
+	PUSH	{R1}
+
+	LDR		r1, vApplicationFPUSafeIRQHandlerConst
+	BLX		r1
+
+	POP		{R0}
+	/* VPOP	{D16-D31} */
+	VPOP	{D0-D15}
+	VMSR	FPSCR, R0
+
+	POP {PC}
+
 ulICCIARConst:	.word ulICCIAR
 ulICCEOIRConst:	.word ulICCEOIR
 ulICCPMRConst: .word ulICCPMR
@@ -272,6 +310,7 @@ ulMaxAPIPriorityMaskConst: .word ulMaxAPIPriorityMask
 vTaskSwitchContextConst: .word vTaskSwitchContext
 vApplicationIRQHandlerConst: .word vApplicationIRQHandler
 ulPortInterruptNestingConst: .word ulPortInterruptNesting
+vApplicationFPUSafeIRQHandlerConst: .word vApplicationFPUSafeIRQHandler
 
 .end
 

--- a/portable/GCC/ARM_CR5/portASM.S
+++ b/portable/GCC/ARM_CR5/portASM.S
@@ -287,14 +287,12 @@ vApplicationIRQHandler:
 	PUSH	{LR}
 	FMRX	R1,  FPSCR
 	VPUSH	{D0-D15}
-	/* VPUSH {D16-D31} */
 	PUSH	{R1}
 
 	LDR		r1, vApplicationFPUSafeIRQHandlerConst
 	BLX		r1
 
 	POP		{R0}
-	/* VPOP	{D16-D31} */
 	VPOP	{D0-D15}
 	VMSR	FPSCR, R0
 

--- a/portable/GCC/ARM_CR5/portmacro.h
+++ b/portable/GCC/ARM_CR5/portmacro.h
@@ -116,9 +116,18 @@
  * handler for whichever peripheral is used to generate the RTOS tick. */
     void FreeRTOS_Tick_Handler( void );
 
-/* Any task that uses the floating point unit MUST call vPortTaskUsesFPU()
- * before any floating point instructions are executed. */
+/* If configUSE_TASK_FPU_SUPPORT is set to 1 (or left undefined) then tasks are
+created without an FPU context and must call vPortTaskUsesFPU() to give
+themselves an FPU context before using any FPU instructions. If
+configUSE_TASK_FPU_SUPPORT is set to 2 then all tasks will have an FPU context
+by default. */
+#if( configUSE_TASK_FPU_SUPPORT != 2 )
     void vPortTaskUsesFPU( void );
+#else
+    /* Each task has an FPU context already, so define this function away to
+    nothing to prevent it being called accidentally. */
+    #define vPortTaskUsesFPU()
+#endif /* configUSE_TASK_FPU_SUPPORT */
     #define portTASK_USES_FLOATING_POINT()    vPortTaskUsesFPU()
 
     #define portLOWEST_INTERRUPT_PRIORITY           ( ( ( uint32_t ) configUNIQUE_INTERRUPT_PRIORITIES ) - 1UL )


### PR DESCRIPTION
<!--- Title -->
Add support for the `configUSE_TASK_FPU_SUPPORT` constant in the GCC/ARM_CR5 port

Description
-----------
<!--- Describe your changes in detail. -->

In this PR, I have added support for the `configUSE_TASK_FPU_SUPPORT` configuration constant to the GCC/ARM_CR5 port. 

The reason for this is, that when one does compile a FreeRTOS application with FPU on for the Cortex-R5 processor with the GCC compiler, then the compiler by default may make code optimizations using the FP-registers. E.g. code that uses standard functions such as `memcpy` , `memset` and similar ones, the chances are very high, that the compiler will make optimizations using the FPU registers. This will lead certainly to corrupted FP-registers, if these won't be handled accordingly.

In the current state of the GCC/ARM_CR5 port, one could use the function `vPortTaskUsesFPU( void )` to mark a task that uses the FPU, to also save/restore the FP-registers during context switches. However, this only option, to ensure that the FP-registers get saved/restored, on its own is not ideal. I had an issue with our application using the FreeRTOS-Plus-TCP library, in which the IP-Task would be optimized by the compiler to use the FPU registers, and for this task we were not able to set the `vPortTaskUsesFPU( void )`  mark, without making changes to the library.

So, now with the `configUSE_TASK_FPU_SUPPORT`, one can set it to `2` and ensure that every task created in the FreeRTOS application saves/restores the FP-registers. 

All this, of course, is not something new. The GCC/ARM_CA9 port does it already. 

I have also created a topic in the FreeRTOS-Forum, where this issue is being discussed more thoroughly. 
[FreeRTOS + TCP with hard FPU on Xilinx ZynqMP UltraScale CortexR5](https://forums.freertos.org/t/freertos-tcp-with-hard-fpu-on-xilinx-zynqmp-ultrascale-cortexr5/16133)


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

I did test these changes with our application in real hardware and also the FreeRTOS Demo [CORTEX_R5_UltraScale_MPSoC](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/CORTEX_R5_UltraScale_MPSoC), to verify that everything still works as expected and this was the case on both occasions.


Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
