### PR TITLE
Use the extended movx instruction instead of mov

### DIFF
--- a/portable/CCS/MSP430X/portext.asm
+++ b/portable/CCS/MSP430X/portext.asm
@@ -48,7 +48,7 @@ portSAVE_CONTEXT .macro
 
     ;Save the remaining registers.
     pushm_x #12, r15
-    mov.w   &usCriticalNesting, r14
+    movx.w   &usCriticalNesting, r14
     push_x r14
     mov_x   &pxCurrentTCB, r12
     mov_x   sp, 0( r12 )
@@ -60,7 +60,7 @@ portRESTORE_CONTEXT .macro
     mov_x   &pxCurrentTCB, r12
     mov_x   @r12, sp
     pop_x   r15
-    mov.w   r15, &usCriticalNesting
+    movx.w   r15, &usCriticalNesting
     popm_x  #12, r15
     nop
     pop.w   sr


### PR DESCRIPTION
Description
-----------

The following is from the MSP430X instruction set -

```
MOVX.W Move source word to destination word.

The source operand is copied to the destination. The source operand is
not affected. Both operands may be located in the full address space.
```

The movx instruction allows both the operands to be located in the full address space and therefore, works with large data model as well.

Test Steps
-----------
1. Stepped through the assembly and verified that the instruction moves data correctly between 2 bytes memory and register both with large and small data model on MSP-EXP430FR5994.
2. Ran register tests on MSP-EXP430FR5994.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/671

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
