### PR TITLE
POSIX port fixes

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -73,7 +73,7 @@
 typedef struct THREAD
 {
     pthread_t pthread;
-    pdTASK_CODE pxCode;
+    TaskFunction_t pxCode;
     void * pvParams;
     BaseType_t xDying;
     struct event * ev;
@@ -124,9 +124,9 @@ static void prvFatalError( const char * pcCall,
 /*
  * See header file for description.
  */
-portSTACK_TYPE * pxPortInitialiseStack( portSTACK_TYPE * pxTopOfStack,
-                                        portSTACK_TYPE * pxEndOfStack,
-                                        pdTASK_CODE pxCode,
+portSTACK_TYPE * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                        StackType_t * pxEndOfStack,
+                                        TaskFunction_t pxCode,
                                         void * pvParameters )
 {
     Thread_t * thread;

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -71,7 +71,7 @@ typedef unsigned long TickType_t;
 #define portSTACK_GROWTH            ( -1 )
 #define portHAS_STACK_OVERFLOW_CHECKING ( 1 )
 #define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portTICK_RATE_MICROSECONDS  ( ( portTickType ) 1000000 / configTICK_RATE_HZ )
+#define portTICK_RATE_MICROSECONDS  ( ( TickType_t ) 1000000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT          8
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Fix POSIX port

Description
-----------
This change fixes a build failure in the POSIX port on my system (WSL). It also introduces an improvement which helps identifying each of the threads by identifying with a name, which is very useful for debugging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
