### PR TITLE
Check bit-2(SEL) of EXC_RETURN in PendSV_Handler() to determine if MC…

### DIFF
--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -237,7 +237,10 @@ void PendSV_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   mrs r0, psp                                     \n"/* Read PSP in r0. */
+        "   tst lr, #4                                      \n"/* Test if Bit[2] in LR is one(i.e., Process stack pointer) */
+        "   ite ne	                                    \n"
+        "   mrsne r0, psp                                   \n"/* Store PSP value in r0 if Bit[2] is one. */
+        "   bxeq lr                                         \n"/* Branch according MSP if Bit[2] is zero. */
         #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
             "   tst lr, #0x10                                   \n"/* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
             "   it eq                                           \n"


### PR DESCRIPTION
Check bit-2(SEL) of EXC_RETURN in PendSV_Handler() to determine if MCU should return to the main stack or process stack, otherwise the hard fault would occur.
<!--- Title -->

Description
-----------
The Hard fault occurs when interrupts are triggered after peripherals' interrupts are ready, but vRestoreContextOfFirstTask() has not been invoked yet.

To avoid this situation, it is necessary to initialize the flag to FALSE. However, if we consider PendSV_Handler() as an independent module, a defect in PendSV_Handler() is present, where it returns to PSP (Process Stack Pointer) without checking the bit-2 (SEL). This can result in a hard fault if any interrupt is raised with incorrect usage of XXX_FromISR().

The detailed is as following:

In certain situations, the interrupt handler needs to utilize IPC (Inter-Process Communication) APIs to communicate with other processes via XXX_FromISR() and perform a context switch to a task with a higher or equal priority compared to the current task, relying on the flag returned by XXX_FromISR(). However, based on the implementation of XXX_FromISR(), the flag will only be set to TRUE within XXX_FromISR(). This means that if the flag is not initialized to FALSE before invoking XXX_FromISR(), an unexpected context switch may occur. Fortunately, in normal cases, the context switch does not have a fatal effect because there is at least one task in the ready list—the idle task (P.S. It is still a problem if the unexpected context switch occurs in the idle task, but it is a rare occurrence).


<!--- Describe your changes in detail. -->
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
N/A.
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
