### PR TITLE
Fix cast alignment warning in heap_4.c and heap_5.c

### DIFF
--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -444,7 +444,6 @@ void * pvPortCalloc( size_t xNum,
 static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 {
     BlockLink_t * pxFirstFreeBlock;
-    void * pvAlignedHeap;
     portPOINTER_SIZE_TYPE uxAddress;
     size_t xTotalHeapSize = configTOTAL_HEAP_SIZE;
 
@@ -458,7 +457,6 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
         xTotalHeapSize -= ( size_t ) ( uxAddress - ( portPOINTER_SIZE_TYPE ) ucHeap );
     }
 
-    pvAlignedHeap = ( uint8_t * ) uxAddress;
 
     #if ( configENABLE_HEAP_PROTECTOR == 1 )
     {
@@ -468,12 +466,12 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     /* xStart is used to hold a pointer to the first item in the list of free
      * blocks.  The void cast is used to prevent compiler warnings. */
-    xStart.pxNextFreeBlock = ( void * ) heapPROTECT_BLOCK_POINTER( pvAlignedHeap );
+    xStart.pxNextFreeBlock = ( void * ) heapPROTECT_BLOCK_POINTER( uxAddress );
     xStart.xBlockSize = ( size_t ) 0;
 
     /* pxEnd is used to mark the end of the list of free blocks and is inserted
      * at the end of the heap space. */
-    uxAddress = ( portPOINTER_SIZE_TYPE ) ( ( ( uint8_t * ) pvAlignedHeap ) + xTotalHeapSize );
+    uxAddress = ( portPOINTER_SIZE_TYPE ) ( uxAddress + xTotalHeapSize );
     uxAddress -= ( portPOINTER_SIZE_TYPE ) xHeapStructSize;
     uxAddress &= ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK );
     pxEnd = ( BlockLink_t * ) uxAddress;
@@ -482,7 +480,7 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     /* To start with there is a single free block that is sized to take up the
      * entire heap space, minus the space taken by pxEnd. */
-    pxFirstFreeBlock = ( BlockLink_t * ) pvAlignedHeap;
+    pxFirstFreeBlock = ( BlockLink_t * ) uxAddress;
     pxFirstFreeBlock->xBlockSize = ( size_t ) ( uxAddress - ( portPOINTER_SIZE_TYPE ) pxFirstFreeBlock );
     pxFirstFreeBlock->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( pxEnd );
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -444,7 +444,7 @@ void * pvPortCalloc( size_t xNum,
 static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 {
     BlockLink_t * pxFirstFreeBlock;
-    uint8_t * pucAlignedHeap;
+    void * pvAlignedHeap;
     portPOINTER_SIZE_TYPE uxAddress;
     size_t xTotalHeapSize = configTOTAL_HEAP_SIZE;
 
@@ -458,7 +458,7 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
         xTotalHeapSize -= ( size_t ) ( uxAddress - ( portPOINTER_SIZE_TYPE ) ucHeap );
     }
 
-    pucAlignedHeap = ( uint8_t * ) uxAddress;
+    pvAlignedHeap = ( uint8_t * ) uxAddress;
 
     #if ( configENABLE_HEAP_PROTECTOR == 1 )
     {
@@ -468,12 +468,12 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     /* xStart is used to hold a pointer to the first item in the list of free
      * blocks.  The void cast is used to prevent compiler warnings. */
-    xStart.pxNextFreeBlock = ( void * ) heapPROTECT_BLOCK_POINTER( pucAlignedHeap );
+    xStart.pxNextFreeBlock = ( void * ) heapPROTECT_BLOCK_POINTER( pvAlignedHeap );
     xStart.xBlockSize = ( size_t ) 0;
 
     /* pxEnd is used to mark the end of the list of free blocks and is inserted
      * at the end of the heap space. */
-    uxAddress = ( portPOINTER_SIZE_TYPE ) ( pucAlignedHeap + xTotalHeapSize );
+    uxAddress = ( portPOINTER_SIZE_TYPE ) ( ( ( uint8_t * ) pvAlignedHeap ) + xTotalHeapSize );
     uxAddress -= ( portPOINTER_SIZE_TYPE ) xHeapStructSize;
     uxAddress &= ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK );
     pxEnd = ( BlockLink_t * ) uxAddress;
@@ -482,7 +482,7 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     /* To start with there is a single free block that is sized to take up the
      * entire heap space, minus the space taken by pxEnd. */
-    pxFirstFreeBlock = ( BlockLink_t * ) pucAlignedHeap;
+    pxFirstFreeBlock = ( BlockLink_t * ) pvAlignedHeap;
     pxFirstFreeBlock->xBlockSize = ( size_t ) ( uxAddress - ( portPOINTER_SIZE_TYPE ) pxFirstFreeBlock );
     pxFirstFreeBlock->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( pxEnd );
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -457,7 +457,6 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
         xTotalHeapSize -= ( size_t ) ( uxAddress - ( portPOINTER_SIZE_TYPE ) ucHeap );
     }
 
-
     #if ( configENABLE_HEAP_PROTECTOR == 1 )
     {
         vApplicationGetRandomHeapCanary( &( xHeapCanary ) );

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -140,7 +140,7 @@
 
     #define heapPROTECT_BLOCK_POINTER( pxBlock )     ( pxBlock )
 
-    #define heapVALIDATE_BLOCK_POINTER( pxBlock )    ( pxBlock )
+    #define heapVALIDATE_BLOCK_POINTER( pxBlock )
 
 #endif /* configENABLE_HEAP_PROTECTOR */
 
@@ -562,7 +562,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
         if( ( xAddress & portBYTE_ALIGNMENT_MASK ) != 0 )
         {
             xAddress += ( portBYTE_ALIGNMENT - 1 );
-            xAddress &= ~portBYTE_ALIGNMENT_MASK;
+            xAddress &= ~( portPOINTER_SIZE_TYPE )portBYTE_ALIGNMENT_MASK;
 
             /* Adjust the size for the bytes lost to alignment. */
             xTotalRegionSize -= ( size_t ) ( xAddress - ( portPOINTER_SIZE_TYPE ) pxHeapRegion->pucStartAddress );

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -138,7 +138,7 @@
 
 #else /* if ( configENABLE_HEAP_PROTECTOR == 1 ) */
 
-    #define heapPROTECT_BLOCK_POINTER( pxBlock )     ( pxBlock )
+    #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( pxBlock )
 
     #define heapVALIDATE_BLOCK_POINTER( pxBlock )
 
@@ -562,7 +562,7 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) /* PRIVI
         if( ( xAddress & portBYTE_ALIGNMENT_MASK ) != 0 )
         {
             xAddress += ( portBYTE_ALIGNMENT - 1 );
-            xAddress &= ~( portPOINTER_SIZE_TYPE )portBYTE_ALIGNMENT_MASK;
+            xAddress &= ~( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK;
 
             /* Adjust the size for the bytes lost to alignment. */
             xTotalRegionSize -= ( size_t ) ( xAddress - ( portPOINTER_SIZE_TYPE ) pxHeapRegion->pucStartAddress );


### PR DESCRIPTION
Description
-----------
Without this change, the code produces the following warning when compiled with ```-Wcast-align``` flag:
```
cast increases required alignment of target type
```

Test Steps
-----------

1. Build the code and see that it does not produce any warning.
2. Run soak tests on GCC ARM CM3 and CM4 platforms.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://forums.freertos.org/t/freertos-heap-4-c-cast-error/18105


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
