### PR TITLE
Use the bigger priority whenever possible.

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2462,8 +2462,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 #if ( configUSE_MUTEXES == 1 )
                 {
                     /* Only change the priority being used if the task is not
-                     * currently using an inherited priority. */
-                    if( pxTCB->uxBasePriority == pxTCB->uxPriority )
+                     * currently using an inherited priority or the new priority
+                     * is bigger than the inherited priority. */
+                    if( ( pxTCB->uxBasePriority == pxTCB->uxPriority ) || ( uxNewPriority > pxTCB->uxPriority ) )
                     {
                         pxTCB->uxPriority = uxNewPriority;
                     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
For `vTaskPrioritySet` with mutex enabled,  there are three situations:
- The task doesn’t hold a mutex, or the mutex doesn’t inherit priority yet.
- The task has inherit priority from mutex, and we are setting a new priority bigger than the inherited priority.
- The task has inherit priority from mutex, and we are setting a new priority not bigger than the inherited priority.

For case 1, we can directly change task’s running priority;
For case 3, we shoudn’t change task’s running priority;
For case 2, I think we should change the task’s running priority to the bigger priority.

Case 1 is already handled in the existing code, this PR is handling case 2.

The previous discussion is in [Here](https://forums.freertos.org/t/question-about-vtaskpriorityset-with-mutex-enabled/17989).  

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
