### PR TITLE
Fix warning issue for warning in arithmetic conversion for UBaseType_t

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -308,7 +308,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     if( ( pxQueue != NULL ) &&
         ( pxQueue->uxLength >= 1U ) &&
         /* Check for multiplication overflow. */
-        ( ( UBaseType_t ) ( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
+        ( ( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
     {
         taskENTER_CRITICAL();
         {

--- a/queue.c
+++ b/queue.c
@@ -308,7 +308,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     if( ( pxQueue != NULL ) &&
         ( pxQueue->uxLength >= 1U ) &&
         /* Check for multiplication overflow. */
-        ( ( UBaseType_t )( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
+        ( ( UBaseType_t ) ( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
     {
         taskENTER_CRITICAL();
         {

--- a/queue.c
+++ b/queue.c
@@ -1329,7 +1329,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
              * can be assumed there is no mutex holder and no need to determine if
              * priority disinheritance is needed.  Simply increase the count of
              * messages (semaphores) available. */
-            pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting + 1 );
+            pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting + ( UBaseType_t ) 1 );
 
             /* The event list is not altered if the queue is locked.  This will
              * be done when the queue is unlocked later. */
@@ -1474,7 +1474,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 /* Data available, remove one item. */
                 prvCopyDataFromQueue( pxQueue, pvBuffer );
                 traceQUEUE_RECEIVE( pxQueue );
-                pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting - 1 );
+                pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting - ( UBaseType_t ) 1 );
 
                 /* There is now space in the queue, were any tasks waiting to
                  * post to the queue?  If so, unblock the highest priority waiting
@@ -1631,7 +1631,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
 
                 /* Semaphores are queues with a data size of zero and where the
                  * messages waiting is the semaphore's count.  Reduce the count. */
-                pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxSemaphoreCount - 1 );
+                pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxSemaphoreCount - ( UBaseType_t ) 1 );
 
                 #if ( configUSE_MUTEXES == 1 )
                 {
@@ -2003,7 +2003,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
             traceQUEUE_RECEIVE_FROM_ISR( pxQueue );
 
             prvCopyDataFromQueue( pxQueue, pvBuffer );
-            pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting - 1 );
+            pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting - ( UBaseType_t ) 1 );
 
             /* If the queue is locked the event list will not be modified.
              * Instead update the lock count so the task that unlocks the queue
@@ -2250,7 +2250,7 @@ UBaseType_t uxQueueGetQueueItemSize( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTI
          * mutex. */
         if( listCURRENT_LIST_LENGTH( &( pxQueue->xTasksWaitingToReceive ) ) > 0U )
         {
-            uxHighestPriorityOfWaitingTasks = ( UBaseType_t ) ( configMAX_PRIORITIES - listGET_ITEM_VALUE_OF_HEAD_ENTRY( &( pxQueue->xTasksWaitingToReceive ) ) );
+            uxHighestPriorityOfWaitingTasks = ( UBaseType_t ) ( ( UBaseType_t ) configMAX_PRIORITIES - ( UBaseType_t ) listGET_ITEM_VALUE_OF_HEAD_ENTRY( &( pxQueue->xTasksWaitingToReceive ) ) );
         }
         else
         {
@@ -2340,7 +2340,7 @@ static BaseType_t prvCopyDataToQueue( Queue_t * const pxQueue,
         }
     }
 
-    pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting + 1 );
+    pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting + ( UBaseType_t ) 1 );
 
     return xReturn;
 }

--- a/queue.c
+++ b/queue.c
@@ -308,7 +308,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     if( ( pxQueue != NULL ) &&
         ( pxQueue->uxLength >= 1U ) &&
         /* Check for multiplication overflow. */
-        ( ( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
+        ( ( UBaseType_t )( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
     {
         taskENTER_CRITICAL();
         {

--- a/queue.c
+++ b/queue.c
@@ -490,7 +490,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
             /* Check for multiplication overflow. */
             ( ( SIZE_MAX / uxQueueLength ) >= uxItemSize ) &&
             /* Check for addition overflow. */
-            ( ( SIZE_MAX - sizeof( Queue_t ) ) >= ( uxQueueLength * uxItemSize ) ) )
+            ( ( UBaseType_t ) ( SIZE_MAX - sizeof( Queue_t ) ) >= ( uxQueueLength * uxItemSize ) ) )
         {
             /* Allocate enough space to hold the maximum number of items that
              * can be in the queue at any time.  It is valid for uxItemSize to be
@@ -1329,7 +1329,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
              * can be assumed there is no mutex holder and no need to determine if
              * priority disinheritance is needed.  Simply increase the count of
              * messages (semaphores) available. */
-            pxQueue->uxMessagesWaiting = uxMessagesWaiting + ( UBaseType_t ) 1;
+            pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting + 1 );
 
             /* The event list is not altered if the queue is locked.  This will
              * be done when the queue is unlocked later. */
@@ -1474,7 +1474,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 /* Data available, remove one item. */
                 prvCopyDataFromQueue( pxQueue, pvBuffer );
                 traceQUEUE_RECEIVE( pxQueue );
-                pxQueue->uxMessagesWaiting = uxMessagesWaiting - ( UBaseType_t ) 1;
+                pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting - 1 );
 
                 /* There is now space in the queue, were any tasks waiting to
                  * post to the queue?  If so, unblock the highest priority waiting
@@ -1631,7 +1631,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
 
                 /* Semaphores are queues with a data size of zero and where the
                  * messages waiting is the semaphore's count.  Reduce the count. */
-                pxQueue->uxMessagesWaiting = uxSemaphoreCount - ( UBaseType_t ) 1;
+                pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxSemaphoreCount - 1 );
 
                 #if ( configUSE_MUTEXES == 1 )
                 {
@@ -2003,7 +2003,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
             traceQUEUE_RECEIVE_FROM_ISR( pxQueue );
 
             prvCopyDataFromQueue( pxQueue, pvBuffer );
-            pxQueue->uxMessagesWaiting = uxMessagesWaiting - ( UBaseType_t ) 1;
+            pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting - 1 );
 
             /* If the queue is locked the event list will not be modified.
              * Instead update the lock count so the task that unlocks the queue
@@ -2137,7 +2137,7 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
 
     taskENTER_CRITICAL();
     {
-        uxReturn = pxQueue->uxLength - pxQueue->uxMessagesWaiting;
+        uxReturn = ( UBaseType_t ) ( pxQueue->uxLength - pxQueue->uxMessagesWaiting );
     }
     taskEXIT_CRITICAL();
 
@@ -2250,7 +2250,7 @@ UBaseType_t uxQueueGetQueueItemSize( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTI
          * mutex. */
         if( listCURRENT_LIST_LENGTH( &( pxQueue->xTasksWaitingToReceive ) ) > 0U )
         {
-            uxHighestPriorityOfWaitingTasks = ( UBaseType_t ) configMAX_PRIORITIES - ( UBaseType_t ) listGET_ITEM_VALUE_OF_HEAD_ENTRY( &( pxQueue->xTasksWaitingToReceive ) );
+            uxHighestPriorityOfWaitingTasks = ( UBaseType_t ) ( configMAX_PRIORITIES - listGET_ITEM_VALUE_OF_HEAD_ENTRY( &( pxQueue->xTasksWaitingToReceive ) ) );
         }
         else
         {
@@ -2340,7 +2340,7 @@ static BaseType_t prvCopyDataToQueue( Queue_t * const pxQueue,
         }
     }
 
-    pxQueue->uxMessagesWaiting = uxMessagesWaiting + ( UBaseType_t ) 1;
+    pxQueue->uxMessagesWaiting = ( UBaseType_t ) ( uxMessagesWaiting + 1 );
 
     return xReturn;
 }

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -1448,7 +1448,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
     uint8_t ucStreamBufferGetStreamBufferType( StreamBufferHandle_t xStreamBuffer )
     {
-        return( xStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER );
+        return( ( uint8_t ) ( xStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) );
     }
 
 #endif /* configUSE_TRACE_FACILITY */

--- a/tasks.c
+++ b/tasks.c
@@ -3969,19 +3969,19 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
                 do
                 {
                     uxQueue--;
-                    uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &( pxReadyTasksLists[ uxQueue ] ), eReady );
+                    uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &( pxReadyTasksLists[ uxQueue ] ), eReady ) );
                 } while( uxQueue > ( UBaseType_t ) tskIDLE_PRIORITY ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
                 /* Fill in an TaskStatus_t structure with information on each
                  * task in the Blocked state. */
-                uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxDelayedTaskList, eBlocked );
-                uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxOverflowDelayedTaskList, eBlocked );
+                uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxDelayedTaskList, eBlocked ) );
+                uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxOverflowDelayedTaskList, eBlocked ) );
 
                 #if ( INCLUDE_vTaskDelete == 1 )
                 {
                     /* Fill in an TaskStatus_t structure with information on
                      * each task that has been deleted but not yet cleaned up. */
-                    uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &xTasksWaitingTermination, eDeleted );
+                    uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &xTasksWaitingTermination, eDeleted ) );
                 }
                 #endif
 
