### PR TITLE
Fix clang warning in croutine and stream buffer

### DIFF
--- a/include/croutine.h
+++ b/include/croutine.h
@@ -53,11 +53,11 @@ typedef void (* crCOROUTINE_CODE)( CoRoutineHandle_t,
 typedef struct corCoRoutineControlBlock
 {
     crCOROUTINE_CODE pxCoRoutineFunction;
-    ListItem_t xGenericListItem; /*< List item used to place the CRCB in ready and blocked queues. */
-    ListItem_t xEventListItem;   /*< List item used to place the CRCB in event lists. */
-    UBaseType_t uxPriority;      /*< The priority of the co-routine in relation to other co-routines. */
-    UBaseType_t uxIndex;         /*< Used to distinguish between co-routines when multiple co-routines use the same co-routine function. */
-    uint16_t uxState;            /*< Used internally by the co-routine implementation. */
+    ListItem_t xGenericListItem; /**< List item used to place the CRCB in ready and blocked queues. */
+    ListItem_t xEventListItem;   /**< List item used to place the CRCB in event lists. */
+    UBaseType_t uxPriority;      /**< The priority of the co-routine in relation to other co-routines. */
+    UBaseType_t uxIndex;         /**< Used to distinguish between co-routines when multiple co-routines use the same co-routine function. */
+    uint16_t uxState;            /**< Used internally by the co-routine implementation. */
 } CRCB_t;                        /* Co-routine control block.  Note must be identical in size down to uxPriority with TCB_t. */
 
 /**

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -478,7 +478,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
                                               StaticStreamBuffer_t ** ppxStaticStreamBuffer )
     {
         BaseType_t xReturn;
-        const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
+        StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
 
         configASSERT( pxStreamBuffer );
         configASSERT( ppucStreamBufferStorageArea );


### PR DESCRIPTION
* Fix document warning in croutine
* Fix cast-qual warning in stream buffer

Description
-----------
* Update " /*<" to "/**<" in croutine.h
* Remove const qualifier in get static buffer in stream buffer

Test Steps
-----------
Consume the FreeRTOS-Kernel/CMakeLists.txt with clang compiler.
clang version 10.0.0-4ubuntu1
Adding the following suppression
```
target_compile_options( freertos_kernel
  PRIVATE
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-cast-align>
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-covered-switch-default>
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-missing-variable-declarations>
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-padded>
    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-macros>
)
target_compile_options( freertos_kernel_port
  PRIVATE
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-disabled-macro-expansion>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-padded>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-reserved-id-macro>
)
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
