### PR TITLE
Align StackSize and StackAddress for macOs

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -61,6 +61,10 @@
 #include <sys/times.h>
 #include <time.h>
 
+#ifdef __APPLE__
+    #include <mach/mach_vm.h>
+#endif
+
 /* Scheduler includes. */
 #include "FreeRTOS.h"
 #include "task.h"
@@ -145,6 +149,11 @@ portSTACK_TYPE * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     thread = ( Thread_t * ) ( pxTopOfStack + 1 ) - 1;
     pxTopOfStack = ( portSTACK_TYPE * ) thread - 1;
     ulStackSize = ( size_t )( pxTopOfStack + 1 - pxEndOfStack ) * sizeof( *pxTopOfStack );
+
+    #ifdef __APPLE__
+        pxEndOfStack = mach_vm_round_page ( pxEndOfStack );
+        ulStackSize = mach_vm_trunc_page ( ulStackSize );
+    #endif
 
     thread->pxCode = pxCode;
     thread->pvParams = pvParameters;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
MAC OS pthread_attr_setstack has an extra requirement of stack address and stack size to be suitably aligned. Adding the changes for the alignement of both.

```
int
pthread_attr_setstack(pthread_attr_t *attr, void *stackaddr, size_t stacksize)
{
	int ret = EINVAL;
	if (attr->sig == _PTHREAD_ATTR_SIG &&
			(((mach_vm_address_t)stackaddr & vm_page_mask) == 0) &&
			((stacksize & vm_page_mask) == 0) &&
			stacksize >= PTHREAD_STACK_MIN) {
		attr->stackaddr = (void *)((uintptr_t)stackaddr + stacksize);
		attr->stacksize = stacksize;
		ret = 0;
	}
	return ret;
}
```

<!--- Describe your changes in detail. -->

Test Steps
-----------
Build and run [GCC_POSIX](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/Posix_GCC) demo on Linux and MacOS.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
