### PR TITLE
Remove empty expression statement compiler warning

### DIFF
--- a/croutine.c
+++ b/croutine.c
@@ -66,13 +66,13 @@
  * used from within an ISR.
  */
     #define prvAddCoRoutineToReadyQueue( pxCRCB )                                                                               \
-    {                                                                                                                           \
+    do {                                                                                                                        \
         if( ( pxCRCB )->uxPriority > uxTopCoRoutineReadyPriority )                                                              \
         {                                                                                                                       \
             uxTopCoRoutineReadyPriority = ( pxCRCB )->uxPriority;                                                               \
         }                                                                                                                       \
         vListInsertEnd( ( List_t * ) &( pxReadyCoRoutineLists[ ( pxCRCB )->uxPriority ] ), &( ( pxCRCB )->xGenericListItem ) ); \
-    }
+    } while( 0 )
 
 /*
  * Utility to ready all the lists used by the scheduler.  This is called

--- a/include/croutine.h
+++ b/include/croutine.h
@@ -307,12 +307,14 @@ void vCoRoutineSchedule( void );
  * \defgroup crDELAY crDELAY
  * \ingroup Tasks
  */
-#define crDELAY( xHandle, xTicksToDelay )                      \
-    if( ( xTicksToDelay ) > 0 )                                \
-    {                                                          \
-        vCoRoutineAddToDelayedList( ( xTicksToDelay ), NULL ); \
-    }                                                          \
-    crSET_STATE0( ( xHandle ) );
+#define crDELAY( xHandle, xTicksToDelay )                          \
+    do {                                                           \
+        if( ( xTicksToDelay ) > 0 )                                \
+        {                                                          \
+            vCoRoutineAddToDelayedList( ( xTicksToDelay ), NULL ); \
+        }                                                          \
+        crSET_STATE0( ( xHandle ) );                               \
+    } while( 0 )
 
 /**
  * @code{c}
@@ -400,7 +402,7 @@ void vCoRoutineSchedule( void );
  * \ingroup Tasks
  */
 #define crQUEUE_SEND( xHandle, pxQueue, pvItemToQueue, xTicksToWait, pxResult )           \
-    {                                                                                     \
+    do {                                                                                  \
         *( pxResult ) = xQueueCRSend( ( pxQueue ), ( pvItemToQueue ), ( xTicksToWait ) ); \
         if( *( pxResult ) == errQUEUE_BLOCKED )                                           \
         {                                                                                 \
@@ -412,7 +414,7 @@ void vCoRoutineSchedule( void );
             crSET_STATE1( ( xHandle ) );                                                  \
             *pxResult = pdPASS;                                                           \
         }                                                                                 \
-    }
+    } while( 0 )
 
 /**
  * croutine. h
@@ -494,7 +496,7 @@ void vCoRoutineSchedule( void );
  * \ingroup Tasks
  */
 #define crQUEUE_RECEIVE( xHandle, pxQueue, pvBuffer, xTicksToWait, pxResult )           \
-    {                                                                                   \
+    do {                                                                                \
         *( pxResult ) = xQueueCRReceive( ( pxQueue ), ( pvBuffer ), ( xTicksToWait ) ); \
         if( *( pxResult ) == errQUEUE_BLOCKED )                                         \
         {                                                                               \
@@ -506,7 +508,7 @@ void vCoRoutineSchedule( void );
             crSET_STATE1( ( xHandle ) );                                                \
             *( pxResult ) = pdPASS;                                                     \
         }                                                                               \
-    }
+    } while( 0 )
 
 /**
  * croutine. h

--- a/include/semphr.h
+++ b/include/semphr.h
@@ -95,13 +95,13 @@ typedef QueueHandle_t SemaphoreHandle_t;
  */
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     #define vSemaphoreCreateBinary( xSemaphore )                                                                                     \
-    {                                                                                                                                \
+    do {                                                                                                                             \
         ( xSemaphore ) = xQueueGenericCreate( ( UBaseType_t ) 1, semSEMAPHORE_QUEUE_ITEM_LENGTH, queueQUEUE_TYPE_BINARY_SEMAPHORE ); \
         if( ( xSemaphore ) != NULL )                                                                                                 \
         {                                                                                                                            \
             ( void ) xSemaphoreGive( ( xSemaphore ) );                                                                               \
         }                                                                                                                            \
-    }
+    } while( 0 )
 #endif
 
 /**

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -57,13 +57,13 @@
 
 /* Only the current stack state is to be checked. */
     #define taskCHECK_FOR_STACK_OVERFLOW()                                                            \
