### PR TITLE
Do not call exit() on MSVC Port when calling vPortEndScheduler

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -565,7 +565,7 @@ uint32_t ulErrorCode;
 
 void vPortEndScheduler( void )
 {
-
+    xPortRunning = pdFALSE;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -176,7 +176,8 @@ TIMECAPS xTimeCaps;
         {
             Sleep( portTICK_PERIOD_MS );
         }
-        if(pdTRUE == xPortRunning)
+
+        if( xPortRunning == pdTRUE )
         {
             configASSERT( xPortRunning );
 

--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -160,7 +160,7 @@ TIMECAPS xTimeCaps;
     /* Just to prevent compiler warnings. */
     ( void ) lpParameter;
 
-    while(pdTRUE == xPortRunning)
+    while( xPortRunning == pdTRUE )
     {
         /* Wait until the timer expires and we can access the simulated interrupt
         variables.  *NOTE* this is not a 'real time' way of generating tick

--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -160,7 +160,7 @@ TIMECAPS xTimeCaps;
     /* Just to prevent compiler warnings. */
     ( void ) lpParameter;
 
-    for( ;; )
+    while(pdTRUE == xPortRunning)
     {
         /* Wait until the timer expires and we can access the simulated interrupt
         variables.  *NOTE* this is not a 'real time' way of generating tick
@@ -176,33 +176,32 @@ TIMECAPS xTimeCaps;
         {
             Sleep( portTICK_PERIOD_MS );
         }
+        if(pdTRUE == xPortRunning)
+        {
+            configASSERT( xPortRunning );
 
-        configASSERT( xPortRunning );
+            /* Can't proceed if in a critical section as pvInterruptEventMutex won't
+            be available. */
+            WaitForSingleObject( pvInterruptEventMutex, INFINITE );
 
-        /* Can't proceed if in a critical section as pvInterruptEventMutex won't
-        be available. */
-        WaitForSingleObject( pvInterruptEventMutex, INFINITE );
+            /* The timer has expired, generate the simulated tick event. */
+            ulPendingInterrupts |= ( 1 << portINTERRUPT_TICK );
 
-        /* The timer has expired, generate the simulated tick event. */
-        ulPendingInterrupts |= ( 1 << portINTERRUPT_TICK );
+            /* The interrupt is now pending - notify the simulated interrupt
+            handler thread.  Must be outside of a critical section to get here so
+            the handler thread can execute immediately pvInterruptEventMutex is
+            released. */
+            configASSERT( ulCriticalNesting == 0UL );
+            SetEvent( pvInterruptEvent );
 
-        /* The interrupt is now pending - notify the simulated interrupt
-        handler thread.  Must be outside of a critical section to get here so
-        the handler thread can execute immediately pvInterruptEventMutex is
-        released. */
-        configASSERT( ulCriticalNesting == 0UL );
-        SetEvent( pvInterruptEvent );
-
-        /* Give back the mutex so the simulated interrupt handler unblocks
-        and can access the interrupt handler variables. */
-        ReleaseMutex( pvInterruptEventMutex );
+            /* Give back the mutex so the simulated interrupt handler unblocks
+            and can access the interrupt handler variables. */
+            ReleaseMutex( pvInterruptEventMutex );
+        }
     }
 
-    #ifdef __GNUC__
-        /* Should never reach here - MingW complains if you leave this line out,
-        MSVC complains if you put it in. */
-        return 0;
-    #endif
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 
@@ -566,7 +565,7 @@ uint32_t ulErrorCode;
 
 void vPortEndScheduler( void )
 {
-    exit( 0 );
+
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
See description in issue
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/623


Test Steps
-----------
Call vPortEndScheduler() instead of just ending the scheduler the problem is completely stopped

Related Issue
-----------



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
