### PR TITLE
Heap protect

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1071,6 +1071,10 @@
     #define configAPPLICATION_ALLOCATED_HEAP    0
 #endif
 
+#ifndef configENABLE_HEAP_PROTECTOR
+    #define configENABLE_HEAP_PROTECTOR    0
+#endif
+
 #ifndef configUSE_TASK_NOTIFICATIONS
     #define configUSE_TASK_NOTIFICATIONS    1
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1071,8 +1071,8 @@
     #define configAPPLICATION_ALLOCATED_HEAP    0
 #endif
 
-#ifndef configENABLE_HEAP_PROTECTOR
-    #define configENABLE_HEAP_PROTECTOR    0
+#ifndef configENABLE_HEAP_PROTECTION
+    #define configENABLE_HEAP_PROTECTION    0
 #endif
 
 #ifndef configUSE_TASK_NOTIFICATIONS

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1071,8 +1071,8 @@
     #define configAPPLICATION_ALLOCATED_HEAP    0
 #endif
 
-#ifndef configENABLE_HEAP_PROTECTION
-    #define configENABLE_HEAP_PROTECTION    0
+#ifndef configENABLE_HEAP_PROTECTOR
+    #define configENABLE_HEAP_PROTECTOR    0
 #endif
 
 #ifndef configUSE_TASK_NOTIFICATIONS

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -109,20 +109,20 @@ typedef struct A_BLOCK_LINK
  */
 #if ( configENABLE_HEAP_PROTECTOR == 1 )
 
-    /**
-     * @brief Application provided function to get a random value to be used as canary.
-     *
-     * @param pxHeapCanary [out] Output parameter to return the canary value.
-     */
+/**
+ * @brief Application provided function to get a random value to be used as canary.
+ *
+ * @param pxHeapCanary [out] Output parameter to return the canary value.
+ */
     extern void vApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxHeapCanary );
 
-    /* Canary value for protecting internal heap pointers. */
+/* Canary value for protecting internal heap pointers. */
     PRIVILEGED_DATA static portPOINTER_SIZE_TYPE xHeapCanary;
 
-    /* Macro to load/store BlockLink_t pointers to memory. By XORing the
-     * pointers with a random canary value, heap overflows will result
-     * in randomly unpredictable pointer values which will be caught by
-     * heapVALIDATE_BLOCK_POINTER assert. */
+/* Macro to load/store BlockLink_t pointers to memory. By XORing the
+ * pointers with a random canary value, heap overflows will result
+ * in randomly unpredictable pointer values which will be caught by
+ * heapVALIDATE_BLOCK_POINTER assert. */
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( ( BlockLink_t * ) ( ( ( portPOINTER_SIZE_TYPE ) ( pxBlock ) ) ^ xHeapCanary ) )
 #else
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -70,6 +70,9 @@
 /* Check if adding a and b will result in overflow. */
 #define heapADD_WILL_OVERFLOW( a, b )         ( ( a ) > ( heapSIZE_MAX - ( b ) ) )
 
+/* Check if subtracting a from b will result in underflow. */
+#define heapSUBTRACT_WILL_UNDERFLOW( a, b )         ( ( a ) > ( b ) )
+
 /* MSB of the xBlockSize member of an BlockLink_t structure is used to track
  * the allocation status of a block.  When MSB of the xBlockSize member of
  * an BlockLink_t structure is set then the block belongs to the application.
@@ -99,6 +102,33 @@ typedef struct A_BLOCK_LINK
     struct A_BLOCK_LINK * pxNextFreeBlock; /**< The next free block in the list. */
     size_t xBlockSize;                     /**< The size of the free block. */
 } BlockLink_t;
+
+/* Enabling configENABLE_HEAP_PROTECTOR provides a security enhanced version of heap_4.c that
+ * implements pointer protection using a canary value to reduce the risk of code execution
+ * should a heap buffer overflow vulnerability occur.
+ * It also implements additional arithmetic and bounds checks on heap values.
+ */
+#if ( configENABLE_HEAP_PROTECTOR == 1 )
+/* We require xApplicationGetRandomNumber in order to initialize our canary value */
+    extern BaseType_t xApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxRandomNumber );
+/* Canary value for protecting internal heap pointers */
+    PRIVILEGED_DATA static portPOINTER_SIZE_TYPE xHeapCanary;
+
+/* Macro to load/store pxNextFreeBlock pointers to memory. By XORing the
+ * pointers with a random canary value, intentional heap overwrites will
+ * result in randomly unpredictable pointer values. If configASSERT() is defined
+ * out of bound values will result in a safe abend due to bounds checks. */
+#define heapPROTECT_POINTER( pxNextFreeBlock )       ( ( struct A_BLOCK_LINK *) ( ( ( portPOINTER_SIZE_TYPE ) ( pxNextFreeBlock ) ) ^ xHeapCanary ) )
+/* Macro to perform a bounds check of heap pointers such that a heap pointer that
+ * falls outside of ucHeap will trigger an assertion. */
+#define heapPROTECT_BOUNDS_CHECK( pxBlock )          configASSERT( ( ( uint8_t * ) ( pxBlock ) >= ucHeap ) && \
+    ( ( uint8_t * ) ( pxBlock ) < ( ucHeap + configTOTAL_HEAP_SIZE ) ) )
+#else
+
+#define heapPROTECT_POINTER( pxNextFreeBlock )       ( pxNextFreeBlock )
+#define heapPROTECT_BOUNDS_CHECK( pxBlock )           do {} while(0)
+
+#endif /* configENABLE_HEAP_PROTECTOR */
 
 /*-----------------------------------------------------------*/
 
@@ -206,12 +236,14 @@ void * pvPortMalloc( size_t xWantedSize )
                 /* Traverse the list from the start (lowest address) block until
                  * one of adequate size is found. */
                 pxPreviousBlock = &xStart;
-                pxBlock = xStart.pxNextFreeBlock;
+                pxBlock = heapPROTECT_POINTER( xStart.pxNextFreeBlock );
+                heapPROTECT_BOUNDS_CHECK( pxBlock );
 
-                while( ( pxBlock->xBlockSize < xWantedSize ) && ( pxBlock->pxNextFreeBlock != NULL ) )
+                while( ( pxBlock->xBlockSize < xWantedSize ) && ( pxBlock->pxNextFreeBlock != heapPROTECT_POINTER( NULL ) ) )
                 {
                     pxPreviousBlock = pxBlock;
-                    pxBlock = pxBlock->pxNextFreeBlock;
+                    pxBlock = heapPROTECT_POINTER( pxBlock->pxNextFreeBlock );
+                    heapPROTECT_BOUNDS_CHECK( pxBlock );
                 }
 
                 /* If the end marker was reached then a block of adequate size
@@ -220,14 +252,17 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     /* Return the memory space pointed to - jumping over the
                      * BlockLink_t structure at its start. */
