### PR TITLE
Update MPU wrapper for xTimerGenericCommand API

### DIFF
--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -223,11 +223,16 @@ void MPU_vTimerSetTimerID( TimerHandle_t xTimer,
                            void * pvNewID ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTimerIsTimerActive( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) FREERTOS_SYSTEM_CALL;
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
 const char * MPU_pcTimerGetName( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
                               const UBaseType_t uxAutoReload ) FREERTOS_SYSTEM_CALL;

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -156,7 +156,8 @@
         #define vTimerSetTimerID                  MPU_vTimerSetTimerID
         #define xTimerIsTimerActive               MPU_xTimerIsTimerActive
         #define xTimerGetTimerDaemonTaskHandle    MPU_xTimerGetTimerDaemonTaskHandle
-        #define xTimerGenericCommand              MPU_xTimerGenericCommand
+        #define xTimerGenericCommandFromTask      MPU_xTimerGenericCommandFromTask
+        #define xTimerGenericCommandFromISR       MPU_xTimerGenericCommandFromISR
         #define pcTimerGetName                    MPU_pcTimerGetName
         #define vTimerSetReloadMode               MPU_vTimerSetReloadMode
         #define uxTimerGetReloadMode              MPU_uxTimerGetReloadMode

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/mpu_wrappers_v2_asm.c
@@ -1726,41 +1726,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0, r1}                                         \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " movs r1, #1                                           \n"
-        " tst r0, r1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0, r1}                                      \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0, r1}                                      \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0, r1}                                                 \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " movs r1, #1                                                   \n"
+        " tst r0, r1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0, r1}                                              \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0, r1}                                              \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                                      \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                          \n"
+        "                                                                      \n"
+        " push {r0, r1}                                                        \n"
+        " mrs r0, ipsr                                                         \n"
+        " cmp r0, #0                                                           \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                             \n"
+        " mrs r0, control                                                      \n"
+        " movs r1, #1                                                          \n"
+        " tst r0, r1                                                           \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                             \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                              \n"
+        "     pop {r0, r1}                                                     \n"
+        "     svc %0                                                           \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                           \n"
+        "     svc %1                                                           \n"
+        "     bx lr                                                            \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                                \n"
+        "     pop {r0, r1}                                                     \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                            \n"
+        "                                                                      \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/mpu_wrappers_v2_asm.c
@@ -1726,41 +1726,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0, r1}                                         \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " movs r1, #1                                           \n"
-        " tst r0, r1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0, r1}                                      \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0, r1}                                      \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0, r1}                                                 \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " movs r1, #1                                                   \n"
+        " tst r0, r1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0, r1}                                              \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0, r1}                                              \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0, r1}                                                \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " movs r1, #1                                                  \n"
+        " tst r0, r1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0, r1}                                             \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0, r1}                                             \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/mpu_wrappers_v2_asm.S
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/mpu_wrappers_v2_asm.S
@@ -945,27 +945,51 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0, r1}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     movs r1, #1
     tst r0, r1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0, r1}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0, r1}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0, r1}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    movs r1, #1
+    tst r0, r1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0, r1}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0, r1}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1532,9 +1556,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/mpu_wrappers_v2_asm.S
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/mpu_wrappers_v2_asm.S
@@ -945,27 +945,51 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0, r1}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     movs r1, #1
     tst r0, r1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0, r1}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0, r1}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0, r1}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    movs r1, #1
+    tst r0, r1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0, r1}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0, r1}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1532,9 +1556,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/mpu_wrappers_v2_asm.S
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/mpu_wrappers_v2_asm.S
@@ -895,26 +895,49 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     tst r0, #1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    tst r0, #1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1461,9 +1484,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -1943,11 +1943,11 @@
 /*-----------------------------------------------------------*/
 
     #if ( configUSE_TIMERS == 1 )
