### PR TITLE
Enable MSVC Port to leave the prvProcessSimulatedInterrupts loop when scheduler is stopped

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -389,11 +389,17 @@ CONTEXT xContext;
     SetEvent( pvInterruptEvent );
 
     xPortRunning = pdTRUE;
-
-    for(;;)
+    const uint32_t timeoutMs = 1000;
+    while(pdTRUE == xPortRunning)
     {
         xInsideInterrupt = pdFALSE;
-        WaitForMultipleObjects( sizeof( pvObjectList ) / sizeof( void * ), pvObjectList, TRUE, INFINITE );
+
+        //wait with timeout to allow returning from this loop when scheduler is stopped
+        if(WAIT_TIMEOUT == WaitForMultipleObjects( sizeof( pvObjectList ) / sizeof( void * ), pvObjectList, TRUE, timeoutMs )
+        {
+            //no event received
+            continue;
+        }
 
         /* Cannot be in a critical section to get here.  Tasks that exit a
         critical section will block on a yield mutex to wait for an interrupt to

--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -340,6 +340,9 @@ SYSTEM_INFO xSystemInfo;
         /* Start the first task. */
         ResumeThread( pxThreadState->pvThread );
 
+        /* The scheduler is now running. */
+        xPortRunning = pdTRUE;
+
         /* Handle all simulated interrupts - including yield requests and
         simulated ticks. */
         prvProcessSimulatedInterrupts();
@@ -376,6 +379,8 @@ uint32_t ulSwitchRequired, i;
 ThreadState_t *pxThreadState;
 void *pvObjectList[ 2 ];
 CONTEXT xContext;
+DWORD xWinApiResult;
+const DWORD xTimeoutMilliseconds = 1000;
 
     /* Going to block on the mutex that ensured exclusive access to the simulated
     interrupt objects, and the event that signals that a simulated interrupt
@@ -388,111 +393,109 @@ CONTEXT xContext;
     ulPendingInterrupts |= ( 1 << portINTERRUPT_TICK );
     SetEvent( pvInterruptEvent );
 
-    xPortRunning = pdTRUE;
-    const uint32_t timeoutMs = 1000;
-    while(pdTRUE == xPortRunning)
+    while( xPortRunning == pdTRUE )
     {
         xInsideInterrupt = pdFALSE;
 
-        //wait with timeout to allow returning from this loop when scheduler is stopped
-        if(WAIT_TIMEOUT == WaitForMultipleObjects( sizeof( pvObjectList ) / sizeof( void * ), pvObjectList, TRUE, timeoutMs ))
+        /* Wait with timeout so that we can exit from this loop when
+         * the scheduler is stopped by calling vPortEndScheduler. */
+        xWinApiResult = WaitForMultipleObjects( sizeof( pvObjectList ) / sizeof( void * ), pvObjectList, TRUE, xTimeoutMilliseconds );
+
+        if( xWinApiResult != WAIT_TIMEOUT )
         {
-            //no event received
-            continue;
-        }
+            /* Cannot be in a critical section to get here.  Tasks that exit a
+            critical section will block on a yield mutex to wait for an interrupt to
+            process if an interrupt was set pending while the task was inside the
+            critical section.  xInsideInterrupt prevents interrupts that contain
+            critical sections from doing the same. */
+            xInsideInterrupt = pdTRUE;
 
-        /* Cannot be in a critical section to get here.  Tasks that exit a
-        critical section will block on a yield mutex to wait for an interrupt to
-        process if an interrupt was set pending while the task was inside the
-        critical section.  xInsideInterrupt prevents interrupts that contain
-        critical sections from doing the same. */
-        xInsideInterrupt = pdTRUE;
+            /* Used to indicate whether the simulated interrupt processing has
+            necessitated a context switch to another task/thread. */
+            ulSwitchRequired = pdFALSE;
 
-        /* Used to indicate whether the simulated interrupt processing has
-        necessitated a context switch to another task/thread. */
-        ulSwitchRequired = pdFALSE;
-
-        /* For each interrupt we are interested in processing, each of which is
-        represented by a bit in the 32bit ulPendingInterrupts variable. */
-        for( i = 0; i < portMAX_INTERRUPTS; i++ )
-        {
-            /* Is the simulated interrupt pending? */
-            if( ( ulPendingInterrupts & ( 1UL << i ) ) != 0 )
+            /* For each interrupt we are interested in processing, each of which is
+            represented by a bit in the 32bit ulPendingInterrupts variable. */
+            for( i = 0; i < portMAX_INTERRUPTS; i++ )
             {
-                /* Is a handler installed? */
-                if( ulIsrHandler[ i ] != NULL )
+                /* Is the simulated interrupt pending? */
+                if( ( ulPendingInterrupts & ( 1UL << i ) ) != 0 )
                 {
-                    /* Run the actual handler.  Handlers return pdTRUE if they
-                    necessitate a context switch. */
-                    if( ulIsrHandler[ i ]() != pdFALSE )
+                    /* Is a handler installed? */
+                    if( ulIsrHandler[ i ] != NULL )
                     {
-                        /* A bit mask is used purely to help debugging. */
-                        ulSwitchRequired |= ( 1 << i );
+                        /* Run the actual handler.  Handlers return pdTRUE if they
+                        necessitate a context switch. */
+                        if( ulIsrHandler[ i ]() != pdFALSE )
+                        {
+                            /* A bit mask is used purely to help debugging. */
+                            ulSwitchRequired |= ( 1 << i );
+                        }
                     }
+
+                    /* Clear the interrupt pending bit. */
+                    ulPendingInterrupts &= ~( 1UL << i );
                 }
-
-                /* Clear the interrupt pending bit. */
-                ulPendingInterrupts &= ~( 1UL << i );
             }
-        }
 
-        if( ulSwitchRequired != pdFALSE )
-        {
-            void *pvOldCurrentTCB;
-
-            pvOldCurrentTCB = pxCurrentTCB;
-
-            /* Select the next task to run. */
-            vTaskSwitchContext();
-
-            /* If the task selected to enter the running state is not the task
-            that is already in the running state. */
-            if( pvOldCurrentTCB != pxCurrentTCB )
+            if( ulSwitchRequired != pdFALSE )
             {
-                /* Suspend the old thread.  In the cases where the (simulated)
-                interrupt is asynchronous (tick event swapping a task out rather
-                than a task blocking or yielding) it doesn't matter if the
-                'suspend' operation doesn't take effect immediately - if it
-                doesn't it would just be like the interrupt occurring slightly
-                later.  In cases where the yield was caused by a task blocking
-                or yielding then the task will block on a yield event after the
-                yield operation in case the 'suspend' operation doesn't take
-                effect immediately.  */
-                pxThreadState = ( ThreadState_t *) *( ( size_t * ) pvOldCurrentTCB );
-                SuspendThread( pxThreadState->pvThread );
+                void *pvOldCurrentTCB;
 
-                /* Ensure the thread is actually suspended by performing a
-                synchronous operation that can only complete when the thread is
-                actually suspended.  The below code asks for dummy register
-                data.  Experimentation shows that these two lines don't appear
-                to do anything now, but according to
-                https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743
-                they do - so as they do not harm (slight run-time hit). */
-                xContext.ContextFlags = CONTEXT_INTEGER;
-                ( void ) GetThreadContext( pxThreadState->pvThread, &xContext );
+                pvOldCurrentTCB = pxCurrentTCB;
 
-                /* Obtain the state of the task now selected to enter the
-                Running state. */
-                pxThreadState = ( ThreadState_t * ) ( *( size_t *) pxCurrentTCB );
+                /* Select the next task to run. */
+                vTaskSwitchContext();
 
-                /* pxThreadState->pvThread can be NULL if the task deleted
-                itself - but a deleted task should never be resumed here. */
-                configASSERT( pxThreadState->pvThread != NULL );
-                ResumeThread( pxThreadState->pvThread );
+                /* If the task selected to enter the running state is not the task
+                that is already in the running state. */
+                if( pvOldCurrentTCB != pxCurrentTCB )
+                {
+                    /* Suspend the old thread.  In the cases where the (simulated)
+                    interrupt is asynchronous (tick event swapping a task out rather
+                    than a task blocking or yielding) it doesn't matter if the
+                    'suspend' operation doesn't take effect immediately - if it
+                    doesn't it would just be like the interrupt occurring slightly
+                    later.  In cases where the yield was caused by a task blocking
+                    or yielding then the task will block on a yield event after the
+                    yield operation in case the 'suspend' operation doesn't take
+                    effect immediately.  */
+                    pxThreadState = ( ThreadState_t *) *( ( size_t * ) pvOldCurrentTCB );
+                    SuspendThread( pxThreadState->pvThread );
+
+                    /* Ensure the thread is actually suspended by performing a
+                    synchronous operation that can only complete when the thread is
+                    actually suspended.  The below code asks for dummy register
+                    data.  Experimentation shows that these two lines don't appear
+                    to do anything now, but according to
+                    https://devblogs.microsoft.com/oldnewthing/20150205-00/?p=44743
+                    they do - so as they do not harm (slight run-time hit). */
+                    xContext.ContextFlags = CONTEXT_INTEGER;
+                    ( void ) GetThreadContext( pxThreadState->pvThread, &xContext );
+
+                    /* Obtain the state of the task now selected to enter the
+                    Running state. */
+                    pxThreadState = ( ThreadState_t * ) ( *( size_t *) pxCurrentTCB );
+
+                    /* pxThreadState->pvThread can be NULL if the task deleted
+                    itself - but a deleted task should never be resumed here. */
+                    configASSERT( pxThreadState->pvThread != NULL );
+                    ResumeThread( pxThreadState->pvThread );
+                }
             }
-        }
 
-        /* If the thread that is about to be resumed stopped running
-        because it yielded then it will wait on an event when it resumed
-        (to ensure it does not continue running after the call to
-        SuspendThread() above as SuspendThread() is asynchronous).
-        Signal the event to ensure the thread can proceed now it is
-        valid for it to do so.  Signaling the event is benign in the case that
-        the task was switched out asynchronously by an interrupt as the event
-        is reset before the task blocks on it. */
-        pxThreadState = ( ThreadState_t * ) ( *( size_t *) pxCurrentTCB );
-        SetEvent( pxThreadState->pvYieldEvent );
-        ReleaseMutex( pvInterruptEventMutex );
+            /* If the thread that is about to be resumed stopped running
+            because it yielded then it will wait on an event when it resumed
+            (to ensure it does not continue running after the call to
+            SuspendThread() above as SuspendThread() is asynchronous).
+            Signal the event to ensure the thread can proceed now it is
+            valid for it to do so.  Signaling the event is benign in the case that
+            the task was switched out asynchronously by an interrupt as the event
+            is reset before the task blocks on it. */
+            pxThreadState = ( ThreadState_t * ) ( *( size_t *) pxCurrentTCB );
+            SetEvent( pxThreadState->pvYieldEvent );
+            ReleaseMutex( pvInterruptEventMutex );
+        }
     }
 }
 /*-----------------------------------------------------------*/

--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -395,7 +395,7 @@ CONTEXT xContext;
         xInsideInterrupt = pdFALSE;
 
         //wait with timeout to allow returning from this loop when scheduler is stopped
-        if(WAIT_TIMEOUT == WaitForMultipleObjects( sizeof( pvObjectList ) / sizeof( void * ), pvObjectList, TRUE, timeoutMs )
+        if(WAIT_TIMEOUT == WaitForMultipleObjects( sizeof( pvObjectList ) / sizeof( void * ), pvObjectList, TRUE, timeoutMs ))
         {
             //no event received
             continue;


### PR DESCRIPTION
Enable MSVC Port to leave the prvProcessSimulatedInterrupts loop when scheduler is stopped

Description
-----------
At the moment, the prvProcessSimulatedInterrupts is stuck in an endless loop even when the scheduler is stopped. This change pulls the xPortRunning Flag (which is set to false by vPortEndScheduler() within the loop. If set to false the loop is exited.
However this is needed when FreeRTOS based modules are tested using GoogleTest (otherwise the test won't stop)


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