-                    pvReturn = ( void * ) ( ( ( uint8_t * ) pxPreviousBlock->pxNextFreeBlock ) + xHeapStructSize );
+                    pvReturn = ( void * ) ( ( ( uint8_t * ) heapPROTECT_POINTER( pxPreviousBlock->pxNextFreeBlock ) ) + xHeapStructSize );
+                    heapPROTECT_BOUNDS_CHECK( pvReturn );
 
                     /* This block is being returned for use so must be taken out
                      * of the list of free blocks. */
                     pxPreviousBlock->pxNextFreeBlock = pxBlock->pxNextFreeBlock;
 
                     /* If the block is larger than required it can be split into
-                     * two. */
+                     * two. Also check for underflow as this can occur if xBlockSize is
+                     * overwritten in a heap block */
+                    configASSERT( !heapSUBTRACT_WILL_UNDERFLOW( xWantedSize, pxBlock->xBlockSize ) );
                     if( ( pxBlock->xBlockSize - xWantedSize ) > heapMINIMUM_BLOCK_SIZE )
                     {
                         /* This block is to be split into two.  Create a new
@@ -244,7 +279,7 @@ void * pvPortMalloc( size_t xWantedSize )
 
                         /* Insert the new block into the list of free blocks. */
                         pxNewBlockLink->pxNextFreeBlock = pxPreviousBlock->pxNextFreeBlock;
-                        pxPreviousBlock->pxNextFreeBlock = pxNewBlockLink;
+                        pxPreviousBlock->pxNextFreeBlock = heapPROTECT_POINTER( pxNewBlockLink );
                     }
                     else
                     {
@@ -318,7 +353,8 @@ void vPortFree( void * pv )
 
         /* This casting is to keep the compiler from issuing warnings. */
         pxLink = ( void * ) puc;
-
+        /* This will assert if pv is out of heap range */
+        heapPROTECT_BOUNDS_CHECK( pxLink );
         configASSERT( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 );
         configASSERT( pxLink->pxNextFreeBlock == NULL );
 
@@ -331,6 +367,9 @@ void vPortFree( void * pv )
                 heapFREE_BLOCK( pxLink );
                 #if ( configHEAP_CLEAR_MEMORY_ON_FREE == 1 )
                 {
+                    /* Check for underflow as this can occur if xBlockSize is
+                     * overwritten in a heap block */
+                    configASSERT( !heapSUBTRACT_WILL_UNDERFLOW( xHeapStructSize, pxLink->xBlockSize ) );
                     ( void ) memset( puc + xHeapStructSize, 0, pxLink->xBlockSize - xHeapStructSize );
                 }
                 #endif
@@ -414,9 +453,13 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     pucAlignedHeap = ( uint8_t * ) uxAddress;
 
+#if ( configENABLE_HEAP_PROTECTOR == 1)
+            xApplicationGetRandomHeapCanary( &xHeapCanary );
+#endif
+
     /* xStart is used to hold a pointer to the first item in the list of free
      * blocks.  The void cast is used to prevent compiler warnings. */
-    xStart.pxNextFreeBlock = ( void * ) pucAlignedHeap;
+    xStart.pxNextFreeBlock = ( void * ) heapPROTECT_POINTER( pucAlignedHeap );
     xStart.xBlockSize = ( size_t ) 0;
 
     /* pxEnd is used to mark the end of the list of free blocks and is inserted
@@ -426,13 +469,13 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
     uxAddress &= ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK );
     pxEnd = ( BlockLink_t * ) uxAddress;
     pxEnd->xBlockSize = 0;
-    pxEnd->pxNextFreeBlock = NULL;
+    pxEnd->pxNextFreeBlock = heapPROTECT_POINTER( NULL );
 
     /* To start with there is a single free block that is sized to take up the
      * entire heap space, minus the space taken by pxEnd. */
     pxFirstFreeBlock = ( BlockLink_t * ) pucAlignedHeap;
     pxFirstFreeBlock->xBlockSize = ( size_t ) ( uxAddress - ( portPOINTER_SIZE_TYPE ) pxFirstFreeBlock );
-    pxFirstFreeBlock->pxNextFreeBlock = pxEnd;
+    pxFirstFreeBlock->pxNextFreeBlock = heapPROTECT_POINTER( pxEnd );
 
     /* Only one block exists - and it covers the entire usable heap space. */
     xMinimumEverFreeBytesRemaining = pxFirstFreeBlock->xBlockSize;
@@ -445,11 +488,17 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVI
     BlockLink_t * pxIterator;
     uint8_t * puc;
 
+    /* Ensure the block to insert is within the heap region */
+    heapPROTECT_BOUNDS_CHECK( pxBlockToInsert );
+
     /* Iterate through the list until a block is found that has a higher address
      * than the block being inserted. */
-    for( pxIterator = &xStart; pxIterator->pxNextFreeBlock < pxBlockToInsert; pxIterator = pxIterator->pxNextFreeBlock )
+    for( pxIterator = &xStart; heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) < pxBlockToInsert; pxIterator = heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) )
     {
         /* Nothing to do here, just iterate to the right position. */
+    }
+    if ( pxIterator != &xStart ) {
+        heapPROTECT_BOUNDS_CHECK( pxIterator );
     }
 
     /* Do the block being inserted, and the block it is being inserted after
@@ -470,17 +519,17 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVI
      * make a contiguous block of memory? */
     puc = ( uint8_t * ) pxBlockToInsert;
 
-    if( ( puc + pxBlockToInsert->xBlockSize ) == ( uint8_t * ) pxIterator->pxNextFreeBlock )
+    if( ( puc + pxBlockToInsert->xBlockSize ) == ( uint8_t * ) heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) )
     {
-        if( pxIterator->pxNextFreeBlock != pxEnd )
+        if( heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) != pxEnd )
         {
             /* Form one big block from the two blocks. */
-            pxBlockToInsert->xBlockSize += pxIterator->pxNextFreeBlock->xBlockSize;
-            pxBlockToInsert->pxNextFreeBlock = pxIterator->pxNextFreeBlock->pxNextFreeBlock;
+            pxBlockToInsert->xBlockSize += heapPROTECT_POINTER( pxIterator->pxNextFreeBlock )->xBlockSize;
+            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_POINTER( pxIterator->pxNextFreeBlock )->pxNextFreeBlock;
         }
         else
         {
-            pxBlockToInsert->pxNextFreeBlock = pxEnd;
+            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_POINTER( pxEnd );
         }
     }
     else
@@ -494,7 +543,7 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVI
      * to itself. */
     if( pxIterator != pxBlockToInsert )
     {
-        pxIterator->pxNextFreeBlock = pxBlockToInsert;
+        pxIterator->pxNextFreeBlock = heapPROTECT_POINTER( pxBlockToInsert );
     }
     else
     {
@@ -510,7 +559,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
 
     vTaskSuspendAll();
     {
-        pxBlock = xStart.pxNextFreeBlock;
+        pxBlock = heapPROTECT_POINTER( xStart.pxNextFreeBlock );
 
         /* pxBlock will be NULL if the heap has not been initialised.  The heap
          * is initialised automatically when the first allocation is made. */
@@ -534,7 +583,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
 
                 /* Move to the next block in the chain until the last block is
                  * reached. */
-                pxBlock = pxBlock->pxNextFreeBlock;
+                pxBlock = heapPROTECT_POINTER( pxBlock->pxNextFreeBlock );
             }
         }
     }

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -114,7 +114,7 @@ typedef struct A_BLOCK_LINK
      *
      * @param pxHeapCanary [out] Output parameter to return the canary value.
      */
-    extern void xApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxHeapCanary );
+    extern void vApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxHeapCanary );
 
     /* Canary value for protecting internal heap pointers. */
     PRIVILEGED_DATA static portPOINTER_SIZE_TYPE xHeapCanary;