@@ -3989,7 +3989,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
                 {
                     /* Fill in an TaskStatus_t structure with information on
                      * each task in the Suspended state. */
-                    uxTask += prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &xSuspendedTaskList, eSuspended );
+                    uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &xSuspendedTaskList, eSuspended ) );
                 }
                 #endif
 


### PR DESCRIPTION
Description
-----------
This PR gives the fix for the bug reported in PR#[718](https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/718)

Test Steps
-----------
Added the warning flag ```-Wconversion``` and run the [demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/AVR_ATMega323_WinAVR)
Before change 
```
../../Source/queue.c: In function 'xQueueGenericCreate':
../../Source/queue.c:489: warning: comparison between signed and unsigned
../../Source/queue.c: In function 'xQueueGiveFromISR':
../../Source/queue.c:1320: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/queue.c: In function 'xQueueReceive':
../../Source/queue.c:1465: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/queue.c: In function 'xQueueSemaphoreTake':
../../Source/queue.c:1614: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/queue.c: In function 'xQueueReceiveFromISR':
../../Source/queue.c:1970: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/queue.c: In function 'uxQueueSpacesAvailable':
../../Source/queue.c:2104: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/queue.c: In function 'prvGetDisinheritPriorityAfterTimeout':
../../Source/queue.c:2211: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/queue.c: In function 'prvCopyDataToQueue':
../../Source/queue.c:2301: warning: conversion to 'UBaseType_t' from 'int' may alter its value

../../Source/tasks.c: In function 'uxTaskGetSystemState':
../../Source/tasks.c:2566: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/tasks.c:2571: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/tasks.c:2572: warning: conversion to 'UBaseType_t' from 'int' may alter its value
../../Source/tasks.c:2578: warning: conversion to 'UBaseType_t' from 'int' may alter its value
```

After change, compiles without warning

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#718 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
