### PR TITLE
Add configRESET_TLS_BLOCK macro, adjust formatting.

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -117,19 +117,23 @@
 #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
 
     #ifndef configTLS_BLOCK_TYPE
-        #error Missing definition:  configTLS_BLOCK_TYPE must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+        #error Missing definition:  configTLS_BLOCK_TYPE must be defined when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
     #endif
 
     #ifndef configINIT_TLS_BLOCK
-        #error Missing definition:  configINIT_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+        #error Missing definition:  configINIT_TLS_BLOCK must be defined when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
     #endif
 
     #ifndef configSET_TLS_BLOCK
-        #error Missing definition:  configSET_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+        #error Missing definition:  configSET_TLS_BLOCK must be defined when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+    #endif
+
+    #ifndef configRESET_TLS_BLOCK
+        #error Missing definition:  configRESET_TLS_BLOCK must be defined when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
     #endif
 
     #ifndef configDEINIT_TLS_BLOCK
-        #error Missing definition:  configDEINIT_TLS_BLOCK must be defined in FreeRTOSConfig.h when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
+        #error Missing definition:  configDEINIT_TLS_BLOCK must be defined when configUSE_C_RUNTIME_TLS_SUPPORT is set to 1.
     #endif
 #endif /* if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 ) */
 

--- a/include/newlib-freertos.h
+++ b/include/newlib-freertos.h
@@ -65,6 +65,15 @@
     while( 0 )
 #endif /* configSET_TLS_BLOCK */
 
+#ifndef configRESET_TLS_BLOCK
+    #define configRESET_TLS_BLOCK()       \
+    do                                    \
+    {                                     \
+        _impure_ptr = _global_impure_ptr; \
+    }                                     \
+    while( 0 )
+#endif /* configRESET_TLS_BLOCK */
+
 #ifndef configDEINIT_TLS_BLOCK
     #define configDEINIT_TLS_BLOCK( xTLSBlock ) \
     do                                          \

--- a/include/newlib-freertos.h
+++ b/include/newlib-freertos.h
@@ -45,18 +45,33 @@
 
 #ifndef configTLS_BLOCK_TYPE
     #define configTLS_BLOCK_TYPE           struct _reent
-#endif
+#endif /* configTLS_BLOCK_TYPE */
 
 #ifndef configINIT_TLS_BLOCK
-    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )    _REENT_INIT_PTR( &( xTLSBlock ) )
-#endif
+    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack ) \
+    do                                                      \
+    {                                                       \
+        _REENT_INIT_PTR( &( xTLSBlock ) );                  \
+    }                                                       \
+    while( 0 )
+#endif /* configINIT_TLS_BLOCK */
 
 #ifndef configSET_TLS_BLOCK
-    #define configSET_TLS_BLOCK( xTLSBlock )    _impure_ptr = &( xTLSBlock )
-#endif
+    #define configSET_TLS_BLOCK( xTLSBlock ) \
+    do                                       \
+    {                                        \
+        _impure_ptr = &( xTLSBlock );        \
+    }                                        \
+    while( 0 )
+#endif /* configSET_TLS_BLOCK */
 
 #ifndef configDEINIT_TLS_BLOCK
-    #define configDEINIT_TLS_BLOCK( xTLSBlock )    _reclaim_reent( &( xTLSBlock ) )
-#endif
+    #define configDEINIT_TLS_BLOCK( xTLSBlock ) \
+    do                                          \
+    {                                           \
+        _reclaim_reent( &( xTLSBlock ) );       \
+    }                                           \
+    while( 0 )
+#endif /* configDEINIT_TLS_BLOCK */
 
 #endif /* INC_NEWLIB_FREERTOS_H */

--- a/include/picolibc-freertos.h
+++ b/include/picolibc-freertos.h
@@ -92,6 +92,10 @@
     #define configSET_TLS_BLOCK( xTLSBlock )    _set_tls( xTLSBlock )
 #endif /* configSET_TLS_BLOCK */
 
+#ifndef configRESET_TLS_BLOCK
+    #define configRESET_TLS_BLOCK( xTLSBlock )
+#endif /* configRESET_TLS_BLOCK */
+
 #ifndef configDEINIT_TLS_BLOCK
     #define configDEINIT_TLS_BLOCK( xTLSBlock )
 #endif /* configDEINIT_TLS_BLOCK */


### PR DESCRIPTION
Description
-----------
Add configRESET_TLS_BLOCK macro to allow using newlibc functions from Interrupt / Exception handlers.

Repro Steps
-----------
Attempt to call printf from a fault handler / interrupt. 
Note that if the last task to run had not yet initialized stdio, the call may fail due to attempts to allocate heap memory.

Fix
-----------
Add a configRESET_TLS_BLOCK macro which may be called to reset the thread local storage to a particular context for use in interrupt handlers. For newlibc, this sets _impure_ptr = _global_impure_ptr.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