@@ -462,7 +462,7 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     #if ( configENABLE_HEAP_PROTECTION == 1 )
     {
-        xApplicationGetRandomHeapCanary( &( xHeapCanary ) );
+        vApplicationGetRandomHeapCanary( &( xHeapCanary ) );
     }
     #endif
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -65,13 +65,13 @@
 #define heapSIZE_MAX              ( ~( ( size_t ) 0 ) )
 
 /* Check if multiplying a and b will result in overflow. */
-#define heapMULTIPLY_WILL_OVERFLOW( a, b )    ( ( ( a ) > 0 ) && ( ( b ) > ( heapSIZE_MAX / ( a ) ) ) )
+#define heapMULTIPLY_WILL_OVERFLOW( a, b )     ( ( ( a ) > 0 ) && ( ( b ) > ( heapSIZE_MAX / ( a ) ) ) )
 
 /* Check if adding a and b will result in overflow. */
-#define heapADD_WILL_OVERFLOW( a, b )         ( ( a ) > ( heapSIZE_MAX - ( b ) ) )
+#define heapADD_WILL_OVERFLOW( a, b )          ( ( a ) > ( heapSIZE_MAX - ( b ) ) )
 
-/* Check if subtracting a from b will result in underflow. */
-#define heapSUBTRACT_WILL_UNDERFLOW( a, b )         ( ( a ) > ( b ) )
+/* Check if the subtraction operation ( a - b ) will result in underflow. */
+#define heapSUBTRACT_WILL_UNDERFLOW( a, b )    ( ( a ) < ( b ) )
 
 /* MSB of the xBlockSize member of an BlockLink_t structure is used to track
  * the allocation status of a block.  When MSB of the xBlockSize member of
@@ -103,32 +103,37 @@ typedef struct A_BLOCK_LINK
     size_t xBlockSize;                     /**< The size of the free block. */
 } BlockLink_t;
 
-/* Enabling configENABLE_HEAP_PROTECTOR provides a security enhanced version of heap_4.c that
- * implements pointer protection using a canary value to reduce the risk of code execution
- * should a heap buffer overflow vulnerability occur.
- * It also implements additional arithmetic and bounds checks on heap values.
+/* Setting configENABLE_HEAP_PROTECTION to 1 enables heap block pointers
+ * protection using an application supplied canary value to catch heap
+ * corruption should a heap buffer overflow occur.
  */
-#if ( configENABLE_HEAP_PROTECTOR == 1 )
-/* We require xApplicationGetRandomNumber in order to initialize our canary value */
-    extern BaseType_t xApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxRandomNumber );
-/* Canary value for protecting internal heap pointers */
+#if ( configENABLE_HEAP_PROTECTION == 1 )
+
+    /**
+     * @brief Application provided function to get a random value to be used as canary.
+     *
+     * @param pxHeapCanary [out] Output parameter to return the canary value.
+     */
+    extern void xApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxHeapCanary );
+
+    /* Canary value for protecting internal heap pointers. */
     PRIVILEGED_DATA static portPOINTER_SIZE_TYPE xHeapCanary;
 
-/* Macro to load/store pxNextFreeBlock pointers to memory. By XORing the
- * pointers with a random canary value, intentional heap overwrites will
- * result in randomly unpredictable pointer values. If configASSERT() is defined
- * out of bound values will result in a safe abend due to bounds checks. */
-#define heapPROTECT_POINTER( pxNextFreeBlock )       ( ( struct A_BLOCK_LINK *) ( ( ( portPOINTER_SIZE_TYPE ) ( pxNextFreeBlock ) ) ^ xHeapCanary ) )
-/* Macro to perform a bounds check of heap pointers such that a heap pointer that
- * falls outside of ucHeap will trigger an assertion. */
-#define heapPROTECT_BOUNDS_CHECK( pxBlock )          configASSERT( ( ( uint8_t * ) ( pxBlock ) >= ucHeap ) && \
-    ( ( uint8_t * ) ( pxBlock ) < ( ucHeap + configTOTAL_HEAP_SIZE ) ) )
+    /* Macro to load/store BlockLink_t pointers to memory. By XORing the
+     * pointers with a random canary value, heap overflows will result
+     * in randomly unpredictable pointer values which will be caught by
+     * heapVALIDATE_BLOCK_POINTER assert. */
+    #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( ( BlockLink_t * ) ( ( ( portPOINTER_SIZE_TYPE ) ( pxBlock ) ) ^ xHeapCanary ) )
 #else
 
-#define heapPROTECT_POINTER( pxNextFreeBlock )       ( pxNextFreeBlock )
-#define heapPROTECT_BOUNDS_CHECK( pxBlock )           do {} while(0)
+    #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( pxBlock )
 
-#endif /* configENABLE_HEAP_PROTECTOR */
+#endif /* configENABLE_HEAP_PROTECTION */
+
+/* Assert that a heap block pointer is within the heap bounds. */
+#define heapVALIDATE_BLOCK_POINTER( pxBlock )                          \
+    configASSERT( ( ( uint8_t * ) ( pxBlock ) >= &( ucHeap[ 0 ] ) ) && \
+                  ( ( uint8_t * ) ( pxBlock ) <= &( ucHeap[ configTOTAL_HEAP_SIZE - 1 ] ) ) )
 
 /*-----------------------------------------------------------*/
 
@@ -236,14 +241,14 @@ void * pvPortMalloc( size_t xWantedSize )
                 /* Traverse the list from the start (lowest address) block until
                  * one of adequate size is found. */
                 pxPreviousBlock = &xStart;
-                pxBlock = heapPROTECT_POINTER( xStart.pxNextFreeBlock );
-                heapPROTECT_BOUNDS_CHECK( pxBlock );
+                pxBlock = heapPROTECT_BLOCK_POINTER( xStart.pxNextFreeBlock );
+                heapVALIDATE_BLOCK_POINTER( pxBlock );
 
-                while( ( pxBlock->xBlockSize < xWantedSize ) && ( pxBlock->pxNextFreeBlock != heapPROTECT_POINTER( NULL ) ) )
+                while( ( pxBlock->xBlockSize < xWantedSize ) && ( pxBlock->pxNextFreeBlock != heapPROTECT_BLOCK_POINTER( NULL ) ) )
                 {
                     pxPreviousBlock = pxBlock;
-                    pxBlock = heapPROTECT_POINTER( pxBlock->pxNextFreeBlock );
-                    heapPROTECT_BOUNDS_CHECK( pxBlock );
+                    pxBlock = heapPROTECT_BLOCK_POINTER( pxBlock->pxNextFreeBlock );
+                    heapVALIDATE_BLOCK_POINTER( pxBlock );
                 }
 
                 /* If the end marker was reached then a block of adequate size
@@ -252,17 +257,17 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     /* Return the memory space pointed to - jumping over the
                      * BlockLink_t structure at its start. */
