### PR TITLE
Fix build failure introduced in PR #597

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -63,6 +63,24 @@
 /* Application specific configuration options. */
 #include "FreeRTOSConfig.h"
 
+#if !defined( configUSE_16_BIT_TICKS ) && !defined( configTICK_TYPE_WIDTH_IN_BITS )
+    #error Missing definition:  One of configUSE_16_BIT_TICKS and configTICK_TYPE_WIDTH_IN_BITS must be defined in FreeRTOSConfig.h.  See the Configuration section of the FreeRTOS API documentation for details.
+#endif
+
+#if defined( configUSE_16_BIT_TICKS ) && defined( configTICK_TYPE_WIDTH_IN_BITS )
+    #error Only one of configUSE_16_BIT_TICKS and configTICK_TYPE_WIDTH_IN_BITS must be defined in FreeRTOSConfig.h.  See the Configuration section of the FreeRTOS API documentation for details.
+#endif
+
+/* Define configTICK_TYPE_WIDTH_IN_BITS according to the
+ * value of configUSE_16_BIT_TICKS for backward compatibility. */
+#ifndef configTICK_TYPE_WIDTH_IN_BITS
+    #if ( configUSE_16_BIT_TICKS == 1 )
+        #define configTICK_TYPE_WIDTH_IN_BITS    TICK_TYPE_WIDTH_16_BITS
+    #else
+        #define configTICK_TYPE_WIDTH_IN_BITS    TICK_TYPE_WIDTH_32_BITS
+    #endif
+#endif
+
 /* Basic FreeRTOS definitions. */
 #include "projdefs.h"
 
@@ -158,24 +176,6 @@
 
 #ifndef configUSE_TICK_HOOK
     #error Missing definition:  configUSE_TICK_HOOK must be defined in FreeRTOSConfig.h as either 1 or 0.  See the Configuration section of the FreeRTOS API documentation for details.
-#endif
-
-#if !defined( configUSE_16_BIT_TICKS ) && !defined( configTICK_TYPE_WIDTH_IN_BITS )
-    #error Missing definition:  One of configUSE_16_BIT_TICKS and configTICK_TYPE_WIDTH_IN_BITS must be defined in FreeRTOSConfig.h.  See the Configuration section of the FreeRTOS API documentation for details.
-#endif
-
-#if defined( configUSE_16_BIT_TICKS ) && defined( configTICK_TYPE_WIDTH_IN_BITS )
-    #error Only one of configUSE_16_BIT_TICKS and configTICK_TYPE_WIDTH_IN_BITS must be defined in FreeRTOSConfig.h.  See the Configuration section of the FreeRTOS API documentation for details.
-#endif
-
-/* Define configTICK_TYPE_WIDTH_IN_BITS according to the
- * value of configUSE_16_BIT_TICKS for backward compatibility. */
-#ifndef configTICK_TYPE_WIDTH_IN_BITS
-    #if ( configUSE_16_BIT_TICKS == 1 )
-        #define configTICK_TYPE_WIDTH_IN_BITS    TICK_TYPE_WIDTH_16_BITS
-    #else
-        #define configTICK_TYPE_WIDTH_IN_BITS    TICK_TYPE_WIDTH_32_BITS
-    #endif
 #endif
 
 #if ( ( configTICK_TYPE_WIDTH_IN_BITS != TICK_TYPE_WIDTH_16_BITS ) && \


### PR DESCRIPTION
# Description

The PR #597 introduced a new config option `configTICK_TYPE_WIDTH_IN_BITS` which can be defined to one of the following:
* `TICK_TYPE_WIDTH_16_BITS` - Tick type is 16 bit wide.
* `TICK_TYPE_WIDTH_32_BITS` - Tick type is 32 bit wide.
* `TICK_TYPE_WIDTH_64_BITS` - Tick type is 64 bit wide.

Earlier we supported 16 and 32 bit width for tick type which was controlled using the config option `configUSE_16_BIT_TICKS.` The PR tried to maintain backward compatibility by honoring `configUSE_16_BIT_TICKS`. The backward compatibility did not work as expected though, as the macro `configTICK_TYPE_WIDTH_IN_BITS` was used before it was defined. This PR addresses it by ensuring that the macro `configTICK_TYPE_WIDTH_IN_BITS` is defined before it is used.