-        BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                             const BaseType_t xCommandID,
-                                             const TickType_t xOptionalValue,
-                                             BaseType_t * const pxHigherPriorityTaskWoken,
-                                             const TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
+        BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                                     const BaseType_t xCommandID,
+                                                     const TickType_t xOptionalValue,
+                                                     BaseType_t * const pxHigherPriorityTaskWoken,
+                                                     const TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
         {
             BaseType_t xReturn;
 
@@ -1956,7 +1956,7 @@
                 portRAISE_PRIVILEGE();
                 portMEMORY_BARRIER();
 
-                xReturn = xTimerGenericCommand( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+                xReturn = xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
                 portMEMORY_BARRIER();
 
                 portRESET_PRIVILEGE();
@@ -1964,7 +1964,37 @@
             }
             else
             {
-                xReturn = xTimerGenericCommand( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+                xReturn = xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+            }
+
+            return xReturn;
+        }
+    #endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+    #if ( configUSE_TIMERS == 1 )
+        BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                                const BaseType_t xCommandID,
+                                                const TickType_t xOptionalValue,
+                                                BaseType_t * const pxHigherPriorityTaskWoken,
+                                                const TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
+        {
+            BaseType_t xReturn;
+
+            if( portIS_PRIVILEGED() == pdFALSE )
+            {
+                portRAISE_PRIVILEGE();
+                portMEMORY_BARRIER();
+
+                xReturn = xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+                portMEMORY_BARRIER();
+
+                portRESET_PRIVILEGE();
+                portMEMORY_BARRIER();
+            }
+            else
+            {
+                xReturn = xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
             }
 
             return xReturn;

--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -2917,17 +2917,17 @@
 
     #if ( configUSE_TIMERS == 1 )
 
-        BaseType_t MPU_xTimerGenericCommandImpl( TimerHandle_t xTimer,
-                                                 const BaseType_t xCommandID,
-                                                 const TickType_t xOptionalValue,
-                                                 BaseType_t * const pxHigherPriorityTaskWoken,
-                                                 const TickType_t xTicksToWait ) PRIVILEGED_FUNCTION;
+        BaseType_t MPU_xTimerGenericCommandFromTaskImpl( TimerHandle_t xTimer,
+                                                         const BaseType_t xCommandID,
+                                                         const TickType_t xOptionalValue,
+                                                         BaseType_t * const pxHigherPriorityTaskWoken,
+                                                         const TickType_t xTicksToWait ) PRIVILEGED_FUNCTION;
 
-        BaseType_t MPU_xTimerGenericCommandImpl( TimerHandle_t xTimer,
-                                                 const BaseType_t xCommandID,
-                                                 const TickType_t xOptionalValue,
-                                                 BaseType_t * const pxHigherPriorityTaskWoken,
-                                                 const TickType_t xTicksToWait ) /* PRIVILEGED_FUNCTION */
+        BaseType_t MPU_xTimerGenericCommandFromTaskImpl( TimerHandle_t xTimer,
+                                                         const BaseType_t xCommandID,
+                                                         const TickType_t xOptionalValue,
+                                                         BaseType_t * const pxHigherPriorityTaskWoken,
+                                                         const TickType_t xTicksToWait ) /* PRIVILEGED_FUNCTION */
         {
             BaseType_t xReturn = pdFALSE;
             TimerHandle_t xInternalTimerHandle = NULL;
@@ -2951,7 +2951,54 @@
 
                     if( xInternalTimerHandle != NULL )
                     {
-                        xReturn = xTimerGenericCommand( xInternalTimerHandle, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+                        xReturn = xTimerGenericCommandFromTask( xInternalTimerHandle, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+                    }
+                }
+            }
+
+            return xReturn;
+        }
+
+    #endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+    #if ( configUSE_TIMERS == 1 )
+
+        BaseType_t MPU_xTimerGenericCommandFromISRImpl( TimerHandle_t xTimer,
+                                                        const BaseType_t xCommandID,
+                                                        const TickType_t xOptionalValue,
+                                                        BaseType_t * const pxHigherPriorityTaskWoken,
+                                                        const TickType_t xTicksToWait ) PRIVILEGED_FUNCTION;
+
+        BaseType_t MPU_xTimerGenericCommandFromISRImpl( TimerHandle_t xTimer,
+                                                        const BaseType_t xCommandID,
+                                                        const TickType_t xOptionalValue,
+                                                        BaseType_t * const pxHigherPriorityTaskWoken,
+                                                        const TickType_t xTicksToWait ) /* PRIVILEGED_FUNCTION */
+        {
+            BaseType_t xReturn = pdFALSE;
+            TimerHandle_t xInternalTimerHandle = NULL;
+            int32_t lIndex;
+            BaseType_t xIsHigherPriorityTaskWokenWriteable = pdFALSE;
+
+            if( pxHigherPriorityTaskWoken != NULL )
+            {
+                xIsHigherPriorityTaskWokenWriteable = xPortIsAuthorizedToAccessBuffer( pxHigherPriorityTaskWoken,
+                                                                                       sizeof( BaseType_t ),
+                                                                                       tskMPU_WRITE_PERMISSION );
+            }
+
+            if( ( pxHigherPriorityTaskWoken == NULL ) || ( xIsHigherPriorityTaskWokenWriteable == pdTRUE ) )
+            {
+                lIndex = ( int32_t ) xTimer;
+
+                if( IS_EXTERNAL_INDEX_VALID( lIndex ) != pdFALSE )
+                {
+                    xInternalTimerHandle = MPU_GetTimerHandleAtIndex( CONVERT_TO_INTERNAL_INDEX( lIndex ) );
+
+                    if( xInternalTimerHandle != NULL )
+                    {
+                        xReturn = xTimerGenericCommandFromISR( xInternalTimerHandle, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
                     }
                 }
             }

--- a/portable/GCC/ARM_CM23/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM23/non_secure/mpu_wrappers_v2_asm.c
@@ -1726,41 +1726,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0, r1}                                         \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " movs r1, #1                                           \n"
-        " tst r0, r1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0, r1}                                      \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0, r1}                                      \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0, r1}                                                 \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " movs r1, #1                                                   \n"
+        " tst r0, r1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0, r1}                                              \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0, r1}                                              \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                                      \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                          \n"
+        "                                                                      \n"
+        " push {r0, r1}                                                        \n"
+        " mrs r0, ipsr                                                         \n"
+        " cmp r0, #0                                                           \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                             \n"
+        " mrs r0, control                                                      \n"
+        " movs r1, #1                                                          \n"
+        " tst r0, r1                                                           \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                             \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                              \n"
+        "     pop {r0, r1}                                                     \n"
+        "     svc %0                                                           \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                           \n"
+        "     svc %1                                                           \n"
+        "     bx lr                                                            \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                                \n"
+        "     pop {r0, r1}                                                     \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                            \n"
+        "                                                                      \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1726,41 +1726,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0, r1}                                         \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " movs r1, #1                                           \n"
-        " tst r0, r1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0, r1}                                      \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0, r1}                                      \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0, r1}                                                 \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " movs r1, #1                                                   \n"
+        " tst r0, r1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0, r1}                                              \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0, r1}                                              \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0, r1}                                                \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " movs r1, #1                                                  \n"
+        " tst r0, r1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0, r1}                                             \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0, r1}                                             \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM33/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM33/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM35P/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM35P/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM3_MPU/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM3_MPU/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                      \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                      \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                       \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                         \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                     \n"
+        "                                                               \n"
+        "                                                               \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM55/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM55/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM85/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM85/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1676,41 +1676,85 @@ TaskHandle_t MPU_xTimerGetTimerDaemonTaskHandle( void ) /* __attribute__ (( nake
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
-                                     const BaseType_t xCommandID,
-                                     const TickType_t xOptionalValue,
-                                     BaseType_t * const pxHigherPriorityTaskWoken,
-                                     const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
 {
     __asm volatile
     (
-        " .syntax unified                                       \n"
-        " .extern MPU_xTimerGenericCommandImpl                  \n"
-        "                                                       \n"
-        " push {r0}                                             \n"
-        " mrs r0, ipsr                                          \n"
-        " cmp r0, #0                                            \n"
-        " bne MPU_xTimerGenericCommand_Priv                     \n"
-        " mrs r0, control                                       \n"
-        " tst r0, #1                                            \n"
-        " beq MPU_xTimerGenericCommand_Priv                     \n"
-        " MPU_xTimerGenericCommand_Unpriv:                      \n"
-        "     pop {r0}                                          \n"
-        "     svc %0                                            \n"
-        "     bl MPU_xTimerGenericCommandImpl                   \n"
-        "     svc %1                                            \n"
-        "     bx lr                                             \n"
-        " MPU_xTimerGenericCommand_Priv:                        \n"
-        "     pop {r0}                                          \n"
-        "     b MPU_xTimerGenericCommandImpl                    \n"
-        "                                                       \n"
-        "                                                       \n"
+        " .syntax unified                                               \n"
+        " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
+        "                                                               \n"
+        " push {r0}                                                     \n"
+        " mrs r0, ipsr                                                  \n"
+        " cmp r0, #0                                                    \n"
+        " bne MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " mrs r0, control                                               \n"
+        " tst r0, #1                                                    \n"
+        " beq MPU_xTimerGenericCommandFromTask_Priv                     \n"
+        " MPU_xTimerGenericCommandFromTask_Unpriv:                      \n"
+        "     pop {r0}                                                  \n"
+        "     svc %0                                                    \n"
+        "     bl MPU_xTimerGenericCommandFromTaskImpl                   \n"
+        "     svc %1                                                    \n"
+        "     bx lr                                                     \n"
+        " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
+        "     pop {r0}                                                  \n"
+        "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
+        "                                                               \n"
+        "                                                               \n"
+        : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
+    );
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) __attribute__ (( naked )) FREERTOS_SYSTEM_CALL;
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
+                                            const BaseType_t xCommandID,
+                                            const TickType_t xOptionalValue,
+                                            BaseType_t * const pxHigherPriorityTaskWoken,
+                                            const TickType_t xTicksToWait ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+{
+    __asm volatile
+    (
+        " .syntax unified                                              \n"
+        " .extern MPU_xTimerGenericCommandFromISRImpl                  \n"
+        "                                                              \n"
+        " push {r0}                                                    \n"
+        " mrs r0, ipsr                                                 \n"
+        " cmp r0, #0                                                   \n"
+        " bne MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " mrs r0, control                                              \n"
+        " tst r0, #1                                                   \n"
+        " beq MPU_xTimerGenericCommandFromISR_Priv                     \n"
+        " MPU_xTimerGenericCommandFromISR_Unpriv:                      \n"
+        "     pop {r0}                                                 \n"
+        "     svc %0                                                   \n"
+        "     bl MPU_xTimerGenericCommandFromISRImpl                   \n"
+        "     svc %1                                                   \n"
+        "     bx lr                                                    \n"
+        " MPU_xTimerGenericCommandFromISR_Priv:                        \n"
+        "     pop {r0}                                                 \n"
+        "     b MPU_xTimerGenericCommandFromISRImpl                    \n"
+        "                                                              \n"
+        "                                                              \n"
         : : "i" ( portSVC_SYSTEM_CALL_ENTER_1 ), "i" ( portSVC_SYSTEM_CALL_EXIT ) : "memory"
     );
 }

--- a/portable/IAR/ARM_CM23/non_secure/mpu_wrappers_v2_asm.S
+++ b/portable/IAR/ARM_CM23/non_secure/mpu_wrappers_v2_asm.S
@@ -945,27 +945,51 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0, r1}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     movs r1, #1
     tst r0, r1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0, r1}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0, r1}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0, r1}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    movs r1, #1
