### PR TITLE
Draft: RFC: Enable granular locks for critical sections instead of a single kernel lock

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1304,6 +1304,7 @@ typedef struct xSTATIC_QUEUE
         UBaseType_t uxDummy8;
         uint8_t ucDummy9;
     #endif
+    portMUX_TYPE xDummyQueueLock;
 } StaticQueue_t;
 typedef StaticQueue_t StaticSemaphore_t;
 
@@ -1333,6 +1334,7 @@ typedef struct xSTATIC_EVENT_GROUP
     #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
         uint8_t ucDummy4;
     #endif
+    portMUX_TYPE xDummyEventGroupLock;
 } StaticEventGroup_t;
 
 /*
@@ -1360,6 +1362,7 @@ typedef struct xSTATIC_TIMER
         UBaseType_t uxDummy7;
     #endif
     uint8_t ucDummy8;
+    portMUX_TYPE xDummyStreamBufferLock;
 } StaticTimer_t;
 
 /*

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -240,6 +240,10 @@
     #define configUSE_TIMERS    0
 #endif
 
+#ifndef configCHECK_MUTEX_GIVEN_BY_OWNER
+    #define configCHECK_MUTEX_GIVEN_BY_OWNER    0
+#endif
+
 #ifndef configUSE_COUNTING_SEMAPHORES
     #define configUSE_COUNTING_SEMAPHORES    0
 #endif

--- a/include/task.h
+++ b/include/task.h
@@ -203,8 +203,8 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()               portENTER_CRITICAL()
-#define taskENTER_CRITICAL_FROM_ISR()      portSET_INTERRUPT_MASK_FROM_ISR()
+#define taskENTER_CRITICAL( x )            portENTER_CRITICAL( x )
+#define taskENTER_CRITICAL_FROM_ISR( x )   portSET_INTERRUPT_MASK_FROM_ISR( x )
 
 /**
  * task. h
@@ -218,7 +218,7 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                portEXIT_CRITICAL()
+#define taskEXIT_CRITICAL( x )             portEXIT_CRITICAL( x )
 #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 
 /**

--- a/queue.c
+++ b/queue.c
@@ -790,6 +790,12 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
         }
     #endif
 
+#if ( configUSE_MUTEXES == 1 && configCHECK_MUTEX_GIVEN_BY_OWNER == 1)
+    configASSERT( pxQueue->uxQueueType != queueQUEUE_IS_MUTEX
+                 || pxQueue->u.xSemaphore.xMutexHolder == NULL
+                 || pxQueue->u.xSemaphore.xMutexHolder == xTaskGetCurrentTaskHandle() );
+#endif
+
     /*lint -save -e904 This function relaxes the coding standard somewhat to
      * allow return statements within the function itself.  This is done in the
      * interest of execution time efficiency. */

--- a/timers.c
+++ b/timers.c
@@ -142,6 +142,7 @@
     PRIVILEGED_DATA static QueueHandle_t xTimerQueue = NULL;
     PRIVILEGED_DATA static TaskHandle_t xTimerTaskHandle = NULL;
 
+    PRIVILEGED_DATA portMUX_TYPE xTimerLock = portMUX_INITIALIZER_UNLOCKED;
 /*lint -restore */
 
 /*-----------------------------------------------------------*/
@@ -483,7 +484,7 @@
         Timer_t * pxTimer = xTimer;
 
         configASSERT( xTimer );
-        taskENTER_CRITICAL();
+        taskENTER_CRITICAL( &xTimerLock );
         {
             if( uxAutoReload != pdFALSE )
             {
@@ -494,7 +495,7 @@
                 pxTimer->ucStatus &= ~tmrSTATUS_IS_AUTORELOAD;
             }
         }
-        taskEXIT_CRITICAL();
+        taskEXIT_CRITICAL( &xTimerLock );
     }
 /*-----------------------------------------------------------*/
 
