### PR TITLE
Initialize register space in stack with value other than stack fill byte

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -89,7 +89,6 @@
  * value so the high water mark can be determined.  If none of the following are
  * set then don't fill the stack so there is no unnecessary dependency on memset. */
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) || ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark2 == 1 ) )
-{
     #define tskSET_NEW_STACKS_TO_KNOWN_VALUE    1
     #if ( configINITIALISED_STACK_FILL_DEPTH > 0 )
     {
@@ -98,11 +97,8 @@
         #endif
     }
     #endif /* #if ( configINITIALISED_STACK_FILL_DEPTH > 0 ) */
-}
 #else
-{
     #define tskSET_NEW_STACKS_TO_KNOWN_VALUE    0
-}
 #endif
 
 /*

--- a/tasks.c
+++ b/tasks.c
@@ -89,10 +89,10 @@
  * value so the high water mark can be determined.  If none of the following are
  * set then don't fill the stack so there is no unnecessary dependency on memset. */
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) || ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark2 == 1 ) )
-    #define tskSET_NEW_STACKS_TO_KNOWN_VALUE    1
+    #define tskSET_NEW_STACKS_TO_KNOWN_VALUE             1
     #if ( configINITIALISED_STACK_FILL_DEPTH > 0 )
         #ifndef configINITIALISED_STACK_FILL_BYTE
-            #define configINITIALISED_STACK_FILL_BYTE   0
+            #define configINITIALISED_STACK_FILL_BYTE    0
         #endif
     #endif /* #if ( configINITIALISED_STACK_FILL_DEPTH > 0 ) */
 #else
@@ -1533,7 +1533,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             pxNewTCB->pxEndOfStack = pxTopOfStack;
         }
         #endif /* configRECORD_STACK_HIGH_ADDRESS */
-        
+
         /* Avoid dependency on memset() if it is not required. */
         #if ( ( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 ) && ( configINITIALISED_STACK_FILL_DEPTH > 0 ) )
         {
@@ -1543,7 +1543,6 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             pxTopOfStack += configINITIALISED_STACK_FILL_DEPTH;
         }
         #endif /* ( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 ) && ( configINITIALISED_STACK_FILL_DEPTH > 0 ) */
-
     }
     #else /* portSTACK_GROWTH */
     {
@@ -1564,7 +1563,6 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             ( void ) memset( pxNewTCB->pxStack, ( int ) configINITIALISED_STACK_FILL_BYTE, ( size_t ) configINITIALISED_STACK_FILL_DEPTH * sizeof( StackType_t ) );
         }
         #endif /* ( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 ) && ( configINITIALISED_STACK_FILL_DEPTH > 0 ) */
-        
     }
     #endif /* portSTACK_GROWTH */
 

--- a/tasks.c
+++ b/tasks.c
@@ -91,11 +91,9 @@
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) || ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark2 == 1 ) )
     #define tskSET_NEW_STACKS_TO_KNOWN_VALUE    1
     #if ( configINITIALISED_STACK_FILL_DEPTH > 0 )
-    {
         #ifndef configINITIALISED_STACK_FILL_BYTE
             #define configINITIALISED_STACK_FILL_BYTE   0
         #endif
-    }
     #endif /* #if ( configINITIALISED_STACK_FILL_DEPTH > 0 ) */
 #else
     #define tskSET_NEW_STACKS_TO_KNOWN_VALUE    0
@@ -1539,8 +1537,10 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* Avoid dependency on memset() if it is not required. */
         #if ( ( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 ) && ( configINITIALISED_STACK_FILL_DEPTH > 0 ) )
         {
+            pxTopOfStack -= configINITIALISED_STACK_FILL_DEPTH;
             /* Fill the part of the stack initialized in pxPortInitialiseStack with a known value. */
-            ( void ) memset( pxTopOfStack - ( StackType_t * ) ( configINITIALISED_STACK_FILL_DEPTH ), ( int ) configINITIALISED_STACK_FILL_BYTE, ( size_t ) configINITIALISED_STACK_FILL_DEPTH * sizeof( StackType_t ) );
+            ( void ) memset( pxTopOfStack, ( int ) configINITIALISED_STACK_FILL_BYTE, ( size_t ) configINITIALISED_STACK_FILL_DEPTH * sizeof( StackType_t ) );
+            pxTopOfStack += configINITIALISED_STACK_FILL_DEPTH;
         }
         #endif /* ( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 ) && ( configINITIALISED_STACK_FILL_DEPTH > 0 ) */
 

--- a/tasks.c
+++ b/tasks.c
@@ -1544,7 +1544,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         #if ( ( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 ) && ( configINITIALISED_STACK_FILL_DEPTH > 0 ) )
         {
             /* Fill the part of the stack initialized in pxPortInitialiseStack with a known value. */
-            ( void ) memset( pxTopOfStack - configINITIALISED_STACK_FILL_DEPTH, ( int ) configINITIALISED_STACK_FILL_BYTE, ( size_t ) configINITIALISED_STACK_FILL_DEPTH * sizeof( StackType_t ) );
+            ( void ) memset( pxTopOfStack - ( StackType_t * ) ( configINITIALISED_STACK_FILL_DEPTH ), ( int ) configINITIALISED_STACK_FILL_BYTE, ( size_t ) configINITIALISED_STACK_FILL_DEPTH * sizeof( StackType_t ) );
         }
         #endif /* ( tskSET_NEW_STACKS_TO_KNOWN_VALUE == 1 ) && ( configINITIALISED_STACK_FILL_DEPTH > 0 ) */
 


### PR DESCRIPTION
Initialize register space in stack with value other than stack fill byte

Description
-----------
There is an issue where prvTaskCheckFreeStackSpace() could show an increase in free space over time for a task. This is due to the fact that pxPortInitialiseStack() for many ports leaves many of the register values uninitialized. This means the registers are loaded with tskSTACK_FILL_BYTE when the task first runs, then untouched registers when pushed to the stack can make used stack areas look untouched.

This pull request adds two new config settings, configINITIALISED_STACK_FILL_DEPTH and configINITIALISED_STACK_FILL_BYTE. When configINITIALISED_STACK_FILL_DEPTH is greater than 0, that number of stack entries on the stack are filled with configINITIALISED_STACK_FILL_BYTE.

Test Steps
-----------
This issue was identified by source code inspection.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
No related Issue ID


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
