### PR TITLE
ARMv7M: Adjust implemented priority bit assertions

### DIFF
--- a/portable/CCS/ARM_CM3/port.c
+++ b/portable/CCS/ARM_CM3/port.c
@@ -287,19 +287,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/CCS/ARM_CM4F/port.c
+++ b/portable/CCS/ARM_CM4F/port.c
@@ -306,19 +306,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/GCC/ARM_CM3/port.c
+++ b/portable/GCC/ARM_CM3/port.c
@@ -330,19 +330,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -452,21 +452,25 @@ BaseType_t xPortStartScheduler( void )
             }
 
             #ifdef __NVIC_PRIO_BITS
-                {
-                    /* Check the CMSIS configuration that defines the number of
-                     * priority bits matches the number of priority bits actually queried
-                     * from the hardware. */
-                    configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
-                }
+            {
+                /*
+                 * Check that the number of implemented priority bits queried from
+                 * hardware is at least as many as specified in the CMSIS
+                 * __NVIC_PRIO_BITS configuration macro.
+                 */
+                configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
+            }
             #endif
 
             #ifdef configPRIO_BITS
-                {
-                    /* Check the FreeRTOS configuration that defines the number of
-                     * priority bits matches the number of priority bits actually queried
-                     * from the hardware. */
-                    configASSERT( ulImplementedPrioBits == configPRIO_BITS );
-                }
+            {
+                /*
+                 * Check that the number of implemented priority bits queried from
+                 * hardware is at least as many as specified in the FreeRTOS
+                 * configPRIO_BITS configuration macro.
+                 */
+                configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
+            }
             #endif
 
             /* Shift the priority group value back to its position within the AIRCR

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -373,19 +373,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -495,21 +495,25 @@ BaseType_t xPortStartScheduler( void )
             }
 
             #ifdef __NVIC_PRIO_BITS
-                {
-                    /* Check the CMSIS configuration that defines the number of
-                     * priority bits matches the number of priority bits actually queried
-                     * from the hardware. */
-                    configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
-                }
+            {
+                /*
+                 * Check that the number of implemented priority bits queried
+                 * from hardware is at least as many as specified in the
+                 * CMSIS __NVIC_PRIO_BITS configuration macro.
+                 */
+                configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
+            }
             #endif
 
             #ifdef configPRIO_BITS
-                {
-                    /* Check the FreeRTOS configuration that defines the number of
-                     * priority bits matches the number of priority bits actually queried
-                     * from the hardware. */
-                    configASSERT( ulImplementedPrioBits == configPRIO_BITS );
-                }
+            {
+                /*
+                 * Check that the number of implemented priority bits queried
+                 * from hardware is at least as many as specified in the
+                 * FreeRTOS configPRIO_BITS configuration macro.
+                 */
+                configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
+            }
             #endif
 
             /* Shift the priority group value back to its position within the AIRCR

--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -361,19 +361,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/IAR/ARM_CM3/port.c
+++ b/portable/IAR/ARM_CM3/port.c
@@ -279,19 +279,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/IAR/ARM_CM4F/port.c
+++ b/portable/IAR/ARM_CM4F/port.c
@@ -317,19 +317,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -431,19 +431,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/IAR/ARM_CM7/r0p1/port.c
+++ b/portable/IAR/ARM_CM7/r0p1/port.c
@@ -305,19 +305,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/MikroC/ARM_CM4F/port.c
+++ b/portable/MikroC/ARM_CM4F/port.c
@@ -367,19 +367,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/RVDS/ARM_CM3/port.c
+++ b/portable/RVDS/ARM_CM3/port.c
@@ -332,19 +332,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/RVDS/ARM_CM4F/port.c
+++ b/portable/RVDS/ARM_CM4F/port.c
@@ -398,19 +398,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -491,19 +491,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 

--- a/portable/RVDS/ARM_CM7/r0p1/port.c
+++ b/portable/RVDS/ARM_CM7/r0p1/port.c
@@ -382,19 +382,23 @@ BaseType_t xPortStartScheduler( void )
 
         #ifdef __NVIC_PRIO_BITS
         {
-            /* Check the CMSIS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == __NVIC_PRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the CMSIS
+             * __NVIC_PRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= __NVIC_PRIO_BITS );
         }
         #endif
 
         #ifdef configPRIO_BITS
         {
-            /* Check the FreeRTOS configuration that defines the number of
-             * priority bits matches the number of priority bits actually queried
-             * from the hardware. */
-            configASSERT( ulImplementedPrioBits == configPRIO_BITS );
+            /*
+             * Check that the number of implemented priority bits queried from
+             * hardware is at least as many as specified in the FreeRTOS
+             * configPRIO_BITS configuration macro.
+             */
+            configASSERT( ulImplementedPrioBits >= configPRIO_BITS );
         }
         #endif
 


### PR DESCRIPTION
Description
-----------
Adjust assertions related to the CMSIS __NVIC_PRIO_BITS and FreeRTOS configPRIO_BITS configuration macros such that these macros specify the minimum number of implemented priority bits supported by a config build rather than the exact number of implemented priority bits.

Test Steps
-----------
Run the kernel in qemu with the mps2-an385 target with __NVIC_PRIO_BITS and configPRIO_BITS set to all valid values: 3,4,5,6,7,8.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ N/A ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Related to [Qemu issue #1122](https://gitlab.com/qemu-project/qemu/-/issues/1122). See related discussion on the [qemu mailing list](https://lore.kernel.org/qemu-devel/20220813112559.1974427-1-anton.kochkov@proton.me/T/#u.).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
