### PR TITLE
fix performance counting for SMP

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -396,8 +396,8 @@ PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t
 
 /* Do not move these variables to function scope as doing so prevents the
  * code working with debuggers that need to remove the static qualifier. */
-    PRIVILEGED_DATA static uint32_t ulTaskSwitchedInTime = 0UL;    /*< Holds the value of a timer/counter the last time a task was switched in. */
-    PRIVILEGED_DATA static volatile uint32_t ulTotalRunTime = 0UL; /*< Holds the total amount of execution time as defined by the run time counter clock. */
+    PRIVILEGED_DATA static uint32_t ulTaskSwitchedInTime[ configNUM_CORES ] = { 0UL };    /*< Holds the value of a timer/counter the last time a task was switched in. */
+    PRIVILEGED_DATA static volatile uint32_t ulTotalRunTime[ configNUM_CORES ] = { 0UL }; /*< Holds the total amount of execution time as defined by the run time counter clock. */
 
 #endif
 
@@ -3877,9 +3877,9 @@ void vTaskSwitchContext( BaseType_t xCoreID )
             #if ( configGENERATE_RUN_TIME_STATS == 1 )
                 {
                     #ifdef portALT_GET_RUN_TIME_COUNTER_VALUE
-                        portALT_GET_RUN_TIME_COUNTER_VALUE( ulTotalRunTime );
+                        portALT_GET_RUN_TIME_COUNTER_VALUE( ulTotalRunTime[ xCoreID ] );
                     #else
-                        ulTotalRunTime = portGET_RUN_TIME_COUNTER_VALUE();
+                        ulTotalRunTime[ xCoreID ] = portGET_RUN_TIME_COUNTER_VALUE();
                     #endif
 
                     /* Add the amount of time the task has been running to the
@@ -3889,16 +3889,16 @@ void vTaskSwitchContext( BaseType_t xCoreID )
                      * overflows.  The guard against negative values is to protect
                      * against suspect run time stat counter implementations - which
                      * are provided by the application, not the kernel. */
-                    if( ulTotalRunTime > ulTaskSwitchedInTime )
+                    if( ulTotalRunTime[ xCoreID ] > ulTaskSwitchedInTime[ xCoreID ] )
                     {
-                        pxCurrentTCB->ulRunTimeCounter += ( ulTotalRunTime - ulTaskSwitchedInTime );
+                        pxCurrentTCB->ulRunTimeCounter += ( ulTotalRunTime[ xCoreID ] - ulTaskSwitchedInTime[ xCoreID ] );
                     }
                     else
                     {
                         mtCOVERAGE_TEST_MARKER();
                     }
 
-                    ulTaskSwitchedInTime = ulTotalRunTime;
+                    ulTaskSwitchedInTime[ xCoreID ] = ulTotalRunTime[ xCoreID ];
                 }
             #endif /* configGENERATE_RUN_TIME_STATS */
 


### PR DESCRIPTION
Description
-----------
ulTaskSwitchedInTime must be an array, index is core number.

On single core devices this change has no effect, but on multicore devices (mine: RP2040) counting is currently wrong, because ulTaskSwitchedInTime is just a scalar type and counts only half of the actual CPU time.

Test Steps
-----------
Performance counting should count configNUM_CORES * (ticks of portALT_GET_RUN_TIME_COUNTER_VALUE()).
Without this change it only counts (ticks of portALT_GET_RUN_TIME_COUNTER_VALUE()).

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