-                    pvReturn = ( void * ) ( ( ( uint8_t * ) heapPROTECT_POINTER( pxPreviousBlock->pxNextFreeBlock ) ) + xHeapStructSize );
-                    heapPROTECT_BOUNDS_CHECK( pvReturn );
+                    pvReturn = ( void * ) ( ( ( uint8_t * ) heapPROTECT_BLOCK_POINTER( pxPreviousBlock->pxNextFreeBlock ) ) + xHeapStructSize );
+                    heapVALIDATE_BLOCK_POINTER( pvReturn );
 
                     /* This block is being returned for use so must be taken out
                      * of the list of free blocks. */
                     pxPreviousBlock->pxNextFreeBlock = pxBlock->pxNextFreeBlock;
 
                     /* If the block is larger than required it can be split into
-                     * two. Also check for underflow as this can occur if xBlockSize is
-                     * overwritten in a heap block */
-                    configASSERT( !heapSUBTRACT_WILL_UNDERFLOW( xWantedSize, pxBlock->xBlockSize ) );
+                     * two. */
+                    configASSERT( heapSUBTRACT_WILL_UNDERFLOW( pxBlock->xBlockSize, xWantedSize ) == 0 );
+
                     if( ( pxBlock->xBlockSize - xWantedSize ) > heapMINIMUM_BLOCK_SIZE )
                     {
                         /* This block is to be split into two.  Create a new
@@ -279,7 +284,7 @@ void * pvPortMalloc( size_t xWantedSize )
 
                         /* Insert the new block into the list of free blocks. */
                         pxNewBlockLink->pxNextFreeBlock = pxPreviousBlock->pxNextFreeBlock;
-                        pxPreviousBlock->pxNextFreeBlock = heapPROTECT_POINTER( pxNewBlockLink );
+                        pxPreviousBlock->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( pxNewBlockLink );
                     }
                     else
                     {
@@ -353,8 +358,8 @@ void vPortFree( void * pv )
 
         /* This casting is to keep the compiler from issuing warnings. */
         pxLink = ( void * ) puc;
-        /* This will assert if pv is out of heap range */
-        heapPROTECT_BOUNDS_CHECK( pxLink );
+
+        heapVALIDATE_BLOCK_POINTER( pxLink );
         configASSERT( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 );
         configASSERT( pxLink->pxNextFreeBlock == NULL );
 
@@ -368,9 +373,11 @@ void vPortFree( void * pv )
                 #if ( configHEAP_CLEAR_MEMORY_ON_FREE == 1 )
                 {
                     /* Check for underflow as this can occur if xBlockSize is
-                     * overwritten in a heap block */
-                    configASSERT( !heapSUBTRACT_WILL_UNDERFLOW( xHeapStructSize, pxLink->xBlockSize ) );
-                    ( void ) memset( puc + xHeapStructSize, 0, pxLink->xBlockSize - xHeapStructSize );
+                     * overwritten in a heap block. */
+                    if( heapSUBTRACT_WILL_UNDERFLOW( pxLink->xBlockSize, xHeapStructSize ) == 0 )
+                    {
+                        ( void ) memset( puc + xHeapStructSize, 0, pxLink->xBlockSize - xHeapStructSize );
+                    }
                 }
                 #endif
 
@@ -453,13 +460,15 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     pucAlignedHeap = ( uint8_t * ) uxAddress;
 
-#if ( configENABLE_HEAP_PROTECTOR == 1)
-            xApplicationGetRandomHeapCanary( &xHeapCanary );
-#endif
+    #if ( configENABLE_HEAP_PROTECTION == 1 )
+    {
+        xApplicationGetRandomHeapCanary( &( xHeapCanary ) );
+    }
+    #endif
 
     /* xStart is used to hold a pointer to the first item in the list of free
      * blocks.  The void cast is used to prevent compiler warnings. */
-    xStart.pxNextFreeBlock = ( void * ) heapPROTECT_POINTER( pucAlignedHeap );
+    xStart.pxNextFreeBlock = ( void * ) heapPROTECT_BLOCK_POINTER( pucAlignedHeap );
     xStart.xBlockSize = ( size_t ) 0;
 
     /* pxEnd is used to mark the end of the list of free blocks and is inserted
@@ -469,13 +478,13 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
     uxAddress &= ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK );
     pxEnd = ( BlockLink_t * ) uxAddress;
     pxEnd->xBlockSize = 0;
-    pxEnd->pxNextFreeBlock = heapPROTECT_POINTER( NULL );
+    pxEnd->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( NULL );
 
     /* To start with there is a single free block that is sized to take up the
      * entire heap space, minus the space taken by pxEnd. */
     pxFirstFreeBlock = ( BlockLink_t * ) pucAlignedHeap;
     pxFirstFreeBlock->xBlockSize = ( size_t ) ( uxAddress - ( portPOINTER_SIZE_TYPE ) pxFirstFreeBlock );
-    pxFirstFreeBlock->pxNextFreeBlock = heapPROTECT_POINTER( pxEnd );
+    pxFirstFreeBlock->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( pxEnd );
 
     /* Only one block exists - and it covers the entire usable heap space. */
     xMinimumEverFreeBytesRemaining = pxFirstFreeBlock->xBlockSize;
@@ -488,17 +497,16 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVI
     BlockLink_t * pxIterator;
     uint8_t * puc;
 
-    /* Ensure the block to insert is within the heap region */
-    heapPROTECT_BOUNDS_CHECK( pxBlockToInsert );
-
     /* Iterate through the list until a block is found that has a higher address
      * than the block being inserted. */
-    for( pxIterator = &xStart; heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) < pxBlockToInsert; pxIterator = heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) )
+    for( pxIterator = &xStart; heapPROTECT_BLOCK_POINTER( pxIterator->pxNextFreeBlock ) < pxBlockToInsert; pxIterator = heapPROTECT_BLOCK_POINTER( pxIterator->pxNextFreeBlock ) )
     {
         /* Nothing to do here, just iterate to the right position. */
     }
-    if ( pxIterator != &xStart ) {
-        heapPROTECT_BOUNDS_CHECK( pxIterator );
+
+    if( pxIterator != &xStart )
+    {
+        heapVALIDATE_BLOCK_POINTER( pxIterator );
     }
 
     /* Do the block being inserted, and the block it is being inserted after
@@ -519,17 +527,17 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVI
      * make a contiguous block of memory? */
     puc = ( uint8_t * ) pxBlockToInsert;
 
-    if( ( puc + pxBlockToInsert->xBlockSize ) == ( uint8_t * ) heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) )
+    if( ( puc + pxBlockToInsert->xBlockSize ) == ( uint8_t * ) heapPROTECT_BLOCK_POINTER( pxIterator->pxNextFreeBlock ) )
     {
-        if( heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) != pxEnd )
+        if( heapPROTECT_BLOCK_POINTER( pxIterator->pxNextFreeBlock ) != pxEnd )
         {
             /* Form one big block from the two blocks. */
-            pxBlockToInsert->xBlockSize += heapPROTECT_POINTER( pxIterator->pxNextFreeBlock )->xBlockSize;
-            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_POINTER( pxIterator->pxNextFreeBlock )->pxNextFreeBlock;
+            pxBlockToInsert->xBlockSize += heapPROTECT_BLOCK_POINTER( pxIterator->pxNextFreeBlock )->xBlockSize;
+            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( pxIterator->pxNextFreeBlock )->pxNextFreeBlock;
         }
         else
         {
-            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_POINTER( pxEnd );
+            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( pxEnd );
         }
     }
     else