+    tst r0, r1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0, r1}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0, r1}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1532,9 +1556,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/mpu_wrappers_v2_asm.S
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/mpu_wrappers_v2_asm.S
@@ -945,27 +945,51 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0, r1}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     movs r1, #1
     tst r0, r1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0, r1}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0, r1}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0, r1}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    movs r1, #1
+    tst r0, r1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0, r1}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0, r1}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1532,9 +1556,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/IAR/ARM_CM33/non_secure/mpu_wrappers_v2_asm.S
+++ b/portable/IAR/ARM_CM33/non_secure/mpu_wrappers_v2_asm.S
@@ -895,26 +895,49 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     tst r0, #1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    tst r0, #1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1461,9 +1484,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/IAR/ARM_CM35P/non_secure/mpu_wrappers_v2_asm.S
+++ b/portable/IAR/ARM_CM35P/non_secure/mpu_wrappers_v2_asm.S
@@ -895,26 +895,49 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     tst r0, #1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    tst r0, #1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1461,9 +1484,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/IAR/ARM_CM4F_MPU/mpu_wrappers_v2_asm.S
+++ b/portable/IAR/ARM_CM4F_MPU/mpu_wrappers_v2_asm.S
@@ -899,26 +899,49 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     tst r0, #1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    tst r0, #1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1465,9 +1488,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/IAR/ARM_CM55/non_secure/mpu_wrappers_v2_asm.S
+++ b/portable/IAR/ARM_CM55/non_secure/mpu_wrappers_v2_asm.S
@@ -895,26 +895,49 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     tst r0, #1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    tst r0, #1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1461,9 +1484,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/IAR/ARM_CM85/non_secure/mpu_wrappers_v2_asm.S
+++ b/portable/IAR/ARM_CM85/non_secure/mpu_wrappers_v2_asm.S
@@ -895,26 +895,49 @@ MPU_xTimerGetTimerDaemonTaskHandle:
         bx lr
 /*-----------------------------------------------------------*/
 
