### PR TITLE
fix: block when below trigger level

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -891,7 +891,8 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
     }
     else
     {
-        xBytesToStoreMessageLength = 0;
+        // force task to block if the buffer contains less bytes than trigger level
+        xBytesToStoreMessageLength = pxStreamBuffer->xTriggerLevelBytes;
     }
 
     if( xTicksToWait != ( TickType_t ) 0 )


### PR DESCRIPTION
stream buffers appear to only block when the buffer is empty, which doesn't seem to help anybody... This will force the current task to block until the trigger level has been reached

Description
-----------
This allows the stream buffer to block when the amount of data in a stream buffer is less than the trigger level.

Test Steps
-----------
Reference issue below.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

- We have tested the stream buffer works as we expect.  We have not ran existing tests to confirm no regressions have been made.
- We have not added any unit tests.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#643 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