@@ -543,7 +551,7 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVI
      * to itself. */
     if( pxIterator != pxBlockToInsert )
     {
-        pxIterator->pxNextFreeBlock = heapPROTECT_POINTER( pxBlockToInsert );
+        pxIterator->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( pxBlockToInsert );
     }
     else
     {
@@ -559,7 +567,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
 
     vTaskSuspendAll();
     {
-        pxBlock = heapPROTECT_POINTER( xStart.pxNextFreeBlock );
+        pxBlock = heapPROTECT_BLOCK_POINTER( xStart.pxNextFreeBlock );
 
         /* pxBlock will be NULL if the heap has not been initialised.  The heap
          * is initialised automatically when the first allocation is made. */
@@ -583,7 +591,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
 
                 /* Move to the next block in the chain until the last block is
                  * reached. */
-                pxBlock = heapPROTECT_POINTER( pxBlock->pxNextFreeBlock );
+                pxBlock = heapPROTECT_BLOCK_POINTER( pxBlock->pxNextFreeBlock );
             }
         }
     }

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -103,11 +103,11 @@ typedef struct A_BLOCK_LINK
     size_t xBlockSize;                     /**< The size of the free block. */
 } BlockLink_t;
 
-/* Setting configENABLE_HEAP_PROTECTION to 1 enables heap block pointers
+/* Setting configENABLE_HEAP_PROTECTOR to 1 enables heap block pointers
  * protection using an application supplied canary value to catch heap
  * corruption should a heap buffer overflow occur.
  */
-#if ( configENABLE_HEAP_PROTECTION == 1 )
+#if ( configENABLE_HEAP_PROTECTOR == 1 )
 
     /**
      * @brief Application provided function to get a random value to be used as canary.
@@ -128,7 +128,7 @@ typedef struct A_BLOCK_LINK
 
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( pxBlock )
 
-#endif /* configENABLE_HEAP_PROTECTION */
+#endif /* configENABLE_HEAP_PROTECTOR */
 
 /* Assert that a heap block pointer is within the heap bounds. */
 #define heapVALIDATE_BLOCK_POINTER( pxBlock )                          \
@@ -460,7 +460,7 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     pucAlignedHeap = ( uint8_t * ) uxAddress;
 
-    #if ( configENABLE_HEAP_PROTECTION == 1 )
+    #if ( configENABLE_HEAP_PROTECTOR == 1 )
     {
         vApplicationGetRandomHeapCanary( &( xHeapCanary ) );
     }

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -150,7 +150,7 @@ typedef struct A_BLOCK_LINK
      * heapVALIDATE_BLOCK_POINTER assert. */
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( ( BlockLink_t * ) ( ( ( portPOINTER_SIZE_TYPE ) ( pxBlock ) ) ^ xHeapCanary ) )
 
-#else  /* if ( configENABLE_HEAP_PROTECTOR == 1 ) */
+#else /* if ( configENABLE_HEAP_PROTECTOR == 1 ) */
 
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( pxBlock )
 

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -104,6 +104,9 @@
 /* Check if adding a and b will result in overflow. */
 #define heapADD_WILL_OVERFLOW( a, b )         ( ( a ) > ( heapSIZE_MAX - ( b ) ) )
 
+/* Check if subtracting a from b will result in underflow. */
+#define heapSUBTRACT_WILL_UNDERFLOW( a, b )         ( ( a ) > ( b ) )
+
 /* MSB of the xBlockSize member of an BlockLink_t structure is used to track
  * the allocation status of a block.  When MSB of the xBlockSize member of
  * an BlockLink_t structure is set then the block belongs to the application.
@@ -123,6 +126,38 @@ typedef struct A_BLOCK_LINK
     struct A_BLOCK_LINK * pxNextFreeBlock; /**< The next free block in the list. */
     size_t xBlockSize;                     /**< The size of the free block. */
 } BlockLink_t;
+
+/* Enabling configENABLE_HEAP_PROTECTOR provides a security enhanced version of heap_4.c that
+ * implements pointer protection using a canary value to reduce the risk of code execution
+ * should a heap buffer overflow vulnerability occur.
+ * It also implements additional arithmetic and bounds checks on heap values.
+ */
+#if ( configENABLE_HEAP_PROTECTOR == 1 )
+/* We require xApplicationGetRandomNumber in order to initialize our canary value */
+    extern BaseType_t xApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxRandomNumber );
+/* Canary value for protecting internal heap pointers */
+    static portPOINTER_SIZE_TYPE xHeapCanary;
+/* Highest and lowest heap addresses for bounds checking */
+    static void * pxHeapHighAddress = NULL;
+    static void * pxHeapLowAddress = NULL;
+
+/* Macro to load/store pxNextFreeBlock pointers to memory. By XORing the
+ * pointers with a random canary value, intentional heap overwrites will
+ * result in randomly unpredictable pointer values. If configASSERT() is defined
+ * out of bound values will result in a safe abend due to bounds checks. */
+#define heapPROTECT_POINTER( pxNextFreeBlock )       ( ( struct A_BLOCK_LINK *) ( ( ( portPOINTER_SIZE_TYPE ) ( pxNextFreeBlock ) ) ^ xHeapCanary ) )
+/* Macro to perform a bounds check of heap pointers such that a heap pointer that
+ * falls outside of ucHeap will trigger an assertion. For heap_5.c we check that
+ * pointers are greater than the lowest address in the lowest region, and less than
+ * the highest address in the highest region. */
+#define heapPROTECT_BOUNDS_CHECK( pxBlock )          configASSERT( pxHeapHighAddress && pxHeapLowAddress && \
+    ( ( void * ) ( pxBlock ) >= pxHeapLowAddress ) && ( ( void * ) ( pxBlock ) < pxHeapHighAddress ) )
+#else
+
+#define heapPROTECT_POINTER( pxNextFreeBlock )       ( pxNextFreeBlock )
+#define heapPROTECT_BOUNDS_CHECK( pxBlock )           do {} while(0)
+
+#endif /* configENABLE_HEAP_PROTECTOR */
 
 /*-----------------------------------------------------------*/
 
@@ -217,12 +252,14 @@ void * pvPortMalloc( size_t xWantedSize )
                 /* Traverse the list from the start (lowest address) block until
                  * one of adequate size is found. */
                 pxPreviousBlock = &xStart;
-                pxBlock = xStart.pxNextFreeBlock;
+                pxBlock = heapPROTECT_POINTER( xStart.pxNextFreeBlock );
+                heapPROTECT_BOUNDS_CHECK( pxBlock );
 
-                while( ( pxBlock->xBlockSize < xWantedSize ) && ( pxBlock->pxNextFreeBlock != NULL ) )
+                while( ( pxBlock->xBlockSize < xWantedSize ) && ( pxBlock->pxNextFreeBlock != heapPROTECT_POINTER( NULL ) ) )
                 {
                     pxPreviousBlock = pxBlock;
-                    pxBlock = pxBlock->pxNextFreeBlock;
+                    pxBlock = heapPROTECT_POINTER( pxBlock->pxNextFreeBlock );
+                    heapPROTECT_BOUNDS_CHECK( pxBlock );
                 }
 
                 /* If the end marker was reached then a block of adequate size
@@ -231,14 +268,17 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     /* Return the memory space pointed to - jumping over the
                      * BlockLink_t structure at its start. */
