### PR TITLE
move non-critical code out of critical section.

### DIFF
--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -159,6 +159,45 @@ void * pvPortMalloc( size_t xWantedSize )
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
 
+    if( xWantedSize > 0 )
+    {
+        /* The wanted size must be increased so it can contain a BlockLink_t
+            * structure in addition to the requested amount of bytes. */
+        if( heapADD_WILL_OVERFLOW( xWantedSize, xHeapStructSize ) == 0 )
+        {
+            xWantedSize += xHeapStructSize;
+
+            /* Ensure that blocks are always aligned to the required number
+                * of bytes. */
+            if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
+            {
+                /* Byte alignment required. */
+                xAdditionalRequiredSize = portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK );
+
+                if( heapADD_WILL_OVERFLOW( xWantedSize, xAdditionalRequiredSize ) == 0 )
+                {
+                    xWantedSize += xAdditionalRequiredSize;
+                }
+                else
+                {
+                    xWantedSize = 0;
+                }
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+        }
+        else
+        {
+            xWantedSize = 0;
+        }
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
+
     vTaskSuspendAll();
     {
         /* If this is the first call to malloc then the heap will require
@@ -167,23 +206,6 @@ void * pvPortMalloc( size_t xWantedSize )
         {
             prvHeapInit();
             xHeapHasBeenInitialised = pdTRUE;
-        }
-
-        if( xWantedSize > 0 )
-        {
-            /* The wanted size must be increased so it can contain a BlockLink_t
-             * structure in addition to the requested amount of bytes. Some
-             * additional increment may also be needed for alignment. */
-            xAdditionalRequiredSize = heapSTRUCT_SIZE + portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK );
-
-            if( heapADD_WILL_OVERFLOW( xWantedSize, xAdditionalRequiredSize ) == 0 )
-            {
-                xWantedSize += xAdditionalRequiredSize;
-            }
-            else
-            {
-                xWantedSize = 0;
-            }
         }
 
         /* Check the block size we are trying to allocate is not so large that the

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -143,6 +143,45 @@ void * pvPortMalloc( size_t xWantedSize )
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
 
+    if( xWantedSize > 0 )
+    {
+        /* The wanted size must be increased so it can contain a BlockLink_t
+            * structure in addition to the requested amount of bytes. */
+        if( heapADD_WILL_OVERFLOW( xWantedSize, xHeapStructSize ) == 0 )
+        {
+            xWantedSize += xHeapStructSize;
+
+            /* Ensure that blocks are always aligned to the required number
+                * of bytes. */
+            if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
+            {
+                /* Byte alignment required. */
+                xAdditionalRequiredSize = portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK );
+
+                if( heapADD_WILL_OVERFLOW( xWantedSize, xAdditionalRequiredSize ) == 0 )
+                {
+                    xWantedSize += xAdditionalRequiredSize;
+                }
+                else
+                {
+                    xWantedSize = 0;
+                }
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+        }
+        else
+        {
+            xWantedSize = 0;
+        }
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
+
     vTaskSuspendAll();
     {
         /* If this is the first call to malloc then the heap will require
@@ -150,45 +189,6 @@ void * pvPortMalloc( size_t xWantedSize )
         if( pxEnd == NULL )
         {
             prvHeapInit();
-        }
-        else
-        {
-            mtCOVERAGE_TEST_MARKER();
-        }
-
-        if( xWantedSize > 0 )
-        {
-            /* The wanted size must be increased so it can contain a BlockLink_t
-             * structure in addition to the requested amount of bytes. */
-            if( heapADD_WILL_OVERFLOW( xWantedSize, xHeapStructSize ) == 0 )
-            {
-                xWantedSize += xHeapStructSize;
-
-                /* Ensure that blocks are always aligned to the required number
-                 * of bytes. */
-                if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
-                {
-                    /* Byte alignment required. */
-                    xAdditionalRequiredSize = portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK );
-
-                    if( heapADD_WILL_OVERFLOW( xWantedSize, xAdditionalRequiredSize ) == 0 )
-                    {
-                        xWantedSize += xAdditionalRequiredSize;
-                    }
-                    else
-                    {
-                        xWantedSize = 0;
-                    }
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
-            }
-            else
-            {
-                xWantedSize = 0;
-            }
         }
         else
         {

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -165,47 +165,47 @@ void * pvPortMalloc( size_t xWantedSize )
      * prvPortMalloc(). */
     configASSERT( pxEnd );
 
-    vTaskSuspendAll();
+    if( xWantedSize > 0 )
     {
-        if( xWantedSize > 0 )
+        /* The wanted size must be increased so it can contain a BlockLink_t
+            * structure in addition to the requested amount of bytes. */
+        if( heapADD_WILL_OVERFLOW( xWantedSize, xHeapStructSize ) == 0 )
         {
-            /* The wanted size must be increased so it can contain a BlockLink_t
-             * structure in addition to the requested amount of bytes. */
-            if( heapADD_WILL_OVERFLOW( xWantedSize, xHeapStructSize ) == 0 )
+            xWantedSize += xHeapStructSize;
+
+            /* Ensure that blocks are always aligned to the required number
+                * of bytes. */
+            if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
             {
-                xWantedSize += xHeapStructSize;
+                /* Byte alignment required. */
+                xAdditionalRequiredSize = portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK );
 
-                /* Ensure that blocks are always aligned to the required number
-                 * of bytes. */
-                if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
+                if( heapADD_WILL_OVERFLOW( xWantedSize, xAdditionalRequiredSize ) == 0 )
                 {
-                    /* Byte alignment required. */
-                    xAdditionalRequiredSize = portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK );
-
-                    if( heapADD_WILL_OVERFLOW( xWantedSize, xAdditionalRequiredSize ) == 0 )
-                    {
-                        xWantedSize += xAdditionalRequiredSize;
-                    }
-                    else
-                    {
-                        xWantedSize = 0;
-                    }
+                    xWantedSize += xAdditionalRequiredSize;
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = 0;
                 }
             }
             else
             {
-                xWantedSize = 0;
+                mtCOVERAGE_TEST_MARKER();
             }
         }
         else
         {
-            mtCOVERAGE_TEST_MARKER();
+            xWantedSize = 0;
         }
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
 
+    vTaskSuspendAll();
+    {
         /* Check the block size we are trying to allocate is not so large that the
          * top bit is set.  The top bit of the block size member of the BlockLink_t
          * structure is used to determine who owns the block - the application or


### PR DESCRIPTION
<!--- Title -->
move non-critical code out of critical section.

Description
-----------
<!--- Describe your changes in detail. -->
The size calculation in `pvPortMalloc` is non-critical code, we can move it out of critical section, make critical section as small as possible.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
