### PR TITLE
Use portTASK_FUNCTION_PROTO to replace portNORETURN

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -895,10 +895,6 @@
     #define portDONT_DISCARD
 #endif
 
-#ifndef portNORETURN
-    #define portNORETURN
-#endif
-
 #ifndef configUSE_TIME_SLICING
     #define configUSE_TIME_SLICING    1
 #endif

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME         "Cortex-M23"
 #define portHAS_BASEPRI       0
 #define portDONT_DISCARD      __attribute__( ( used ) )
-#define portNORETURN          __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME         "Cortex-M23"
 #define portHAS_BASEPRI       0
 #define portDONT_DISCARD      __attribute__( ( used ) )
-#define portNORETURN          __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME                       "Cortex-M33"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME                       "Cortex-M33"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME                       "Cortex-M35P"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
@@ -56,7 +56,6 @@
 #define portARCH_NAME                       "Cortex-M55"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
@@ -56,7 +56,6 @@
 #define portARCH_NAME                       "Cortex-M85"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -79,7 +79,6 @@ typedef unsigned long    UBaseType_t;
 #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT    8
 #define portDONT_DISCARD      __attribute__( ( used ) )
-#define portNORETURN          __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME         "Cortex-M23"
 #define portHAS_BASEPRI       0
 #define portDONT_DISCARD      __attribute__( ( used ) )
-#define portNORETURN          __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME         "Cortex-M23"
 #define portHAS_BASEPRI       0
 #define portDONT_DISCARD      __attribute__( ( used ) )
-#define portNORETURN          __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -79,7 +79,6 @@
     #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
     #define portBYTE_ALIGNMENT    8
     #define portDONT_DISCARD      __attribute__( ( used ) )
-    #define portNORETURN         __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME                       "Cortex-M33"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME                       "Cortex-M33"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME                       "Cortex-M35P"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -51,7 +51,6 @@
 #define portARCH_NAME                       "Cortex-M35P"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -115,7 +115,6 @@
     #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
     #define portBYTE_ALIGNMENT    8
     #define portDONT_DISCARD      __attribute__( ( used ) )
-    #define portNORETURN         __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* SVC numbers for various services. */

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -82,7 +82,6 @@
     #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
     #define portBYTE_ALIGNMENT    8
     #define portDONT_DISCARD      __attribute__( ( used ) )
-    #define portNORETURN         __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -203,7 +203,6 @@ typedef struct MPU_SETTINGS
 #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT    8
 #define portDONT_DISCARD      __attribute__( ( used ) )
-#define portNORETURN         __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* SVC numbers for various services. */

--- a/portable/GCC/ARM_CM55/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacro.h
@@ -56,7 +56,6 @@
 #define portARCH_NAME                       "Cortex-M55"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -56,7 +56,6 @@
 #define portARCH_NAME                       "Cortex-M55"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -79,7 +79,6 @@
     #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
     #define portBYTE_ALIGNMENT    8
     #define portDONT_DISCARD      __attribute__( ( used ) )
-    #define portNORETURN         __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */

--- a/portable/GCC/ARM_CM85/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacro.h
@@ -56,7 +56,6 @@
 #define portARCH_NAME                       "Cortex-M85"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -56,7 +56,6 @@
 #define portARCH_NAME                       "Cortex-M85"
 #define portHAS_BASEPRI                     1
 #define portDONT_DISCARD                    __attribute__( ( used ) )
-#define portNORETURN                        __attribute__( ( noreturn ) )
 /*-----------------------------------------------------------*/
 
 /* ARMv8-M common port configurations. */

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -70,8 +70,6 @@ typedef unsigned long TickType_t;
 /*-----------------------------------------------------------*/
 
 /* Architecture specifics. */
-#define portNORETURN               __attribute__( ( noreturn ) )
-
 #define portSTACK_GROWTH            ( -1 )
 #define portHAS_STACK_OVERFLOW_CHECKING ( 1 )
 #define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
@@ -114,7 +112,7 @@ extern void vPortCancelThread( void *pxTaskToDelete );
 #define portCLEAN_UP_TCB( pxTCB )   vPortCancelThread( pxTCB )
 /*-----------------------------------------------------------*/
 
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters ) __attribute__( ( noreturn ) )
 #define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -80,7 +80,6 @@
     #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
     #define portBYTE_ALIGNMENT    8
     #define portDONT_DISCARD      __attribute__( ( used ) )
-    #define portNORETURN         __attribute__( ( noreturn ) )
     /* We have to use PICO_DIVIDER_DISABLE_INTERRUPTS as the source of truth rathern than our config,
      * as our FreeRTOSConfig.h header cannot be included by ASM code - which is what this affects in the SDK */
     #define portUSE_DIVIDER_SAVE_RESTORE !PICO_DIVIDER_DISABLE_INTERRUPTS

--- a/portable/ThirdParty/GCC/Xtensa_ESP32/include/portmacro.h
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/include/portmacro.h
@@ -335,8 +335,6 @@
 /*-----------------------------------------------------------*/
 
 /* Architecture specifics. */
-    #define portNORETURN               __attribute__( ( noreturn ) )
-
     #define portSTACK_GROWTH      ( -1 )
     #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
     #define portBYTE_ALIGNMENT    4

--- a/tasks.c
+++ b/tasks.c
@@ -432,7 +432,7 @@ static void prvInitialiseTaskLists( void ) PRIVILEGED_FUNCTION;
  * void prvIdleTask( void *pvParameters );
  *
  */
-static portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) portNORETURN PRIVILEGED_FUNCTION;
+static portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
 
 /*
  * Utility to free all memory allocated by the scheduler to hold a TCB,
@@ -3486,7 +3486,7 @@ void vTaskMissedYield( void )
  *
  */
 
-portTASK_FUNCTION( prvIdleTask, pvParameters )
+static portTASK_FUNCTION( prvIdleTask, pvParameters )
 {
     /* Stop warnings. */
     ( void ) pvParameters;

--- a/timers.c
+++ b/timers.c
@@ -158,7 +158,7 @@
  * task.  Other tasks communicate with the timer service task using the
  * xTimerQueue queue.
  */
-    static portTASK_FUNCTION_PROTO( prvTimerTask, pvParameters ) portNORETURN PRIVILEGED_FUNCTION;
+    static portTASK_FUNCTION_PROTO( prvTimerTask, pvParameters ) PRIVILEGED_FUNCTION;
 
 /*
  * Called by the timer service task to interpret and process a command it


### PR DESCRIPTION
* Use portTASK_FUNCTION_PROTO to replace portNORETURN for GCC port

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
Consume the FreeRTOS-kernel/CMakeLists.txt with Posix-GCC port. Compile with clang should not have missing-noreturn error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
