### PR TITLE
Fix MPU wrapper for vTaskDelete for calling task deletion

### DIFF
--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -1360,12 +1360,12 @@
                 xInternalTaskHandle = xTaskGetCurrentTaskHandle();
                 lIndex = MPU_GetIndexForTaskHandle( xInternalTaskHandle );
 
-                vTaskDelete( xInternalTaskHandle );
-
                 if( lIndex != -1 )
                 {
                     MPU_SetIndexFreeInKernelObjectPool( lIndex );
                 }
+
+                vTaskDelete( xInternalTaskHandle );
             }
             else
             {
@@ -1377,8 +1377,8 @@
 
                     if( xInternalTaskHandle != NULL )
                     {
-                        vTaskDelete( xInternalTaskHandle );
                         MPU_SetIndexFreeInKernelObjectPool( CONVERT_TO_INTERNAL_INDEX( lIndex ) );
+                        vTaskDelete( xInternalTaskHandle );
                     }
                 }
             }


### PR DESCRIPTION
Description
-----------
MPU wrapper for `vTaskDelete` called `vTaskDelete` first and then freed the slot in the Kernel Object Handle Pool. When a task deletes itself, any instruction after `vTaskDelete` is not executed. As a result, when a task deleted itself, we were not freeing the corresponding slot in the Kernel Object Handle Pool thereby, exhausting the pool eventually. This PR fixes the issue by freeing the slot in Kernel Object Handle Pool first and then calling  `vTaskDelete`.

Test Steps
-----------
1. Create a Privileged task, Task1, with priority 1. 
2. Task1 creates another privileged task, Task2, with priority 2.
3. Task2 deletes itself by calling vTaskDelete.

```c
/* Task1's priority is 1. */
void Task1( void * pvParam )
{
    BaseType xTaskCreationResult;

    ( void ) pvParam;

    for( ;; )
    {
        /* Create Task2 with priority 2. */
        xTaskCreationResult = xTaskCreateRestricted( ... );
        configASSET( xTaskCreationResult != pdFAIL );

        /* Give idle task a chance to clean up resources. */
        vTaskDelay( pdMS_TO_TICKS( 100 ) );
    }
}

/* Task2's priority is 2. */
void Task2( void * pvParam )
{
    ( void ) pvParam;

    vTaskDelete( NULL );
}
```

Without the changes in this PR, we hit the assert `configASSET( xTaskCreationResult != pdFAIL );`. With the changes in this PR, the code runs successfully without hitting the assert.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
