### PR TITLE
Remove C90 requirement from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,5 +292,3 @@ target_link_libraries(freertos_kernel
 )
 
 ########################################################################
-# Requirements
-set_property(TARGET freertos_kernel PROPERTY C_STANDARD 90)


### PR DESCRIPTION
Description
-----------
This is needed as it is breaking projects - https://forums.freertos.org/t/freertos-gcc-cmake/16984

We will re-evaluate and accordingly add this later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Related Issue: https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/646