### PR TITLE
Add functions to get the buffers of statically created objects

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1464,13 +1464,24 @@ ppdc
 ppio
 ppitc
 ppmc
+ppucmessagebufferstoragearea
+ppucqueuestorage
+ppucstreambufferstoragearea
 ppudr
 ppuer
 ppusr
+ppuxstackbuffer
 ppvdestination
 ppwm
+ppxeventgroupbuffer
 ppxidletaskstackbuffer
 ppxidletasktcbbuffer
+ppxsemaphorebuffer
+ppxstaticmessagebuffer
+ppxstaticqueue
+ppxstaticstreambuffer
+ppxtaskbuffer
+ppxtimerbuffer
 ppxtimertaskstackbuffer
 ppxtimertasktcbbuffer
 pr
@@ -2723,6 +2734,7 @@ xeventgroupcreatestatic
 xeventgroupdelete
 xeventgroupgetbits
 xeventgroupgetbitsfromisr
+xeventgroupgetstaticbuffer
 xeventgroupsetbits
 xeventgroupsetbitsfromisr
 xeventgroupsync
@@ -2796,6 +2808,7 @@ xmessage
 xmessagebuffer
 xmessagebuffercreate
 xmessagebuffercreatestatic
+xmessagebuffergetstaticbuffers
 xmessagebufferisempty
 xmessagebufferisfull
 xmessagebuffernextlengthbytes
@@ -2865,6 +2878,7 @@ xqueuecreatestatic
 xqueuegenericsend
 xqueuegenericsendfromisr
 xqueuegetmutexholder
+xqueuegetstaticbuffers
 xqueuegivefromisr
 xqueuegivemutexrecursive
 xqueueorsemaphore
@@ -2919,6 +2933,7 @@ xsemaphorecreaterecursivemutex
 xsemaphorecreaterecursivemutexstatic
 xsemaphoregetmutexholder
 xsemaphoregetmutexholderfromisr
+xsemaphoregetstaticbuffer
 xsemaphoregive
 xsemaphoregivefromisr
 xsemaphoregivemutexrecursive
@@ -2943,6 +2958,7 @@ xstreambuffer
 xstreambufferbytesavailable
 xstreambuffercreate
 xstreambuffercreatestatic
+xstreambuffergetstaticbuffers
 xstreambufferisempty
 xstreambufferisfull
 xstreambuffernextmessagelengthbytes
@@ -2981,6 +2997,7 @@ xtaskgetcurrenttaskhandle
 xtaskgethandle
 xtaskgetidletaskhandle
 xtaskgetschedulerstate
+xtaskgetstaticbuffers
 xtaskgettickcount
 xtaskgettickcountfromisr
 xtaskhandle
@@ -3048,6 +3065,7 @@ xtimerdelete
 xtimergetexpirytime
 xtimergetperiod
 xtimergetreloadmode
+xtimergetstaticbuffer
 xtimergettimerdaemontaskhandle
 xtimeristimeractive
 xtimerlistitem

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -3099,3 +3099,4 @@ xwritevalue
 xxr
 xyieldpending
 xzr
+

--- a/event_groups.c
+++ b/event_groups.c
@@ -689,7 +689,7 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 
         #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
         {
-            /* Check if the event group was statically allocated */
+            /* Check if the event group was statically allocated. */
             if( pxEventBits->ucStaticallyAllocated == ( uint8_t ) pdTRUE )
             {
                 *ppxEventGroupBuffer = ( StaticEventGroup_t * ) pxEventBits;
@@ -702,7 +702,7 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
         }
         #else /* configSUPPORT_DYNAMIC_ALLOCATION */
         {
-            /* Event group must have been statically allocated */
+            /* Event group must have been statically allocated. */
             *ppxEventGroupBuffer = ( StaticEventGroup_t * ) pxEventBits;
             xReturn = pdTRUE;
         }

--- a/event_groups.c
+++ b/event_groups.c
@@ -677,6 +677,42 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 }
 /*-----------------------------------------------------------*/
 
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BaseType_t xEventGroupGetStaticBuffer( EventGroupHandle_t xEventGroup,
+                                           StaticEventGroup_t ** ppxEventGroupBuffer )
+    {
+        BaseType_t xReturn;
+        EventGroup_t * pxEventBits = xEventGroup;
+
+        configASSERT( pxEventBits );
+        configASSERT( ppxEventGroupBuffer );
+
+        #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+        {
+            /* Check if the event group was statically allocated */
+            if( pxEventBits->ucStaticallyAllocated == ( uint8_t ) pdTRUE )
+            {
+                *ppxEventGroupBuffer = ( StaticEventGroup_t * ) pxEventBits;
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                xReturn = pdFALSE;
+            }
+        }
+        #else /* configSUPPORT_DYNAMIC_ALLOCATION */
+        {
+            /* Event group must have been statically allocated */
+            *ppxEventGroupBuffer = ( StaticEventGroup_t * ) pxEventBits;
+            xReturn = pdTRUE;
+        }
+        #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+        return xReturn;
+    }
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+/*-----------------------------------------------------------*/
+
 /* For internal use only - execute a 'set bits' command that was pended from
  * an interrupt. */
 void vEventGroupSetBitsCallback( void * pvEventGroup,

--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -763,6 +763,29 @@ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup ) PRIVILEG
  */
 void vEventGroupDelete( EventGroupHandle_t xEventGroup ) PRIVILEGED_FUNCTION;
 
