### PR TITLE
Fix eTaskGetState for pending ready tasks

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -1351,6 +1351,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         eTaskState eReturn;
         List_t const * pxStateList;
+        List_t const * pxEventList;
         List_t const * pxDelayedList;
         List_t const * pxOverflowedDelayedList;
         const TCB_t * const pxTCB = xTask;
@@ -1367,12 +1368,20 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
             taskENTER_CRITICAL();
             {
                 pxStateList = listLIST_ITEM_CONTAINER( &( pxTCB->xStateListItem ) );
+                pxEventList = listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) );
                 pxDelayedList = pxDelayedTaskList;
                 pxOverflowedDelayedList = pxOverflowDelayedTaskList;
             }
             taskEXIT_CRITICAL();
 
-            if( ( pxStateList == pxDelayedList ) || ( pxStateList == pxOverflowedDelayedList ) )
+            if( pxEventList == &xPendingReadyList )
+            {
+                /* The task has been placed on the pending ready list, so its
+                 * state is eReady regardless of what list the task's state list
+                 * item is currently placed on. */
+                eReturn = eReady;
+            }
+            else if( ( pxStateList == pxDelayedList ) || ( pxStateList == pxOverflowedDelayedList ) )
             {
                 /* The task being queried is referenced from one of the Blocked
                  * lists. */


### PR DESCRIPTION
Original PR - https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/577

Description
-----------

The description of the `eReady` enum is inclusive of tasks that are pending ready

```c
    eReady,       /* The task being queried is in a ready or pending ready list. */
```
However, the current implementation of the `eTaskGetState` function only checks a task's state list item, thus will return a non-`eReady` state for tasks that are pending ready.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

1. From a main task, create a task_A.
2. task_A blocks/suspends itself
3. Main task calls `vTaskSuspendAll()`
4. Main task triggers an ISR. The ISR unblocks task_A
5. Main task then calls `eTaskGetState` on task_A which returns `eBlocked`/`eSuspended` even though task_A has been unblocked by the ISR.

Notes:

- We discovered this issue through one of our kernel unit tests. I can post the test source code here if that helps
- The SMP branch should also have the same issue. But I can raise a PR for the SMP branch once the fix for the mainline branch has been finalized.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.