### PR TITLE
iar: platform independent __CLZ

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -1005,7 +1005,7 @@ static void prvYieldForTask( TCB_t * pxTCB,
 
                     while( uxCoreMap != 0 )
                     {
-                        int uxCore = 31UL - ( uint32_t ) __builtin_clz( uxCoreMap );
+                        int uxCore = 31UL - ( uint32_t ) __CLZ( uxCoreMap );
 
                         configASSERT( taskVALID_CORE_ID( uxCore ) );
 


### PR DESCRIPTION
__builtin_clz is only available with GCC but not IAR

Description
-----------
Replacement of GCC specific function with platform independent

Test Steps
-----------
Compile using IAR

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

I don't really know how to really test this. I'm pretty new to FreeRTOS.

Related Issue
-----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
