### PR TITLE
Add constant type for portMAX_DELAY in port

### DIFF
--- a/portable/GCC/AVR32_UC3/portmacro.h
+++ b/portable/GCC/AVR32_UC3/portmacro.h
@@ -116,7 +116,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/CORTUS_APS3/portmacro.h
+++ b/portable/GCC/CORTUS_APS3/portmacro.h
@@ -65,7 +65,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/ColdFire_V2/portmacro.h
+++ b/portable/GCC/ColdFire_V2/portmacro.h
@@ -63,7 +63,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/H8S2329/portmacro.h
+++ b/portable/GCC/H8S2329/portmacro.h
@@ -64,7 +64,7 @@ typedef unsigned char UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/HCS12/portmacro.h
+++ b/portable/GCC/HCS12/portmacro.h
@@ -65,7 +65,7 @@ typedef unsigned char UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/MSP430F449/portmacro.h
+++ b/portable/GCC/MSP430F449/portmacro.h
@@ -63,7 +63,7 @@ typedef unsigned short UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/PPC405_Xilinx/portmacro.h
+++ b/portable/GCC/PPC405_Xilinx/portmacro.h
@@ -65,7 +65,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/PPC440_Xilinx/portmacro.h
+++ b/portable/GCC/PPC440_Xilinx/portmacro.h
@@ -65,7 +65,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/RL78/portmacro.h
+++ b/portable/GCC/RL78/portmacro.h
@@ -59,7 +59,7 @@ typedef unsigned short UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/GCC/STR75x/portmacro.h
+++ b/portable/GCC/STR75x/portmacro.h
@@ -64,7 +64,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/78K0R/portmacro.h
+++ b/portable/IAR/78K0R/portmacro.h
@@ -64,7 +64,7 @@ typedef unsigned short UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/ATMega323/portmacro.h
+++ b/portable/IAR/ATMega323/portmacro.h
@@ -71,7 +71,7 @@ typedef unsigned char UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/AVR32_UC3/portmacro.h
+++ b/portable/IAR/AVR32_UC3/portmacro.h
@@ -119,7 +119,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/AVR_AVRDx/portmacro.h
+++ b/portable/IAR/AVR_AVRDx/portmacro.h
@@ -65,7 +65,7 @@ typedef unsigned char    UBaseType_t;
     #define portMAX_DELAY    ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/AVR_Mega0/portmacro.h
+++ b/portable/IAR/AVR_Mega0/portmacro.h
@@ -65,7 +65,7 @@ typedef unsigned char    UBaseType_t;
     #define portMAX_DELAY    ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/AtmelSAM7S64/portmacro.h
+++ b/portable/IAR/AtmelSAM7S64/portmacro.h
@@ -64,7 +64,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/AtmelSAM9XE/portmacro.h
+++ b/portable/IAR/AtmelSAM9XE/portmacro.h
@@ -67,7 +67,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/LPC2000/portmacro.h
+++ b/portable/IAR/LPC2000/portmacro.h
@@ -67,7 +67,7 @@ typedef unsigned long UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/MSP430/portmacro.h
+++ b/portable/IAR/MSP430/portmacro.h
@@ -58,7 +58,7 @@ typedef unsigned short UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/MSP430X/portmacro.h
+++ b/portable/IAR/MSP430X/portmacro.h
@@ -67,7 +67,7 @@ typedef unsigned short UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/IAR/RL78/portmacro.h
+++ b/portable/IAR/RL78/portmacro.h
@@ -82,7 +82,7 @@ typedef unsigned short UBaseType_t;
     #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif

--- a/portable/WizC/PIC18/portmacro.h
+++ b/portable/WizC/PIC18/portmacro.h
@@ -63,7 +63,7 @@ typedef unsigned char UBaseType_t;
     #define portMAX_DELAY ( TickType_t )    ( 0xFFFF )
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
     typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFF )
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif


### PR DESCRIPTION
Add constant type for portMAX_DELAY in port

Description
-----------
* Add constant type UL for porMAX_DELAY if tick type is 32bits

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
