### PR TITLE
Update mpu_wrappers_v2.c

### DIFF
--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -2215,7 +2215,7 @@
 
         const char * MPU_pcQueueGetNameImpl( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTION */
         {
-            const char * pcReturn;
+            const char * pcReturn = NULL;
             QueueHandle_t xInternalQueueHandle = NULL;
             int32_t lIndex;
 
@@ -3330,7 +3330,7 @@
                                          const EventBits_t uxBitsToWaitFor,
                                          TickType_t xTicksToWait ) /* PRIVILEGED_FUNCTION */
     {
-        EventBits_t xReturn;
+        EventBits_t xReturn = 0;
         EventGroupHandle_t xInternalEventGroupHandle = NULL;
         int32_t lIndex;
 

--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -2133,7 +2133,7 @@
         {
             BaseType_t xReturn = pdFAIL;
             QueueSetMemberHandle_t xInternalQueueSetMemberHandle = NULL;
-            QueueSetHandle_t xInternalQueueSetHandle;
+            QueueSetHandle_t xInternalQueueSetHandle = NULL;
             int32_t lIndexQueueSet, lIndexQueueSetMember;
 
             lIndexQueueSet = ( int32_t ) xQueueSet;
@@ -2519,7 +2519,7 @@
         {
             BaseType_t xReturn = pdFAIL;
             QueueSetMemberHandle_t xInternalQueueSetMemberHandle = NULL;
-            QueueSetHandle_t xInternalQueueSetHandle;
+            QueueSetHandle_t xInternalQueueSetHandle = NULL;
             int32_t lIndexQueueSet, lIndexQueueSetMember;
 
             lIndexQueueSet = ( int32_t ) xQueueSet;


### PR DESCRIPTION
Description
-----------
This PR updates mpu_wrappers_v2.c to add value to uninitialized variables .

Test Steps
-----------
Run [CORTEX_MPU_M3_MPS2_QEMU_GCC](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
