### PR TITLE
Fix compilation warnings with Clang

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -472,6 +472,14 @@
 
 #endif
 
+#ifndef configUSE_CORE_AFFINITY
+    #define configUSE_CORE_AFFINITY 0
+#endif /* configUSE_CORE_AFFINITY */
+
+#ifndef configUSE_MINIMAL_IDLE_HOOK
+    #define configUSE_MINIMAL_IDLE_HOOK 0
+#endif /* configUSE_MINIMAL_IDLE_HOOK */
+
 /* The timers module relies on xTaskGetSchedulerState(). */
 #if configUSE_TIMERS == 1
 

--- a/include/task.h
+++ b/include/task.h
@@ -715,7 +715,7 @@ typedef enum
  * a call to xTaskCreateRestricted().  These regions can be redefined using
  * vTaskAllocateMPURegions().
  *
- * @param xTask The handle of the task being updated.
+ * @param xTaskToModify The handle of the task being updated.
  *
  * @param[in] pxRegions A pointer to a MemoryRegion_t structure that contains the
  * new memory region definitions.

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -120,8 +120,8 @@
  * of their memory address. */
 typedef struct A_BLOCK_LINK
 {
-    struct A_BLOCK_LINK * pxNextFreeBlock; /*<< The next free block in the list. */
-    size_t xBlockSize;                     /*<< The size of the free block. */
+    struct A_BLOCK_LINK * pxNextFreeBlock; /**< The next free block in the list. */
+    size_t xBlockSize;                     /**< The size of the free block. */
 } BlockLink_t;
 
 /*-----------------------------------------------------------*/

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -584,12 +584,12 @@ static void prvSetupSignalsAndSchedulerPolicy( void )
 }
 /*-----------------------------------------------------------*/
 
-unsigned long ulPortGetRunTime( void )
+uint32_t ulPortGetRunTime( void )
 {
     struct tms xTimes;
 
     times( &xTimes );
 
-    return ( unsigned long ) xTimes.tms_utime;
+    return ( uint32_t ) xTimes.tms_utime;
 }
 /*-----------------------------------------------------------*/

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -37,6 +37,7 @@
 /* *INDENT-ON* */
 
 #include <limits.h>
+#include <stdint.h>
 
 /*-----------------------------------------------------------
  * Port specific definitions.
@@ -126,7 +127,7 @@ extern void vPortCancelThread( void *pxTaskToDelete );
  */
 #define portMEMORY_BARRIER() __asm volatile( "" ::: "memory" )
 
-extern unsigned long ulPortGetRunTime( void );
+extern uint32_t ulPortGetRunTime( void );
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() /* no-op */
 #define portGET_RUN_TIME_COUNTER_VALUE()         ulPortGetRunTime()
 


### PR DESCRIPTION
Description
-----------
Fix compilation warnings with Clang.

Test Steps
-----------
Build the Posix GCC demo locally with both GCC and Clang.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
