### PR TITLE
paranthesize expression-like macro

### DIFF
--- a/include/newlib-freertos.h
+++ b/include/newlib-freertos.h
@@ -52,7 +52,7 @@
 #endif
 
 #ifndef configSET_TLS_BLOCK
-    #define configSET_TLS_BLOCK( xTLSBlock )    _impure_ptr = &( xTLSBlock )
+    #define configSET_TLS_BLOCK( xTLSBlock )   ( _impure_ptr = &( xTLSBlock ) )
 #endif
 
 #ifndef configDEINIT_TLS_BLOCK


### PR DESCRIPTION
fixed a lint warning

Description
-----------
Lint complains about the macro `configSET_TLS_BLOCK` not being parenthesized. I fixed that in `newlib-freertos.h`.
The macro is used in two places in `tasks.c` and parenthesizing the macro has no effect at all, but removes one lint warning.

Test Steps
-----------
see above.

Related Issue
-----------
none.