@@ -504,7 +505,7 @@
         UBaseType_t uxReturn;
 
         configASSERT( xTimer );
-        taskENTER_CRITICAL();
+        taskENTER_CRITICAL( &xTimerLock );
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_AUTORELOAD ) == 0 )
             {
@@ -517,7 +518,7 @@
                 uxReturn = ( UBaseType_t ) pdTRUE;
             }
         }
-        taskEXIT_CRITICAL();
+        taskEXIT_CRITICAL( &xTimerLock );
 
         return uxReturn;
     }
@@ -993,7 +994,7 @@
         /* Check that the list from which active timers are referenced, and the
          * queue used to communicate with the timer service, have been
          * initialised. */
-        taskENTER_CRITICAL();
+        taskENTER_CRITICAL( &xTimerLock );
         {
             if( xTimerQueue == NULL )
             {
@@ -1035,7 +1036,7 @@
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        taskEXIT_CRITICAL( &xTimerLock );
     }
 /*-----------------------------------------------------------*/
 
@@ -1047,7 +1048,7 @@
         configASSERT( xTimer );
 
         /* Is the timer in the list of active timers? */
-        taskENTER_CRITICAL();
+        taskENTER_CRITICAL( &xTimerLock );
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_ACTIVE ) == 0 )
             {
@@ -1058,7 +1059,7 @@
                 xReturn = pdTRUE;
             }
         }
-        taskEXIT_CRITICAL();
+        taskEXIT_CRITICAL( &xTimerLock );
 
         return xReturn;
     } /*lint !e818 Can't be pointer to const due to the typedef. */
@@ -1071,11 +1072,11 @@
 
         configASSERT( xTimer );
 
-        taskENTER_CRITICAL();
+        taskENTER_CRITICAL( &xTimerLock );
         {
             pvReturn = pxTimer->pvTimerID;
         }
-        taskEXIT_CRITICAL();
+        taskEXIT_CRITICAL( &xTimerLock );
 
         return pvReturn;
     }
@@ -1088,11 +1089,11 @@
 
         configASSERT( xTimer );
 
-        taskENTER_CRITICAL();
+        taskENTER_CRITICAL( &xTimerLock );
         {
             pxTimer->pvTimerID = pvNewID;
         }
-        taskEXIT_CRITICAL();
+        taskEXIT_CRITICAL( &xTimerLock );
     }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Enable granular locks for critical sections instead of a single kernel lock

Description
-----------
This commit updates all critical section APIs, viz., `task*_CRITICAL()`, to accept a spinlock variable. These spinlocks are defined locally to each of the kernel data structures. This change moves away from the single kernel lock design therefore ensuring lesser contentions for critical section locks. This effectively increases the performance of the SMP kernel.

The idea here is to have granularity in the critical section spinlocks. An example of how this improves performance is as below:

`Current Design:`
TaskA running on core#0 is in a critical section by calling a blocking function such as `uxTaskPriorityGet()`.
TaskB running on core#1 is performing a queue operation by calling `xQueueGenericSend()`. TaskB will have to contest for the kernel lock in order to complete the queue operation. This would mean that TaskB will be blocked until TaskA releases the lock.

`Proposed Changes:`
Under the new scheme with the above scenario, TaskB need not wait for TaskA to complete its operation as both the tasks will be contesting for separate locks which are local to the tasks module and the queue module respectively. This enables many kernel related operations to happen simultaneously across the cores, thereby helping in performance improvements in SMP systems.

Things to be considered
-----------
1. Currently the the `task*_CRITICAL()` macros are routed to the `vTaskEnterCritical()` function which ensures atomicity but also has the scope of checking for state change of a task via the function `prvCheckForRunStateChange()`. Under the proposed design change, the task state change may need a rethink. It could be abstracted out to the port layer.

2. Critical section nesting would need to be handled by the ports under the new design. This is currently handled by the kernel directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