+/**
+ * event_groups.h
+ * @code{c}
+ *  BaseType_t xEventGroupGetStaticBuffer( EventGroupHandle_t xEventGroup,
+ *                                         StaticEventGroup_t ** ppxEventGroupBuffer );
+ * @endcode
+ *
+ * This function fetches a pointer to the memory buffer of a statically created
+ * event group.
+ *
+ * @param xEventGroup The handle of the event group
+ *
+ * @param ppxEventGroupBuffer Used to pass back a pointer to the event groups's
+ * data structure buffer.
+ *
+ * @return pdTRUE if the buffer were fetched. pdFALSE if the event group was not
+ * statically created.
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BaseType_t xEventGroupGetStaticBuffer( EventGroupHandle_t xEventGroup,
+                                           StaticEventGroup_t ** ppxEventGroupBuffer ) PRIVILEGED_FUNCTION;
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
 /* For internal use only. */
 void vEventGroupSetBitsCallback( void * pvEventGroup,
                                  const uint32_t ulBitsToSet ) PRIVILEGED_FUNCTION;

--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -770,16 +770,15 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup ) PRIVILEGED_FUNCTION;
  *                                         StaticEventGroup_t ** ppxEventGroupBuffer );
  * @endcode
  *
- * This function fetches a pointer to the memory buffer of a statically created
- * event group.
+ * Retrieve a pointer to a statically created event groups's data structure
+ * buffer. It is the same buffer that is supplied at the time of creation.
  *
- * @param xEventGroup The handle of the event group
+ * @param xEventGroup The event group for which to retrieve the buffer.
  *
- * @param ppxEventGroupBuffer Used to pass back a pointer to the event groups's
+ * @param ppxEventGroupBuffer Used to return a pointer to the event groups's
  * data structure buffer.
  *
- * @return pdTRUE if the buffer were fetched. pdFALSE if the event group was not
- * statically created.
+ * @return pdTRUE if the buffer was retrieved, pdFALSE otherwise.
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     BaseType_t xEventGroupGetStaticBuffer( EventGroupHandle_t xEventGroup,

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -251,7 +251,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * @code{c}
  * BaseType_t xMessageBufferGetStaticBuffers( MessageBufferHandle_t xMessageBuffer,
  *                                            uint8_t ** ppucMessageBufferStorageArea,
-   *                                          StaticMessageBuffer_t ** ppxStaticMessageBuffer );
+ *                                            StaticMessageBuffer_t ** ppxStaticMessageBuffer );
  * @endcode
  *
  * Retrieve pointers to a statically created message buffer's data structure

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -250,30 +250,30 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  *
  * @code{c}
  * BaseType_t xMessageBufferGetStaticBuffers( MessageBufferHandle_t xMessageBuffer,
- *                                          uint8_t ** ppucMessageBufferStorageArea,
- *                                          StaticMessageBuffer_t ** ppxStaticMessageBuffer );
+ *                                            uint8_t ** ppucMessageBufferStorageArea,
+   *                                          StaticMessageBuffer_t ** ppxStaticMessageBuffer );
  * @endcode
  *
- * This function fetches the pointers to the memory buffers of a statically
- * created message buffer.
+ * Retrieve pointers to a statically created message buffer's data structure
+ * buffer and storage area buffer. These are the same buffers that are supplied
+ * at the time of creation.
  *
- * @param xMessageBuffer The handle to the message buffer
+ * @param xMessageBuffer The message buffer for which to retrieve the buffers.
  *
- * @param ppucMessageBufferStorageArea Used to pass back a pointer to the
+ * @param ppucMessageBufferStorageArea Used to return a pointer to the
  * message buffer's storage area buffer.
  *
- * @param ppxStaticMessageBuffer Used to pass back a pointer to the message
+ * @param ppxStaticMessageBuffer Used to return a pointer to the message
  * buffer's data structure buffer.
  *
