### PR TITLE
Fix Pico compile warning

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -194,7 +194,7 @@
     static inline void vPortRecursiveLock(uint32_t ulLockNum, spin_lock_t *pxSpinLock, BaseType_t uxAcquire) {
         static uint8_t ucOwnedByCore[ portMAX_CORE_COUNT ];
         static uint8_t ucRecursionCountByLock[ portRTOS_SPINLOCK_COUNT ];
-        configASSERT(ulLockNum >= 0 && ulLockNum < portRTOS_SPINLOCK_COUNT );
+        configASSERT( ulLockNum < portRTOS_SPINLOCK_COUNT );
         uint32_t ulCoreNum = get_core_num();
         uint32_t ulLockBit = 1u << ulLockNum;
         configASSERT(ulLockBit < 256u );

--- a/tasks.c
+++ b/tasks.c
@@ -760,7 +760,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     static void prvYieldCore( BaseType_t xCoreID )
     {
         /* This must be called from a critical section and xCoreID must be valid. */
-        if( ( portCHECK_IF_IN_ISR() == pdTRUE ) && ( xCoreID == portGET_CORE_ID() ) )
+        if( ( portCHECK_IF_IN_ISR() == pdTRUE ) && ( xCoreID == ( BaseType_t ) portGET_CORE_ID() ) )
         {
             xYieldPendings[ xCoreID ] = pdTRUE;
         }
@@ -768,7 +768,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         {
             if( pxCurrentTCBs[ xCoreID ]->xTaskRunState != taskTASK_YIELDING )
             {
-                if( xCoreID == portGET_CORE_ID() )
+                if( xCoreID == ( BaseType_t ) portGET_CORE_ID() )
                 {
                     xYieldPendings[ xCoreID ] = pdTRUE;
                 }
@@ -2002,7 +2002,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             /* Force a reschedule if the task that has just been deleted was running. */
             if( ( xSchedulerRunning != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) )
             {
-                if( pxTCB->xTaskRunState == portGET_CORE_ID() )
+                if( pxTCB->xTaskRunState == ( TaskRunning_t ) portGET_CORE_ID() )
                 {
                     configASSERT( uxSchedulerSuspended == 0 );
                     vTaskYieldWithinAPI();
@@ -2829,7 +2829,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             {
                 if( xSchedulerRunning != pdFALSE )
                 {
-                    if( xTaskRunningOnCore == portGET_CORE_ID() )
+                    if( xTaskRunningOnCore == ( TaskRunning_t ) portGET_CORE_ID() )
                     {
                         /* The current task has just been suspended. */
                         configASSERT( uxSchedulerSuspended == 0 );
@@ -3511,7 +3511,7 @@ BaseType_t xTaskResumeAll( void )
         taskENTER_CRITICAL();
         {
             BaseType_t xCoreID;
-            xCoreID = portGET_CORE_ID();
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
             /* If uxSchedulerSuspended is zero then this function does not match a
              * previous call to vTaskSuspendAll(). */
@@ -4398,7 +4398,7 @@ BaseType_t xTaskIncrementTick( void )
             #else /* #if ( configNUMBER_OF_CORES == 1 ) */
             {
                 BaseType_t xCoreID, xCurrentCoreID;
-                xCurrentCoreID = portGET_CORE_ID();
+                xCurrentCoreID = ( BaseType_t ) portGET_CORE_ID();
 
                 for( xCoreID = 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
                 {


### PR DESCRIPTION
<!--- Title -->
Fix Pico compile warning

Description
-----------
<!--- Describe your changes in detail. -->
As #731 reported, there is a compile warning message in Ubuntu/GCC environment.
This change fixes the warning message by removing redundant condition.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
- Compile Pico project

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