-                    pvReturn = ( void * ) ( ( ( uint8_t * ) pxPreviousBlock->pxNextFreeBlock ) + xHeapStructSize );
+                    pvReturn = ( void * ) ( ( ( uint8_t * ) heapPROTECT_POINTER( pxPreviousBlock->pxNextFreeBlock ) ) + xHeapStructSize );
+                    heapPROTECT_BOUNDS_CHECK( pvReturn );
 
                     /* This block is being returned for use so must be taken out
                      * of the list of free blocks. */
                     pxPreviousBlock->pxNextFreeBlock = pxBlock->pxNextFreeBlock;
 
                     /* If the block is larger than required it can be split into
-                     * two. */
+                     * two. Also check for underflow as this can occur if xBlockSize is
+                     * overwritten in a heap block */
+                    configASSERT( !heapSUBTRACT_WILL_UNDERFLOW( xWantedSize, pxBlock->xBlockSize ) );
                     if( ( pxBlock->xBlockSize - xWantedSize ) > heapMINIMUM_BLOCK_SIZE )
                     {
                         /* This block is to be split into two.  Create a new
@@ -246,6 +286,7 @@ void * pvPortMalloc( size_t xWantedSize )
                          * cast is used to prevent byte alignment warnings from the
                          * compiler. */
                         pxNewBlockLink = ( void * ) ( ( ( uint8_t * ) pxBlock ) + xWantedSize );
+                        configASSERT( ( ( ( size_t ) pxNewBlockLink ) & portBYTE_ALIGNMENT_MASK ) == 0 );
 
                         /* Calculate the sizes of two blocks split from the
                          * single block. */
@@ -254,7 +295,7 @@ void * pvPortMalloc( size_t xWantedSize )
 
                         /* Insert the new block into the list of free blocks. */
                         pxNewBlockLink->pxNextFreeBlock = pxPreviousBlock->pxNextFreeBlock;
-                        pxPreviousBlock->pxNextFreeBlock = pxNewBlockLink;
+                        pxPreviousBlock->pxNextFreeBlock = heapPROTECT_POINTER( pxNewBlockLink );
                     }
                     else
                     {
@@ -310,6 +351,7 @@ void * pvPortMalloc( size_t xWantedSize )
     }
     #endif /* if ( configUSE_MALLOC_FAILED_HOOK == 1 ) */
 
+    configASSERT( ( ( ( size_t ) pvReturn ) & ( size_t ) portBYTE_ALIGNMENT_MASK ) == 0 );
     return pvReturn;
 }
 /*-----------------------------------------------------------*/
@@ -327,7 +369,8 @@ void vPortFree( void * pv )
 
         /* This casting is to keep the compiler from issuing warnings. */
         pxLink = ( void * ) puc;
-
+        /* This will assert if pv is out of heap range */
+        heapPROTECT_BOUNDS_CHECK( pxLink );
         configASSERT( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 );
         configASSERT( pxLink->pxNextFreeBlock == NULL );
 
@@ -340,6 +383,9 @@ void vPortFree( void * pv )
                 heapFREE_BLOCK( pxLink );
                 #if ( configHEAP_CLEAR_MEMORY_ON_FREE == 1 )
                 {
+                    /* Check for underflow as this can occur if xBlockSize is
+                     * overwritten in a heap block */
+                    configASSERT( !heapSUBTRACT_WILL_UNDERFLOW( xHeapStructSize, pxLink->xBlockSize ) );
                     ( void ) memset( puc + xHeapStructSize, 0, pxLink->xBlockSize - xHeapStructSize );
                 }
                 #endif
@@ -403,11 +449,17 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert )
     BlockLink_t * pxIterator;
     uint8_t * puc;
 
+    /* Ensure the block to insert is within the heap region */
+    heapPROTECT_BOUNDS_CHECK( pxBlockToInsert );
+
     /* Iterate through the list until a block is found that has a higher address
      * than the block being inserted. */
-    for( pxIterator = &xStart; pxIterator->pxNextFreeBlock < pxBlockToInsert; pxIterator = pxIterator->pxNextFreeBlock )
+    for( pxIterator = &xStart; heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) < pxBlockToInsert; pxIterator = heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) )
     {
         /* Nothing to do here, just iterate to the right position. */
+    }
+    if ( pxIterator != &xStart ) {
+        heapPROTECT_BOUNDS_CHECK( pxIterator );
     }
 
     /* Do the block being inserted, and the block it is being inserted after
@@ -428,17 +480,17 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert )
      * make a contiguous block of memory? */
     puc = ( uint8_t * ) pxBlockToInsert;
 
-    if( ( puc + pxBlockToInsert->xBlockSize ) == ( uint8_t * ) pxIterator->pxNextFreeBlock )
+    if( ( puc + pxBlockToInsert->xBlockSize ) == ( uint8_t * ) heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) )
     {
-        if( pxIterator->pxNextFreeBlock != pxEnd )
+        if( heapPROTECT_POINTER( pxIterator->pxNextFreeBlock ) != pxEnd )
         {
             /* Form one big block from the two blocks. */
-            pxBlockToInsert->xBlockSize += pxIterator->pxNextFreeBlock->xBlockSize;
-            pxBlockToInsert->pxNextFreeBlock = pxIterator->pxNextFreeBlock->pxNextFreeBlock;
+            pxBlockToInsert->xBlockSize += heapPROTECT_POINTER( pxIterator->pxNextFreeBlock )->xBlockSize;
+            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_POINTER( pxIterator->pxNextFreeBlock )->pxNextFreeBlock;
         }
         else
         {
-            pxBlockToInsert->pxNextFreeBlock = pxEnd;
+            pxBlockToInsert->pxNextFreeBlock = heapPROTECT_POINTER( pxEnd );
         }
     }
     else
@@ -446,13 +498,13 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert )
         pxBlockToInsert->pxNextFreeBlock = pxIterator->pxNextFreeBlock;
     }
 
-    /* If the block being inserted plugged a gab, so was merged with the block
+    /* If the block being inserted plugged a gap, so was merged with the block
      * before and the block after, then it's pxNextFreeBlock pointer will have
      * already been set, and should not be set here as that would make it point
      * to itself. */
     if( pxIterator != pxBlockToInsert )
     {
-        pxIterator->pxNextFreeBlock = pxBlockToInsert;
+        pxIterator->pxNextFreeBlock = heapPROTECT_POINTER( pxBlockToInsert );
     }
     else
     {
@@ -471,8 +523,13 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions )
     portPOINTER_SIZE_TYPE xAddress;
     const HeapRegion_t * pxHeapRegion;
 
+
     /* Can only call once! */
     configASSERT( pxEnd == NULL );
+
+#if ( configENABLE_HEAP_PROTECTOR == 1)
+    xApplicationGetRandomHeapCanary( &xHeapCanary );
+#endif
 
     pxHeapRegion = &( pxHeapRegions[ xDefinedRegions ] );
 
@@ -499,14 +556,17 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions )
         {
             /* xStart is used to hold a pointer to the first item in the list of
              *  free blocks.  The void cast is used to prevent compiler warnings. */
-            xStart.pxNextFreeBlock = ( BlockLink_t * ) xAlignedHeap;
+            xStart.pxNextFreeBlock = ( BlockLink_t * ) heapPROTECT_POINTER( xAlignedHeap );
             xStart.xBlockSize = ( size_t ) 0;
+#if ( configENABLE_HEAP_PROTECTOR == 1 )
+            pxHeapLowAddress = ( void * ) xAlignedHeap;
+#endif
         }
         else
         {
             /* Should only get here if one region has already been added to the
              * heap. */
-            configASSERT( pxEnd != NULL );
+            configASSERT( pxEnd != heapPROTECT_POINTER( NULL ) );
 
             /* Check blocks are passed in with increasing start addresses. */
             configASSERT( ( size_t ) xAddress > ( size_t ) pxEnd );
@@ -523,24 +583,27 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions )
         xAddress &= ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK );
         pxEnd = ( BlockLink_t * ) xAddress;
         pxEnd->xBlockSize = 0;
