### PR TITLE
Fix heap_4 Cast Conversion Issue

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,23 @@
+name: Format Pull Request Files
+
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  bashPass: \033[32;1mPASSED -
+  bashInfo: \033[33;1mINFO -
+  bashFail: \033[31;1mFAILED -
+  bashEnd:  \033[0m
+
+jobs:
+  Formatting:
+    name: Run Formatting Check
+    if: ${{ github.event.issue.pull_request }} &&
+        ( ( github.event.comment.body == '/bot run uncrustify' ) ||
+          ( github.event.comment.body == '/bot run formatting' ) )
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Apply Formatting Fix
+      uses: FreeRTOS/CI-CD-Github-Actions/formatting-bot@v2
+      id: check-formatting

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -470,7 +470,7 @@ static void prvHeapInit( void ) /* PRIVILEGED_FUNCTION */
 
     /* pxEnd is used to mark the end of the list of free blocks and is inserted
      * at the end of the heap space. */
-    uxAddress = ( portPOINTER_SIZE_TYPE ) ( uxAddress + xTotalHeapSize );
+    uxAddress = uxAddress + ( portPOINTER_SIZE_TYPE ) xTotalHeapSize;
     uxAddress -= ( portPOINTER_SIZE_TYPE ) xHeapStructSize;
     uxAddress &= ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK );
     pxEnd = ( BlockLink_t * ) uxAddress;


### PR DESCRIPTION
Description
-----------

Pull Request #771 introduced the following warning in `heap_4.c`:
```
/home/runner/work/FreeRTOS-Plus-TCP/FreeRTOS-Plus-TCP/build/_deps/freertos_kernel-src/portable/MemMang/heap_4.c: In function ‘prvHeapInit’:
  /home/runner/work/FreeRTOS-Plus-TCP/FreeRTOS-Plus-TCP/build/_deps/freertos_kernel-src/portable/MemMang/heap_4.c:473:55: error: conversion to ‘long unsigned int’ from ‘intptr_t’ {aka ‘long int’} may change the sign of the result [-Werror=sign-conversion]
    473 |     uxAddress = ( portPOINTER_SIZE_TYPE ) ( uxAddress + xTotalHeapSize );
        |                                                       ^
  cc1: all warnings being treated as errors
```

The reason of the warning is that the types two variables being added, namely `uxAddress` and `xTotalHeapSize`, differ in signedness. This PR adds a cast to avoid this warning.

Test Steps
-----------
The warning is no longer there after the fix:
```
# cmake -S . -B build
-DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL; cmake --build build
--target freertos_plus_tcp_build_test
-- Detected UNIX/Posix system setting FREERTOS_PLUS_TCP_NETWORK_IF =
POSIX
-- Using FreeRTOS-Plus-TCP Test Configuration : ENABLE_ALL
CMake Warning at CMakeLists.txt:168 (message):
  FreeRTOS-Kernel configuration settings are configured by FreeRTOS-
Plus-TCP


-- Configuring done
-- Generating done
-- Build files have been written to:
/home/ANT.AMAZON.COM/skptak/repos/fork/FreeRTOS-Plus-TCP_Soren/build
[  4%] Built target freertos_kernel_port
[  5%] Building C object _deps/freertos_kernel-
build/CMakeFiles/freertos_kernel.dir/portable/MemMang/heap_4.c.o
[  7%] Linking C static library libfreertos_kernel.a
.
.
.
[ 98%] Building C object test/build-
combination/CMakeFiles/freertos_plus_tcp_build_test.dir/Common/main.c.o
[100%] Linking C executable freertos_plus_tcp_build_test
[100%] Built target freertos_plus_tcp_build_test
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
