### PR TITLE
Fixed buffer underflow in `prvSelectHighestPriorityTask`.

### DIFF
--- a/.github/workflows/kernel-checks.yml
+++ b/.github/workflows/kernel-checks.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Tool Setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.10
+          python-version: 3.11.0
           architecture:   x64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tasks.c
+++ b/tasks.c
@@ -938,7 +938,9 @@ static void prvYieldForTask( TCB_t * pxTCB,
             {
                 if( xDecrementTopPriority != pdFALSE )
                 {
-                    uxTopReadyPriority--;
+                    if(uxTopReadyPriority > 0) {
+                        uxTopReadyPriority--;    
+                    }
                     #if ( ( configRUN_MULTIPLE_PRIORITIES == 0 ) && ( configNUM_CORES > 1 ) )
                         {
                             xPriorityDropped = pdTRUE;
@@ -956,7 +958,9 @@ static void prvYieldForTask( TCB_t * pxTCB,
             }
 
             configASSERT( ( uxCurrentPriority > tskIDLE_PRIORITY ) || ( xTaskScheduled == pdTRUE ) );
-            uxCurrentPriority--;
+            if(uxCurrentPriority > 0) {
+                uxCurrentPriority--;
+            }
         }
 
         configASSERT( taskTASK_IS_RUNNING( pxCurrentTCBs[ xCoreID ]->xTaskRunState ) );


### PR DESCRIPTION
Fixed buffer underflow in `prvSelectHighestPriorityTask`.

Description
-----------
The function `prvSelectHighestPriorityTask` is called from `vTaskSwitchContext` whenever the scheduler selects a new task to run. It can also be called from `vTaskSuspend` before the scheduler is running and before the idle tasks have been created. 

In the latter case, the global variable `uxTopReadyPriority` is decreased to -1. During the next regular context switch, `prvSelectHighestPriorityTask` tries to access the global ready list array `pxReadyTasksLists[ uxCurrentPriority ]`. This causes a memory error.

Test Steps
-----------
Initialize the ready lists stored in `pxReadyTasksLists` to be empty and call `prvSelectHighestPriorityTask`. Check that after the the function terminates, the global variable `uxTopReadyPriority` has value -1. Call `vTaskSwitchContext` and check that it causes a buffer underflow.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
