### PR TITLE
Fix some CMake documentation typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ elseif((FREERTOS_PORT STREQUAL "A_CUSTOM_PORT") AND (NOT TARGET freertos_kernel_
     "   target_include_directories(freertos_kernel_port\n"
     "     PUBLIC\n"
     "      .)\n"
-    "   taget_link_libraries(freertos_kernel_port\n"
+    "   target_link_libraries(freertos_kernel_port\n"
     "     PRIVATE\n"
     "       freertos_kernel)")
 endif()

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the following into your project's main or a subdirectory's `CMakeLists.txt`:
 ```cmake
 FetchContent_Declare( freertos_kernel
   GIT_REPOSITORY https://github.com/FreeRTOS/FreeRTOS-Kernel.git
-  GIT_TAG        master #Note: Best practice to use specific git-hash or tagged version
+  GIT_TAG        main #Note: Best practice to use specific git-hash or tagged version
 )
 ```
 


### PR DESCRIPTION
Description
-----------

The quick start instructions for CMake mention the "master"
git branch which has been replaced by "main" in the current
repo.

The main CMakeLists.txt documents how to integrate a
custom port. Fix a typo in the suggested CMake code.

Test Steps
-----------
Integrate into a simple CMake project setting `set(FREERTOS_PORT "A_CUSTOM_PORT" CACHE STRING "" FORCE)` but don't provide a `freertos_kernel_port` library. Check the error message no longer contains the typo `taget_link_libraries(`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