-        pxEnd->pxNextFreeBlock = NULL;
+        pxEnd->pxNextFreeBlock = heapPROTECT_POINTER( NULL );
 
         /* To start with there is a single free block in this region that is
          * sized to take up the entire heap region minus the space taken by the
          * free block structure. */
         pxFirstFreeBlockInRegion = ( BlockLink_t * ) xAlignedHeap;
         pxFirstFreeBlockInRegion->xBlockSize = ( size_t ) ( xAddress - ( portPOINTER_SIZE_TYPE ) pxFirstFreeBlockInRegion );
-        pxFirstFreeBlockInRegion->pxNextFreeBlock = pxEnd;
+        pxFirstFreeBlockInRegion->pxNextFreeBlock = heapPROTECT_POINTER( pxEnd );
 
         /* If this is not the first region that makes up the entire heap space
          * then link the previous region to this region. */
         if( pxPreviousFreeBlock != NULL )
         {
-            pxPreviousFreeBlock->pxNextFreeBlock = pxFirstFreeBlockInRegion;
+            pxPreviousFreeBlock->pxNextFreeBlock = heapPROTECT_POINTER( pxFirstFreeBlockInRegion );
         }
 
         xTotalHeapSize += pxFirstFreeBlockInRegion->xBlockSize;
 
+#if ( configENABLE_HEAP_PROTECTOR == 1 )
+        pxHeapHighAddress = ( ( uint8_t *  )pxFirstFreeBlockInRegion ) + pxFirstFreeBlockInRegion->xBlockSize;
+#endif
         /* Move onto the next HeapRegion_t structure. */
         xDefinedRegions++;
         pxHeapRegion = &( pxHeapRegions[ xDefinedRegions ] );
@@ -561,7 +624,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
 
     vTaskSuspendAll();
     {
-        pxBlock = xStart.pxNextFreeBlock;
+        pxBlock = heapPROTECT_POINTER( xStart.pxNextFreeBlock );
 
         /* pxBlock will be NULL if the heap has not been initialised.  The heap
          * is initialised automatically when the first allocation is made. */
@@ -591,7 +654,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats )
 
                 /* Move to the next block in the chain until the last block is
                  * reached. */
-                pxBlock = pxBlock->pxNextFreeBlock;
+                pxBlock = heapPROTECT_POINTER( pxBlock->pxNextFreeBlock );
             }
         }
     }

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -284,8 +284,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     pxPreviousBlock->pxNextFreeBlock = pxBlock->pxNextFreeBlock;
 
                     /* If the block is larger than required it can be split into
-                     * two. Also check for underflow as this can occur if xBlockSize is
-                     * overwritten in a heap block */
+                     * two. */
                     configASSERT( heapSUBTRACT_WILL_UNDERFLOW( pxBlock->xBlockSize, xWantedSize ) == 0 );
 
                     if( ( pxBlock->xBlockSize - xWantedSize ) > heapMINIMUM_BLOCK_SIZE )
@@ -532,7 +531,6 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
     BaseType_t xDefinedRegions = 0;
     portPOINTER_SIZE_TYPE xAddress;
     const HeapRegion_t * pxHeapRegion;
-
 
     /* Can only call once! */
     configASSERT( pxEnd == NULL );

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -138,7 +138,7 @@ typedef struct A_BLOCK_LINK
      *
      * @param pxHeapCanary [out] Output parameter to return the canary value.
      */
-    extern void xApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxHeapCanary );
+    extern void vApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxHeapCanary );
 
     /* Canary value for protecting internal heap pointers. */
     PRIVILEGED_DATA static portPOINTER_SIZE_TYPE xHeapCanary;
@@ -539,7 +539,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
 
     #if ( configENABLE_HEAP_PROTECTION == 1 )
     {
-        xApplicationGetRandomHeapCanary( &( xHeapCanary ) );
+        vApplicationGetRandomHeapCanary( &( xHeapCanary ) );
     }
     #endif
 
@@ -570,15 +570,6 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
              *  free blocks.  The void cast is used to prevent compiler warnings. */
             xStart.pxNextFreeBlock = ( BlockLink_t * ) heapPROTECT_BLOCK_POINTER( xAlignedHeap );
             xStart.xBlockSize = ( size_t ) 0;
-            #if ( configENABLE_HEAP_PROTECTION == 1 )
-            {
-                if( ( pucHeapLowAddress == NULL ) ||
-                    ( ( uint8_t * ) xAlignedHeap < pucHeapLowAddress ) )
-                {
-                    pucHeapLowAddress = ( uint8_t * ) xAlignedHeap;
-                }
-            }
-            #endif /* configENABLE_HEAP_PROTECTION */
         }
         else
         {
@@ -589,6 +580,16 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
             /* Check blocks are passed in with increasing start addresses. */
             configASSERT( ( size_t ) xAddress > ( size_t ) pxEnd );
         }
+
+        #if ( configENABLE_HEAP_PROTECTION == 1 )
+        {
+            if( ( pucHeapLowAddress == NULL ) ||
+                ( ( uint8_t * ) xAlignedHeap < pucHeapLowAddress ) )
+            {
+                pucHeapLowAddress = ( uint8_t * ) xAlignedHeap;
+            }
+        }
+        #endif /* configENABLE_HEAP_PROTECTION */
 
         /* Remember the location of the end marker in the previous region, if
          * any. */

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -133,21 +133,21 @@ typedef struct A_BLOCK_LINK
  */
 #if ( configENABLE_HEAP_PROTECTOR == 1 )
 
-    /**
-     * @brief Application provided function to get a random value to be used as canary.
-     *
-     * @param pxHeapCanary [out] Output parameter to return the canary value.
-     */
+/**
+ * @brief Application provided function to get a random value to be used as canary.
+ *
+ * @param pxHeapCanary [out] Output parameter to return the canary value.
+ */
     extern void vApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxHeapCanary );
 
-    /* Canary value for protecting internal heap pointers. */
+/* Canary value for protecting internal heap pointers. */
     PRIVILEGED_DATA static portPOINTER_SIZE_TYPE xHeapCanary;
 
 
-    /* Macro to load/store BlockLink_t pointers to memory. By XORing the
-     * pointers with a random canary value, heap overflows will result
-     * in randomly unpredictable pointer values which will be caught by
-     * heapVALIDATE_BLOCK_POINTER assert. */
+/* Macro to load/store BlockLink_t pointers to memory. By XORing the
+ * pointers with a random canary value, heap overflows will result
+ * in randomly unpredictable pointer values which will be caught by
+ * heapVALIDATE_BLOCK_POINTER assert. */
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( ( BlockLink_t * ) ( ( ( portPOINTER_SIZE_TYPE ) ( pxBlock ) ) ^ xHeapCanary ) )
 
 #else /* if ( configENABLE_HEAP_PROTECTOR == 1 ) */

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -136,10 +136,10 @@ typedef struct A_BLOCK_LINK
 /* We require xApplicationGetRandomNumber in order to initialize our canary value */
     extern BaseType_t xApplicationGetRandomHeapCanary( portPOINTER_SIZE_TYPE * pxRandomNumber );
 /* Canary value for protecting internal heap pointers */
