### PR TITLE
Add ePendingReady state for task in a pending ready list

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -607,6 +607,7 @@ epage
 epc
 epclear
 epeds
+ependingready
 ependofwr
 epint
 epread

--- a/include/task.h
+++ b/include/task.h
@@ -95,13 +95,13 @@ typedef BaseType_t (* TaskHookFunction_t)( void * );
 /* Task states returned by eTaskGetState. */
 typedef enum
 {
-    eRunning = 0, /* A task is querying the state of itself, so must be running. */
-    eReady,       /* The task being queried is in a ready list. */
-    ePendingReady,/* The task being queried is in a pending ready list. */
-    eBlocked,     /* The task being queried is in the Blocked state. */
-    eSuspended,   /* The task being queried is in the Suspended state, or is in the Blocked state with an infinite time out. */
-    eDeleted,     /* The task being queried has been deleted, but its TCB has not yet been freed. */
-    eInvalid      /* Used as an 'invalid state' value. */
+    eRunning = 0,  /* A task is querying the state of itself, so must be running. */
+    eReady,        /* The task being queried is in a ready list. */
+    ePendingReady, /* The task being queried is in a pending ready list. */
+    eBlocked,      /* The task being queried is in the Blocked state. */
+    eSuspended,    /* The task being queried is in the Suspended state, or is in the Blocked state with an infinite time out. */
+    eDeleted,      /* The task being queried has been deleted, but its TCB has not yet been freed. */
+    eInvalid       /* Used as an 'invalid state' value. */
 } eTaskState;
 
 /* Actions that can be performed when vTaskNotify() is called. */

--- a/include/task.h
+++ b/include/task.h
@@ -96,7 +96,8 @@ typedef BaseType_t (* TaskHookFunction_t)( void * );
 typedef enum
 {
     eRunning = 0, /* A task is querying the state of itself, so must be running. */
-    eReady,       /* The task being queried is in a ready or pending ready list. */
+    eReady,       /* The task being queried is in a ready list. */
+    ePendingReady,/* The task being queried is in a pending ready list. */
     eBlocked,     /* The task being queried is in the Blocked state. */
     eSuspended,   /* The task being queried is in the Suspended state, or is in the Blocked state with an infinite time out. */
     eDeleted,     /* The task being queried has been deleted, but its TCB has not yet been freed. */

--- a/tasks.c
+++ b/tasks.c
@@ -1376,10 +1376,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
 
             if( pxEventList == &xPendingReadyList )
             {
-                /* The task has been placed on the pending ready list, so its
-                 * state is eReady regardless of what list the task's state list
-                 * item is currently placed on. */
-                eReturn = eReady;
+                /* The task has been placed on the pending ready list. */
+                eReturn = ePendingReady;
             }
             else if( ( pxStateList == pxDelayedList ) || ( pxStateList == pxOverflowedDelayedList ) )
             {
@@ -1442,7 +1440,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
             else /*lint !e525 Negative indentation is intended to make use of pre-processor clearer. */
             {
                 /* If the task is not in any other state, it must be in the
-                 * Ready (including pending ready) state. */
+                 * Ready state. */
                 eReturn = eReady;
             }
         }


### PR DESCRIPTION
Add ePendingReady state.
The unit test is updated in another PR.

Description
-----------
* Add ePendingReady state for task in a pending ready list.

Test Steps
-----------
Run the unit test case [test_eTaskGetState_success_not_current_tcb_pending_ready](https://github.com/FreeRTOS/FreeRTOS/blob/8f3233e0a0730b16f4fed3669d89954cbdd39ea2/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c#L1724).
* Before this PR, eReady is expected.
* After this PR, ePendingReady should be expected.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