- * @return pdTRUE if buffers were fetched. pdFALSE if the message buffer was not
- * statically created.
+ * @return pdTRUE if buffers were retrieved, pdFALSE otherwise..
  *
  * \defgroup xMessageBufferGetStaticBuffers xMessageBufferGetStaticBuffers
  * \ingroup MessageBufferManagement
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     #define xMessageBufferGetStaticBuffers( xMessageBuffer, ppucMessageBufferStorageArea, ppxStaticMessageBuffer ) \
-    xStreamBufferGenericGetStaticBuffers( ( xMessageBuffer ), ( ppucMessageBufferStorageArea ), ( ppxStaticMessageBuffer ) )
+    xStreamBufferGetStaticBuffers( ( xMessageBuffer ), ( ppucMessageBufferStorageArea ), ( ppxStaticMessageBuffer ) )
 #endif /* configSUPPORT_STATIC_ALLOCATION */
 
 /**

--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -249,6 +249,37 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * message_buffer.h
  *
  * @code{c}
+ * BaseType_t xMessageBufferGetStaticBuffers( MessageBufferHandle_t xMessageBuffer,
+ *                                          uint8_t ** ppucMessageBufferStorageArea,
+ *                                          StaticMessageBuffer_t ** ppxStaticMessageBuffer );
+ * @endcode
+ *
+ * This function fetches the pointers to the memory buffers of a statically
+ * created message buffer.
+ *
+ * @param xMessageBuffer The handle to the message buffer
+ *
+ * @param ppucMessageBufferStorageArea Used to pass back a pointer to the
+ * message buffer's storage area buffer.
+ *
+ * @param ppxStaticMessageBuffer Used to pass back a pointer to the message
+ * buffer's data structure buffer.
+ *
+ * @return pdTRUE if buffers were fetched. pdFALSE if the message buffer was not
+ * statically created.
+ *
+ * \defgroup xMessageBufferGetStaticBuffers xMessageBufferGetStaticBuffers
+ * \ingroup MessageBufferManagement
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define xMessageBufferGetStaticBuffers( xMessageBuffer, ppucMessageBufferStorageArea, ppxStaticMessageBuffer ) \
+    xStreamBufferGenericGetStaticBuffers( ( xMessageBuffer ), ( ppucMessageBufferStorageArea ), ( ppxStaticMessageBuffer ) )
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
+/**
+ * message_buffer.h
+ *
+ * @code{c}
  * size_t xMessageBufferSend( MessageBufferHandle_t xMessageBuffer,
  *                         const void *pvTxData,
  *                         size_t xDataLengthBytes,

--- a/include/queue.h
+++ b/include/queue.h
@@ -243,19 +243,19 @@ typedef struct QueueDefinition   * QueueSetMemberHandle_t;
  *                                    StaticQueue_t ** ppxStaticQueue );
  * @endcode
  *
- * This function fetches the pointers to the memory buffers of a statically
- * created queue.
+ * Retrieve pointers to a statically created queue's data structure buffer
+ * and storage area buffer. These are the same buffers that are supplied
+ * at the time of creation.
  *
- * @param xQueue The handle to the queue
+ * @param xQueue The queue for which to retrieve the buffers.
  *
- * @param ppucQueueStorage Used to pass back a pointer to the queue's storage
+ * @param ppucQueueStorage Used to return a pointer to the queue's storage
  * area buffer.
  *
- * @param ppxStaticQueue Used to pass back a pointer to the queue's data
+ * @param ppxStaticQueue Used to return a pointer to the queue's data
  * structure buffer.
  *
- * @return pdTRUE if buffers were fetched. pdFALSE if the queue was not
- * created using xQueueCreateStatic().
+ * @return pdTRUE if buffers were retrieved, pdFALSE otherwise.
  *
  * \defgroup xQueueGetStaticBuffers xQueueGetStaticBuffers
  * \ingroup QueueManagement
@@ -1572,10 +1572,10 @@ BaseType_t xQueueGiveMutexRecursive( QueueHandle_t xMutex ) PRIVILEGED_FUNCTION;
 #endif
 
 /*
- * Generic version of the function used to get the buffers of statically created
- * queues. This is called by other functions and macros that get the buffers
- * of other statically created RTOS objects that use the queue structure as
- * their base.
+ * Generic version of the function used to retrieve the buffers of statically
+ * created queues. This is called by other functions and macros that retrieve
+ * the buffers of other statically created RTOS objects that use the queue
+ * structure as their base.
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     BaseType_t xQueueGenericGetStaticBuffers( QueueHandle_t xQueue,

--- a/include/queue.h
+++ b/include/queue.h
@@ -238,6 +238,35 @@ typedef struct QueueDefinition   * QueueSetMemberHandle_t;
 /**
  * queue. h
  * @code{c}
+ * BaseType_t xQueueGetStaticBuffers( QueueHandle_t xQueue,
+ *                                    uint8_t ** ppucQueueStorage,
+ *                                    StaticQueue_t ** ppxStaticQueue );
+ * @endcode
+ *
+ * This function fetches the pointers to the memory buffers of a statically
+ * created queue.
+ *
+ * @param xQueue The handle to the queue
+ *
+ * @param ppucQueueStorage Used to pass back a pointer to the queue's storage
+ * area buffer.
+ *
+ * @param ppxStaticQueue Used to pass back a pointer to the queue's data
+ * structure buffer.
+ *
+ * @return pdTRUE if buffers were fetched. pdFALSE if the queue was not
+ * created using xQueueCreateStatic().
+ *
+ * \defgroup xQueueGetStaticBuffers xQueueGetStaticBuffers
+ * \ingroup QueueManagement
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define xQueueGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue )    xQueueGenericGetStaticBuffers( ( xQueue ), ( ppucQueueStorage ), ( ppxStaticQueue ) )
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
+/**
+ * queue. h
+ * @code{c}
  * BaseType_t xQueueSendToToFront(
  *                                 QueueHandle_t    xQueue,
  *                                 const void       *pvItemToQueue,
@@ -1540,6 +1569,18 @@ BaseType_t xQueueGiveMutexRecursive( QueueHandle_t xMutex ) PRIVILEGED_FUNCTION;
                                              uint8_t * pucQueueStorage,
                                              StaticQueue_t * pxStaticQueue,
                                              const uint8_t ucQueueType ) PRIVILEGED_FUNCTION;
+#endif
+
+/*
+ * Generic version of the function used to get the buffers of statically created
+ * queues. This is called by other functions and macros that get the buffers
+ * of other statically created RTOS objects that use the queue structure as
+ * their base.
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BaseType_t xQueueGenericGetStaticBuffers( QueueHandle_t xQueue,
+                                              uint8_t ** ppucQueueStorage,
+                                              StaticQueue_t ** ppxStaticQueue ) PRIVILEGED_FUNCTION;
 #endif
 
 /*

--- a/include/semphr.h
+++ b/include/semphr.h
@@ -1190,4 +1190,25 @@ typedef QueueHandle_t SemaphoreHandle_t;
  */
 #define uxSemaphoreGetCountFromISR( xSemaphore )    uxQueueMessagesWaitingFromISR( ( QueueHandle_t ) ( xSemaphore ) )
 