-    PUBLIC MPU_xTimerGenericCommand
-MPU_xTimerGenericCommand:
+    PUBLIC MPU_xTimerGenericCommandFromTask
+MPU_xTimerGenericCommandFromTask:
     push {r0}
     /* This function can be called from ISR also and therefore, we need a check
      * to take privileged path, if called from ISR. */
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromTask_Priv
     mrs r0, control
     tst r0, #1
-    beq MPU_xTimerGenericCommand_Priv
-    MPU_xTimerGenericCommand_Unpriv:
+    beq MPU_xTimerGenericCommandFromTask_Priv
+    MPU_xTimerGenericCommandFromTask_Unpriv:
         pop {r0}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromTaskImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-    MPU_xTimerGenericCommand_Priv:
+    MPU_xTimerGenericCommandFromTask_Priv:
         pop {r0}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromTaskImpl
+
+/*-----------------------------------------------------------*/
+
+    PUBLIC MPU_xTimerGenericCommandFromISR
+MPU_xTimerGenericCommandFromISR:
+    push {r0}
+    /* This function can be called from ISR also and therefore, we need a check
+     * to take privileged path, if called from ISR. */
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromISR_Priv
+    mrs r0, control
+    tst r0, #1
+    beq MPU_xTimerGenericCommandFromISR_Priv
+    MPU_xTimerGenericCommandFromISR_Unpriv:
+        pop {r0}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromISRImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+    MPU_xTimerGenericCommandFromISR_Priv:
+        pop {r0}
+        b MPU_xTimerGenericCommandFromISRImpl
 
 /*-----------------------------------------------------------*/
 
