### PR TITLE
Introduce portMEMORY_BARRIER for Microblaze port.

### DIFF
--- a/portable/GCC/MicroBlaze/portmacro.h
+++ b/portable/GCC/MicroBlaze/portmacro.h
@@ -115,6 +115,7 @@ void vTaskSwitchContext();
 #define portSTACK_GROWTH            ( -1 )
 #define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portNOP()                   asm volatile ( "NOP" )
+#define portMEMORY_BARRIER()        asm volatile ( "" ::: "memory" )
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */

--- a/portable/GCC/MicroBlazeV8/portmacro.h
+++ b/portable/GCC/MicroBlazeV8/portmacro.h
@@ -152,6 +152,7 @@ extern volatile uint32_t ulTaskSwitchRequested;
 #define portSTACK_GROWTH            ( -1 )
 #define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portNOP()                   asm volatile ( "NOP" )
+#define portMEMORY_BARRIER()        asm volatile ( "" ::: "memory" )
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */

--- a/portable/GCC/MicroBlazeV9/portmacro.h
+++ b/portable/GCC/MicroBlazeV9/portmacro.h
@@ -152,6 +152,7 @@ extern volatile uint32_t ulTaskSwitchRequested;
 #define portSTACK_GROWTH            ( -1 )
 #define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portNOP()                   asm volatile ( "NOP" )
+#define portMEMORY_BARRIER()        asm volatile ( "" ::: "memory" )
 /*-----------------------------------------------------------*/
 
 #if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The introduction of `portMEMORY_BARRIER` will ensure the places in the kernel use a barrier will work. For example, `xTaskResumeAll` has a memory barrier to ensure its correctness when compiled with optimization enabled. Without the barrier `xTaskResumeAll` can fail (e.g. start reading and writing to address 0 and/or infinite looping) when `xPendingReadyList` contains more than one task to restore.

In `xTaskResumeAll` the compiler chooses to cache the `pxTCB` the first time through the loop for use in every subsequent loop. This is incorrect as the removal of `pxTCB->xEventListItem` will actually change the value of `pxTCB` if it was read again
at the top of the loop. The barrier forces the compiler to read `pxTCB` again at the top of the loop.

The compiler is operating correctly. The removal `pxTCB->xEventListItem` executes on a `List_t *` and `ListItem_t *`.  This means that the compiler can assume that any `MiniListItem_t` values are unchanged by the loop (i.e. "strict-aliasing"). This allows the compiler to cache `pxTCB` as it is obtained via a `MiniListItem_t`. This is incorrect in this case because it is possible for a `ListItem_t *` to actually alias a `MiniListItem_t`. This is technically a "violation of aliasing rules" so we use the the barrier to disable the strict-aliasing optimization in this loop.

Test Steps
-----------
I tested manually. Is there some tests that I should write? As I mention below I am not sure if I should be defining this for all ports.

Related Issue
-----------
https://forums.freertos.org/t/should-the-microblaze-freertos-port-define-portmemory-barrier/16704/5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
