### PR TITLE
Update uxTaskGetSystemState for tasks in pending ready list

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3843,6 +3843,18 @@ static void prvCheckTasksWaitingTermination( void )
                     }
                 }
                 #endif /* INCLUDE_vTaskSuspend */
+
+                /* Tasks can be in pending ready list and other state list at the
+                 * same time. These tasks are in ready state no matter what state
+                 * list the task is in. */
+                taskENTER_CRITICAL();
+                {
+                    if( listIS_CONTAINED_WITHIN( &xPendingReadyList, &( pxTCB->xEventListItem ) ) != pdFALSE )
+                    {
+                        pxTaskStatus->eCurrentState = eReady;
+                    }
+                }
+                taskEXIT_CRITICAL();
             }
         }
         else

--- a/tasks.c
+++ b/tasks.c
@@ -2567,6 +2567,15 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
                 } while( uxQueue > ( UBaseType_t ) tskIDLE_PRIORITY ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
                 /* Fill in an TaskStatus_t structure with information on each
+                 * task in the pending ready list. Tasks in pending ready list are
+                 * in eReady state. */
+                taskENTER_CRITICAL();
+                {
+                    uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &xPendingReadyList, eReady );
+                }
+                taskEXIT_CRITICAL();
+
+                /* Fill in an TaskStatus_t structure with information on each
                  * task in the Blocked state. */
                 uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxDelayedTaskList, eBlocked );
                 uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxOverflowDelayedTaskList, eBlocked );
@@ -3874,7 +3883,6 @@ static void prvCheckTasksWaitingTermination( void )
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TRACE_FACILITY == 1 )
-
     static UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
                                                      List_t * pxList,
                                                      eTaskState eState )
@@ -3894,8 +3902,26 @@ static void prvCheckTasksWaitingTermination( void )
             do
             {
                 listGET_OWNER_OF_NEXT_ENTRY( pxNextTCB, pxList ); /*lint !e9079 void * is used as this macro is used with timers and co-routines too.  Alignment is known to be fine as the type of the pointer stored and retrieved is the same. */
-                vTaskGetInfo( ( TaskHandle_t ) pxNextTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
-                uxTask++;
+
+                /* Tasks in pending ready list are in eReady state regardless of
+                 * what list the task's state list item is currently placed on.
+                 * Thus, these tasks can be enumerated in this function directly. */
+                if( pxList == &xPendingReadyList )
+                {
+                    vTaskGetInfo( ( TaskHandle_t ) pxNextTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
+                    uxTask++;
+                }
+                else
+                {
+                    /* Tasks may be in pending ready list and other state list at
+                     * the same time. These tasks should be enumuerated in xPendingReadyList
+                     * only. */
+                    if( listIS_CONTAINED_WITHIN( &xPendingReadyList, &( pxNextTCB->xEventListItem ) ) == pdFALSE )
+                    {
+                        vTaskGetInfo( ( TaskHandle_t ) pxNextTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
+                        uxTask++;
+                    }
+                }
             } while( pxNextTCB != pxFirstTCB );
         }
         else

--- a/tasks.c
+++ b/tasks.c
@@ -3874,13 +3874,13 @@ static void prvCheckTasksWaitingTermination( void )
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TRACE_FACILITY == 1 )
+
     static UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
                                                      List_t * pxList,
                                                      eTaskState eState )
     {
         configLIST_VOLATILE TCB_t * pxNextTCB;
         configLIST_VOLATILE TCB_t * pxFirstTCB;
-        List_t const * pxEventList;
         UBaseType_t uxTask = 0;
 
         if( listCURRENT_LIST_LENGTH( pxList ) > ( UBaseType_t ) 0 )
@@ -3894,26 +3894,8 @@ static void prvCheckTasksWaitingTermination( void )
             do
             {
                 listGET_OWNER_OF_NEXT_ENTRY( pxNextTCB, pxList ); /*lint !e9079 void * is used as this macro is used with timers and co-routines too.  Alignment is known to be fine as the type of the pointer stored and retrieved is the same. */
-
-                taskENTER_CRITICAL();
-                {
-                    pxEventList = listLIST_ITEM_CONTAINER( &( pxNextTCB->xEventListItem ) );
-                }
-                taskEXIT_CRITICAL();
-
-                /* Tasks can be in pending ready list and other state list at
-                 * the same time. These tasks are in ready state no matter what state list
-                 * the task is in. */
-                if( pxEventList == &xPendingReadyList )
-                {
-                    vTaskGetInfo( ( TaskHandle_t ) pxNextTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eReady );
-                    uxTask++;
-                }
-                else
-                {
-                    vTaskGetInfo( ( TaskHandle_t ) pxNextTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
-                    uxTask++;
-                }
+                vTaskGetInfo( ( TaskHandle_t ) pxNextTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
+                uxTask++;
             } while( pxNextTCB != pxFirstTCB );
         }
         else


### PR DESCRIPTION
Description
-----------
* Sync with eTaskGetState. Task in pending ready list is in eReady state.
* Update in vTaskGetInfo function to return eReady state for task in a pending ready list.

Test Steps
-----------
Create a task with the following function.
```
vTaskSuspendAll();
{
    /* Waiting for ISR to resume a task. */

    vTaskList( pcPrintBuffer );
    printf( pcPrintBuffer );
}
xTaskResumeAll();
```

Before this patch
```
testTask        X       6       67      2
TzCtrl          R       1       1021    1
IDLE            R       0       67      4
testTask2       B       5       67      3        # task is in eBlocked state
Tmr Svc         B       6       137     5
```

After this patch
```
testTask        X       6       67      2
IDLE            R       0       67      4
TzCtrl          B       1       1021    1
testTask2       R       5       67      3        # task is in eReady state
Tmr Svc         B       6       137     5
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