+/**
+ * semphr.h
+ * @code{c}
+ * BaseType_t xSemaphoreGetStaticBuffer( SemaphoreHandle_t xSemaphore );
+ * @endcode
+ *
+ * This function fetches a pointer to the memory buffer of a statically created
+ * binary semaphore, counting semaphore, or mutex semaphore.
+ *
+ * @param xSemaphore The handle of the statically created semaphore
+ *
+ * @param ppxSemaphoreBuffer Used to pass back a pointer to the semaphore's
+ * data structure buffer
+ *
+ * @return pdTRUE if buffer was fetched. pdFALSE if the semaphore was not
+ * statically allocated.
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define xSemaphoreGetStaticBuffer( xSemaphore, ppxSemaphoreBuffer )    xQueueGenericGetStaticBuffers( ( QueueHandle_t ) ( xSemaphore ), NULL, ( ppxSemaphoreBuffer ) )
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
 #endif /* SEMAPHORE_H */

--- a/include/semphr.h
+++ b/include/semphr.h
@@ -1196,16 +1196,16 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * BaseType_t xSemaphoreGetStaticBuffer( SemaphoreHandle_t xSemaphore );
  * @endcode
  *
- * This function fetches a pointer to the memory buffer of a statically created
- * binary semaphore, counting semaphore, or mutex semaphore.
+ * Retrieve pointer to a statically created binary semaphore, counting semaphore,
+ * or mutex semaphore's data structure buffer. This is the same buffer that is
+ * supplied at the time of creation.
  *
- * @param xSemaphore The handle of the statically created semaphore
+ * @param xSemaphore The semaphore for which to retrieve the buffer.
  *
- * @param ppxSemaphoreBuffer Used to pass back a pointer to the semaphore's
- * data structure buffer
+ * @param ppxSemaphoreBuffer Used to return a pointer to the semaphore's
+ * data structure buffer.
  *
- * @return pdTRUE if buffer was fetched. pdFALSE if the semaphore was not
- * statically allocated.
+ * @return pdTRUE if buffer was retrieved, pdFALSE otherwise.
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     #define xSemaphoreGetStaticBuffer( xSemaphore, ppxSemaphoreBuffer )    xQueueGenericGetStaticBuffers( ( QueueHandle_t ) ( xSemaphore ), NULL, ( ppxSemaphoreBuffer ) )

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -269,26 +269,27 @@ typedef void (* StreamBufferCallbackFunction_t)( StreamBufferHandle_t xStreamBuf
  *                                           StaticStreamBuffer_t ** ppxStaticStreamBuffer );
  * @endcode
  *
- * This function fetches the pointers to the memory buffers of a statically
- * created stream buffer.
+ * Retrieve pointers to a statically created stream buffer's data structure
+ * buffer and storage area buffer. These are the same buffers that are supplied
+ * at the time of creation.
  *
- * @param xStreamBuffer The handle to the stream buffer
+ * @param xStreamBuffer The stream buffer for which to retrieve the buffers.
  *
- * @param ppucStreamBufferStorageArea Used to pass back a pointer to the stream
+ * @param ppucStreamBufferStorageArea Used to return a pointer to the stream
  * buffer's storage area buffer.
  *
- * @param ppxStaticStreamBuffer Used to pass back a pointer to the stream
+ * @param ppxStaticStreamBuffer Used to return a pointer to the stream
  * buffer's data structure buffer.
  *
