### PR TITLE
parenthesize expression-like macro

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -94,7 +94,7 @@
     #endif
 
     #ifndef configSET_TLS_BLOCK
-        #define configSET_TLS_BLOCK( xTLSBlock )    _impure_ptr = &( xTLSBlock )
+        #define configSET_TLS_BLOCK( xTLSBlock )   ( _impure_ptr = &( xTLSBlock ) )
     #endif
 
     #ifndef configDEINIT_TLS_BLOCK

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -94,7 +94,7 @@
     #endif
 
     #ifndef configSET_TLS_BLOCK
-        #define configSET_TLS_BLOCK( xTLSBlock )   ( _impure_ptr = &( xTLSBlock ) )
+        #define configSET_TLS_BLOCK( xTLSBlock )    ( _impure_ptr = &( xTLSBlock ) )
     #endif
 
     #ifndef configDEINIT_TLS_BLOCK


### PR DESCRIPTION
Fixed a lint warning

Description
-----------
Lint complains about the macro `configSET_TLS_BLOCK` not being parenthesized. I fixed that in `FreeRTOS.h`.
The macro is used in two places in `tasks.c` and parenthesizing the macro has no effect at all, but removes one lint warning.

Test Steps
-----------
see above.

Related Issue
-----------
none.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
