### PR TITLE
Remove prvSelectHighestPriorityTask call in vTaskSuspend

### DIFF
--- a/.github/workflows/kernel-checks.yml
+++ b/.github/workflows/kernel-checks.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Tool Setup
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.10
+          python-version: 3.11.0
           architecture:   x64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR extends the discussion in #607 to prevent uxTopReadyPriority decreased to -1 in the implementation.

Description
-----------
* Every core starts with an idle task in SMP implementation and taskTASK_IS_RUNNING only return ture when the task is idle task before scheduler started. So prvSelectHighestPriorityTask won't be called in vTaskSuspend before scheduler started.
* Update prvSelectHighestPriorityTask and also ensure that this function is called only when scheduler started.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
