### PR TITLE
Move the prototype for vApplicationIdleHook to task.h.

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -1649,6 +1649,24 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
 
 #endif
 
+#if ( configUSE_IDLE_HOOK == 1 )
+
+/**
+ * task.h
+ * @code{c}
+ * void vApplicationIdleHook( void );
+ * @endcode
+ *
+ * The application idle hook is called by the idle task.
+ * This allows the application designer to add background functionality without
+ * the overhead of a separate task.
+ * NOTE: vApplicationIdleHook() MUST NOT, UNDER ANY CIRCUMSTANCES, CALL A FUNCTION THAT MIGHT BLOCK.
+ */
+    void vApplicationIdleHook( void );
+
+#endif
+
+
 #if  ( configUSE_TICK_HOOK > 0 )
 
 /**

--- a/tasks.c
+++ b/tasks.c
@@ -3477,13 +3477,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 
         #if ( configUSE_IDLE_HOOK == 1 )
         {
-            extern void vApplicationIdleHook( void );
-
-            /* Call the user defined function from within the idle task.  This
-             * allows the application designer to add background functionality
-             * without the overhead of a separate task.
-             * NOTE: vApplicationIdleHook() MUST NOT, UNDER ANY CIRCUMSTANCES,
-             * CALL A FUNCTION THAT MIGHT BLOCK. */
+            /* Call the user defined function from within the idle task. */
             vApplicationIdleHook();
         }
         #endif /* configUSE_IDLE_HOOK */


### PR DESCRIPTION
There is a prototype for `vApplicationIdleHook` that is local to the idle task.
To have the code more unified, the prototype should be moved to `task.h`, similar to `vApplicationStackOverflowHook`.
This is because compilers may generate warnings if the prototype for the `vApplicationIdleHook` is missing. In that case, application software can simply include `task.h` to have the prototype defined.

Description
-----------
Moved the prototype for `vApplicationIdleHook` from `task.c` to `task.h`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
