### PR TITLE
SMP FreeRTOS: Fix critical section bugs

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1225,6 +1225,7 @@ typedef struct xSTATIC_TCB
     #endif
     #if ( portCRITICAL_NESTING_IN_TCB == 1 )
         UBaseType_t uxDummy9;
+        UBaseType_t uxDummy9b;
     #endif
     #if ( configUSE_TRACE_FACILITY == 1 )
         UBaseType_t uxDummy10[ 2 ];


### PR DESCRIPTION
<!--- Title -->
Fix multiple critical section bugs in SMP FreeRTOS

# Task critical sections do not restore the previous interrupt state

Description
-----------
<!--- Describe your changes in detail. -->

If a task disables interrupts first (via `portDISABLE_INTERRUPTS()`) and then enters and exits a critical section via `taskENTER_CRITICAL()`/`taskEXIT_CRTIICAL()`, the exit will reenable interrupts entirely (instead of restoring the pre-entry interrupt priority level).

Note: ISR critical sections are not affected by this issue, as the ISR critical section macros `taskENTER_CRITICAL_FROM_ISR()`/`taskEXIT_CRITICAL_FROM_ISR( x )` save and restore the pre-entry interrupt status via the returned/accepted variable.

Test Steps
-----------

<details>
  <summary>The following test case recreates this issue</summary>
  
  ```c
  TEST_CASE("Tasks: Test critical sections preserve interrupt state", "[freertos]")
  {
      UBaseType_t uxIntrStatusPreCrit;
      UBaseType_t uxIntrStatusPostCrit;
  
      // Disable interrupts before entering the critical section to change the current interrupt mask status
      portDISABLE_INTERRUPTS();
      uxIntrStatusPreCrit = portGET_INTERRUPT_STATUS();
  
      taskENTER_CRITICAL();
      taskEXIT_CRITICAL();
  
      // Interrupt status should be the same before and after the critical section
      uxIntrStatusPostCrit = portGET_INTERRUPT_STATUS();
      TEST_ASSERT_EQUAL(uxIntrStatusPreCrit, uxIntrStatusPostCrit);
  
      // Reenable interrupts
      portENABLE_INTERRUPTS();
  
  }
  ```
</details>

Proposed Fix
------------------

The proposed fix now adds a `uxSavedInterruptMask` to the TCB used to save the pre-entry interrupt state when calling `taskENTER_CRITICAL()`.

# Critical sections before the scheduler has started

Description
-----------
<!--- Describe your changes in detail. -->

Calling `taskENTER_CRITICAL()`/`taskEXIT_CRITICAL()` before the starting the scheduler has the following issues:

- `taskENTER_CRITICAL()` will disable interrupts, but calling `taskEXIT_CRITICAL()` does not restore them
- Similarly disabling interrupts first and then entering/exiting a critical section will not restore the pre-entry interrupt state.
- Critical sections do not keep track of nesting

Proposed Fixes
-----------
<!-- Describe the steps to reproduce. -->

The proposed fixed now adds

-  `uxCriticalNestingBeforeSched` per-core to keep track of critical nesting before the scheduler starts
- `uxSavedInterruptMaskBeforeSched` per-core to make sure critical exits before the scheduler starts will restore the correct interrupt state.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

I also have a separate concern about the current yielding implementation of `taskENTER_CRITICAL()->prvCheckForRunStateChange()`. Using the example above, if a task first disables interrupts via `portDISABLE_INTERRUPTS()` and then calls `taskENTER_CRITICAL()`, there is a chance that the task can yield (if its run state has changed). However, I'm not if allow tasks that have disabled interrupts to yield is something that is safe to do.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
