### PR TITLE
Fix pxTopOfStack calculation in configINIT_TLS_BLOCK for picolib

### DIFF
--- a/include/picolibc-freertos.h
+++ b/include/picolibc-freertos.h
@@ -58,19 +58,19 @@
 #endif
 
 /* Allocate thread local storage block off the end of the
-* stack. The picolibcTLS_SIZE macro returns the size (in
-* bytes) of the total TLS area used by the application.
-* Calculate the top of stack address. */
+ * stack. The picolibcTLS_SIZE macro returns the size (in
+ * bytes) of the total TLS area used by the application.
+ * Calculate the top of stack address. */
 #if ( portSTACK_GROWTH < 0 )
 
-    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                                     \
-    do {                                                                                        \
-        xTLSBlock = ( void * ) ( ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack ) -                 \
-                                   picolibcTLS_SIZE ) &                                         \
-                                 ~picolibcTLS_ALIGNMENT_MASK );                                 \
-        pxTopOfStack = ( StackType_t * ) ( ( ( ( portPOINTER_SIZE_TYPE ) xTLSBlock ) - 1 ) &    \
-                                           ~picolibcSTACK_ALIGNMENT_MASK );                     \
-        _init_tls( xTLSBlock );                                                                 \
+    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                                  \
+    do {                                                                                     \
+        xTLSBlock = ( void * ) ( ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack ) -              \
+                                   picolibcTLS_SIZE ) &                                      \
+                                 ~picolibcTLS_ALIGNMENT_MASK );                              \
+        pxTopOfStack = ( StackType_t * ) ( ( ( ( portPOINTER_SIZE_TYPE ) xTLSBlock ) - 1 ) & \
+                                           ~picolibcSTACK_ALIGNMENT_MASK );                  \
+        _init_tls( xTLSBlock );                                                              \
     } while( 0 )
 #else /* portSTACK_GROWTH */
     #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                                          \

--- a/include/picolibc-freertos.h
+++ b/include/picolibc-freertos.h
@@ -58,18 +58,19 @@
 #endif
 
 /* Allocate thread local storage block off the end of the
-* stack. The _tls_size() function returns the size (in
-* bytes) of the total TLS area used by the application */
+* stack. The picolibcTLS_SIZE macro returns the size (in
+* bytes) of the total TLS area used by the application.
+* Calculate the top of stack address. */
 #if ( portSTACK_GROWTH < 0 )
 
-    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                             \
-    do {                                                                                \
-        pxTopOfStack = ( StackType_t * ) ( ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack ) \
-                                             - picolibcTLS_SIZE ) & ~                   \
-                                           configMAX( picolibcSTACK_ALIGNMENT_MASK,     \
-                                                      picolibcTLS_ALIGNMENT_MASK ) );   \
-        xTLSBlock = pxTopOfStack;                                                       \
-        _init_tls( xTLSBlock );                                                         \
+    #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                                     \
+    do {                                                                                        \
+        xTLSBlock = ( void * ) ( ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack ) -                 \
+                                   picolibcTLS_SIZE ) &                                         \
+                                 ~picolibcTLS_ALIGNMENT_MASK );                                 \
+        pxTopOfStack = ( StackType_t * ) ( ( ( ( portPOINTER_SIZE_TYPE ) xTLSBlock ) - 1 ) &    \
+                                           ~picolibcSTACK_ALIGNMENT_MASK );                     \
+        _init_tls( xTLSBlock );                                                                 \
     } while( 0 )
 #else /* portSTACK_GROWTH */
     #define configINIT_TLS_BLOCK( xTLSBlock, pxTopOfStack )                                          \

--- a/portable/GCC/ARM_CR5/port.c
+++ b/portable/GCC/ARM_CR5/port.c
@@ -280,12 +280,13 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     /*
      * Setup the initial stack of the task.  The stack is set exactly as
      * expected by the portRESTORE_CONTEXT() macro.
-     *
+     * 
+     * The stack must be decremented before being used.
+     * 
      * The fist real value on the stack is the status register, which is set for
      * system mode, with interrupts enabled.  A few NULLs are added first to ensure
      * GDB does not try decoding a non-existent return address.
      * 
-     * Decrement the stack before assigning values to it, such that TLS variables do not overlap
      */
     pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) NULL;

--- a/portable/GCC/ARM_CR5/port.c
+++ b/portable/GCC/ARM_CR5/port.c
@@ -280,15 +280,11 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     /*
      * Setup the initial stack of the task.  The stack is set exactly as
      * expected by the portRESTORE_CONTEXT() macro.
-     * 
-     * The stack must be decremented before being used.
-     * 
+     *
      * The fist real value on the stack is the status register, which is set for
      * system mode, with interrupts enabled.  A few NULLs are added first to ensure
      * GDB does not try decoding a non-existent return address.
-     * 
      */
-    pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) NULL;
     pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) NULL;

--- a/portable/GCC/ARM_CR5/port.c
+++ b/portable/GCC/ARM_CR5/port.c
@@ -284,7 +284,10 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
      * The fist real value on the stack is the status register, which is set for
      * system mode, with interrupts enabled.  A few NULLs are added first to ensure
      * GDB does not try decoding a non-existent return address.
+     * 
+     * Decrement the stack before assigning values to it, such that TLS variables do not overlap
      */
+    pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) NULL;
     pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) NULL;


### PR DESCRIPTION
Description
-----------
The  `pxTopOfStack` calculation in `configINIT_TLS_BLOCK` for picolib needs to decrement  `pxTopOfStack`  in order to meet the expectation of `pxPortInitialiseStack` function. 
 
Details described in https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/714.

Test Steps
-----------
Described in attached issue. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
* https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/714


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