-    static portPOINTER_SIZE_TYPE xHeapCanary;
+    PRIVILEGED_DATA static portPOINTER_SIZE_TYPE xHeapCanary;
 /* Highest and lowest heap addresses for bounds checking */
-    static void * pxHeapHighAddress = NULL;
-    static void * pxHeapLowAddress = NULL;
+    PRIVILEGED_DATA static void * pxHeapHighAddress = NULL;
+    PRIVILEGED_DATA static void * pxHeapLowAddress = NULL;
 
 /* Macro to load/store pxNextFreeBlock pointers to memory. By XORing the
  * pointers with a random canary value, intentional heap overwrites will
@@ -167,8 +167,8 @@ typedef struct A_BLOCK_LINK
  * the block in front it and/or the block behind it if the memory blocks are
  * adjacent to each other.
  */
-static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert );
-
+static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) PRIVILEGED_FUNCTION;
+void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /* The size of the structure placed at the beginning of each allocated memory
@@ -176,15 +176,15 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert );
 static const size_t xHeapStructSize = ( sizeof( BlockLink_t ) + ( ( size_t ) ( portBYTE_ALIGNMENT - 1 ) ) ) & ~( ( size_t ) portBYTE_ALIGNMENT_MASK );
 
 /* Create a couple of list links to mark the start and end of the list. */
-static BlockLink_t xStart;
-static BlockLink_t * pxEnd = NULL;
+PRIVILEGED_DATA static BlockLink_t xStart;
+PRIVILEGED_DATA static BlockLink_t * pxEnd = NULL;
 
 /* Keeps track of the number of calls to allocate and free memory as well as the
  * number of free bytes remaining, but says nothing about fragmentation. */
-static size_t xFreeBytesRemaining = 0U;
-static size_t xMinimumEverFreeBytesRemaining = 0U;
-static size_t xNumberOfSuccessfulAllocations = 0;
-static size_t xNumberOfSuccessfulFrees = 0;
+PRIVILEGED_DATA static size_t xFreeBytesRemaining = 0U;
+PRIVILEGED_DATA static size_t xMinimumEverFreeBytesRemaining = 0U;
+PRIVILEGED_DATA static size_t xNumberOfSuccessfulAllocations = 0;
+PRIVILEGED_DATA static size_t xNumberOfSuccessfulFrees = 0;
 
 /*-----------------------------------------------------------*/
 
@@ -444,7 +444,7 @@ void * pvPortCalloc( size_t xNum,
 }
 /*-----------------------------------------------------------*/
 
-static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert )
+static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert ) /* PRIVILEGED_FUNCTION */
 {
     BlockLink_t * pxIterator;
     uint8_t * puc;
@@ -513,7 +513,7 @@ static void prvInsertBlockIntoFreeList( BlockLink_t * pxBlockToInsert )
 }
 /*-----------------------------------------------------------*/
 
-void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions )
+void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVILEGED_FUNCTION */
 {
     BlockLink_t * pxFirstFreeBlockInRegion = NULL;
     BlockLink_t * pxPreviousFreeBlock;

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -127,11 +127,11 @@ typedef struct A_BLOCK_LINK
     size_t xBlockSize;                     /**< The size of the free block. */
 } BlockLink_t;
 
-/* Setting configENABLE_HEAP_PROTECTION to 1 enables heap block pointers
+/* Setting configENABLE_HEAP_PROTECTOR to 1 enables heap block pointers
  * protection using an application supplied canary value to catch heap
  * corruption should a heap buffer overflow occur.
  */
-#if ( configENABLE_HEAP_PROTECTION == 1 )
+#if ( configENABLE_HEAP_PROTECTOR == 1 )
 
     /**
      * @brief Application provided function to get a random value to be used as canary.
@@ -150,11 +150,11 @@ typedef struct A_BLOCK_LINK
      * heapVALIDATE_BLOCK_POINTER assert. */
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( ( BlockLink_t * ) ( ( ( portPOINTER_SIZE_TYPE ) ( pxBlock ) ) ^ xHeapCanary ) )
 
-#else  /* if ( configENABLE_HEAP_PROTECTION == 1 ) */
+#else  /* if ( configENABLE_HEAP_PROTECTOR == 1 ) */
 
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( pxBlock )
 
-#endif /* configENABLE_HEAP_PROTECTION */
+#endif /* configENABLE_HEAP_PROTECTOR */
 
 /* Highest and lowest heap addresses used for heap block bounds checking. */
 PRIVILEGED_DATA static uint8_t * pucHeapHighAddress = NULL;
@@ -537,7 +537,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
     /* Can only call once! */
     configASSERT( pxEnd == NULL );
 
-    #if ( configENABLE_HEAP_PROTECTION == 1 )
+    #if ( configENABLE_HEAP_PROTECTOR == 1 )
     {
         vApplicationGetRandomHeapCanary( &( xHeapCanary ) );
     }
@@ -581,7 +581,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
             configASSERT( ( size_t ) xAddress > ( size_t ) pxEnd );
         }
 
-        #if ( configENABLE_HEAP_PROTECTION == 1 )
+        #if ( configENABLE_HEAP_PROTECTOR == 1 )
         {
             if( ( pucHeapLowAddress == NULL ) ||
                 ( ( uint8_t * ) xAlignedHeap < pucHeapLowAddress ) )
@@ -589,7 +589,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
                 pucHeapLowAddress = ( uint8_t * ) xAlignedHeap;
             }
         }
-        #endif /* configENABLE_HEAP_PROTECTION */
+        #endif /* configENABLE_HEAP_PROTECTOR */
 
         /* Remember the location of the end marker in the previous region, if
          * any. */
@@ -620,7 +620,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
 
         xTotalHeapSize += pxFirstFreeBlockInRegion->xBlockSize;
 
-        #if ( configENABLE_HEAP_PROTECTION == 1 )
+        #if ( configENABLE_HEAP_PROTECTOR == 1 )
         {
             if( ( pucHeapHighAddress == NULL ) ||
                 ( ( ( ( uint8_t * ) pxFirstFreeBlockInRegion ) + pxFirstFreeBlockInRegion->xBlockSize ) > pucHeapHighAddress ) )


### PR DESCRIPTION
Implement configENABLE_HEAP_PROTECTOR.

Description
-----------
* Setting `configENABLE_HEAP_PROTECTOR` to `1` obfuscates heap block pointers by XORing them with an application supplied canary value. This obfuscation helps to catch heap corruption should a heap buffer overflow occur. 
* This PR also adds heap bounds checking to heap_4 and heap_5.
* This PR also adds some additional integer underflow checks. 

Test Steps
-----------
Test harnesses to verify the effect of the change in the POSIX simulator are available here:
* https://github.com/oliverlavery/FreeRTOS/tree/heap-harness
* https://github.com/oliverlavery/FreeRTOS/tree/heap-harness-5

With `configENABLE_HEAP_PROTECTOR` set to 1, overwriting a free list block leads to an assert on an out of bounds heap pointer. I have also manually verified allocation, free, and corruption in GDB.

The POSIX simulator full demo works correctly with both heap_4.c and heap_5.c regardless of the `configENABLE_HEAP_PROTECTOR` setting.

Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