# Test Steps

1. `configUSE_16_BIT_TICKS` is defined to 0.

Source (function xTaskIncrementTick in tasks.c):
```
const TickType_t xConstTickCount = xTickCount + ( TickType_t ) 1;
```

Assembly:
```
109e:       4b50            ldr     r3, [pc, #320]  ; (11e0 <xTaskIncrementTick+0x150>)
10a0:       f8d3 4134       ldr.w   r4, [r3, #308]  ; 0x134
10a4:       3401            adds    r4, #1
10a6:       f8c3 4134       str.w   r4, [r3, #308]  ; 0x134
```

It is clear from assembly that the tick type is 32 bit.

2. `configUSE_16_BIT_TICKS` is defined to 1.

Source (function xTaskIncrementTick in tasks.c):
```
const TickType_t xConstTickCount = xTickCount + ( TickType_t ) 1;
```

Assembly:
```
10e2:       4b53            ldr     r3, [pc, #332]  ; (1230 <xTaskIncrementTick+0x15c>)
10e4:       f8b3 4134       ldrh.w  r4, [r3, #308]  ; 0x134
10e8:       b2a4            uxth    r4, r4
10ea:       3401            adds    r4, #1
10ec:       b2a4            uxth    r4, r4
10ee:       f8a3 4134       strh.w  r4, [r3, #308]  ; 0x134
```

It is clear from assembly that the tick type is 16 bit.

3. `configTICK_TYPE_WIDTH_IN_BITS` is defined to `TICK_TYPE_WIDTH_16_BITS`.

Source (function xTaskIncrementTick in tasks.c):
```
const TickType_t xConstTickCount = xTickCount + ( TickType_t ) 1;
```

Assembly:
```
10e2:       4b53            ldr     r3, [pc, #332]  ; (1230 <xTaskIncrementTick+0x15c>)
10e4:       f8b3 4134       ldrh.w  r4, [r3, #308]  ; 0x134
10e8:       b2a4            uxth    r4, r4
10ea:       3401            adds    r4, #1
10ec:       b2a4            uxth    r4, r4
10ee:       f8a3 4134       strh.w  r4, [r3, #308]  ; 0x134
```

It is clear from assembly that the tick type is 16 bit.

4. `configTICK_TYPE_WIDTH_IN_BITS` is defined to `TICK_TYPE_WIDTH_32_BITS`.

Source (function xTaskIncrementTick in tasks.c):
```
const TickType_t xConstTickCount = xTickCount + ( TickType_t ) 1;
```

Assembly:
```
109e:       4b50            ldr     r3, [pc, #320]  ; (11e0 <xTaskIncrementTick+0x150>)
10a0:       f8d3 4134       ldr.w   r4, [r3, #308]  ; 0x134
10a4:       3401            adds    r4, #1
10a6:       f8c3 4134       str.w   r4, [r3, #308]  ; 0x134
```

It is clear from assembly that the tick type is 32 bit.

5. `configTICK_TYPE_WIDTH_IN_BITS` is defined to `TICK_TYPE_WIDTH_64_BITS`.

```
 #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
```

The testing was done for GCC/ARM_CM3 port which does not support 64 bit tick type.

6. Neither `configUSE_16_BIT_TICKS` nor `configTICK_TYPE_WIDTH_IN_BITS` defined.

```
 #error Missing definition:  One of configUSE_16_BIT_TICKS and
 configTICK_TYPE_WIDTH_IN_BITS must be defined in FreeRTOSConfig.h.
 See the Configuration section of the FreeRTOS API documentation for
 details.
```

7. Both `configUSE_16_BIT_TICKS` and `configTICK_TYPE_WIDTH_IN_BITS` defined.

```
 #error Only one of configUSE_16_BIT_TICKS and
 configTICK_TYPE_WIDTH_IN_BITS must be defined in FreeRTOSConfig.h.
 See the Configuration section of the FreeRTOS API documentation for
 details.
```

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/628


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
