### PR TITLE
Align some Linux and RL78 port types with other ports

### DIFF
--- a/portable/GCC/RL78/port.c
+++ b/portable/GCC/RL78/port.c
@@ -136,7 +136,7 @@ uint32_t *pulLocal;
 }
 /*-----------------------------------------------------------*/
 
-portBASE_TYPE xPortStartScheduler( void )
+BaseType_t xPortStartScheduler( void )
 {
     /* Setup the hardware to generate the tick.  Interrupts are disabled when
     this function is called. */

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -100,10 +100,10 @@ static pthread_once_t hSigSetupThread = PTHREAD_ONCE_INIT;
 static sigset_t xAllSignals;
 static sigset_t xSchedulerOriginalSignalMask;
 static pthread_t hMainThread = ( pthread_t ) NULL;
-static volatile portBASE_TYPE uxCriticalNesting;
+static volatile BaseType_t uxCriticalNesting;
 /*-----------------------------------------------------------*/
 
-static portBASE_TYPE xSchedulerEnd = pdFALSE;
+static BaseType_t xSchedulerEnd = pdFALSE;
 /*-----------------------------------------------------------*/
 
 static void prvSetupSignalsAndSchedulerPolicy( void );
@@ -131,10 +131,10 @@ void prvFatalError( const char * pcCall,
 /*
  * See header file for description.
  */
-portSTACK_TYPE * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                        StackType_t * pxEndOfStack,
-                                        TaskFunction_t pxCode,
-                                        void * pvParameters )
+StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                     StackType_t * pxEndOfStack,
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters )
 {
     Thread_t * thread;
     pthread_attr_t xThreadAttributes;
@@ -147,7 +147,7 @@ portSTACK_TYPE * pxPortInitialiseStack( StackType_t * pxTopOfStack,
      * Store the additional thread data at the start of the stack.
      */
     thread = ( Thread_t * ) ( pxTopOfStack + 1 ) - 1;
-    pxTopOfStack = ( portSTACK_TYPE * ) thread - 1;
+    pxTopOfStack = ( StackType_t * ) thread - 1;
     ulStackSize = ( size_t )( pxTopOfStack + 1 - pxEndOfStack ) * sizeof( *pxTopOfStack );
 
     #ifdef __APPLE__
@@ -197,7 +197,7 @@ void vPortStartFirstTask( void )
 /*
  * See header file for description.
  */
-portBASE_TYPE xPortStartScheduler( void )
+BaseType_t xPortStartScheduler( void )
 {
     int iSignal;
     sigset_t xSignals;


### PR DESCRIPTION
Align some Linux and RL78 port types with other ports

Description
-----------

POSIX and RL78 port layers still use portSTACK_TYPE and portBASE_TYPE while it was changed to StackType_t and BaseType_t everywhere else.


Test Steps
-----------
no steps

Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
no issue id

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