- * @return pdTRUE if buffers were fetched. pdFALSE if the stream buffer was not
- * statically created.
+ * @return pdTRUE if buffers were retrieved, pdFALSE otherwise.
  *
  * \defgroup xStreamBufferGetStaticBuffers xStreamBufferGetStaticBuffers
  * \ingroup StreamBufferManagement
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-    #define xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer ) \
-    xStreamBufferGenericGetStaticBuffers( ( xStreamBuffer ), ( ppucStreamBufferStorageArea ), ( ppxStaticStreamBuffer ) )
+    BaseType_t xStreamBufferGetStaticBuffers( StreamBufferHandle_t xStreamBuffer,
+                                              uint8_t ** ppucStreamBufferStorageArea,
+                                              StaticStreamBuffer_t ** ppxStaticStreamBuffer ) PRIVILEGED_FUNCTION;
 #endif /* configSUPPORT_STATIC_ALLOCATION */
 
 /**
@@ -925,16 +926,6 @@ StreamBufferHandle_t xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
                                                        StaticStreamBuffer_t * const pxStaticStreamBuffer,
                                                        StreamBufferCallbackFunction_t pxSendCompletedCallback,
                                                        StreamBufferCallbackFunction_t pxReceiveCompletedCallback ) PRIVILEGED_FUNCTION;
-
-/*
- * Generic version of the function used to get the buffers of statically created
- * stream or message buffer.
- */
-#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-    BaseType_t xStreamBufferGenericGetStaticBuffers( StreamBufferHandle_t xStreamBuffer,
-                                                     uint8_t ** ppucStreamBufferStorageArea,
-                                                     StaticStreamBuffer_t ** ppxStaticStreamBuffer ) PRIVILEGED_FUNCTION;
-#endif /* configSUPPORT_STATIC_ALLOCATION */
 
 size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer ) PRIVILEGED_FUNCTION;
 

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -264,6 +264,37 @@ typedef void (* StreamBufferCallbackFunction_t)( StreamBufferHandle_t xStreamBuf
  * stream_buffer.h
  *
  * @code{c}
+ * BaseType_t xStreamBufferGetStaticBuffers( StreamBufferHandle_t xStreamBuffer,
+ *                                           uint8_t ** ppucStreamBufferStorageArea,
+ *                                           StaticStreamBuffer_t ** ppxStaticStreamBuffer );
+ * @endcode
+ *
+ * This function fetches the pointers to the memory buffers of a statically
+ * created stream buffer.
+ *
+ * @param xStreamBuffer The handle to the stream buffer
+ *
+ * @param ppucStreamBufferStorageArea Used to pass back a pointer to the stream
+ * buffer's storage area buffer.
+ *
+ * @param ppxStaticStreamBuffer Used to pass back a pointer to the stream
+ * buffer's data structure buffer.
+ *
+ * @return pdTRUE if buffers were fetched. pdFALSE if the stream buffer was not
+ * statically created.
+ *
+ * \defgroup xStreamBufferGetStaticBuffers xStreamBufferGetStaticBuffers
+ * \ingroup StreamBufferManagement
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer ) \
+    xStreamBufferGenericGetStaticBuffers( ( xStreamBuffer ), ( ppucStreamBufferStorageArea ), ( ppxStaticStreamBuffer ) )
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
+/**
+ * stream_buffer.h
+ *
+ * @code{c}
  * size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
  *                        const void *pvTxData,
  *                        size_t xDataLengthBytes,
@@ -894,6 +925,16 @@ StreamBufferHandle_t xStreamBufferGenericCreateStatic( size_t xBufferSizeBytes,
                                                        StaticStreamBuffer_t * const pxStaticStreamBuffer,
                                                        StreamBufferCallbackFunction_t pxSendCompletedCallback,
                                                        StreamBufferCallbackFunction_t pxReceiveCompletedCallback ) PRIVILEGED_FUNCTION;
+
+/*
+ * Generic version of the function used to get the buffers of statically created
+ * stream or message buffer.
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BaseType_t xStreamBufferGenericGetStaticBuffers( StreamBufferHandle_t xStreamBuffer,
+                                                     uint8_t ** ppucStreamBufferStorageArea,
+                                                     StaticStreamBuffer_t ** ppxStaticStreamBuffer ) PRIVILEGED_FUNCTION;
+#endif /* configSUPPORT_STATIC_ALLOCATION */
 
 size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer ) PRIVILEGED_FUNCTION;
 

