### PR TITLE
Fix circular dependency in CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ elseif((FREERTOS_PORT STREQUAL "A_CUSTOM_PORT") AND (NOT TARGET freertos_kernel_
     "      .)\n"
     "   target_link_libraries(freertos_kernel_port\n"
     "     PRIVATE\n"
-    "       freertos_kernel)")
+    "       freertos_kernel_include)")
 endif()
 
 ########################################################################
@@ -264,6 +264,7 @@ add_compile_options(
 
 
 ########################################################################
+add_subdirectory(include)
 add_subdirectory(portable)
 
 add_library(freertos_kernel STATIC
@@ -279,17 +280,10 @@ add_library(freertos_kernel STATIC
     $<IF:$<BOOL:$<FILTER:${FREERTOS_HEAP},EXCLUDE,^[1-5]$>>,${FREERTOS_HEAP},portable/MemMang/heap_${FREERTOS_HEAP}.c>
 )
 
-target_include_directories(freertos_kernel
-    PUBLIC
-        include
-        # Note: DEPRECATED but still supported, may be removed in a future release.
-        $<$<NOT:$<TARGET_EXISTS:freertos_config>>:${FREERTOS_CONFIG_FILE_DIRECTORY}>
-)
-
 target_link_libraries(freertos_kernel
     PUBLIC
-        $<$<TARGET_EXISTS:freertos_config>:freertos_config>
         freertos_kernel_port
+        freertos_kernel_include
 )
 
 ########################################################################

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,8 +4,7 @@ add_library(freertos_kernel_include INTERFACE)
 
 target_include_directories(freertos_kernel_include
     INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<INSTALL_INTERFACE:.>
+        .
         # Note: DEPRECATED but still supported, may be removed in a future release.
         $<$<NOT:$<TARGET_EXISTS:freertos_config>>:${FREERTOS_CONFIG_FILE_DIRECTORY}>
 )

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,16 @@
+# FreeRTOS internal cmake file. Do not use it in user top-level project
+
+add_library(freertos_kernel_include INTERFACE)
+
+target_include_directories(freertos_kernel_include
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:.>
+        # Note: DEPRECATED but still supported, may be removed in a future release.
+        $<$<NOT:$<TARGET_EXISTS:freertos_config>>:${FREERTOS_CONFIG_FILE_DIRECTORY}>
+)
+
+target_link_libraries(freertos_kernel_include
+    INTERFACE
+        $<$<TARGET_EXISTS:freertos_config>:freertos_config>
+)

--- a/portable/CMakeLists.txt
+++ b/portable/CMakeLists.txt
@@ -1035,7 +1035,7 @@ target_link_libraries(freertos_kernel_port
         $<$<STREQUAL:${FREERTOS_PORT},GCC_RP2040>:pico_base_headers>
         $<$<STREQUAL:${FREERTOS_PORT},GCC_XTENSA_ESP32>:idf::esp32>
     PRIVATE
-        freertos_kernel
+        freertos_kernel_include
         $<$<STREQUAL:${FREERTOS_PORT},GCC_POSIX>:Threads::Threads>
         "$<$<STREQUAL:${FREERTOS_PORT},GCC_RP2040>:hardware_clocks;hardware_exception>"
         $<$<STREQUAL:${FREERTOS_PORT},MSVC_MINGW>:winmm> # Windows library which implements timers


### PR DESCRIPTION

<!--- Title -->
Fix circular dependency in CMake project

Description
-----------
<!--- Describe your changes in detail. -->
Move includes into an interface library.
The kernel and port link against this interface.
The port no longer links against the kernel, breaking the cycle.

In order for custom ports to also break the cycle, they must link against `freertos_kernel_include` instead of `freertos_kernel`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
This PR introduces no code changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/687

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
