### PR TITLE
Fix bug of heap_2 introduced by pr738.

### DIFF
--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -230,7 +230,7 @@ void * pvPortMalloc( size_t xWantedSize )
                         pxBlock->xBlockSize = xWantedSize;
 
                         /* Insert the new block into the list of free blocks.
-                         * The list of free blocks is linked by their size, we have to 
+                         * The list of free blocks is sorted by their size, we have to
                          * iterate to find the right place to insert new block. */
                         prvInsertBlockIntoFreeList( ( pxNewBlockLink ) );
                     }

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -229,9 +229,10 @@ void * pvPortMalloc( size_t xWantedSize )
                         pxNewBlockLink->xBlockSize = pxBlock->xBlockSize - xWantedSize;
                         pxBlock->xBlockSize = xWantedSize;
 
-                        /* Insert the new block into the list of free blocks. */
-                        pxNewBlockLink->pxNextFreeBlock = pxPreviousBlock->pxNextFreeBlock;
-                        pxPreviousBlock->pxNextFreeBlock = pxNewBlockLink;
+                        /* Insert the new block into the list of free blocks.
+                         * The list of free blocks is linked by their size, we have to 
+                         * iterate to find the right place to insert new block. */
+                        prvInsertBlockIntoFreeList( ( pxNewBlockLink ) );
                     }
 
                     xFreeBytesRemaining -= pxBlock->xBlockSize;


### PR DESCRIPTION
<!--- Title -->
Fix bug of heap_2 introduced by [pr738](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/738)

Description
-----------
<!--- Describe your changes in detail. -->
In secure_heap\heap_4\heap_5, the list of free blocks is linked by the block **address**.
In heap_2,  the list of free blocks is linked by the block **size**.
In heap_2, when a large free block is split into a smaller free block and a using block, we have to iterate the list of free blocks to find the right place to insert the smaller free block.

With [pr738 ](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/738), I mistakenly changed heap_2 along with other heap, now I have fixed this bug and added some comment in heap_2. 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