--- a/include/task.h
+++ b/include/task.h
@@ -1510,6 +1510,36 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION; /*lint !e
 TaskHandle_t xTaskGetHandle( const char * pcNameToQuery ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
 
 /**
+ * task. h
+ * @code{c}
+ * BaseType_t xTaskGetStaticBuffers( TaskHandle_t xTask,
+ *                                   StackType_t ** ppuxStackBuffer,
+ *                                   StaticTask_t ** ppxTaskBuffer );
+ * @endcode
+ *
+ * This function fetches a pointer to the memory buffers of a statically created
+ * task.
+ *
+ * @param xTask The handle of the statically created task
+ *
+ * @param ppuxStackBuffer Used to pass back a pointer to the task's stack buffer
+ *
+ * @param ppxTaskBuffer Used to pass back a pointer to the task's data structure
+ * buffer
+ *
+ * @return pdTRUE if buffers were fetched. pdFALSE if the task was not
+ * statically created.
+ *
+ * \defgroup xTaskGetStaticBuffers xTaskGetStaticBuffers
+ * \ingroup TaskUtils
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BaseType_t xTaskGetStaticBuffers( TaskHandle_t xTask,
+                                      StackType_t ** ppuxStackBuffer,
+                                      StaticTask_t ** ppxTaskBuffer ) PRIVILEGED_FUNCTION;
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
+/**
  * task.h
  * @code{c}
  * UBaseType_t uxTaskGetStackHighWaterMark( TaskHandle_t xTask );

--- a/include/task.h
+++ b/include/task.h
@@ -1517,18 +1517,18 @@ TaskHandle_t xTaskGetHandle( const char * pcNameToQuery ) PRIVILEGED_FUNCTION; /
  *                                   StaticTask_t ** ppxTaskBuffer );
  * @endcode
  *
- * This function fetches a pointer to the memory buffers of a statically created
- * task.
+ * Retrieve pointers to a statically created task's data structure
+ * buffer and stack buffer. These are the same buffers that are supplied
+ * at the time of creation.
  *
- * @param xTask The handle of the statically created task
+ * @param xTask The task for which to retrieve the buffers.
  *
- * @param ppuxStackBuffer Used to pass back a pointer to the task's stack buffer
+ * @param ppuxStackBuffer Used to return a pointer to the task's stack buffer.
  *
- * @param ppxTaskBuffer Used to pass back a pointer to the task's data structure
- * buffer
+ * @param ppxTaskBuffer Used to return a pointer to the task's data structure
+ * buffer.
  *
- * @return pdTRUE if buffers were fetched. pdFALSE if the task was not
- * statically created.
+ * @return pdTRUE if buffers were retrieved, pdFALSE otherwise.
  *
  * \defgroup xTaskGetStaticBuffers xTaskGetStaticBuffers
  * \ingroup TaskUtils

--- a/include/timers.h
+++ b/include/timers.h
@@ -1323,6 +1323,26 @@ TickType_t xTimerGetPeriod( TimerHandle_t xTimer ) PRIVILEGED_FUNCTION;
  */
 TickType_t xTimerGetExpiryTime( TimerHandle_t xTimer ) PRIVILEGED_FUNCTION;
 