@@ -1461,9 +1484,13 @@ MPU_xTimerIsTimerActiveImpl:
 MPU_xTimerGetTimerDaemonTaskHandleImpl:
     b MPU_xTimerGetTimerDaemonTaskHandleImpl
 
-    PUBWEAK MPU_xTimerGenericCommandImpl
-MPU_xTimerGenericCommandImpl:
-    b MPU_xTimerGenericCommandImpl
+    PUBWEAK MPU_xTimerGenericCommandFromTaskImpl
+MPU_xTimerGenericCommandFromTaskImpl:
+    b MPU_xTimerGenericCommandFromTaskImpl
+
+    PUBWEAK MPU_xTimerGenericCommandFromISRImpl
+MPU_xTimerGenericCommandFromISRImpl:
+    b MPU_xTimerGenericCommandFromISRImpl
 
     PUBWEAK MPU_pcTimerGetNameImpl
 MPU_pcTimerGetNameImpl:

--- a/portable/RVDS/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
+++ b/portable/RVDS/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
@@ -1426,37 +1426,75 @@ MPU_xTimerGetTimerDaemonTaskHandle_Unpriv
 
 #if ( configUSE_TIMERS == 1 )
 
-BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
+BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                             const BaseType_t xCommandID,
+                                             const TickType_t xOptionalValue,
+                                             BaseType_t * const pxHigherPriorityTaskWoken,
+                                             const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
+
+__asm BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
+                                                   const BaseType_t xCommandID,
+                                                   const TickType_t xOptionalValue,
+                                                   BaseType_t * const pxHigherPriorityTaskWoken,
+                                                   const TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
+{
+    PRESERVE8
+    extern MPU_xTimerGenericCommandFromTaskImpl
+
+    push {r0}
+    mrs r0, ipsr
+    cmp r0, #0
+    bne MPU_xTimerGenericCommandFromTask_Priv
+    mrs r0, control
+    tst r0, #1
+    beq MPU_xTimerGenericCommandFromTask_Priv
+MPU_xTimerGenericCommandFromTask_Unpriv
+        pop {r0}
+        svc #portSVC_SYSTEM_CALL_ENTER_1
+        bl MPU_xTimerGenericCommandFromTaskImpl
+        svc #portSVC_SYSTEM_CALL_EXIT
+        bx lr
+MPU_xTimerGenericCommandFromTask_Priv
+        pop {r0}
+        b MPU_xTimerGenericCommandFromTaskImpl
+}
+
+#endif /* if ( configUSE_TIMERS == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TIMERS == 1 )
+
+BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
                                      const BaseType_t xCommandID,
                                      const TickType_t xOptionalValue,
                                      BaseType_t * const pxHigherPriorityTaskWoken,
                                      const TickType_t xTicksToWait ) FREERTOS_SYSTEM_CALL;
 
