### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,12 @@ target_compile_options(freertos_kernel PRIVATE
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
 
-    # TODO: Add in other Compilers here.
+    # Suppressions required to build clean with clang.
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-macros>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-padded>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-missing-variable-declarations>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-covered-switch-default>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-cast-align>
 )
 
 

--- a/croutine.c
+++ b/croutine.c
@@ -43,12 +43,12 @@
 
 
 /* Lists for ready and blocked co-routines. --------------------*/
-    static List_t pxReadyCoRoutineLists[ configMAX_CO_ROUTINE_PRIORITIES ]; /*< Prioritised ready co-routines. */
-    static List_t xDelayedCoRoutineList1;                                   /*< Delayed co-routines. */
-    static List_t xDelayedCoRoutineList2;                                   /*< Delayed co-routines (two lists are used - one for delays that have overflowed the current tick count. */
-    static List_t * pxDelayedCoRoutineList = NULL;                          /*< Points to the delayed co-routine list currently being used. */
-    static List_t * pxOverflowDelayedCoRoutineList = NULL;                  /*< Points to the delayed co-routine list currently being used to hold co-routines that have overflowed the current tick count. */
-    static List_t xPendingReadyCoRoutineList;                               /*< Holds co-routines that have been readied by an external event.  They cannot be added directly to the ready lists as the ready lists cannot be accessed by interrupts. */
+    static List_t pxReadyCoRoutineLists[ configMAX_CO_ROUTINE_PRIORITIES ]; /**< Prioritised ready co-routines. */
+    static List_t xDelayedCoRoutineList1;                                   /**< Delayed co-routines. */
+    static List_t xDelayedCoRoutineList2;                                   /**< Delayed co-routines (two lists are used - one for delays that have overflowed the current tick count. */
+    static List_t * pxDelayedCoRoutineList = NULL;                          /**< Points to the delayed co-routine list currently being used. */
+    static List_t * pxOverflowDelayedCoRoutineList = NULL;                  /**< Points to the delayed co-routine list currently being used to hold co-routines that have overflowed the current tick count. */
+    static List_t xPendingReadyCoRoutineList;                               /**< Holds co-routines that have been readied by an external event.  They cannot be added directly to the ready lists as the ready lists cannot be accessed by interrupts. */
 
 /* Other file private variables. --------------------------------*/
     CRCB_t * pxCurrentCoRoutine = NULL;

--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.h
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.h
@@ -26,8 +26,8 @@
  *
  */
 
-#ifndef _WAIT_FOR_EVENT_H_
-#define _WAIT_FOR_EVENT_H_
+#ifndef WAIT_FOR_EVENT_H_
+#define WAIT_FOR_EVENT_H_
 
 #include <stdbool.h>
 #include <time.h>
@@ -43,4 +43,4 @@ void event_signal( struct event * ev );
 
 
 
-#endif /* ifndef _WAIT_FOR_EVENT_H_ */
+#endif /* ifndef WAIT_FOR_EVENT_H_ */


### PR DESCRIPTION
Description
-----------
Fix clang compiler warnings

Test Steps
-----------
Built the `FreeRTOS/Demo/Posix_GCC` demo in the FreeRTOS/FreeRTOS repo with clang-14.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/701


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