+/**
+ * BaseType_t xTimerGetStaticBuffer( TimerHandle_t xTimer,
+ *                                   StaticTimer_t ** ppxTimerBuffer );
+ *
+ * This function fetches a pointer to the memory buffer of a statically created
+ * timer.
+ *
+ * @param xTimer The handle of the timer
+ *
+ * @param ppxTaskBuffer Used to pass back a pointer to the timers's data
+ * structure buffer.
+ *
+ * @return pdTRUE if the buffer were fetched. pdFALSE if the timer was not
+ * statically created.
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BaseType_t xTimerGetStaticBuffer( TimerHandle_t xTimer,
+                                      StaticTimer_t ** ppxTimerBuffer ) PRIVILEGED_FUNCTION;
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
 /*
  * Functions beyond this part are not part of the public API and are intended
  * for use by the kernel only.

--- a/include/timers.h
+++ b/include/timers.h
@@ -1327,16 +1327,16 @@ TickType_t xTimerGetExpiryTime( TimerHandle_t xTimer ) PRIVILEGED_FUNCTION;
  * BaseType_t xTimerGetStaticBuffer( TimerHandle_t xTimer,
  *                                   StaticTimer_t ** ppxTimerBuffer );
  *
- * This function fetches a pointer to the memory buffer of a statically created
- * timer.
+ * Retrieve pointer to a statically created timer's data structure
+ * buffer. This is the same buffer that is supplied at the time of
+ * creation.
  *
- * @param xTimer The handle of the timer
+ * @param xTimer The timer for which to retrieve the buffer.
  *
- * @param ppxTaskBuffer Used to pass back a pointer to the timers's data
+ * @param ppxTaskBuffer Used to return a pointer to the timers's data
  * structure buffer.
  *
- * @return pdTRUE if the buffer were fetched. pdFALSE if the timer was not
- * statically created.
+ * @return pdTRUE if the buffer was retrieved, pdFALSE otherwise.
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     BaseType_t xTimerGetStaticBuffer( TimerHandle_t xTimer,

--- a/queue.c
+++ b/queue.c
@@ -433,7 +433,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
         #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
         {
-            /* Check if the queue was statically allocated */
+            /* Check if the queue was statically allocated. */
             if( pxQueue->ucStaticallyAllocated == ( uint8_t ) pdTRUE )
             {
                 if( ppucQueueStorage != NULL )
@@ -451,7 +451,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         }
         #else /* configSUPPORT_DYNAMIC_ALLOCATION */
         {
-            /* Queue must have been statically allocated */
+            /* Queue must have been statically allocated. */
             if( ppucQueueStorage != NULL )
             {
                 *ppucQueueStorage = ( uint8_t * ) pxQueue->pcHead;

--- a/queue.c
+++ b/queue.c
@@ -419,6 +419,55 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 #endif /* configSUPPORT_STATIC_ALLOCATION */
 /*-----------------------------------------------------------*/
 
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+    BaseType_t xQueueGenericGetStaticBuffers( QueueHandle_t xQueue,
+                                              uint8_t ** ppucQueueStorage,
+                                              StaticQueue_t ** ppxStaticQueue )
+    {
+        BaseType_t xReturn;
+        Queue_t * const pxQueue = xQueue;
+
+        configASSERT( pxQueue );
+        configASSERT( ppxStaticQueue );
+
+        #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+        {
+            /* Check if the queue was statically allocated */
+            if( pxQueue->ucStaticallyAllocated == ( uint8_t ) pdTRUE )
+            {
+                if( ppucQueueStorage != NULL )
+                {
+                    *ppucQueueStorage = ( uint8_t * ) pxQueue->pcHead;
+                }
+
+                *ppxStaticQueue = ( StaticQueue_t * ) pxQueue;
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                xReturn = pdFALSE;
+            }
+        }
+        #else /* configSUPPORT_DYNAMIC_ALLOCATION */
+        {
+            /* Queue must have been statically allocated */
+            if( ppucQueueStorage != NULL )
+            {
+                *ppucQueueStorage = ( uint8_t * ) pxQueue->pcHead;
+            }
+
+            *ppxStaticQueue = ( StaticQueue_t * ) pxQueue;
+            xReturn = pdTRUE;
+        }
+        #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+        return xReturn;
+    }
+
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+/*-----------------------------------------------------------*/
+
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
 
     QueueHandle_t xQueueGenericCreate( const UBaseType_t uxQueueLength,

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -472,6 +472,34 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 #endif /* ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 /*-----------------------------------------------------------*/
 
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    BaseType_t xStreamBufferGenericGetStaticBuffers( StreamBufferHandle_t xStreamBuffer,
+                                                     uint8_t ** ppucStreamBufferStorageArea,
+                                                     StaticStreamBuffer_t ** ppxStaticStreamBuffer )
+    {
+        BaseType_t xReturn;
+        const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
+
+        configASSERT( pxStreamBuffer );
+        configASSERT( ppucStreamBufferStorageArea );
+        configASSERT( ppxStaticStreamBuffer );
+
+        if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_STATICALLY_ALLOCATED ) != ( uint8_t ) 0 )
+        {
+            *ppucStreamBufferStorageArea = pxStreamBuffer->pucBuffer;
+            *ppxStaticStreamBuffer = ( StaticStreamBuffer_t * ) pxStreamBuffer;
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+
+        return xReturn;
+    }
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+/*-----------------------------------------------------------*/
+
 void vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer )
 {
     StreamBuffer_t * pxStreamBuffer = xStreamBuffer;

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -473,9 +473,9 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-    BaseType_t xStreamBufferGenericGetStaticBuffers( StreamBufferHandle_t xStreamBuffer,
-                                                     uint8_t ** ppucStreamBufferStorageArea,
-                                                     StaticStreamBuffer_t ** ppxStaticStreamBuffer )
+    BaseType_t xStreamBufferGetStaticBuffers( StreamBufferHandle_t xStreamBuffer,
+                                              uint8_t ** ppucStreamBufferStorageArea,
+                                              StaticStreamBuffer_t ** ppxStaticStreamBuffer )
     {
         BaseType_t xReturn;
         const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;

--- a/tasks.c
+++ b/tasks.c
@@ -2504,15 +2504,13 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         pxTCB = prvGetTCBFromHandle( xTask );
 
         #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 )
-            if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_AND_TCB )
-        #endif /* tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 */
         {
-            *ppuxStackBuffer = pxTCB->pxStack;
-            *ppxTaskBuffer = ( StaticTask_t * ) pxTCB;
-            xReturn = pdTRUE;
-        }
-
-        #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 )
+            if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_AND_TCB )
+            {
+                *ppuxStackBuffer = pxTCB->pxStack;
+                *ppxTaskBuffer = ( StaticTask_t * ) pxTCB;
+                xReturn = pdTRUE;
+            }
             else if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_ONLY )
             {
                 *ppuxStackBuffer = pxTCB->pxStack;
@@ -2523,6 +2521,13 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
             {
                 xReturn = pdFALSE;
             }
+        }
+        #else /* tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 */
+        {
+            *ppuxStackBuffer = pxTCB->pxStack;
+            *ppxTaskBuffer = ( StaticTask_t * ) pxTCB;
+            xReturn = pdTRUE;
+        }
         #endif /* tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 */
 
         return xReturn;

--- a/tasks.c
+++ b/tasks.c
@@ -2489,6 +2489,37 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 #endif /* INCLUDE_xTaskGetHandle */
 /*-----------------------------------------------------------*/
 
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
+    BaseType_t xTaskGetStaticBuffers( TaskHandle_t xTask,
+                                      StackType_t ** ppuxStackBuffer,
+                                      StaticTask_t ** ppxTaskBuffer )
+    {
+        BaseType_t xReturn;
+        TCB_t * pxTCB;
+
+        configASSERT( ppuxStackBuffer != NULL );
+        configASSERT( ppxTaskBuffer != NULL );
+
+        pxTCB = prvGetTCBFromHandle( xTask );
+
+        if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_AND_TCB )
+        {
+            *ppuxStackBuffer = pxTCB->pxStack;
+            *ppxTaskBuffer = ( StaticTask_t * ) pxTCB;
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+
+        return xReturn;
+    }
+
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+/*-----------------------------------------------------------*/
+
 #if ( configUSE_TRACE_FACILITY == 1 )
 
     UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,