-__asm BaseType_t MPU_xTimerGenericCommand( TimerHandle_t xTimer,
+__asm BaseType_t MPU_xTimerGenericCommandFromISR( TimerHandle_t xTimer,
                                            const BaseType_t xCommandID,
                                            const TickType_t xOptionalValue,
                                            BaseType_t * const pxHigherPriorityTaskWoken,
                                            const TickType_t xTicksToWait ) /* FREERTOS_SYSTEM_CALL */
 {
     PRESERVE8
-    extern MPU_xTimerGenericCommandImpl
+    extern MPU_xTimerGenericCommandFromISRImpl
 
     push {r0}
     mrs r0, ipsr
     cmp r0, #0
-    bne MPU_xTimerGenericCommand_Priv
+    bne MPU_xTimerGenericCommandFromISR_Priv
     mrs r0, control
     tst r0, #1
-    beq MPU_xTimerGenericCommand_Priv
-MPU_xTimerGenericCommand_Unpriv
+    beq MPU_xTimerGenericCommandFromISR_Priv
+MPU_xTimerGenericCommandFromISR_Unpriv
         pop {r0}
         svc #portSVC_SYSTEM_CALL_ENTER_1
-        bl MPU_xTimerGenericCommandImpl
+        bl MPU_xTimerGenericCommandFromISRImpl
         svc #portSVC_SYSTEM_CALL_EXIT
         bx lr
-MPU_xTimerGenericCommand_Priv
+MPU_xTimerGenericCommandFromISR_Priv
         pop {r0}
-        b MPU_xTimerGenericCommandImpl
+        b MPU_xTimerGenericCommandFromISRImpl
 }
 
 #endif /* if ( configUSE_TIMERS == 1 ) */


### PR DESCRIPTION
Description
-----------
This PR updates the MPU wrapper for xTimerGenericCommand API, since in latest FreeRTOS+Kernel code the xTimerGenericCommand API is split into two sub functions

Test Steps
-----------
Build and run Kernel Demo soak tests

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
