### PR TITLE
Fix warning in vTaskGetInfo

### DIFF
--- a/.github/workflows/kernel-demos.yml
+++ b/.github/workflows/kernel-demos.yml
@@ -85,6 +85,11 @@ jobs:
         working-directory: FreeRTOS/Demo/Posix_GCC
         run: make -j
 
+      - name: Build Posix_GCC Demo for Coverage Test
+        shell: bash
+        working-directory: FreeRTOS/Demo/Posix_GCC
+        run: make -j COVERAGE_TEST=1
+
   MSP430-GCC:
     name: GNU MSP430 Toolchain
     runs-on: ubuntu-latest

--- a/tasks.c
+++ b/tasks.c
@@ -5546,7 +5546,7 @@ static void prvCheckTasksWaitingTermination( void )
         pxTaskStatus->uxCurrentPriority = pxTCB->uxPriority;
         pxTaskStatus->pxStackBase = pxTCB->pxStack;
         #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
-            pxTaskStatus->pxTopOfStack = pxTCB->pxTopOfStack;
+            pxTaskStatus->pxTopOfStack = ( StackType_t * ) pxTCB->pxTopOfStack;
             pxTaskStatus->pxEndOfStack = pxTCB->pxEndOfStack;
         #endif
         pxTaskStatus->xTaskNumber = pxTCB->uxTCBNumber;


### PR DESCRIPTION
Description
-----------

The change addresses the following warning:

```
tasks.c:5549:40: warning: assignment discards 'volatile' qualifier from
pointer target type [-Wdiscarded-qualifiers]
 5549 |             pxTaskStatus->pxTopOfStack = pxTCB->pxTopOfStack;
      |
```

Also add the "Build Posix_GCC Demo for Coverage Test" in the PR checks as coverage test target treats warnings as errors and therefore, will catch such warnings in PR checks.

Test Steps
-----------
Built the POSIX demo locally with the following command -
```
make -j COVERAGE_TEST=1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