--- a/tasks.c
+++ b/tasks.c
@@ -2503,16 +2503,27 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 
         pxTCB = prvGetTCBFromHandle( xTask );
 
-        if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_AND_TCB )
+        #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 )
+            if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_AND_TCB )
+        #endif /* tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 */
         {
             *ppuxStackBuffer = pxTCB->pxStack;
             *ppxTaskBuffer = ( StaticTask_t * ) pxTCB;
             xReturn = pdTRUE;
         }
-        else
-        {
-            xReturn = pdFALSE;
-        }
+
+        #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 )
+            else if( pxTCB->ucStaticallyAllocated == tskSTATICALLY_ALLOCATED_STACK_ONLY )
+            {
+                *ppuxStackBuffer = pxTCB->pxStack;
+                *ppxTaskBuffer = NULL;
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                xReturn = pdFALSE;
+            }
+        #endif /* tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 */
 
         return xReturn;
     }

--- a/timers.c
+++ b/timers.c
@@ -510,6 +510,30 @@
     }
 /*-----------------------------------------------------------*/
 
+    #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        BaseType_t xTimerGetStaticBuffer( TimerHandle_t xTimer,
+                                          StaticTimer_t ** ppxTimerBuffer )
+        {
+            BaseType_t xReturn;
+            Timer_t * pxTimer = xTimer;
+
+            configASSERT( ppxTimerBuffer != NULL );
+
+            if( ( pxTimer->ucStatus & tmrSTATUS_IS_STATICALLY_ALLOCATED ) != 0 )
+            {
+                *ppxTimerBuffer = ( StaticTimer_t * ) pxTimer;
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                xReturn = pdFALSE;
+            }
+
+            return xReturn;
+        }
+    #endif /* configSUPPORT_STATIC_ALLOCATION */
+/*-----------------------------------------------------------*/
+
     const char * pcTimerGetName( TimerHandle_t xTimer ) /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
     {
         Timer_t * pxTimer = xTimer;


### PR DESCRIPTION
# Add `...GetStaticBuffers()` Functions
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

This PR adds `...GetStaticBuffers()` functions to get pointers to the buffers used to create a particular static FreeRTOS objects (i.e., objects created using `...CreateStatic()`).

These functions are helpful because some ports (such as ESP-IDF) use the `...CreateStatic()` when an object needs to be allocated from special memory (i.e., not included in the regular `pvPortMalloc()`/`vPortFree()`). "Special Memory" could include things such as memory from a "fast malloc memory pool" or memory from external (i.e., off chip) RAM, and this special memory is allocated/freed using a separate API.

Currently, we need to associate the static object handles and their buffers using some sort of list. For example:

```c
    // Create a task from special memory
    StackType_t *stack_buffer = pvPortSpecialMalloc(2048);
    StaticTask_t *task_obj = pvPortSpecialMalloc(sizeof(StaticTask_t));
    TaskHandle_t task_hdl;
    task_hdl = xTaskCreateStatic(task_func, "task", 2048, NULL, 5, stack_buffer, task_obj);
    // Associate the task_hdl with it's buffers using a linked list
    linked_list_entry_t entry = {
        .task_hdl = task_hdl,
        .stack = stack_buffer,
        .obj = task_obj,
    };
    AddToList(some_list, &entry);

    ...

    // Delete the task
    vTaskDelete(task_hdl);
    // Find the buffers associated with the task and free them
    linked_list_entry_t entry;
    FindFromList(some_list, task_hdl, &entry);
    vPortSpecialFree(entry.stack_buffer);
    vPortSpecialFree(entry.task_obj);
```

But having a `...GetStaticBuffers()` allows us to avoid the list overhead, as we can simply call `...GetStaticBuffers()` to get the associated buffers before the object is deleted. For example:

```c
    // Create a task from special memory
    StackType_t *stack_buffer = pvPortSpecialMalloc(2048);
    StaticTask_t *task_obj = pvPortSpecialMalloc(sizeof(StaticTask_t));
    TaskHandle_t task_hdl;
    task_hdl = xTaskCreateStatic(task_func, "task", 2048, NULL, 5, stack_buffer, task_obj);

    ...

    // Get the task's buffers before deleting it
    StackType_t *stack_buffer_ret;
    StaticTask_t *task_obj_ret;
    xTaskGetStaticBuffers(task_hdl, &stack_buffer_ret, &task_obj_ret);

    // Delete the task
    vTaskDelete(task_hdl);

    // Free the buffers
    vPortSpecialFree(stack_buffer_ret);
    vPortSpecialFree(task_obj_ret);
```




Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