-    {                                                                                                 \
+    do {                                                                                              \
         /* Is the currently saved stack pointer within the stack limit? */                            \
         if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )           \
         {                                                                                             \
             vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pxCurrentTCB->pcTaskName ); \
         }                                                                                             \
-    }
+    } while( 0 )
 
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
@@ -72,14 +72,14 @@
 
 /* Only the current stack state is to be checked. */
     #define taskCHECK_FOR_STACK_OVERFLOW()                                                            \
-    {                                                                                                 \
+    do {                                                                                              \
                                                                                                       \
         /* Is the currently saved stack pointer within the stack limit? */                            \
         if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )      \
         {                                                                                             \
             vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pxCurrentTCB->pcTaskName ); \
         }                                                                                             \
-    }
+    } while( 0 )
 
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
@@ -106,7 +106,7 @@
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH > 0 ) )
 
     #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                                \
-    {                                                                                                                                     \
+    do {                                                                                                                                  \
         int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
         static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
                                                         tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
@@ -122,7 +122,7 @@
         {                                                                                                                                 \
             vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pxCurrentTCB->pcTaskName );                                     \
         }                                                                                                                                 \
-    }
+    } while( 0 )
 
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
 /*-----------------------------------------------------------*/

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -78,7 +78,7 @@
  */
 #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
     #define prvRECEIVE_COMPLETED( pxStreamBuffer )                                               \
-    {                                                                                            \
+    do {                                                                                         \
         if( ( pxStreamBuffer )->pxReceiveCompletedCallback != NULL )                             \
         {                                                                                        \
             ( pxStreamBuffer )->pxReceiveCompletedCallback( ( pxStreamBuffer ), pdFALSE, NULL ); \
@@ -87,7 +87,7 @@
         {                                                                                        \
             sbRECEIVE_COMPLETED( ( pxStreamBuffer ) );                                           \
         }                                                                                        \
-    }
+    } while( 0 )
 #else /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
     #define prvRECEIVE_COMPLETED( pxStreamBuffer )    sbRECEIVE_COMPLETED( ( pxStreamBuffer ) )
 #endif /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
@@ -116,7 +116,7 @@
 #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
     #define prvRECEIVE_COMPLETED_FROM_ISR( pxStreamBuffer,                                                               \
                                            pxHigherPriorityTaskWoken )                                                   \
-    {                                                                                                                    \
+    do {                                                                                                                 \
         if( ( pxStreamBuffer )->pxReceiveCompletedCallback != NULL )                                                     \
         {                                                                                                                \
             ( pxStreamBuffer )->pxReceiveCompletedCallback( ( pxStreamBuffer ), pdTRUE, ( pxHigherPriorityTaskWoken ) ); \
@@ -125,7 +125,7 @@
         {                                                                                                                \
             sbRECEIVE_COMPLETED_FROM_ISR( ( pxStreamBuffer ), ( pxHigherPriorityTaskWoken ) );                           \
         }                                                                                                                \
-    }
+    } while( 0 )
 #else /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
     #define prvRECEIVE_COMPLETED_FROM_ISR( pxStreamBuffer, pxHigherPriorityTaskWoken ) \
     sbRECEIVE_COMPLETED_FROM_ISR( ( pxStreamBuffer ), ( pxHigherPriorityTaskWoken ) )

--- a/tasks.c
+++ b/tasks.c
@@ -124,12 +124,12 @@
 /* uxTopReadyPriority holds the priority of the highest priority ready
  * state task. */
     #define taskRECORD_READY_PRIORITY( uxPriority ) \
-    {                                               \
+    do {                                            \
         if( ( uxPriority ) > uxTopReadyPriority )   \
         {                                           \
             uxTopReadyPriority = ( uxPriority );    \
         }                                           \
-    } /* taskRECORD_READY_PRIORITY */
+    } while( 0 ) /* taskRECORD_READY_PRIORITY */
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Remove empty expression statement compiler warning.
```
#define MACRO( x ) \
{                                \
    ...                           \
}

MACRO( x );
will be expanded to =>
{
     ...
}; /* Compiler's warning about this extra semicolon. */
```
Reference [clang warning doc](https://clang.llvm.org/docs/DiagnosticsReference.html#wextra-semi-stmt) for more information.

Check with the following bash command for all the defined macro
```
grep -n -e "#define.[\{;]" .c include/*.h
```

Description
-----------
* Add do while( 0 ) loop for defined macro

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
