### PR TITLE
added portPOINTER_SIZE_TYPE and SIZE_MAX definition to PIC24/dsPIC port

### DIFF
--- a/portable/MPLAB/PIC24_dsPIC/portmacro.h
+++ b/portable/MPLAB/PIC24_dsPIC/portmacro.h
@@ -52,6 +52,7 @@ extern "C" {
 #define portSTACK_TYPE  uint16_t
 #define portBASE_TYPE   short
 #define portPOINTER_SIZE_TYPE size_t
+#define SIZE_MAX    ( ( size_t ) -1 )
 
 typedef portSTACK_TYPE StackType_t;
 typedef short BaseType_t;

--- a/portable/MPLAB/PIC24_dsPIC/portmacro.h
+++ b/portable/MPLAB/PIC24_dsPIC/portmacro.h
@@ -51,6 +51,7 @@ extern "C" {
 #define portSHORT       short
 #define portSTACK_TYPE  uint16_t
 #define portBASE_TYPE   short
+#define portPOINTER_SIZE_TYPE size_t
 
 typedef portSTACK_TYPE StackType_t;
 typedef short BaseType_t;


### PR DESCRIPTION
added portPOINTER_SIZE_TYPE and SIZE_MAX definitions to PIC24/dsPIC port

Description
-----------
pic24/dsPICs are 16-bit MCUs with 16-bit pointers.  The default value of portPOINTER_SIZE_TYPE is uint32_t so the heap's are compiled with a size mismatch warning.  Using size_t as the pointer size fixes the issue and the code compiles without warnings.

SIZE_MAX is not part of the stdint.h on PIC24/dsPIC.  This definition has been added to the portmacros

Test Steps
-----------
Compile the code and notice the warning.  Add the change, recompile.  No warning.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [-] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
