### PR TITLE
Fix #697: Missing portPOINTER_SIZE_TYPE definition for ATmega port

### DIFF
--- a/portable/ThirdParty/GCC/ATmega/portmacro.h
+++ b/portable/ThirdParty/GCC/ATmega/portmacro.h
@@ -54,6 +54,8 @@
 #define portLONG                    long
 #define portSHORT                   int
 
+#define portPOINTER_SIZE_TYPE    uint16_t
+
 typedef uint8_t                     StackType_t;
 typedef int8_t                      BaseType_t;
 typedef uint8_t                     UBaseType_t;


### PR DESCRIPTION
Related Issue
-----------
Fix #697: Missing portPOINTER_SIZE_TYPE definition for ATmega port


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
