### PR TITLE
Add Trace Hook Macros to all API calls

### DIFF
--- a/croutine.c
+++ b/croutine.c
@@ -107,6 +107,8 @@
         BaseType_t xReturn;
         CRCB_t * pxCoRoutine;
 
+        traceAPI_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex );
+
         /* Allocate the memory that will store the co-routine control block. */
         pxCoRoutine = ( CRCB_t * ) pvPortMalloc( sizeof( CRCB_t ) );
 
@@ -156,6 +158,7 @@
             xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
         }
 
+        traceRETURN_xCoRoutineCreate( xReturn );
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -164,6 +167,8 @@
                                      List_t * pxEventList )
     {
         TickType_t xTimeToWake;
+
+        traceAPI_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList );
 
         /* Calculate the time to wake - this may overflow but this is
          * not a problem. */
@@ -196,6 +201,8 @@
              * function must be called with interrupts disabled. */
             vListInsert( pxEventList, &( pxCurrentCoRoutine->xEventListItem ) );
         }
+
+        traceRETURN_vCoRoutineAddToDelayedList();
     }
 /*-----------------------------------------------------------*/
 
@@ -283,6 +290,8 @@
 
     void vCoRoutineSchedule( void )
     {
+        traceAPI_vCoRoutineSchedule();
+
         /* Only run a co-routine after prvInitialiseCoRoutineLists() has been
          * called.  prvInitialiseCoRoutineLists() is called automatically when a
          * co-routine is created. */
@@ -313,6 +322,8 @@
             /* Call the co-routine. */
             ( pxCurrentCoRoutine->pxCoRoutineFunction )( pxCurrentCoRoutine, pxCurrentCoRoutine->uxIndex );
         }
+
+        traceRETURN_vCoRoutineSchedule();
     }
 /*-----------------------------------------------------------*/
 
@@ -341,6 +352,8 @@
         CRCB_t * pxUnblockedCRCB;
         BaseType_t xReturn;
 
+        traceAPI_xCoRoutineRemoveFromEventList( pxEventList );
+
         /* This function is called from within an interrupt.  It can only access
          * event lists and the pending ready list.  This function assumes that a
          * check has already been made to ensure pxEventList is not empty. */
@@ -357,6 +370,7 @@
             xReturn = pdFALSE;
         }
 
+        traceRETURN_xCoRoutineRemoveFromEventList( xReturn );
         return xReturn;
     }
 

--- a/croutine.c
+++ b/croutine.c
@@ -107,7 +107,7 @@
         BaseType_t xReturn;
         CRCB_t * pxCoRoutine;
 
-        traceAPI_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex );
+        traceENTER_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex );
 
         /* Allocate the memory that will store the co-routine control block. */
         pxCoRoutine = ( CRCB_t * ) pvPortMalloc( sizeof( CRCB_t ) );
@@ -169,7 +169,7 @@
     {
         TickType_t xTimeToWake;
 
-        traceAPI_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList );
+        traceENTER_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList );
 
         /* Calculate the time to wake - this may overflow but this is
          * not a problem. */
@@ -291,7 +291,7 @@
 
     void vCoRoutineSchedule( void )
     {
-        traceAPI_vCoRoutineSchedule();
+        traceENTER_vCoRoutineSchedule();
 
         /* Only run a co-routine after prvInitialiseCoRoutineLists() has been
          * called.  prvInitialiseCoRoutineLists() is called automatically when a
@@ -353,7 +353,7 @@
         CRCB_t * pxUnblockedCRCB;
         BaseType_t xReturn;
 
-        traceAPI_xCoRoutineRemoveFromEventList( pxEventList );
+        traceENTER_xCoRoutineRemoveFromEventList( pxEventList );
 
         /* This function is called from within an interrupt.  It can only access
          * event lists and the pending ready list.  This function assumes that a

--- a/croutine.c
+++ b/croutine.c
@@ -159,6 +159,7 @@
         }
 
         traceRETURN_xCoRoutineCreate( xReturn );
+
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -371,6 +372,7 @@
         }
 
         traceRETURN_xCoRoutineRemoveFromEventList( xReturn );
+
         return xReturn;
     }
 

--- a/event_groups.c
+++ b/event_groups.c
@@ -82,6 +82,8 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     {
         EventGroup_t * pxEventBits;
 
+        traceAPI_xEventGroupCreateStatic( pxEventGroupBuffer );
+
         /* A StaticEventGroup_t object must be provided. */
         configASSERT( pxEventGroupBuffer );
 
@@ -122,6 +124,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
             traceEVENT_GROUP_CREATE_FAILED();
         }
 
+        traceRETURN_xEventGroupCreateStatic( pxEventBits );
         return pxEventBits;
     }
 
@@ -133,6 +136,8 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     EventGroupHandle_t xEventGroupCreate( void )
     {
         EventGroup_t * pxEventBits;
+
+        traceAPI_xEventGroupCreate();
 
         /* Allocate the event group.  Justification for MISRA deviation as
          * follows:  pvPortMalloc() always ensures returned memory blocks are
@@ -170,6 +175,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
             traceEVENT_GROUP_CREATE_FAILED(); /*lint !e9063 Else branch only exists to allow tracing and does not generate code if trace macros are not defined. */
         }
 
+        traceRETURN_xEventGroupCreate( pxEventBits );
         return pxEventBits;
     }
 
@@ -185,6 +191,8 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
     EventGroup_t * pxEventBits = xEventGroup;
     BaseType_t xAlreadyYielded;
     BaseType_t xTimeoutOccurred = pdFALSE;
+
+    traceAPI_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
 
     configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
     configASSERT( uxBitsToWaitFor != 0 );
@@ -303,6 +311,7 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
     /* Prevent compiler warnings when trace macros are not used. */
     ( void ) xTimeoutOccurred;
 
+    traceRETURN_xEventGroupSync( uxReturn );
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -317,6 +326,8 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
     EventBits_t uxReturn, uxControlBits = 0;
     BaseType_t xWaitConditionMet, xAlreadyYielded;
     BaseType_t xTimeoutOccurred = pdFALSE;
+
+    traceAPI_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait );
 
     /* Check the user is not attempting to wait on the bits used by the kernel
      * itself, and that at least one bit is being requested. */
@@ -467,6 +478,7 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
     /* Prevent compiler warnings when trace macros are not used. */
     ( void ) xTimeoutOccurred;
 
+    traceRETURN_xEventGroupWaitBits( uxReturn );
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -476,6 +488,8 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
 {
     EventGroup_t * pxEventBits = xEventGroup;
     EventBits_t uxReturn;
+
+    traceAPI_xEventGroupClearBits( xEventGroup, uxBitsToClear );
 
     /* Check the user is not attempting to clear the bits used by the kernel
      * itself. */
@@ -495,6 +509,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
     }
     taskEXIT_CRITICAL();
 
+    traceRETURN_xEventGroupClearBits( uxReturn );
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -506,9 +521,12 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
     {
         BaseType_t xReturn;
 
+        traceAPI_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear );
+
         traceEVENT_GROUP_CLEAR_BITS_FROM_ISR( xEventGroup, uxBitsToClear );
         xReturn = xTimerPendFunctionCallFromISR( vEventGroupClearBitsCallback, ( void * ) xEventGroup, ( uint32_t ) uxBitsToClear, NULL ); /*lint !e9087 Can't avoid cast to void* as a generic callback function not specific to this use case. Callback casts back to original type so safe. */
 
+        traceRETURN_xEventGroupClearBitsFromISR( xReturn );
         return xReturn;
     }
 
@@ -521,12 +539,15 @@ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup )
     EventGroup_t const * const pxEventBits = xEventGroup;
     EventBits_t uxReturn;
 
+    traceAPI_xEventGroupGetBitsFromISR( xEventGroup );
+
     uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
     {
         uxReturn = pxEventBits->uxEventBits;
     }
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xEventGroupGetBitsFromISR( uxReturn );
     return uxReturn;
 } /*lint !e818 EventGroupHandle_t is a typedef used in other functions to so can't be pointer to const. */
 /*-----------------------------------------------------------*/
@@ -541,6 +562,8 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
     EventBits_t uxBitsToClear = 0, uxBitsWaitedFor, uxControlBits;
     EventGroup_t * pxEventBits = xEventGroup;
     BaseType_t xMatchFound = pdFALSE;
+
+    traceAPI_xEventGroupSetBits( xEventGroup, uxBitsToSet );
 
     /* Check the user is not attempting to set the bits used by the kernel
      * itself. */
@@ -623,6 +646,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
     }
     ( void ) xTaskResumeAll();
 
+    traceRETURN_xEventGroupSetBits( pxEventBits->uxEventBits );
     return pxEventBits->uxEventBits;
 }
 /*-----------------------------------------------------------*/
@@ -631,6 +655,8 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 {
     EventGroup_t * pxEventBits = xEventGroup;
     const List_t * pxTasksWaitingForBits;
+
+    traceAPI_vEventGroupDelete( xEventGroup );
 
     configASSERT( pxEventBits );
 
@@ -670,6 +696,8 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
         }
     }
     #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+    traceRETURN_vEventGroupDelete();
 }
 /*-----------------------------------------------------------*/
 
@@ -714,7 +742,11 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 void vEventGroupSetBitsCallback( void * pvEventGroup,
                                  const uint32_t ulBitsToSet )
 {
+    traceAPI_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet );
+
     ( void ) xEventGroupSetBits( pvEventGroup, ( EventBits_t ) ulBitsToSet ); /*lint !e9079 Can't avoid cast to void* as a generic timer callback prototype. Callback casts back to original type so safe. */
+
+    traceRETURN_vEventGroupSetBitsCallback();
 }
 /*-----------------------------------------------------------*/
 
@@ -723,7 +755,11 @@ void vEventGroupSetBitsCallback( void * pvEventGroup,
 void vEventGroupClearBitsCallback( void * pvEventGroup,
                                    const uint32_t ulBitsToClear )
 {
+    traceAPI_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear );
+
     ( void ) xEventGroupClearBits( pvEventGroup, ( EventBits_t ) ulBitsToClear ); /*lint !e9079 Can't avoid cast to void* as a generic timer callback prototype. Callback casts back to original type so safe. */
+
+    traceRETURN_vEventGroupClearBitsCallback();
 }
 /*-----------------------------------------------------------*/
 
@@ -772,9 +808,12 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     {
         BaseType_t xReturn;
 
+        traceAPI_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken );
+
         traceEVENT_GROUP_SET_BITS_FROM_ISR( xEventGroup, uxBitsToSet );
         xReturn = xTimerPendFunctionCallFromISR( vEventGroupSetBitsCallback, ( void * ) xEventGroup, ( uint32_t ) uxBitsToSet, pxHigherPriorityTaskWoken ); /*lint !e9087 Can't avoid cast to void* as a generic callback function not specific to this use case. Callback casts back to original type so safe. */
 
+        traceRETURN_xEventGroupSetBitsFromISR( xReturn );
         return xReturn;
     }
 
@@ -788,6 +827,8 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
         UBaseType_t xReturn;
         EventGroup_t const * pxEventBits = ( EventGroup_t * ) xEventGroup; /*lint !e9087 !e9079 EventGroupHandle_t is a pointer to an EventGroup_t, but EventGroupHandle_t is kept opaque outside of this file for data hiding purposes. */
 
+        traceAPI_uxEventGroupGetNumber( xEventGroup );
+
         if( xEventGroup == NULL )
         {
             xReturn = 0;
@@ -797,6 +838,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
             xReturn = pxEventBits->uxEventGroupNumber;
         }
 
+        traceRETURN_uxEventGroupGetNumber( xReturn );
         return xReturn;
     }
 
@@ -808,7 +850,11 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     void vEventGroupSetNumber( void * xEventGroup,
                                UBaseType_t uxEventGroupNumber )
     {
+        traceAPI_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber );
+
         ( ( EventGroup_t * ) xEventGroup )->uxEventGroupNumber = uxEventGroupNumber; /*lint !e9087 !e9079 EventGroupHandle_t is a pointer to an EventGroup_t, but EventGroupHandle_t is kept opaque outside of this file for data hiding purposes. */
+
+        traceRETURN_vEventGroupSetNumber();
     }
 
 #endif /* configUSE_TRACE_FACILITY */

--- a/event_groups.c
+++ b/event_groups.c
@@ -82,7 +82,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     {
         EventGroup_t * pxEventBits;
 
-        traceAPI_xEventGroupCreateStatic( pxEventGroupBuffer );
+        traceENTER_xEventGroupCreateStatic( pxEventGroupBuffer );
 
         /* A StaticEventGroup_t object must be provided. */
         configASSERT( pxEventGroupBuffer );
@@ -138,7 +138,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     {
         EventGroup_t * pxEventBits;
 
-        traceAPI_xEventGroupCreate();
+        traceENTER_xEventGroupCreate();
 
         /* Allocate the event group.  Justification for MISRA deviation as
          * follows:  pvPortMalloc() always ensures returned memory blocks are
@@ -194,7 +194,7 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
     BaseType_t xAlreadyYielded;
     BaseType_t xTimeoutOccurred = pdFALSE;
 
-    traceAPI_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
+    traceENTER_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
 
     configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
     configASSERT( uxBitsToWaitFor != 0 );
@@ -330,7 +330,7 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
     BaseType_t xWaitConditionMet, xAlreadyYielded;
     BaseType_t xTimeoutOccurred = pdFALSE;
 
-    traceAPI_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait );
+    traceENTER_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait );
 
     /* Check the user is not attempting to wait on the bits used by the kernel
      * itself, and that at least one bit is being requested. */
@@ -493,7 +493,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
     EventGroup_t * pxEventBits = xEventGroup;
     EventBits_t uxReturn;
 
-    traceAPI_xEventGroupClearBits( xEventGroup, uxBitsToClear );
+    traceENTER_xEventGroupClearBits( xEventGroup, uxBitsToClear );
 
     /* Check the user is not attempting to clear the bits used by the kernel
      * itself. */
@@ -526,7 +526,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
     {
         BaseType_t xReturn;
 
-        traceAPI_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear );
+        traceENTER_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear );
 
         traceEVENT_GROUP_CLEAR_BITS_FROM_ISR( xEventGroup, uxBitsToClear );
         xReturn = xTimerPendFunctionCallFromISR( vEventGroupClearBitsCallback, ( void * ) xEventGroup, ( uint32_t ) uxBitsToClear, NULL ); /*lint !e9087 Can't avoid cast to void* as a generic callback function not specific to this use case. Callback casts back to original type so safe. */
@@ -545,7 +545,7 @@ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup )
     EventGroup_t const * const pxEventBits = xEventGroup;
     EventBits_t uxReturn;
 
-    traceAPI_xEventGroupGetBitsFromISR( xEventGroup );
+    traceENTER_xEventGroupGetBitsFromISR( xEventGroup );
 
     uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
     {
@@ -570,7 +570,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
     EventGroup_t * pxEventBits = xEventGroup;
     BaseType_t xMatchFound = pdFALSE;
 
-    traceAPI_xEventGroupSetBits( xEventGroup, uxBitsToSet );
+    traceENTER_xEventGroupSetBits( xEventGroup, uxBitsToSet );
 
     /* Check the user is not attempting to set the bits used by the kernel
      * itself. */
@@ -664,7 +664,7 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
     EventGroup_t * pxEventBits = xEventGroup;
     const List_t * pxTasksWaitingForBits;
 
-    traceAPI_vEventGroupDelete( xEventGroup );
+    traceENTER_vEventGroupDelete( xEventGroup );
 
     configASSERT( pxEventBits );
 
@@ -716,7 +716,7 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
         BaseType_t xReturn;
         EventGroup_t * pxEventBits = xEventGroup;
 
-        traceAPI_xEventGroupGetStaticBuffer( xEventGroup, ppxEventGroupBuffer );
+        traceENTER_xEventGroupGetStaticBuffer( xEventGroup, ppxEventGroupBuffer );
 
         configASSERT( pxEventBits );
         configASSERT( ppxEventGroupBuffer );
@@ -754,7 +754,7 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 void vEventGroupSetBitsCallback( void * pvEventGroup,
                                  const uint32_t ulBitsToSet )
 {
-    traceAPI_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet );
+    traceENTER_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet );
 
     ( void ) xEventGroupSetBits( pvEventGroup, ( EventBits_t ) ulBitsToSet ); /*lint !e9079 Can't avoid cast to void* as a generic timer callback prototype. Callback casts back to original type so safe. */
 
@@ -767,7 +767,7 @@ void vEventGroupSetBitsCallback( void * pvEventGroup,
 void vEventGroupClearBitsCallback( void * pvEventGroup,
                                    const uint32_t ulBitsToClear )
 {
-    traceAPI_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear );
+    traceENTER_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear );
 
     ( void ) xEventGroupClearBits( pvEventGroup, ( EventBits_t ) ulBitsToClear ); /*lint !e9079 Can't avoid cast to void* as a generic timer callback prototype. Callback casts back to original type so safe. */
 
@@ -820,7 +820,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     {
         BaseType_t xReturn;
 
-        traceAPI_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken );
+        traceENTER_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken );
 
         traceEVENT_GROUP_SET_BITS_FROM_ISR( xEventGroup, uxBitsToSet );
         xReturn = xTimerPendFunctionCallFromISR( vEventGroupSetBitsCallback, ( void * ) xEventGroup, ( uint32_t ) uxBitsToSet, pxHigherPriorityTaskWoken ); /*lint !e9087 Can't avoid cast to void* as a generic callback function not specific to this use case. Callback casts back to original type so safe. */
@@ -840,7 +840,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
         UBaseType_t xReturn;
         EventGroup_t const * pxEventBits = ( EventGroup_t * ) xEventGroup; /*lint !e9087 !e9079 EventGroupHandle_t is a pointer to an EventGroup_t, but EventGroupHandle_t is kept opaque outside of this file for data hiding purposes. */
 
-        traceAPI_uxEventGroupGetNumber( xEventGroup );
+        traceENTER_uxEventGroupGetNumber( xEventGroup );
 
         if( xEventGroup == NULL )
         {
@@ -864,7 +864,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
     void vEventGroupSetNumber( void * xEventGroup,
                                UBaseType_t uxEventGroupNumber )
     {
-        traceAPI_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber );
+        traceENTER_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber );
 
         ( ( EventGroup_t * ) xEventGroup )->uxEventGroupNumber = uxEventGroupNumber; /*lint !e9087 !e9079 EventGroupHandle_t is a pointer to an EventGroup_t, but EventGroupHandle_t is kept opaque outside of this file for data hiding purposes. */
 

--- a/event_groups.c
+++ b/event_groups.c
@@ -125,6 +125,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
         }
 
         traceRETURN_xEventGroupCreateStatic( pxEventBits );
+
         return pxEventBits;
     }
 
@@ -176,6 +177,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
         }
 
         traceRETURN_xEventGroupCreate( pxEventBits );
+
         return pxEventBits;
     }
 
@@ -312,6 +314,7 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
     ( void ) xTimeoutOccurred;
 
     traceRETURN_xEventGroupSync( uxReturn );
+
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -479,6 +482,7 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
     ( void ) xTimeoutOccurred;
 
     traceRETURN_xEventGroupWaitBits( uxReturn );
+
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -510,6 +514,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
     taskEXIT_CRITICAL();
 
     traceRETURN_xEventGroupClearBits( uxReturn );
+
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -527,6 +532,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
         xReturn = xTimerPendFunctionCallFromISR( vEventGroupClearBitsCallback, ( void * ) xEventGroup, ( uint32_t ) uxBitsToClear, NULL ); /*lint !e9087 Can't avoid cast to void* as a generic callback function not specific to this use case. Callback casts back to original type so safe. */
 
         traceRETURN_xEventGroupClearBitsFromISR( xReturn );
+
         return xReturn;
     }
 
@@ -548,6 +554,7 @@ EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup )
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xEventGroupGetBitsFromISR( uxReturn );
+
     return uxReturn;
 } /*lint !e818 EventGroupHandle_t is a typedef used in other functions to so can't be pointer to const. */
 /*-----------------------------------------------------------*/
@@ -647,6 +654,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
     ( void ) xTaskResumeAll();
 
     traceRETURN_xEventGroupSetBits( pxEventBits->uxEventBits );
+
     return pxEventBits->uxEventBits;
 }
 /*-----------------------------------------------------------*/
@@ -708,6 +716,8 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
         BaseType_t xReturn;
         EventGroup_t * pxEventBits = xEventGroup;
 
+        traceAPI_xEventGroupGetStaticBuffer( xEventGroup, ppxEventGroupBuffer );
+
         configASSERT( pxEventBits );
         configASSERT( ppxEventGroupBuffer );
 
@@ -731,6 +741,8 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
             xReturn = pdTRUE;
         }
         #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+        traceRETURN_xEventGroupGetStaticBuffer( xReturn );
 
         return xReturn;
     }
@@ -814,6 +826,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
         xReturn = xTimerPendFunctionCallFromISR( vEventGroupSetBitsCallback, ( void * ) xEventGroup, ( uint32_t ) uxBitsToSet, pxHigherPriorityTaskWoken ); /*lint !e9087 Can't avoid cast to void* as a generic callback function not specific to this use case. Callback casts back to original type so safe. */
 
         traceRETURN_xEventGroupSetBitsFromISR( xReturn );
+
         return xReturn;
     }
 
@@ -839,6 +852,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
         }
 
         traceRETURN_uxEventGroupGetNumber( xReturn );
+
         return xReturn;
     }
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -973,6 +973,1458 @@
     #define traceSTREAM_BUFFER_RECEIVE_FROM_ISR( xStreamBuffer, xReceivedLength )
 #endif
 
+#ifndef traceAPI_xQueueGenericReset
+    #define traceAPI_xQueueGenericReset( xQueue, xNewQueue )
+#endif
+
+#ifndef traceAPI_xQueueGenericCreateStatic
+    #define traceAPI_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType )
+#endif
+
+#ifndef traceAPI_xQueueGenericCreate
+    #define traceAPI_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType )
+#endif
+
+#ifndef traceAPI_xQueueCreateMutex
+    #define traceAPI_xQueueCreateMutex( ucQueueType )
+#endif
+
+#ifndef traceAPI_xQueueCreateMutexStatic
+    #define traceAPI_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue )
+#endif
+
+#ifndef traceAPI_xQueueGetMutexHolder
+    #define traceAPI_xQueueGetMutexHolder( xSemaphore )
+#endif
+
+#ifndef traceAPI_xQueueGetMutexHolderFromISR
+    #define traceAPI_xQueueGetMutexHolderFromISR( xSemaphore )
+#endif
+
+#ifndef traceAPI_xQueueGiveMutexRecursive
+    #define traceAPI_xQueueGiveMutexRecursive( xMutex )
+#endif
+
+#ifndef traceAPI_xQueueTakeMutexRecursive
+    #define traceAPI_xQueueTakeMutexRecursive( xMutex, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xQueueCreateCountingSemaphoreStatic
+    #define traceAPI_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue )
+#endif
+
+#ifndef traceAPI_xQueueCreateCountingSemaphore
+    #define traceAPI_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount )
+#endif
+
+#ifndef traceAPI_xQueueGenericSend
+    #define traceAPI_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition )
+#endif
+
+#ifndef traceAPI_xQueueGenericSendFromISR
+    #define traceAPI_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition )
+#endif
+
+#ifndef traceAPI_xQueueGiveFromISR
+    #define traceAPI_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_xQueueReceive
+    #define traceAPI_xQueueReceive( xQueue, pvBuffer, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xQueueSemaphoreTake
+    #define traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xQueuePeek
+    #define traceAPI_xQueuePeek( xQueue, pvBuffer, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xQueueReceiveFromISR
+    #define traceAPI_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_xQueuePeekFromISR
+    #define traceAPI_xQueuePeekFromISR( xQueue, pvBuffer )
+#endif
+
+#ifndef traceAPI_uxQueueMessagesWaiting
+    #define traceAPI_uxQueueMessagesWaiting( xQueue )
+#endif
+
+#ifndef traceAPI_uxQueueSpacesAvailable
+    #define traceAPI_uxQueueSpacesAvailable( xQueue )
+#endif
+
+#ifndef traceAPI_uxQueueMessagesWaitingFromISR
+    #define traceAPI_uxQueueMessagesWaitingFromISR( xQueue )
+#endif
+
+#ifndef traceAPI_vQueueDelete
+    #define traceAPI_vQueueDelete( xQueue )
+#endif
+
+#ifndef traceAPI_uxQueueGetQueueNumber
+    #define traceAPI_uxQueueGetQueueNumber( xQueue )
+#endif
+
+#ifndef traceAPI_vQueueSetQueueNumber
+    #define traceAPI_vQueueSetQueueNumber( xQueue, uxQueueNumber )
+#endif
+
+#ifndef traceAPI_ucQueueGetQueueType
+    #define traceAPI_ucQueueGetQueueType( xQueue )
+#endif
+
+#ifndef traceAPI_xQueueIsQueueEmptyFromISR
+    #define traceAPI_xQueueIsQueueEmptyFromISR( xQueue )
+#endif
+
+#ifndef traceAPI_xQueueIsQueueFullFromISR
+    #define traceAPI_xQueueIsQueueFullFromISR( xQueue )
+#endif
+
+#ifndef traceAPI_xQueueCRSend
+    #define traceAPI_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xQueueCRReceive
+    #define traceAPI_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xQueueCRSendFromISR
+    #define traceAPI_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken )
+#endif
+
+#ifndef traceAPI_xQueueCRReceiveFromISR
+    #define traceAPI_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken )
+#endif
+
+#ifndef traceAPI_vQueueAddToRegistry
+    #define traceAPI_vQueueAddToRegistry( xQueue, pcQueueName )
+#endif
+
+#ifndef traceAPI_pcQueueGetName
+    #define traceAPI_pcQueueGetName( xQueue )
+#endif
+
+#ifndef traceAPI_vQueueUnregisterQueue
+    #define traceAPI_vQueueUnregisterQueue( xQueue )
+#endif
+
+#ifndef traceAPI_vQueueWaitForMessageRestricted
+    #define traceAPI_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely )
+#endif
+
+#ifndef traceAPI_xQueueCreateSet
+    #define traceAPI_xQueueCreateSet( uxEventQueueLength )
+#endif
+
+#ifndef traceAPI_xQueueAddToSet
+    #define traceAPI_xQueueAddToSet( xQueueOrSemaphore, xQueueSet )
+#endif
+
+#ifndef traceAPI_xQueueRemoveFromSet
+    #define traceAPI_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet )
+#endif
+
+#ifndef traceAPI_xQueueSelectFromSet
+    #define traceAPI_xQueueSelectFromSet( xQueueSet, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xQueueSelectFromSetFromISR
+    #define traceAPI_xQueueSelectFromSetFromISR( xQueueSet )
+#endif
+
+#ifndef traceAPI_xTaskCreateStatic
+    #define traceAPI_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer )
+#endif
+
+#ifndef traceAPI_xTaskCreateRestrictedStatic
+    #define traceAPI_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask )
+#endif
+
+#ifndef traceAPI_xTaskCreateRestricted
+    #define traceAPI_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask )
+#endif
+
+#ifndef traceAPI_xTaskCreate
+    #define traceAPI_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask )
+#endif
+
+#ifndef traceAPI_vTaskDelete
+    #define traceAPI_vTaskDelete( xTaskToDelete )
+#endif
+
+#ifndef traceAPI_xTaskDelayUntil
+    #define traceAPI_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )
+#endif
+
+#ifndef traceAPI_vTaskDelay
+    #define traceAPI_vTaskDelay( xTicksToDelay )
+#endif
+
+#ifndef traceAPI_eTaskGetState
+    #define traceAPI_eTaskGetState( xTask )
+#endif
+
+#ifndef traceAPI_uxTaskPriorityGet
+    #define traceAPI_uxTaskPriorityGet( xTask )
+#endif
+
+#ifndef traceAPI_uxTaskPriorityGetFromISR
+    #define traceAPI_uxTaskPriorityGetFromISR( xTask )
+#endif
+
+#ifndef traceAPI_vTaskPrioritySet
+    #define traceAPI_vTaskPrioritySet( xTask, uxNewPriority )
+#endif
+
+#ifndef traceAPI_vTaskSuspend
+    #define traceAPI_vTaskSuspend( xTaskToSuspend )
+#endif
+
+#ifndef traceAPI_vTaskResume
+    #define traceAPI_vTaskResume( xTaskToResume )
+#endif
+
+#ifndef traceAPI_xTaskResumeFromISR
+    #define traceAPI_xTaskResumeFromISR( xTaskToResume )
+#endif
+
+#ifndef traceAPI_vTaskStartScheduler
+    #define traceAPI_vTaskStartScheduler()
+#endif
+
+#ifndef traceAPI_vTaskEndScheduler
+    #define traceAPI_vTaskEndScheduler()
+#endif
+
+#ifndef traceAPI_vTaskSuspendAll
+    #define traceAPI_vTaskSuspendAll()
+#endif
+
+#ifndef traceAPI_xTaskResumeAll
+    #define traceAPI_xTaskResumeAll()
+#endif
+
+#ifndef traceAPI_xTaskGetTickCount
+    #define traceAPI_xTaskGetTickCount()
+#endif
+
+#ifndef traceAPI_xTaskGetTickCountFromISR
+    #define traceAPI_xTaskGetTickCountFromISR()
+#endif
+
+#ifndef traceAPI_uxTaskGetNumberOfTasks
+    #define traceAPI_uxTaskGetNumberOfTasks()
+#endif
+
+#ifndef traceAPI_pcTaskGetName
+    #define traceAPI_pcTaskGetName( xTaskToQuery )
+#endif
+
+#ifndef traceAPI_xTaskGetHandle
+    #define traceAPI_xTaskGetHandle( pcNameToQuery )
+#endif
+
+#ifndef traceAPI_uxTaskGetSystemState
+    #define traceAPI_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime )
+#endif
+
+#ifndef traceAPI_xTaskGetIdleTaskHandle
+    #define traceAPI_xTaskGetIdleTaskHandle()
+#endif
+
+#ifndef traceAPI_vTaskStepTick
+    #define traceAPI_vTaskStepTick( xTicksToJump )
+#endif
+
+#ifndef traceAPI_xTaskCatchUpTicks
+    #define traceAPI_xTaskCatchUpTicks( xTicksToCatchUp )
+#endif
+
+#ifndef traceAPI_xTaskAbortDelay
+    #define traceAPI_xTaskAbortDelay( xTask )
+#endif
+
+#ifndef traceAPI_xTaskIncrementTick
+    #define traceAPI_xTaskIncrementTick()
+#endif
+
+#ifndef traceAPI_vTaskSetApplicationTaskTag
+    #define traceAPI_vTaskSetApplicationTaskTag( xTask, pxHookFunction )
+#endif
+
+#ifndef traceAPI_xTaskGetApplicationTaskTag
+    #define traceAPI_xTaskGetApplicationTaskTag( xTask )
+#endif
+
+#ifndef traceAPI_xTaskGetApplicationTaskTagFromISR
+    #define traceAPI_xTaskGetApplicationTaskTagFromISR( xTask )
+#endif
+
+#ifndef traceAPI_xTaskCallApplicationTaskHook
+    #define traceAPI_xTaskCallApplicationTaskHook( xTask, pvParameter )
+#endif
+
+#ifndef traceAPI_vTaskPlaceOnEventList
+    #define traceAPI_vTaskPlaceOnEventList( pxEventList, xTicksToWait )
+#endif
+
+#ifndef traceAPI_vTaskPlaceOnUnorderedEventList
+    #define traceAPI_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait )
+#endif
+
+#ifndef traceAPI_vTaskPlaceOnEventListRestricted
+    #define traceAPI_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely )
+#endif
+
+#ifndef traceAPI_xTaskRemoveFromEventList
+    #define traceAPI_xTaskRemoveFromEventList( pxEventList )
+#endif
+
+#ifndef traceAPI_vTaskRemoveFromUnorderedEventList
+    #define traceAPI_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue )
+#endif
+
+#ifndef traceAPI_vTaskSetTimeOutState
+    #define traceAPI_vTaskSetTimeOutState( pxTimeOut )
+#endif
+
+#ifndef traceAPI_vTaskInternalSetTimeOutState
+    #define traceAPI_vTaskInternalSetTimeOutState( pxTimeOut )
+#endif
+
+#ifndef traceAPI_xTaskCheckForTimeOut
+    #define traceAPI_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait )
+#endif
+
+#ifndef traceAPI_vTaskMissedYield
+    #define traceAPI_vTaskMissedYield()
+#endif
+
+#ifndef traceAPI_uxTaskGetTaskNumber
+    #define traceAPI_uxTaskGetTaskNumber( xTask )
+#endif
+
+#ifndef traceAPI_vTaskSetTaskNumber
+    #define traceAPI_vTaskSetTaskNumber( xTask, uxHandle )
+#endif
+
+#ifndef traceAPI_eTaskConfirmSleepModeStatus
+    #define traceAPI_eTaskConfirmSleepModeStatus()
+#endif
+
+#ifndef traceAPI_vTaskSetThreadLocalStoragePointer
+    #define traceAPI_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue )
+#endif
+
+#ifndef traceAPI_pvTaskGetThreadLocalStoragePointer
+    #define traceAPI_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex )
+#endif
+
+#ifndef traceAPI_vTaskAllocateMPURegions
+    #define traceAPI_vTaskAllocateMPURegions( xTaskToModify, xRegions )
+#endif
+
+#ifndef traceAPI_vTaskGetInfo
+    #define traceAPI_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState )
+#endif
+
+#ifndef traceAPI_uxTaskGetStackHighWaterMark2
+    #define traceAPI_uxTaskGetStackHighWaterMark2( xTask )
+#endif
+
+#ifndef traceAPI_uxTaskGetStackHighWaterMark
+    #define traceAPI_uxTaskGetStackHighWaterMark( xTask )
+#endif
+
+#ifndef traceAPI_pxTaskGetStackStart
+    #define traceAPI_pxTaskGetStackStart( xTask )
+#endif
+
+#ifndef traceAPI_xTaskGetCurrentTaskHandle
+    #define traceAPI_xTaskGetCurrentTaskHandle()
+#endif
+
+#ifndef traceAPI_xTaskGetSchedulerState
+    #define traceAPI_xTaskGetSchedulerState()
+#endif
+
+#ifndef traceAPI_xTaskPriorityInherit
+    #define traceAPI_xTaskPriorityInherit( pxMutexHolder )
+#endif
+
+#ifndef traceAPI_xTaskPriorityDisinherit
+    #define traceAPI_xTaskPriorityDisinherit( pxMutexHolder )
+#endif
+
+#ifndef traceAPI_vTaskPriorityDisinheritAfterTimeout
+    #define traceAPI_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask )
+#endif
+
+#ifndef traceAPI_vTaskEnterCritical
+    #define traceAPI_vTaskEnterCritical()
+#endif
+
+#ifndef traceAPI_vTaskExitCritical
+    #define traceAPI_vTaskExitCritical()
+#endif
+
+#ifndef traceAPI_vTaskList
+    #define traceAPI_vTaskList( pcWriteBuffer )
+#endif
+
+#ifndef traceAPI_vTaskGetRunTimeStats
+    #define traceAPI_vTaskGetRunTimeStats( pcWriteBuffer )
+#endif
+
+#ifndef traceAPI_uxTaskResetEventItemValue
+    #define traceAPI_uxTaskResetEventItemValue()
+#endif
+
+#ifndef traceAPI_pvTaskIncrementMutexHeldCount
+    #define traceAPI_pvTaskIncrementMutexHeldCount()
+#endif
+
+#ifndef traceAPI_ulTaskGenericNotifyTake
+    #define traceAPI_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xTaskGenericNotifyWait
+    #define traceAPI_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xTaskGenericNotify
+    #define traceAPI_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue )
+#endif
+
+#ifndef traceAPI_xTaskGenericNotifyFromISR
+    #define traceAPI_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_vTaskGenericNotifyGiveFromISR
+    #define traceAPI_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_xTaskGenericNotifyStateClear
+    #define traceAPI_xTaskGenericNotifyStateClear( xTask, uxIndexToClear )
+#endif
+
+#ifndef traceAPI_ulTaskGenericNotifyValueClear
+    #define traceAPI_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear )
+#endif
+
+#ifndef traceAPI_ulTaskGetIdleRunTimeCounter
+    #define traceAPI_ulTaskGetIdleRunTimeCounter()
+#endif
+
+#ifndef traceAPI_ulTaskGetIdleRunTimePercent
+    #define traceAPI_ulTaskGetIdleRunTimePercent()
+#endif
+
+#ifndef traceAPI_vTaskCoreAffinitySet
+    #define traceAPI_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask )
+#endif
+
+#ifndef traceAPI_vTaskCoreAffinityGet
+    #define traceAPI_vTaskCoreAffinityGet( xTask )
+#endif
+
+#ifndef traceAPI_vTaskPreemptionDisable
+    #define traceAPI_vTaskPreemptionDisable( xTask )
+#endif
+
+#ifndef traceAPI_vTaskPreemptionEnable
+    #define traceAPI_vTaskPreemptionEnable( xTask )
+#endif
+
+#ifndef traceAPI_vTaskYieldWithinAPI
+    #define traceAPI_vTaskYieldWithinAPI()
+#endif
+
+#ifndef traceAPI_vTaskEnterCriticalFromISR
+    #define traceAPI_vTaskEnterCriticalFromISR()
+#endif
+
+#ifndef traceAPI_vTaskExitCriticalFromISR
+    #define traceAPI_vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#endif
+
+#ifndef traceAPI_ulTaskGetRunTimeCounter
+    #define traceAPI_ulTaskGetRunTimeCounter( xTask )
+#endif
+
+#ifndef traceAPI_xTimerCreateTimerTask
+    #define traceAPI_xTimerCreateTimerTask()
+#endif
+
+#ifndef traceAPI_xTimerCreate
+    #define traceAPI_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction )
+#endif
+
+#ifndef traceAPI_xTimerCreateStatic
+    #define traceAPI_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer )
+#endif
+
+#ifndef traceAPI_xTimerGenericCommandFromTask
+    #define traceAPI_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xTimerGenericCommandFromISR
+    #define traceAPI_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xTimerGetTimerDaemonTaskHandle
+    #define traceAPI_xTimerGetTimerDaemonTaskHandle()
+#endif
+
+#ifndef traceAPI_xTimerGetPeriod
+    #define traceAPI_xTimerGetPeriod( xTimer )
+#endif
+
+#ifndef traceAPI_vTimerSetReloadMode
+    #define traceAPI_vTimerSetReloadMode( xTimer, xAutoReload )
+#endif
+
+#ifndef traceAPI_xTimerGetReloadMode
+    #define traceAPI_xTimerGetReloadMode( xTimer )
+#endif
+
+#ifndef traceAPI_xTimerGetExpiryTime
+    #define traceAPI_xTimerGetExpiryTime( xTimer )
+#endif
+
+#ifndef traceAPI_pcTimerGetName
+    #define traceAPI_pcTimerGetName( xTimer )
+#endif
+
+#ifndef traceAPI_xTimerIsTimerActive
+    #define traceAPI_xTimerIsTimerActive( xTimer )
+#endif
+
+#ifndef traceAPI_pvTimerGetTimerID
+    #define traceAPI_pvTimerGetTimerID( xTimer )
+#endif
+
+#ifndef traceAPI_vTimerSetTimerID
+    #define traceAPI_vTimerSetTimerID( xTimer, pvNewID )
+#endif
+
+#ifndef traceAPI_xTimerPendFunctionCallFromISR
+    #define traceAPI_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_xTimerPendFunctionCall
+    #define traceAPI_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait )
+#endif
+
+#ifndef traceAPI_uxTimerGetTimerNumber
+    #define traceAPI_uxTimerGetTimerNumber( xTimer )
+#endif
+
+#ifndef traceAPI_vTimerSetTimerNumber
+    #define traceAPI_vTimerSetTimerNumber( xTimer, uxTimerNumber )
+#endif
+
+#ifndef traceAPI_vListInitialise
+    #define traceAPI_vListInitialise( pxList )
+#endif
+
+#ifndef traceAPI_vListInitialiseItem
+    #define traceAPI_vListInitialiseItem( pxItem )
+#endif
+
+#ifndef traceAPI_vListInsertEnd
+    #define traceAPI_vListInsertEnd( pxList, pxNewListItem )
+#endif
+
+#ifndef traceAPI_vListInsert
+    #define traceAPI_vListInsert( pxList, pxNewListItem )
+#endif
+
+#ifndef traceAPI_uxListRemove
+    #define traceAPI_uxListRemove( pxItemToRemove )
+#endif
+
+#ifndef traceAPI_xCoRoutineCreate
+    #define traceAPI_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex )
+#endif
+
+#ifndef traceAPI_vCoRoutineAddToDelayedList
+    #define traceAPI_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList )
+#endif
+
+#ifndef traceAPI_vCoRoutineSchedule
+    #define traceAPI_vCoRoutineSchedule()
+#endif
+
+#ifndef traceAPI_xCoRoutineRemoveFromEventList
+    #define traceAPI_xCoRoutineRemoveFromEventList( pxEventList )
+#endif
+
+#ifndef traceAPI_xEventGroupCreateStatic
+    #define traceAPI_xEventGroupCreateStatic( pxEventGroupBuffer )
+#endif
+
+#ifndef traceAPI_xEventGroupCreate
+    #define traceAPI_xEventGroupCreate()
+#endif
+
+#ifndef traceAPI_xEventGroupSync
+    #define traceAPI_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xEventGroupWaitBits
+    #define traceAPI_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xEventGroupClearBits
+    #define traceAPI_xEventGroupClearBits( xEventGroup, uxBitsToClear )
+#endif
+
+#ifndef traceAPI_xEventGroupClearBitsFromISR
+    #define traceAPI_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear )
+#endif
+
+#ifndef traceAPI_xEventGroupGetBitsFromISR
+    #define traceAPI_xEventGroupGetBitsFromISR( xEventGroup )
+#endif
+
+#ifndef traceAPI_xEventGroupSetBits
+    #define traceAPI_xEventGroupSetBits( xEventGroup, uxBitsToSet )
+#endif
+
+#ifndef traceAPI_vEventGroupDelete
+    #define traceAPI_vEventGroupDelete( xEventGroup )
+#endif
+
+#ifndef traceAPI_vEventGroupSetBitsCallback
+    #define traceAPI_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet )
+#endif
+
+#ifndef traceAPI_vEventGroupClearBitsCallback
+    #define traceAPI_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear )
+#endif
+
+#ifndef traceAPI_xEventGroupSetBitsFromISR
+    #define traceAPI_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_uxEventGroupGetNumber
+    #define traceAPI_uxEventGroupGetNumber( xEventGroup )
+#endif
+
+#ifndef traceAPI_vEventGroupSetNumber
+    #define traceAPI_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber )
+#endif
+
+#ifndef traceAPI_xStreamBufferGenericCreate
+    #define traceAPI_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
+#endif
+
+#ifndef traceAPI_xStreamBufferGenericCreateStatic
+    #define traceAPI_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
+#endif
+
+#ifndef traceAPI_vStreamBufferDelete
+    #define traceAPI_vStreamBufferDelete( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_xStreamBufferReset
+    #define traceAPI_xStreamBufferReset( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_xStreamBufferSetTriggerLevel
+    #define traceAPI_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel )
+#endif
+
+#ifndef traceAPI_xStreamBufferSpacesAvailable
+    #define traceAPI_xStreamBufferSpacesAvailable( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_xStreamBufferBytesAvailable
+    #define traceAPI_xStreamBufferBytesAvailable( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_xStreamBufferSend
+    #define traceAPI_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xStreamBufferSendFromISR
+    #define traceAPI_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_xStreamBufferReceive
+    #define traceAPI_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait )
+#endif
+
+#ifndef traceAPI_xStreamBufferNextMessageLengthBytes
+    #define traceAPI_xStreamBufferNextMessageLengthBytes( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_xStreamBufferReceiveFromISR
+    #define traceAPI_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_xStreamBufferIsEmpty
+    #define traceAPI_xStreamBufferIsEmpty( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_xStreamBufferIsFull
+    #define traceAPI_xStreamBufferIsFull( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_xStreamBufferSendCompletedFromISR
+    #define traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer,pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_xStreamBufferReceiveCompletedFromISR
+    #define traceAPI_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceAPI_uxStreamBufferGetStreamBufferNumber
+    #define traceAPI_uxStreamBufferGetStreamBufferNumber( xStreamBuffer )
+#endif
+
+#ifndef traceAPI_vStreamBufferSetStreamBufferNumber
+    #define traceAPI_vStreamBufferSetStreamBufferNumber()
+#endif
+
+#ifndef traceAPI_ucStreamBufferGetStreamBufferType
+    #define traceAPI_ucStreamBufferGetStreamBufferType( xStreamBuffer )
+#endif
+
+#ifndef traceRETURN_xQueueGenericReset
+    #define traceRETURN_xQueueGenericReset( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueGenericCreateStatic
+    #define traceRETURN_xQueueGenericCreateStatic( pxNewQueue )
+#endif
+
+#ifndef traceRETURN_xQueueGenericCreate
+    #define traceRETURN_xQueueGenericCreate( pxNewQueue )
+#endif
+
+#ifndef traceRETURN_xQueueCreateMutex
+    #define traceRETURN_xQueueCreateMutex( xNewQueue )
+#endif
+
+#ifndef traceRETURN_xQueueCreateMutexStatic
+    #define traceRETURN_xQueueCreateMutexStatic( xNewQueue )
+#endif
+
+#ifndef traceRETURN_xQueueGetMutexHolder
+    #define traceRETURN_xQueueGetMutexHolder( pxReturn )
+#endif
+
+#ifndef traceRETURN_xQueueGetMutexHolderFromISR
+    #define traceRETURN_xQueueGetMutexHolderFromISR( pxReturn )
+#endif
+
+#ifndef traceRETURN_xQueueGiveMutexRecursive
+    #define traceRETURN_xQueueGiveMutexRecursive( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueTakeMutexRecursive
+    #define traceRETURN_xQueueTakeMutexRecursive( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueCreateCountingSemaphoreStatic
+    #define traceRETURN_xQueueCreateCountingSemaphoreStatic( xHandle )
+#endif
+
+#ifndef traceRETURN_xQueueCreateCountingSemaphore
+    #define traceRETURN_xQueueCreateCountingSemaphore( xHandle )
+#endif
+
+#ifndef traceRETURN_xQueueGenericSend
+    #define traceRETURN_xQueueGenericSend( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueGenericSendFromISR
+    #define traceRETURN_xQueueGenericSendFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueGiveFromISR
+    #define traceRETURN_xQueueGiveFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueReceive
+    #define traceRETURN_xQueueReceive( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueSemaphoreTake
+    #define traceRETURN_xQueueSemaphoreTake( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueuePeek
+    #define traceRETURN_xQueuePeek( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueReceiveFromISR
+    #define traceRETURN_xQueueReceiveFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueuePeekFromISR
+    #define traceRETURN_xQueuePeekFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_uxQueueMessagesWaiting
+    #define traceRETURN_uxQueueMessagesWaiting( uxReturn )
+#endif
+
+#ifndef traceRETURN_uxQueueSpacesAvailable
+    #define traceRETURN_uxQueueSpacesAvailable( uxReturn )
+#endif
+
+#ifndef traceRETURN_uxQueueMessagesWaitingFromISR
+    #define traceRETURN_uxQueueMessagesWaitingFromISR( uxReturn )
+#endif
+
+#ifndef traceRETURN_vQueueDelete
+    #define traceRETURN_vQueueDelete()
+#endif
+
+#ifndef traceRETURN_uxQueueGetQueueNumber
+    #define traceRETURN_uxQueueGetQueueNumber( uxQueueNumber )
+#endif
+
+#ifndef traceRETURN_vQueueSetQueueNumber
+    #define traceRETURN_vQueueSetQueueNumber()
+#endif
+
+#ifndef traceRETURN_ucQueueGetQueueType
+    #define traceRETURN_ucQueueGetQueueType( ucQueueType )
+#endif
+
+#ifndef traceRETURN_xQueueIsQueueEmptyFromISR
+    #define traceRETURN_xQueueIsQueueEmptyFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueIsQueueFullFromISR
+    #define traceRETURN_xQueueIsQueueFullFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueCRSend
+    #define traceRETURN_xQueueCRSend( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueCRReceive
+    #define traceRETURN_xQueueCRReceive( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueCRSendFromISR
+    #define traceRETURN_xQueueCRSendFromISR( xCoRoutinePreviouslyWoken )
+#endif
+
+#ifndef traceRETURN_xQueueCRReceiveFromISR
+    #define traceRETURN_xQueueCRReceiveFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_vQueueAddToRegistry
+    #define traceRETURN_vQueueAddToRegistry()
+#endif
+
+#ifndef traceRETURN_pcQueueGetName
+    #define traceRETURN_pcQueueGetName( pcReturn )
+#endif
+
+#ifndef traceRETURN_vQueueUnregisterQueue
+    #define traceRETURN_vQueueUnregisterQueue()
+#endif
+
+#ifndef traceRETURN_vQueueWaitForMessageRestricted
+    #define traceRETURN_vQueueWaitForMessageRestricted()
+#endif
+
+#ifndef traceRETURN_xQueueCreateSet
+    #define traceRETURN_xQueueCreateSet( pxQueue )
+#endif
+
+#ifndef traceRETURN_xQueueAddToSet
+    #define traceRETURN_xQueueAddToSet( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueRemoveFromSet
+    #define traceRETURN_xQueueRemoveFromSet( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueSelectFromSet
+    #define traceRETURN_xQueueSelectFromSet( xReturn )
+#endif
+
+#ifndef traceRETURN_xQueueSelectFromSetFromISR
+    #define traceRETURN_xQueueSelectFromSetFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskCreateStatic
+    #define traceRETURN_xTaskCreateStatic( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskCreateRestrictedStatic
+    #define traceRETURN_xTaskCreateRestrictedStatic( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskCreateRestricted
+    #define traceRETURN_xTaskCreateRestricted( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskCreate
+    #define traceRETURN_xTaskCreate( xReturn )
+#endif
+
+#ifndef traceRETURN_vTaskDelete
+    #define traceRETURN_vTaskDelete()
+#endif
+
+#ifndef traceRETURN_xTaskDelayUntil
+    #define traceRETURN_xTaskDelayUntil( xShouldDelay )
+#endif
+
+#ifndef traceRETURN_vTaskDelay
+    #define traceRETURN_vTaskDelay()
+#endif
+
+#ifndef traceRETURN_eTaskGetState
+    #define traceRETURN_eTaskGetState( eReturn )
+#endif
+
+#ifndef traceRETURN_uxTaskPriorityGet
+    #define traceRETURN_uxTaskPriorityGet( uxReturn )
+#endif
+
+#ifndef traceRETURN_uxTaskPriorityGetFromISR
+    #define traceRETURN_uxTaskPriorityGetFromISR( uxReturn )
+#endif
+
+#ifndef traceRETURN_vTaskPrioritySet
+    #define traceRETURN_vTaskPrioritySet()
+#endif
+
+#ifndef traceRETURN_vTaskSuspend
+    #define traceRETURN_vTaskSuspend()
+#endif
+
+#ifndef traceRETURN_vTaskResume
+    #define traceRETURN_vTaskResume()
+#endif
+
+#ifndef traceRETURN_xTaskResumeFromISR
+    #define traceRETURN_xTaskResumeFromISR( xYieldRequired )
+#endif
+
+#ifndef traceRETURN_vTaskStartScheduler
+    #define traceRETURN_vTaskStartScheduler()
+#endif
+
+#ifndef traceRETURN_vTaskEndScheduler
+    #define traceRETURN_vTaskEndScheduler()
+#endif
+
+#ifndef traceRETURN_vTaskSuspendAll
+    #define traceRETURN_vTaskSuspendAll()
+#endif
+
+#ifndef traceRETURN_xTaskResumeAll
+    #define traceRETURN_xTaskResumeAll( xAlreadyYielded )
+#endif
+
+#ifndef traceRETURN_xTaskGetTickCount
+    #define traceRETURN_xTaskGetTickCount( xTicks )
+#endif
+
+#ifndef traceRETURN_xTaskGetTickCountFromISR
+    #define traceRETURN_xTaskGetTickCountFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_uxTaskGetNumberOfTasks
+    #define traceRETURN_uxTaskGetNumberOfTasks( uxCurrentNumberOfTasks )
+#endif
+
+#ifndef traceRETURN_pcTaskGetName
+    #define traceRETURN_pcTaskGetName( pcTaskName )
+#endif
+
+#ifndef traceRETURN_xTaskGetHandle
+    #define traceRETURN_xTaskGetHandle( pxTCB )
+#endif
+
+#ifndef traceRETURN_uxTaskGetSystemState
+    #define traceRETURN_uxTaskGetSystemState( uxTask )
+#endif
+
+#ifndef traceRETURN_xTaskGetIdleTaskHandle
+    #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
+#endif
+
+#ifndef traceRETURN_vTaskStepTick
+    #define traceRETURN_vTaskStepTick()
+#endif
+
+#ifndef traceRETURN_xTaskCatchUpTicks
+    #define traceRETURN_xTaskCatchUpTicks( xYieldOccurred )
+#endif
+
+#ifndef traceRETURN_xTaskAbortDelay
+    #define traceRETURN_xTaskAbortDelay( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskIncrementTick
+    #define traceRETURN_xTaskIncrementTick( xSwitchRequired )
+#endif
+
+#ifndef traceRETURN_vTaskSetApplicationTaskTag
+    #define traceRETURN_vTaskSetApplicationTaskTag()
+#endif
+
+#ifndef traceRETURN_xTaskGetApplicationTaskTag
+    #define traceRETURN_xTaskGetApplicationTaskTag( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskGetApplicationTaskTagFromISR
+    #define traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskCallApplicationTaskHook
+    #define traceRETURN_xTaskCallApplicationTaskHook( xReturn )
+#endif
+
+#ifndef traceRETURN_vTaskPlaceOnEventList
+    #define traceRETURN_vTaskPlaceOnEventList()
+#endif
+
+#ifndef traceRETURN_vTaskPlaceOnUnorderedEventList
+    #define traceRETURN_vTaskPlaceOnUnorderedEventList()
+#endif
+
+#ifndef traceRETURN_vTaskPlaceOnEventListRestricted
+    #define traceRETURN_vTaskPlaceOnEventListRestricted()
+#endif
+
+#ifndef traceRETURN_xTaskRemoveFromEventList
+    #define traceRETURN_xTaskRemoveFromEventList( xReturn )
+#endif
+
+#ifndef traceRETURN_vTaskRemoveFromUnorderedEventList
+    #define traceRETURN_vTaskRemoveFromUnorderedEventList()
+#endif
+
+#ifndef traceRETURN_vTaskSetTimeOutState
+    #define traceRETURN_vTaskSetTimeOutState()
+#endif
+
+#ifndef traceRETURN_vTaskInternalSetTimeOutState
+    #define traceRETURN_vTaskInternalSetTimeOutState()
+#endif
+
+#ifndef traceRETURN_xTaskCheckForTimeOut
+    #define traceRETURN_xTaskCheckForTimeOut( xReturn )
+#endif
+
+#ifndef traceRETURN_vTaskMissedYield
+    #define traceRETURN_vTaskMissedYield()
+#endif
+
+#ifndef traceRETURN_uxTaskGetTaskNumber
+    #define traceRETURN_uxTaskGetTaskNumber( uxReturn )
+#endif
+
+#ifndef traceRETURN_vTaskSetTaskNumber
+    #define traceRETURN_vTaskSetTaskNumber()
+#endif
+
+#ifndef traceRETURN_eTaskConfirmSleepModeStatus
+    #define traceRETURN_eTaskConfirmSleepModeStatus( eReturn )
+#endif
+
+#ifndef traceRETURN_vTaskSetThreadLocalStoragePointer
+    #define traceRETURN_vTaskSetThreadLocalStoragePointer()
+#endif
+
+#ifndef traceRETURN_pvTaskGetThreadLocalStoragePointer
+    #define traceRETURN_pvTaskGetThreadLocalStoragePointer( pvReturn )
+#endif
+
+#ifndef traceRETURN_vTaskAllocateMPURegions
+    #define traceRETURN_vTaskAllocateMPURegions()
+#endif
+
+#ifndef traceRETURN_vTaskGetInfo
+    #define traceRETURN_vTaskGetInfo()
+#endif
+
+#ifndef traceRETURN_uxTaskGetStackHighWaterMark2
+    #define traceRETURN_uxTaskGetStackHighWaterMark2( uxReturn )
+#endif
+
+#ifndef traceRETURN_uxTaskGetStackHighWaterMark
+    #define traceRETURN_uxTaskGetStackHighWaterMark( uxReturn )
+#endif
+
+#ifndef traceRETURN_pxTaskGetStackStart
+    #define traceRETURN_pxTaskGetStackStart( pxStack )
+#endif
+
+#ifndef traceRETURN_xTaskGetCurrentTaskHandle
+    #define traceRETURN_xTaskGetCurrentTaskHandle( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskGetSchedulerState
+    #define traceRETURN_xTaskGetSchedulerState( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskPriorityInherit
+    #define traceRETURN_xTaskPriorityInherit( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskPriorityDisinherit
+    #define traceRETURN_xTaskPriorityDisinherit( xReturn )
+#endif
+
+#ifndef traceRETURN_vTaskPriorityDisinheritAfterTimeout
+    #define traceRETURN_vTaskPriorityDisinheritAfterTimeout()
+#endif
+
+#ifndef traceRETURN_vTaskEnterCritical
+    #define traceRETURN_vTaskEnterCritical()
+#endif
+
+#ifndef traceRETURN_vTaskExitCritical
+    #define traceRETURN_vTaskExitCritical()
+#endif
+
+#ifndef traceRETURN_vTaskList
+    #define traceRETURN_vTaskList()
+#endif
+
+#ifndef traceRETURN_vTaskGetRunTimeStats
+    #define traceRETURN_vTaskGetRunTimeStats()
+#endif
+
+#ifndef traceRETURN_uxTaskResetEventItemValue
+    #define traceRETURN_uxTaskResetEventItemValue( uxReturn )
+#endif
+
+#ifndef traceRETURN_pvTaskIncrementMutexHeldCount
+    #define traceRETURN_pvTaskIncrementMutexHeldCount( pxCurrentTCB )
+#endif
+
+#ifndef traceRETURN_ulTaskGenericNotifyTake
+    #define traceRETURN_ulTaskGenericNotifyTake( ulReturn )
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotifyWait
+    #define traceRETURN_xTaskGenericNotifyWait( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotify
+    #define traceRETURN_xTaskGenericNotify( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotifyFromISR
+    #define traceRETURN_xTaskGenericNotifyFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_vTaskGenericNotifyGiveFromISR
+    #define traceRETURN_vTaskGenericNotifyGiveFromISR()
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotifyStateClear
+    #define traceRETURN_xTaskGenericNotifyStateClear( xReturn )
+#endif
+
+#ifndef traceRETURN_ulTaskGenericNotifyValueClear
+    #define traceRETURN_ulTaskGenericNotifyValueClear( ulReturn )
+#endif
+
+#ifndef traceRETURN_ulTaskGetIdleRunTimeCounter
+    #define traceRETURN_ulTaskGetIdleRunTimeCounter( ulReturn )
+#endif
+
+#ifndef traceRETURN_ulTaskGetIdleRunTimePercent
+    #define traceRETURN_ulTaskGetIdleRunTimePercent( ulReturn )
+#endif
+
+#ifndef traceRETURN_vTaskCoreAffinitySet
+    #define traceRETURN_vTaskCoreAffinitySet()
+#endif
+
+#ifndef traceRETURN_vTaskCoreAffinityGet
+    #define traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask )
+#endif
+
+#ifndef traceRETURN_vTaskPreemptionDisable
+    #define traceRETURN_vTaskPreemptionDisable()
+#endif
+
+#ifndef traceRETURN_vTaskPreemptionEnable
+    #define traceRETURN_vTaskPreemptionEnable()
+#endif
+
+#ifndef traceRETURN_vTaskYieldWithinAPI
+    #define traceRETURN_vTaskYieldWithinAPI()
+#endif
+
+#ifndef traceRETURN_vTaskEnterCriticalFromISR
+    #define traceRETURN_vTaskEnterCriticalFromISR( uxSavedInterruptStatus )
+#endif
+
+#ifndef traceRETURN_vTaskExitCriticalFromISR
+    #define traceRETURN_vTaskExitCriticalFromISR()
+#endif
+
+#ifndef traceRETURN_ulTaskGetRunTimeCounter
+    #define traceRETURN_ulTaskGetRunTimeCounter( ulRunTimeCounter )
+#endif
+
+#ifndef traceRETURN_xTimerCreateTimerTask
+    #define traceRETURN_xTimerCreateTimerTask( xReturn )
+#endif
+
+#ifndef traceRETURN_xTimerCreate
+    #define traceRETURN_xTimerCreate( pxNewTimer )
+#endif
+
+#ifndef traceRETURN_xTimerCreateStatic
+    #define traceRETURN_xTimerCreateStatic( pxNewTimer )
+#endif
+
+#ifndef traceRETURN_xTimerGenericCommand
+    #define traceRETURN_xTimerGenericCommand( xReturn )
+#endif
+
+#ifndef traceRETURN_xTimerGenericCommandFromTask
+    #define traceRETURN_xTimerGenericCommandFromTask( xReturn )
+#endif
+
+#ifndef traceRETURN_xTimerGenericCommandFromISR
+    #define traceRETURN_xTimerGenericCommandFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xTimerGetTimerDaemonTaskHandle
+    #define traceRETURN_xTimerGetTimerDaemonTaskHandle( xTimerTaskHandle )
+#endif
+
+#ifndef traceRETURN_xTimerGetPeriod
+    #define traceRETURN_xTimerGetPeriod( xTimerPeriodInTicks )
+#endif
+
+#ifndef traceRETURN_vTimerSetReloadMode
+    #define traceRETURN_vTimerSetReloadMode()
+#endif
+
+#ifndef traceRETURN_xTimerGetReloadMode
+    #define traceRETURN_xTimerGetReloadMode( xReturn )
+#endif
+
+#ifndef traceRETURN_xTimerGetExpiryTime
+    #define traceRETURN_xTimerGetExpiryTime( xReturn )
+#endif
+
+#ifndef traceRETURN_pcTimerGetName
+    #define traceRETURN_pcTimerGetName( pcTimerName )
+#endif
+
+#ifndef traceRETURN_xTimerIsTimerActive
+    #define traceRETURN_xTimerIsTimerActive( xReturn )
+#endif
+
+#ifndef traceRETURN_pvTimerGetTimerID
+    #define traceRETURN_pvTimerGetTimerID( pvReturn )
+#endif
+
+#ifndef traceRETURN_vTimerSetTimerID
+    #define traceRETURN_vTimerSetTimerID()
+#endif
+
+#ifndef traceRETURN_xTimerPendFunctionCallFromISR
+    #define traceRETURN_xTimerPendFunctionCallFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xTimerPendFunctionCall
+    #define traceRETURN_xTimerPendFunctionCall( xReturn )
+#endif
+
+#ifndef traceRETURN_uxTimerGetTimerNumber
+    #define traceRETURN_uxTimerGetTimerNumber( uxTimerNumber )
+#endif
+
+#ifndef traceRETURN_vTimerSetTimerNumber
+    #define traceRETURN_vTimerSetTimerNumber()
+#endif
+
+#ifndef traceRETURN_vListInitialise
+    #define traceRETURN_vListInitialise()
+#endif
+
+#ifndef traceRETURN_vListInitialiseItem
+    #define traceRETURN_vListInitialiseItem()
+#endif
+
+#ifndef traceRETURN_vListInsertEnd
+    #define traceRETURN_vListInsertEnd()
+#endif
+
+#ifndef traceRETURN_vListInsert
+    #define traceRETURN_vListInsert()
+#endif
+
+#ifndef traceRETURN_uxListRemove
+    #define traceRETURN_uxListRemove( uxNumberOfItems )
+#endif
+
+#ifndef traceRETURN_xCoRoutineCreate
+    #define traceRETURN_xCoRoutineCreate( xReturn )
+#endif
+
+#ifndef traceRETURN_vCoRoutineAddToDelayedList
+    #define traceRETURN_vCoRoutineAddToDelayedList()
+#endif
+
+#ifndef traceRETURN_vCoRoutineSchedule
+    #define traceRETURN_vCoRoutineSchedule()
+#endif
+
+#ifndef traceRETURN_xCoRoutineRemoveFromEventList
+    #define traceRETURN_xCoRoutineRemoveFromEventList( xReturn )
+#endif
+
+#ifndef traceRETURN_xEventGroupCreateStatic
+    #define traceRETURN_xEventGroupCreateStatic( pxEventBits )
+#endif
+
+#ifndef traceRETURN_xEventGroupCreate
+    #define traceRETURN_xEventGroupCreate( pxEventBits )
+#endif
+
+#ifndef traceRETURN_xEventGroupSync
+    #define traceRETURN_xEventGroupSync( uxReturn )
+#endif
+
+#ifndef traceRETURN_xEventGroupWaitBits
+    #define traceRETURN_xEventGroupWaitBits( uxReturn )
+#endif
+
+#ifndef traceRETURN_xEventGroupClearBits
+    #define traceRETURN_xEventGroupClearBits( uxReturn )
+#endif
+
+#ifndef traceRETURN_xEventGroupClearBitsFromISR
+    #define traceRETURN_xEventGroupClearBitsFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xEventGroupGetBitsFromISR
+    #define traceRETURN_xEventGroupGetBitsFromISR( uxReturn )
+#endif
+
+#ifndef traceRETURN_xEventGroupSetBits
+    #define traceRETURN_xEventGroupSetBits( uxEventBits )
+#endif
+
+#ifndef traceRETURN_vEventGroupDelete
+    #define traceRETURN_vEventGroupDelete()
+#endif
+
+#ifndef traceRETURN_vEventGroupSetBitsCallback
+    #define traceRETURN_vEventGroupSetBitsCallback()
+#endif
+
+#ifndef traceRETURN_vEventGroupClearBitsCallback
+    #define traceRETURN_vEventGroupClearBitsCallback()
+#endif
+
+#ifndef traceRETURN_xEventGroupSetBitsFromISR
+    #define traceRETURN_xEventGroupSetBitsFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_uxEventGroupGetNumber
+    #define traceRETURN_uxEventGroupGetNumber( xReturn )
+#endif
+
+#ifndef traceRETURN_vEventGroupSetNumber
+    #define traceRETURN_vEventGroupSetNumber()
+#endif
+
+#ifndef traceRETURN_xStreamBufferGenericCreate
+    #define traceRETURN_xStreamBufferGenericCreate( pucAllocatedMemory )
+#endif
+
+#ifndef traceRETURN_xStreamBufferGenericCreateStatic
+    #define traceRETURN_xStreamBufferGenericCreateStatic( xReturn )
+#endif
+
+#ifndef traceRETURN_vStreamBufferDelete
+    #define traceRETURN_vStreamBufferDelete()
+#endif
+
+#ifndef traceRETURN_xStreamBufferReset
+    #define traceRETURN_xStreamBufferReset( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferSetTriggerLevel
+    #define traceRETURN_xStreamBufferSetTriggerLevel( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferSpacesAvailable
+    #define traceRETURN_xStreamBufferSpacesAvailable( xSpace )
+#endif
+
+#ifndef traceRETURN_xStreamBufferBytesAvailable
+    #define traceRETURN_xStreamBufferBytesAvailable( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferSend
+    #define traceRETURN_xStreamBufferSend( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferSendFromISR
+    #define traceRETURN_xStreamBufferSendFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferReceive
+    #define traceRETURN_xStreamBufferReceive( xReceivedLength )
+#endif
+
+#ifndef traceRETURN_xStreamBufferNextMessageLengthBytes
+    #define traceRETURN_xStreamBufferNextMessageLengthBytes( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferReceiveFromISR
+    #define traceRETURN_xStreamBufferReceiveFromISR( xReceivedLength )
+#endif
+
+#ifndef traceRETURN_xStreamBufferIsEmpty
+    #define traceRETURN_xStreamBufferIsEmpty( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferIsFull
+    #define traceRETURN_xStreamBufferIsFull( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferSendCompletedFromISR
+    #define traceRETURN_xStreamBufferSendCompletedFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_xStreamBufferReceiveCompletedFromISR
+    #define traceRETURN_xStreamBufferReceiveCompletedFromISR( xReturn )
+#endif
+
+#ifndef traceRETURN_uxStreamBufferGetStreamBufferNumber
+    #define traceRETURN_uxStreamBufferGetStreamBufferNumber( uxStreamBufferNumber )
+#endif
+
+#ifndef traceRETURN_vStreamBufferSetStreamBufferNumber
+    #define traceRETURN_vStreamBufferSetStreamBufferNumber()
+#endif
+
+#ifndef traceRETURN_ucStreamBufferGetStreamBufferType
+    #define traceRETURN_ucStreamBufferGetStreamBufferType( ucFlags )
+#endif
+
 #ifndef configGENERATE_RUN_TIME_STATS
     #define configGENERATE_RUN_TIME_STATS    0
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -978,1456 +978,1540 @@
     #define traceSTREAM_BUFFER_RECEIVE_FROM_ISR( xStreamBuffer, xReceivedLength )
 #endif
 
-#ifndef traceAPI_xQueueGenericReset
-    #define traceAPI_xQueueGenericReset( xQueue, xNewQueue )
-#endif
-
-#ifndef traceAPI_xQueueGenericCreateStatic
-    #define traceAPI_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType )
-#endif
-
-#ifndef traceAPI_xQueueGenericCreate
-    #define traceAPI_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType )
-#endif
-
-#ifndef traceAPI_xQueueCreateMutex
-    #define traceAPI_xQueueCreateMutex( ucQueueType )
-#endif
-
-#ifndef traceAPI_xQueueCreateMutexStatic
-    #define traceAPI_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue )
-#endif
-
-#ifndef traceAPI_xQueueGetMutexHolder
-    #define traceAPI_xQueueGetMutexHolder( xSemaphore )
-#endif
-
-#ifndef traceAPI_xQueueGetMutexHolderFromISR
-    #define traceAPI_xQueueGetMutexHolderFromISR( xSemaphore )
-#endif
-
-#ifndef traceAPI_xQueueGiveMutexRecursive
-    #define traceAPI_xQueueGiveMutexRecursive( xMutex )
-#endif
-
-#ifndef traceAPI_xQueueTakeMutexRecursive
-    #define traceAPI_xQueueTakeMutexRecursive( xMutex, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xQueueCreateCountingSemaphoreStatic
-    #define traceAPI_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue )
-#endif
-
-#ifndef traceAPI_xQueueCreateCountingSemaphore
-    #define traceAPI_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount )
-#endif
-
-#ifndef traceAPI_xQueueGenericSend
-    #define traceAPI_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition )
-#endif
-
-#ifndef traceAPI_xQueueGenericSendFromISR
-    #define traceAPI_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition )
-#endif
-
-#ifndef traceAPI_xQueueGiveFromISR
-    #define traceAPI_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_xQueueReceive
-    #define traceAPI_xQueueReceive( xQueue, pvBuffer, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xQueueSemaphoreTake
-    #define traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xQueuePeek
-    #define traceAPI_xQueuePeek( xQueue, pvBuffer, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xQueueReceiveFromISR
-    #define traceAPI_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_xQueuePeekFromISR
-    #define traceAPI_xQueuePeekFromISR( xQueue, pvBuffer )
-#endif
-
-#ifndef traceAPI_uxQueueMessagesWaiting
-    #define traceAPI_uxQueueMessagesWaiting( xQueue )
-#endif
-
-#ifndef traceAPI_uxQueueSpacesAvailable
-    #define traceAPI_uxQueueSpacesAvailable( xQueue )
-#endif
-
-#ifndef traceAPI_uxQueueMessagesWaitingFromISR
-    #define traceAPI_uxQueueMessagesWaitingFromISR( xQueue )
-#endif
-
-#ifndef traceAPI_vQueueDelete
-    #define traceAPI_vQueueDelete( xQueue )
-#endif
-
-#ifndef traceAPI_uxQueueGetQueueNumber
-    #define traceAPI_uxQueueGetQueueNumber( xQueue )
-#endif
-
-#ifndef traceAPI_vQueueSetQueueNumber
-    #define traceAPI_vQueueSetQueueNumber( xQueue, uxQueueNumber )
-#endif
-
-#ifndef traceAPI_ucQueueGetQueueType
-    #define traceAPI_ucQueueGetQueueType( xQueue )
-#endif
-
-#ifndef traceAPI_xQueueIsQueueEmptyFromISR
-    #define traceAPI_xQueueIsQueueEmptyFromISR( xQueue )
-#endif
-
-#ifndef traceAPI_xQueueIsQueueFullFromISR
-    #define traceAPI_xQueueIsQueueFullFromISR( xQueue )
-#endif
-
-#ifndef traceAPI_xQueueCRSend
-    #define traceAPI_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xQueueCRReceive
-    #define traceAPI_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xQueueCRSendFromISR
-    #define traceAPI_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken )
-#endif
-
-#ifndef traceAPI_xQueueCRReceiveFromISR
-    #define traceAPI_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken )
-#endif
-
-#ifndef traceAPI_vQueueAddToRegistry
-    #define traceAPI_vQueueAddToRegistry( xQueue, pcQueueName )
-#endif
-
-#ifndef traceAPI_pcQueueGetName
-    #define traceAPI_pcQueueGetName( xQueue )
-#endif
-
-#ifndef traceAPI_vQueueUnregisterQueue
-    #define traceAPI_vQueueUnregisterQueue( xQueue )
-#endif
-
-#ifndef traceAPI_vQueueWaitForMessageRestricted
-    #define traceAPI_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely )
-#endif
-
-#ifndef traceAPI_xQueueCreateSet
-    #define traceAPI_xQueueCreateSet( uxEventQueueLength )
-#endif
-
-#ifndef traceAPI_xQueueAddToSet
-    #define traceAPI_xQueueAddToSet( xQueueOrSemaphore, xQueueSet )
-#endif
-
-#ifndef traceAPI_xQueueRemoveFromSet
-    #define traceAPI_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet )
-#endif
-
-#ifndef traceAPI_xQueueSelectFromSet
-    #define traceAPI_xQueueSelectFromSet( xQueueSet, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xQueueSelectFromSetFromISR
-    #define traceAPI_xQueueSelectFromSetFromISR( xQueueSet )
-#endif
-
-#ifndef traceAPI_xTaskCreateStatic
-    #define traceAPI_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer )
-#endif
-
-#ifndef traceAPI_xTaskCreateRestrictedStatic
-    #define traceAPI_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask )
-#endif
-
-#ifndef traceAPI_xTaskCreateRestricted
-    #define traceAPI_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask )
-#endif
-
-#ifndef traceAPI_xTaskCreate
-    #define traceAPI_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask )
-#endif
-
-#ifndef traceAPI_vTaskDelete
-    #define traceAPI_vTaskDelete( xTaskToDelete )
-#endif
-
-#ifndef traceAPI_xTaskDelayUntil
-    #define traceAPI_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )
-#endif
-
-#ifndef traceAPI_vTaskDelay
-    #define traceAPI_vTaskDelay( xTicksToDelay )
-#endif
-
-#ifndef traceAPI_eTaskGetState
-    #define traceAPI_eTaskGetState( xTask )
-#endif
-
-#ifndef traceAPI_uxTaskPriorityGet
-    #define traceAPI_uxTaskPriorityGet( xTask )
-#endif
-
-#ifndef traceAPI_uxTaskPriorityGetFromISR
-    #define traceAPI_uxTaskPriorityGetFromISR( xTask )
-#endif
-
-#ifndef traceAPI_vTaskPrioritySet
-    #define traceAPI_vTaskPrioritySet( xTask, uxNewPriority )
-#endif
-
-#ifndef traceAPI_vTaskSuspend
-    #define traceAPI_vTaskSuspend( xTaskToSuspend )
-#endif
-
-#ifndef traceAPI_vTaskResume
-    #define traceAPI_vTaskResume( xTaskToResume )
-#endif
-
-#ifndef traceAPI_xTaskResumeFromISR
-    #define traceAPI_xTaskResumeFromISR( xTaskToResume )
-#endif
-
-#ifndef traceAPI_vTaskStartScheduler
-    #define traceAPI_vTaskStartScheduler()
-#endif
-
-#ifndef traceAPI_vTaskEndScheduler
-    #define traceAPI_vTaskEndScheduler()
-#endif
-
-#ifndef traceAPI_vTaskSuspendAll
-    #define traceAPI_vTaskSuspendAll()
-#endif
-
-#ifndef traceAPI_xTaskResumeAll
-    #define traceAPI_xTaskResumeAll()
-#endif
-
-#ifndef traceAPI_xTaskGetTickCount
-    #define traceAPI_xTaskGetTickCount()
-#endif
-
-#ifndef traceAPI_xTaskGetTickCountFromISR
-    #define traceAPI_xTaskGetTickCountFromISR()
-#endif
-
-#ifndef traceAPI_uxTaskGetNumberOfTasks
-    #define traceAPI_uxTaskGetNumberOfTasks()
-#endif
-
-#ifndef traceAPI_pcTaskGetName
-    #define traceAPI_pcTaskGetName( xTaskToQuery )
-#endif
-
-#ifndef traceAPI_xTaskGetHandle
-    #define traceAPI_xTaskGetHandle( pcNameToQuery )
-#endif
-
-#ifndef traceAPI_uxTaskGetSystemState
-    #define traceAPI_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime )
-#endif
-
-#ifndef traceAPI_xTaskGetIdleTaskHandle
-    #define traceAPI_xTaskGetIdleTaskHandle()
-#endif
-
-#ifndef traceAPI_vTaskStepTick
-    #define traceAPI_vTaskStepTick( xTicksToJump )
-#endif
-
-#ifndef traceAPI_xTaskCatchUpTicks
-    #define traceAPI_xTaskCatchUpTicks( xTicksToCatchUp )
-#endif
-
-#ifndef traceAPI_xTaskAbortDelay
-    #define traceAPI_xTaskAbortDelay( xTask )
-#endif
-
-#ifndef traceAPI_xTaskIncrementTick
-    #define traceAPI_xTaskIncrementTick()
-#endif
-
-#ifndef traceAPI_vTaskSetApplicationTaskTag
-    #define traceAPI_vTaskSetApplicationTaskTag( xTask, pxHookFunction )
-#endif
-
-#ifndef traceAPI_xTaskGetApplicationTaskTag
-    #define traceAPI_xTaskGetApplicationTaskTag( xTask )
-#endif
-
-#ifndef traceAPI_xTaskGetApplicationTaskTagFromISR
-    #define traceAPI_xTaskGetApplicationTaskTagFromISR( xTask )
-#endif
-
-#ifndef traceAPI_xTaskCallApplicationTaskHook
-    #define traceAPI_xTaskCallApplicationTaskHook( xTask, pvParameter )
-#endif
-
-#ifndef traceAPI_vTaskPlaceOnEventList
-    #define traceAPI_vTaskPlaceOnEventList( pxEventList, xTicksToWait )
-#endif
-
-#ifndef traceAPI_vTaskPlaceOnUnorderedEventList
-    #define traceAPI_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait )
-#endif
-
-#ifndef traceAPI_vTaskPlaceOnEventListRestricted
-    #define traceAPI_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely )
-#endif
-
-#ifndef traceAPI_xTaskRemoveFromEventList
-    #define traceAPI_xTaskRemoveFromEventList( pxEventList )
-#endif
-
-#ifndef traceAPI_vTaskRemoveFromUnorderedEventList
-    #define traceAPI_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue )
-#endif
-
-#ifndef traceAPI_vTaskSetTimeOutState
-    #define traceAPI_vTaskSetTimeOutState( pxTimeOut )
-#endif
-
-#ifndef traceAPI_vTaskInternalSetTimeOutState
-    #define traceAPI_vTaskInternalSetTimeOutState( pxTimeOut )
-#endif
-
-#ifndef traceAPI_xTaskCheckForTimeOut
-    #define traceAPI_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait )
-#endif
-
-#ifndef traceAPI_vTaskMissedYield
-    #define traceAPI_vTaskMissedYield()
-#endif
-
-#ifndef traceAPI_uxTaskGetTaskNumber
-    #define traceAPI_uxTaskGetTaskNumber( xTask )
-#endif
-
-#ifndef traceAPI_vTaskSetTaskNumber
-    #define traceAPI_vTaskSetTaskNumber( xTask, uxHandle )
-#endif
-
-#ifndef traceAPI_eTaskConfirmSleepModeStatus
-    #define traceAPI_eTaskConfirmSleepModeStatus()
-#endif
-
-#ifndef traceAPI_vTaskSetThreadLocalStoragePointer
-    #define traceAPI_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue )
-#endif
-
-#ifndef traceAPI_pvTaskGetThreadLocalStoragePointer
-    #define traceAPI_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex )
-#endif
-
-#ifndef traceAPI_vTaskAllocateMPURegions
-    #define traceAPI_vTaskAllocateMPURegions( xTaskToModify, xRegions )
-#endif
-
-#ifndef traceAPI_vTaskGetInfo
-    #define traceAPI_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState )
-#endif
-
-#ifndef traceAPI_uxTaskGetStackHighWaterMark2
-    #define traceAPI_uxTaskGetStackHighWaterMark2( xTask )
-#endif
-
-#ifndef traceAPI_uxTaskGetStackHighWaterMark
-    #define traceAPI_uxTaskGetStackHighWaterMark( xTask )
-#endif
-
-#ifndef traceAPI_pxTaskGetStackStart
-    #define traceAPI_pxTaskGetStackStart( xTask )
-#endif
-
-#ifndef traceAPI_xTaskGetCurrentTaskHandle
-    #define traceAPI_xTaskGetCurrentTaskHandle()
-#endif
-
-#ifndef traceAPI_xTaskGetSchedulerState
-    #define traceAPI_xTaskGetSchedulerState()
-#endif
-
-#ifndef traceAPI_xTaskPriorityInherit
-    #define traceAPI_xTaskPriorityInherit( pxMutexHolder )
-#endif
-
-#ifndef traceAPI_xTaskPriorityDisinherit
-    #define traceAPI_xTaskPriorityDisinherit( pxMutexHolder )
-#endif
-
-#ifndef traceAPI_vTaskPriorityDisinheritAfterTimeout
-    #define traceAPI_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask )
-#endif
-
-#ifndef traceAPI_vTaskEnterCritical
-    #define traceAPI_vTaskEnterCritical()
-#endif
-
-#ifndef traceAPI_vTaskExitCritical
-    #define traceAPI_vTaskExitCritical()
-#endif
-
-#ifndef traceAPI_vTaskList
-    #define traceAPI_vTaskList( pcWriteBuffer )
-#endif
-
-#ifndef traceAPI_vTaskGetRunTimeStats
-    #define traceAPI_vTaskGetRunTimeStats( pcWriteBuffer )
-#endif
-
-#ifndef traceAPI_uxTaskResetEventItemValue
-    #define traceAPI_uxTaskResetEventItemValue()
-#endif
-
-#ifndef traceAPI_pvTaskIncrementMutexHeldCount
-    #define traceAPI_pvTaskIncrementMutexHeldCount()
-#endif
-
-#ifndef traceAPI_ulTaskGenericNotifyTake
-    #define traceAPI_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xTaskGenericNotifyWait
-    #define traceAPI_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xTaskGenericNotify
-    #define traceAPI_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue )
-#endif
-
-#ifndef traceAPI_xTaskGenericNotifyFromISR
-    #define traceAPI_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_vTaskGenericNotifyGiveFromISR
-    #define traceAPI_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_xTaskGenericNotifyStateClear
-    #define traceAPI_xTaskGenericNotifyStateClear( xTask, uxIndexToClear )
-#endif
-
-#ifndef traceAPI_ulTaskGenericNotifyValueClear
-    #define traceAPI_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear )
-#endif
-
-#ifndef traceAPI_ulTaskGetIdleRunTimeCounter
-    #define traceAPI_ulTaskGetIdleRunTimeCounter()
-#endif
-
-#ifndef traceAPI_ulTaskGetIdleRunTimePercent
-    #define traceAPI_ulTaskGetIdleRunTimePercent()
-#endif
-
-#ifndef traceAPI_vTaskCoreAffinitySet
-    #define traceAPI_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask )
-#endif
-
-#ifndef traceAPI_vTaskCoreAffinityGet
-    #define traceAPI_vTaskCoreAffinityGet( xTask )
-#endif
-
-#ifndef traceAPI_vTaskPreemptionDisable
-    #define traceAPI_vTaskPreemptionDisable( xTask )
-#endif
-
-#ifndef traceAPI_vTaskPreemptionEnable
-    #define traceAPI_vTaskPreemptionEnable( xTask )
-#endif
-
-#ifndef traceAPI_vTaskYieldWithinAPI
-    #define traceAPI_vTaskYieldWithinAPI()
-#endif
-
-#ifndef traceAPI_vTaskEnterCriticalFromISR
-    #define traceAPI_vTaskEnterCriticalFromISR()
-#endif
-
-#ifndef traceAPI_vTaskExitCriticalFromISR
-    #define traceAPI_vTaskExitCriticalFromISR( uxSavedInterruptStatus )
-#endif
-
-#ifndef traceAPI_ulTaskGetRunTimeCounter
-    #define traceAPI_ulTaskGetRunTimeCounter( xTask )
-#endif
-
-#ifndef traceAPI_xTimerCreateTimerTask
-    #define traceAPI_xTimerCreateTimerTask()
-#endif
-
-#ifndef traceAPI_xTimerCreate
-    #define traceAPI_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction )
-#endif
-
-#ifndef traceAPI_xTimerCreateStatic
-    #define traceAPI_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer )
-#endif
-
-#ifndef traceAPI_xTimerGenericCommandFromTask
-    #define traceAPI_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xTimerGenericCommandFromISR
-    #define traceAPI_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xTimerGetTimerDaemonTaskHandle
-    #define traceAPI_xTimerGetTimerDaemonTaskHandle()
-#endif
-
-#ifndef traceAPI_xTimerGetPeriod
-    #define traceAPI_xTimerGetPeriod( xTimer )
-#endif
-
-#ifndef traceAPI_vTimerSetReloadMode
-    #define traceAPI_vTimerSetReloadMode( xTimer, xAutoReload )
-#endif
-
-#ifndef traceAPI_xTimerGetReloadMode
-    #define traceAPI_xTimerGetReloadMode( xTimer )
-#endif
-
-#ifndef traceAPI_xTimerGetExpiryTime
-    #define traceAPI_xTimerGetExpiryTime( xTimer )
-#endif
-
-#ifndef traceAPI_pcTimerGetName
-    #define traceAPI_pcTimerGetName( xTimer )
-#endif
-
-#ifndef traceAPI_xTimerIsTimerActive
-    #define traceAPI_xTimerIsTimerActive( xTimer )
-#endif
-
-#ifndef traceAPI_pvTimerGetTimerID
-    #define traceAPI_pvTimerGetTimerID( xTimer )
-#endif
-
-#ifndef traceAPI_vTimerSetTimerID
-    #define traceAPI_vTimerSetTimerID( xTimer, pvNewID )
-#endif
-
-#ifndef traceAPI_xTimerPendFunctionCallFromISR
-    #define traceAPI_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_xTimerPendFunctionCall
-    #define traceAPI_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait )
-#endif
-
-#ifndef traceAPI_uxTimerGetTimerNumber
-    #define traceAPI_uxTimerGetTimerNumber( xTimer )
-#endif
-
-#ifndef traceAPI_vTimerSetTimerNumber
-    #define traceAPI_vTimerSetTimerNumber( xTimer, uxTimerNumber )
-#endif
-
-#ifndef traceAPI_vListInitialise
-    #define traceAPI_vListInitialise( pxList )
-#endif
-
-#ifndef traceAPI_vListInitialiseItem
-    #define traceAPI_vListInitialiseItem( pxItem )
-#endif
-
-#ifndef traceAPI_vListInsertEnd
-    #define traceAPI_vListInsertEnd( pxList, pxNewListItem )
-#endif
-
-#ifndef traceAPI_vListInsert
-    #define traceAPI_vListInsert( pxList, pxNewListItem )
-#endif
-
-#ifndef traceAPI_uxListRemove
-    #define traceAPI_uxListRemove( pxItemToRemove )
-#endif
-
-#ifndef traceAPI_xCoRoutineCreate
-    #define traceAPI_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex )
-#endif
-
-#ifndef traceAPI_vCoRoutineAddToDelayedList
-    #define traceAPI_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList )
-#endif
-
-#ifndef traceAPI_vCoRoutineSchedule
-    #define traceAPI_vCoRoutineSchedule()
-#endif
-
-#ifndef traceAPI_xCoRoutineRemoveFromEventList
-    #define traceAPI_xCoRoutineRemoveFromEventList( pxEventList )
-#endif
-
 #ifndef traceAPI_xEventGroupCreateStatic
     #define traceAPI_xEventGroupCreateStatic( pxEventGroupBuffer )
-#endif
-
-#ifndef traceAPI_xEventGroupCreate
-    #define traceAPI_xEventGroupCreate()
-#endif
-
-#ifndef traceAPI_xEventGroupSync
-    #define traceAPI_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xEventGroupWaitBits
-    #define traceAPI_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xEventGroupClearBits
-    #define traceAPI_xEventGroupClearBits( xEventGroup, uxBitsToClear )
-#endif
-
-#ifndef traceAPI_xEventGroupClearBitsFromISR
-    #define traceAPI_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear )
-#endif
-
-#ifndef traceAPI_xEventGroupGetBitsFromISR
-    #define traceAPI_xEventGroupGetBitsFromISR( xEventGroup )
-#endif
-
-#ifndef traceAPI_xEventGroupSetBits
-    #define traceAPI_xEventGroupSetBits( xEventGroup, uxBitsToSet )
-#endif
-
-#ifndef traceAPI_vEventGroupDelete
-    #define traceAPI_vEventGroupDelete( xEventGroup )
-#endif
-
-#ifndef traceAPI_vEventGroupSetBitsCallback
-    #define traceAPI_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet )
-#endif
-
-#ifndef traceAPI_vEventGroupClearBitsCallback
-    #define traceAPI_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear )
-#endif
-
-#ifndef traceAPI_xEventGroupSetBitsFromISR
-    #define traceAPI_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_uxEventGroupGetNumber
-    #define traceAPI_uxEventGroupGetNumber( xEventGroup )
-#endif
-
-#ifndef traceAPI_vEventGroupSetNumber
-    #define traceAPI_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber )
-#endif
-
-#ifndef traceAPI_xStreamBufferGenericCreate
-    #define traceAPI_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
-#endif
-
-#ifndef traceAPI_xStreamBufferGenericCreateStatic
-    #define traceAPI_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
-#endif
-
-#ifndef traceAPI_vStreamBufferDelete
-    #define traceAPI_vStreamBufferDelete( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_xStreamBufferReset
-    #define traceAPI_xStreamBufferReset( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_xStreamBufferSetTriggerLevel
-    #define traceAPI_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel )
-#endif
-
-#ifndef traceAPI_xStreamBufferSpacesAvailable
-    #define traceAPI_xStreamBufferSpacesAvailable( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_xStreamBufferBytesAvailable
-    #define traceAPI_xStreamBufferBytesAvailable( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_xStreamBufferSend
-    #define traceAPI_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xStreamBufferSendFromISR
-    #define traceAPI_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_xStreamBufferReceive
-    #define traceAPI_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait )
-#endif
-
-#ifndef traceAPI_xStreamBufferNextMessageLengthBytes
-    #define traceAPI_xStreamBufferNextMessageLengthBytes( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_xStreamBufferReceiveFromISR
-    #define traceAPI_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_xStreamBufferIsEmpty
-    #define traceAPI_xStreamBufferIsEmpty( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_xStreamBufferIsFull
-    #define traceAPI_xStreamBufferIsFull( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_xStreamBufferSendCompletedFromISR
-    #define traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_xStreamBufferReceiveCompletedFromISR
-    #define traceAPI_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
-#endif
-
-#ifndef traceAPI_uxStreamBufferGetStreamBufferNumber
-    #define traceAPI_uxStreamBufferGetStreamBufferNumber( xStreamBuffer )
-#endif
-
-#ifndef traceAPI_vStreamBufferSetStreamBufferNumber
-    #define traceAPI_vStreamBufferSetStreamBufferNumber()
-#endif
-
-#ifndef traceAPI_ucStreamBufferGetStreamBufferType
-    #define traceAPI_ucStreamBufferGetStreamBufferType( xStreamBuffer )
-#endif
-
-#ifndef traceRETURN_xQueueGenericReset
-    #define traceRETURN_xQueueGenericReset( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueGenericCreateStatic
-    #define traceRETURN_xQueueGenericCreateStatic( pxNewQueue )
-#endif
-
-#ifndef traceRETURN_xQueueGenericCreate
-    #define traceRETURN_xQueueGenericCreate( pxNewQueue )
-#endif
-
-#ifndef traceRETURN_xQueueCreateMutex
-    #define traceRETURN_xQueueCreateMutex( xNewQueue )
-#endif
-
-#ifndef traceRETURN_xQueueCreateMutexStatic
-    #define traceRETURN_xQueueCreateMutexStatic( xNewQueue )
-#endif
-
-#ifndef traceRETURN_xQueueGetMutexHolder
-    #define traceRETURN_xQueueGetMutexHolder( pxReturn )
-#endif
-
-#ifndef traceRETURN_xQueueGetMutexHolderFromISR
-    #define traceRETURN_xQueueGetMutexHolderFromISR( pxReturn )
-#endif
-
-#ifndef traceRETURN_xQueueGiveMutexRecursive
-    #define traceRETURN_xQueueGiveMutexRecursive( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueTakeMutexRecursive
-    #define traceRETURN_xQueueTakeMutexRecursive( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueCreateCountingSemaphoreStatic
-    #define traceRETURN_xQueueCreateCountingSemaphoreStatic( xHandle )
-#endif
-
-#ifndef traceRETURN_xQueueCreateCountingSemaphore
-    #define traceRETURN_xQueueCreateCountingSemaphore( xHandle )
-#endif
-
-#ifndef traceRETURN_xQueueGenericSend
-    #define traceRETURN_xQueueGenericSend( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueGenericSendFromISR
-    #define traceRETURN_xQueueGenericSendFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueGiveFromISR
-    #define traceRETURN_xQueueGiveFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueReceive
-    #define traceRETURN_xQueueReceive( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueSemaphoreTake
-    #define traceRETURN_xQueueSemaphoreTake( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueuePeek
-    #define traceRETURN_xQueuePeek( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueReceiveFromISR
-    #define traceRETURN_xQueueReceiveFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueuePeekFromISR
-    #define traceRETURN_xQueuePeekFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_uxQueueMessagesWaiting
-    #define traceRETURN_uxQueueMessagesWaiting( uxReturn )
-#endif
-
-#ifndef traceRETURN_uxQueueSpacesAvailable
-    #define traceRETURN_uxQueueSpacesAvailable( uxReturn )
-#endif
-
-#ifndef traceRETURN_uxQueueMessagesWaitingFromISR
-    #define traceRETURN_uxQueueMessagesWaitingFromISR( uxReturn )
-#endif
-
-#ifndef traceRETURN_vQueueDelete
-    #define traceRETURN_vQueueDelete()
-#endif
-
-#ifndef traceRETURN_uxQueueGetQueueNumber
-    #define traceRETURN_uxQueueGetQueueNumber( uxQueueNumber )
-#endif
-
-#ifndef traceRETURN_vQueueSetQueueNumber
-    #define traceRETURN_vQueueSetQueueNumber()
-#endif
-
-#ifndef traceRETURN_ucQueueGetQueueType
-    #define traceRETURN_ucQueueGetQueueType( ucQueueType )
-#endif
-
-#ifndef traceRETURN_xQueueIsQueueEmptyFromISR
-    #define traceRETURN_xQueueIsQueueEmptyFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueIsQueueFullFromISR
-    #define traceRETURN_xQueueIsQueueFullFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueCRSend
-    #define traceRETURN_xQueueCRSend( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueCRReceive
-    #define traceRETURN_xQueueCRReceive( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueCRSendFromISR
-    #define traceRETURN_xQueueCRSendFromISR( xCoRoutinePreviouslyWoken )
-#endif
-
-#ifndef traceRETURN_xQueueCRReceiveFromISR
-    #define traceRETURN_xQueueCRReceiveFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_vQueueAddToRegistry
-    #define traceRETURN_vQueueAddToRegistry()
-#endif
-
-#ifndef traceRETURN_pcQueueGetName
-    #define traceRETURN_pcQueueGetName( pcReturn )
-#endif
-
-#ifndef traceRETURN_vQueueUnregisterQueue
-    #define traceRETURN_vQueueUnregisterQueue()
-#endif
-
-#ifndef traceRETURN_vQueueWaitForMessageRestricted
-    #define traceRETURN_vQueueWaitForMessageRestricted()
-#endif
-
-#ifndef traceRETURN_xQueueCreateSet
-    #define traceRETURN_xQueueCreateSet( pxQueue )
-#endif
-
-#ifndef traceRETURN_xQueueAddToSet
-    #define traceRETURN_xQueueAddToSet( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueRemoveFromSet
-    #define traceRETURN_xQueueRemoveFromSet( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueSelectFromSet
-    #define traceRETURN_xQueueSelectFromSet( xReturn )
-#endif
-
-#ifndef traceRETURN_xQueueSelectFromSetFromISR
-    #define traceRETURN_xQueueSelectFromSetFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskCreateStatic
-    #define traceRETURN_xTaskCreateStatic( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskCreateRestrictedStatic
-    #define traceRETURN_xTaskCreateRestrictedStatic( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskCreateRestricted
-    #define traceRETURN_xTaskCreateRestricted( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskCreate
-    #define traceRETURN_xTaskCreate( xReturn )
-#endif
-
-#ifndef traceRETURN_vTaskDelete
-    #define traceRETURN_vTaskDelete()
-#endif
-
-#ifndef traceRETURN_xTaskDelayUntil
-    #define traceRETURN_xTaskDelayUntil( xShouldDelay )
-#endif
-
-#ifndef traceRETURN_vTaskDelay
-    #define traceRETURN_vTaskDelay()
-#endif
-
-#ifndef traceRETURN_eTaskGetState
-    #define traceRETURN_eTaskGetState( eReturn )
-#endif
-
-#ifndef traceRETURN_uxTaskPriorityGet
-    #define traceRETURN_uxTaskPriorityGet( uxReturn )
-#endif
-
-#ifndef traceRETURN_uxTaskPriorityGetFromISR
-    #define traceRETURN_uxTaskPriorityGetFromISR( uxReturn )
-#endif
-
-#ifndef traceRETURN_vTaskPrioritySet
-    #define traceRETURN_vTaskPrioritySet()
-#endif
-
-#ifndef traceRETURN_vTaskSuspend
-    #define traceRETURN_vTaskSuspend()
-#endif
-
-#ifndef traceRETURN_vTaskResume
-    #define traceRETURN_vTaskResume()
-#endif
-
-#ifndef traceRETURN_xTaskResumeFromISR
-    #define traceRETURN_xTaskResumeFromISR( xYieldRequired )
-#endif
-
-#ifndef traceRETURN_vTaskStartScheduler
-    #define traceRETURN_vTaskStartScheduler()
-#endif
-
-#ifndef traceRETURN_vTaskEndScheduler
-    #define traceRETURN_vTaskEndScheduler()
-#endif
-
-#ifndef traceRETURN_vTaskSuspendAll
-    #define traceRETURN_vTaskSuspendAll()
-#endif
-
-#ifndef traceRETURN_xTaskResumeAll
-    #define traceRETURN_xTaskResumeAll( xAlreadyYielded )
-#endif
-
-#ifndef traceRETURN_xTaskGetTickCount
-    #define traceRETURN_xTaskGetTickCount( xTicks )
-#endif
-
-#ifndef traceRETURN_xTaskGetTickCountFromISR
-    #define traceRETURN_xTaskGetTickCountFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_uxTaskGetNumberOfTasks
-    #define traceRETURN_uxTaskGetNumberOfTasks( uxCurrentNumberOfTasks )
-#endif
-
-#ifndef traceRETURN_pcTaskGetName
-    #define traceRETURN_pcTaskGetName( pcTaskName )
-#endif
-
-#ifndef traceRETURN_xTaskGetHandle
-    #define traceRETURN_xTaskGetHandle( pxTCB )
-#endif
-
-#ifndef traceRETURN_uxTaskGetSystemState
-    #define traceRETURN_uxTaskGetSystemState( uxTask )
-#endif
-
-#ifndef traceRETURN_xTaskGetIdleTaskHandle
-    #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
-#endif
-
-#ifndef traceRETURN_vTaskStepTick
-    #define traceRETURN_vTaskStepTick()
-#endif
-
-#ifndef traceRETURN_xTaskCatchUpTicks
-    #define traceRETURN_xTaskCatchUpTicks( xYieldOccurred )
-#endif
-
-#ifndef traceRETURN_xTaskAbortDelay
-    #define traceRETURN_xTaskAbortDelay( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskIncrementTick
-    #define traceRETURN_xTaskIncrementTick( xSwitchRequired )
-#endif
-
-#ifndef traceRETURN_vTaskSetApplicationTaskTag
-    #define traceRETURN_vTaskSetApplicationTaskTag()
-#endif
-
-#ifndef traceRETURN_xTaskGetApplicationTaskTag
-    #define traceRETURN_xTaskGetApplicationTaskTag( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskGetApplicationTaskTagFromISR
-    #define traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskCallApplicationTaskHook
-    #define traceRETURN_xTaskCallApplicationTaskHook( xReturn )
-#endif
-
-#ifndef traceRETURN_vTaskPlaceOnEventList
-    #define traceRETURN_vTaskPlaceOnEventList()
-#endif
-
-#ifndef traceRETURN_vTaskPlaceOnUnorderedEventList
-    #define traceRETURN_vTaskPlaceOnUnorderedEventList()
-#endif
-
-#ifndef traceRETURN_vTaskPlaceOnEventListRestricted
-    #define traceRETURN_vTaskPlaceOnEventListRestricted()
-#endif
-
-#ifndef traceRETURN_xTaskRemoveFromEventList
-    #define traceRETURN_xTaskRemoveFromEventList( xReturn )
-#endif
-
-#ifndef traceRETURN_vTaskRemoveFromUnorderedEventList
-    #define traceRETURN_vTaskRemoveFromUnorderedEventList()
-#endif
-
-#ifndef traceRETURN_vTaskSetTimeOutState
-    #define traceRETURN_vTaskSetTimeOutState()
-#endif
-
-#ifndef traceRETURN_vTaskInternalSetTimeOutState
-    #define traceRETURN_vTaskInternalSetTimeOutState()
-#endif
-
-#ifndef traceRETURN_xTaskCheckForTimeOut
-    #define traceRETURN_xTaskCheckForTimeOut( xReturn )
-#endif
-
-#ifndef traceRETURN_vTaskMissedYield
-    #define traceRETURN_vTaskMissedYield()
-#endif
-
-#ifndef traceRETURN_uxTaskGetTaskNumber
-    #define traceRETURN_uxTaskGetTaskNumber( uxReturn )
-#endif
-
-#ifndef traceRETURN_vTaskSetTaskNumber
-    #define traceRETURN_vTaskSetTaskNumber()
-#endif
-
-#ifndef traceRETURN_eTaskConfirmSleepModeStatus
-    #define traceRETURN_eTaskConfirmSleepModeStatus( eReturn )
-#endif
-
-#ifndef traceRETURN_vTaskSetThreadLocalStoragePointer
-    #define traceRETURN_vTaskSetThreadLocalStoragePointer()
-#endif
-
-#ifndef traceRETURN_pvTaskGetThreadLocalStoragePointer
-    #define traceRETURN_pvTaskGetThreadLocalStoragePointer( pvReturn )
-#endif
-
-#ifndef traceRETURN_vTaskAllocateMPURegions
-    #define traceRETURN_vTaskAllocateMPURegions()
-#endif
-
-#ifndef traceRETURN_vTaskGetInfo
-    #define traceRETURN_vTaskGetInfo()
-#endif
-
-#ifndef traceRETURN_uxTaskGetStackHighWaterMark2
-    #define traceRETURN_uxTaskGetStackHighWaterMark2( uxReturn )
-#endif
-
-#ifndef traceRETURN_uxTaskGetStackHighWaterMark
-    #define traceRETURN_uxTaskGetStackHighWaterMark( uxReturn )
-#endif
-
-#ifndef traceRETURN_pxTaskGetStackStart
-    #define traceRETURN_pxTaskGetStackStart( pxStack )
-#endif
-
-#ifndef traceRETURN_xTaskGetCurrentTaskHandle
-    #define traceRETURN_xTaskGetCurrentTaskHandle( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskGetSchedulerState
-    #define traceRETURN_xTaskGetSchedulerState( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskPriorityInherit
-    #define traceRETURN_xTaskPriorityInherit( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskPriorityDisinherit
-    #define traceRETURN_xTaskPriorityDisinherit( xReturn )
-#endif
-
-#ifndef traceRETURN_vTaskPriorityDisinheritAfterTimeout
-    #define traceRETURN_vTaskPriorityDisinheritAfterTimeout()
-#endif
-
-#ifndef traceRETURN_vTaskEnterCritical
-    #define traceRETURN_vTaskEnterCritical()
-#endif
-
-#ifndef traceRETURN_vTaskExitCritical
-    #define traceRETURN_vTaskExitCritical()
-#endif
-
-#ifndef traceRETURN_vTaskList
-    #define traceRETURN_vTaskList()
-#endif
-
-#ifndef traceRETURN_vTaskGetRunTimeStats
-    #define traceRETURN_vTaskGetRunTimeStats()
-#endif
-
-#ifndef traceRETURN_uxTaskResetEventItemValue
-    #define traceRETURN_uxTaskResetEventItemValue( uxReturn )
-#endif
-
-#ifndef traceRETURN_pvTaskIncrementMutexHeldCount
-    #define traceRETURN_pvTaskIncrementMutexHeldCount( pxCurrentTCB )
-#endif
-
-#ifndef traceRETURN_ulTaskGenericNotifyTake
-    #define traceRETURN_ulTaskGenericNotifyTake( ulReturn )
-#endif
-
-#ifndef traceRETURN_xTaskGenericNotifyWait
-    #define traceRETURN_xTaskGenericNotifyWait( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskGenericNotify
-    #define traceRETURN_xTaskGenericNotify( xReturn )
-#endif
-
-#ifndef traceRETURN_xTaskGenericNotifyFromISR
-    #define traceRETURN_xTaskGenericNotifyFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_vTaskGenericNotifyGiveFromISR
-    #define traceRETURN_vTaskGenericNotifyGiveFromISR()
-#endif
-
-#ifndef traceRETURN_xTaskGenericNotifyStateClear
-    #define traceRETURN_xTaskGenericNotifyStateClear( xReturn )
-#endif
-
-#ifndef traceRETURN_ulTaskGenericNotifyValueClear
-    #define traceRETURN_ulTaskGenericNotifyValueClear( ulReturn )
-#endif
-
-#ifndef traceRETURN_ulTaskGetIdleRunTimeCounter
-    #define traceRETURN_ulTaskGetIdleRunTimeCounter( ulReturn )
-#endif
-
-#ifndef traceRETURN_ulTaskGetIdleRunTimePercent
-    #define traceRETURN_ulTaskGetIdleRunTimePercent( ulReturn )
-#endif
-
-#ifndef traceRETURN_vTaskCoreAffinitySet
-    #define traceRETURN_vTaskCoreAffinitySet()
-#endif
-
-#ifndef traceRETURN_vTaskCoreAffinityGet
-    #define traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask )
-#endif
-
-#ifndef traceRETURN_vTaskPreemptionDisable
-    #define traceRETURN_vTaskPreemptionDisable()
-#endif
-
-#ifndef traceRETURN_vTaskPreemptionEnable
-    #define traceRETURN_vTaskPreemptionEnable()
-#endif
-
-#ifndef traceRETURN_vTaskYieldWithinAPI
-    #define traceRETURN_vTaskYieldWithinAPI()
-#endif
-
-#ifndef traceRETURN_vTaskEnterCriticalFromISR
-    #define traceRETURN_vTaskEnterCriticalFromISR( uxSavedInterruptStatus )
-#endif
-
-#ifndef traceRETURN_vTaskExitCriticalFromISR
-    #define traceRETURN_vTaskExitCriticalFromISR()
-#endif
-
-#ifndef traceRETURN_ulTaskGetRunTimeCounter
-    #define traceRETURN_ulTaskGetRunTimeCounter( ulRunTimeCounter )
-#endif
-
-#ifndef traceRETURN_xTimerCreateTimerTask
-    #define traceRETURN_xTimerCreateTimerTask( xReturn )
-#endif
-
-#ifndef traceRETURN_xTimerCreate
-    #define traceRETURN_xTimerCreate( pxNewTimer )
-#endif
-
-#ifndef traceRETURN_xTimerCreateStatic
-    #define traceRETURN_xTimerCreateStatic( pxNewTimer )
-#endif
-
-#ifndef traceRETURN_xTimerGenericCommand
-    #define traceRETURN_xTimerGenericCommand( xReturn )
-#endif
-
-#ifndef traceRETURN_xTimerGenericCommandFromTask
-    #define traceRETURN_xTimerGenericCommandFromTask( xReturn )
-#endif
-
-#ifndef traceRETURN_xTimerGenericCommandFromISR
-    #define traceRETURN_xTimerGenericCommandFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xTimerGetTimerDaemonTaskHandle
-    #define traceRETURN_xTimerGetTimerDaemonTaskHandle( xTimerTaskHandle )
-#endif
-
-#ifndef traceRETURN_xTimerGetPeriod
-    #define traceRETURN_xTimerGetPeriod( xTimerPeriodInTicks )
-#endif
-
-#ifndef traceRETURN_vTimerSetReloadMode
-    #define traceRETURN_vTimerSetReloadMode()
-#endif
-
-#ifndef traceRETURN_xTimerGetReloadMode
-    #define traceRETURN_xTimerGetReloadMode( xReturn )
-#endif
-
-#ifndef traceRETURN_xTimerGetExpiryTime
-    #define traceRETURN_xTimerGetExpiryTime( xReturn )
-#endif
-
-#ifndef traceRETURN_pcTimerGetName
-    #define traceRETURN_pcTimerGetName( pcTimerName )
-#endif
-
-#ifndef traceRETURN_xTimerIsTimerActive
-    #define traceRETURN_xTimerIsTimerActive( xReturn )
-#endif
-
-#ifndef traceRETURN_pvTimerGetTimerID
-    #define traceRETURN_pvTimerGetTimerID( pvReturn )
-#endif
-
-#ifndef traceRETURN_vTimerSetTimerID
-    #define traceRETURN_vTimerSetTimerID()
-#endif
-
-#ifndef traceRETURN_xTimerPendFunctionCallFromISR
-    #define traceRETURN_xTimerPendFunctionCallFromISR( xReturn )
-#endif
-
-#ifndef traceRETURN_xTimerPendFunctionCall
-    #define traceRETURN_xTimerPendFunctionCall( xReturn )
-#endif
-
-#ifndef traceRETURN_uxTimerGetTimerNumber
-    #define traceRETURN_uxTimerGetTimerNumber( uxTimerNumber )
-#endif
-
-#ifndef traceRETURN_vTimerSetTimerNumber
-    #define traceRETURN_vTimerSetTimerNumber()
-#endif
-
-#ifndef traceRETURN_vListInitialise
-    #define traceRETURN_vListInitialise()
-#endif
-
-#ifndef traceRETURN_vListInitialiseItem
-    #define traceRETURN_vListInitialiseItem()
-#endif
-
-#ifndef traceRETURN_vListInsertEnd
-    #define traceRETURN_vListInsertEnd()
-#endif
-
-#ifndef traceRETURN_vListInsert
-    #define traceRETURN_vListInsert()
-#endif
-
-#ifndef traceRETURN_uxListRemove
-    #define traceRETURN_uxListRemove( uxNumberOfItems )
-#endif
-
-#ifndef traceRETURN_xCoRoutineCreate
-    #define traceRETURN_xCoRoutineCreate( xReturn )
-#endif
-
-#ifndef traceRETURN_vCoRoutineAddToDelayedList
-    #define traceRETURN_vCoRoutineAddToDelayedList()
-#endif
-
-#ifndef traceRETURN_vCoRoutineSchedule
-    #define traceRETURN_vCoRoutineSchedule()
-#endif
-
-#ifndef traceRETURN_xCoRoutineRemoveFromEventList
-    #define traceRETURN_xCoRoutineRemoveFromEventList( xReturn )
 #endif
 
 #ifndef traceRETURN_xEventGroupCreateStatic
     #define traceRETURN_xEventGroupCreateStatic( pxEventBits )
 #endif
 
+#ifndef traceAPI_xEventGroupCreate
+    #define traceAPI_xEventGroupCreate()
+#endif
+
 #ifndef traceRETURN_xEventGroupCreate
     #define traceRETURN_xEventGroupCreate( pxEventBits )
+#endif
+
+#ifndef traceAPI_xEventGroupSync
+    #define traceAPI_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xEventGroupSync
     #define traceRETURN_xEventGroupSync( uxReturn )
 #endif
 
+#ifndef traceAPI_xEventGroupWaitBits
+    #define traceAPI_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait )
+#endif
+
 #ifndef traceRETURN_xEventGroupWaitBits
     #define traceRETURN_xEventGroupWaitBits( uxReturn )
+#endif
+
+#ifndef traceAPI_xEventGroupClearBits
+    #define traceAPI_xEventGroupClearBits( xEventGroup, uxBitsToClear )
 #endif
 
 #ifndef traceRETURN_xEventGroupClearBits
     #define traceRETURN_xEventGroupClearBits( uxReturn )
 #endif
 
+#ifndef traceAPI_xEventGroupClearBitsFromISR
+    #define traceAPI_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear )
+#endif
+
 #ifndef traceRETURN_xEventGroupClearBitsFromISR
     #define traceRETURN_xEventGroupClearBitsFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xEventGroupGetBitsFromISR
+    #define traceAPI_xEventGroupGetBitsFromISR( xEventGroup )
 #endif
 
 #ifndef traceRETURN_xEventGroupGetBitsFromISR
     #define traceRETURN_xEventGroupGetBitsFromISR( uxReturn )
 #endif
 
+#ifndef traceAPI_xEventGroupSetBits
+    #define traceAPI_xEventGroupSetBits( xEventGroup, uxBitsToSet )
+#endif
+
 #ifndef traceRETURN_xEventGroupSetBits
     #define traceRETURN_xEventGroupSetBits( uxEventBits )
+#endif
+
+#ifndef traceAPI_vEventGroupDelete
+    #define traceAPI_vEventGroupDelete( xEventGroup )
 #endif
 
 #ifndef traceRETURN_vEventGroupDelete
     #define traceRETURN_vEventGroupDelete()
 #endif
 
+#ifndef traceAPI_xEventGroupGetStaticBuffer
+    #define traceAPI_xEventGroupGetStaticBuffer( xEventGroup, ppxEventGroupBuffer )
+#endif
+
+#ifndef traceRETURN_xEventGroupGetStaticBuffer
+    #define traceRETURN_xEventGroupGetStaticBuffer( xReturn )
+#endif
+
+#ifndef traceAPI_vEventGroupSetBitsCallback
+    #define traceAPI_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet )
+#endif
+
 #ifndef traceRETURN_vEventGroupSetBitsCallback
     #define traceRETURN_vEventGroupSetBitsCallback()
+#endif
+
+#ifndef traceAPI_vEventGroupClearBitsCallback
+    #define traceAPI_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear )
 #endif
 
 #ifndef traceRETURN_vEventGroupClearBitsCallback
     #define traceRETURN_vEventGroupClearBitsCallback()
 #endif
 
+#ifndef traceAPI_xEventGroupSetBitsFromISR
+    #define traceAPI_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken )
+#endif
+
 #ifndef traceRETURN_xEventGroupSetBitsFromISR
     #define traceRETURN_xEventGroupSetBitsFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_uxEventGroupGetNumber
+    #define traceAPI_uxEventGroupGetNumber( xEventGroup )
 #endif
 
 #ifndef traceRETURN_uxEventGroupGetNumber
     #define traceRETURN_uxEventGroupGetNumber( xReturn )
 #endif
 
+#ifndef traceAPI_vEventGroupSetNumber
+    #define traceAPI_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber )
+#endif
+
 #ifndef traceRETURN_vEventGroupSetNumber
     #define traceRETURN_vEventGroupSetNumber()
 #endif
 
+#ifndef traceAPI_xQueueGenericReset
+    #define traceAPI_xQueueGenericReset( xQueue, xNewQueue )
+#endif
+
+#ifndef traceRETURN_xQueueGenericReset
+    #define traceRETURN_xQueueGenericReset( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueGenericCreateStatic
+    #define traceAPI_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType )
+#endif
+
+#ifndef traceRETURN_xQueueGenericCreateStatic
+    #define traceRETURN_xQueueGenericCreateStatic( pxNewQueue )
+#endif
+
+#ifndef traceAPI_xQueueGenericGetStaticBuffers
+    #define traceAPI_xQueueGenericGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue )
+#endif
+
+#ifndef traceRETURN_xQueueGenericGetStaticBuffers
+    #define traceRETURN_xQueueGenericGetStaticBuffers( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueGenericCreate
+    #define traceAPI_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType )
+#endif
+
+#ifndef traceRETURN_xQueueGenericCreate
+    #define traceRETURN_xQueueGenericCreate( pxNewQueue )
+#endif
+
+#ifndef traceAPI_xQueueCreateMutex
+    #define traceAPI_xQueueCreateMutex( ucQueueType )
+#endif
+
+#ifndef traceRETURN_xQueueCreateMutex
+    #define traceRETURN_xQueueCreateMutex( xNewQueue )
+#endif
+
+#ifndef traceAPI_xQueueCreateMutexStatic
+    #define traceAPI_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue )
+#endif
+
+#ifndef traceRETURN_xQueueCreateMutexStatic
+    #define traceRETURN_xQueueCreateMutexStatic( xNewQueue )
+#endif
+
+#ifndef traceAPI_xQueueGetMutexHolder
+    #define traceAPI_xQueueGetMutexHolder( xSemaphore )
+#endif
+
+#ifndef traceRETURN_xQueueGetMutexHolder
+    #define traceRETURN_xQueueGetMutexHolder( pxReturn )
+#endif
+
+#ifndef traceAPI_xQueueGetMutexHolderFromISR
+    #define traceAPI_xQueueGetMutexHolderFromISR( xSemaphore )
+#endif
+
+#ifndef traceRETURN_xQueueGetMutexHolderFromISR
+    #define traceRETURN_xQueueGetMutexHolderFromISR( pxReturn )
+#endif
+
+#ifndef traceAPI_xQueueGiveMutexRecursive
+    #define traceAPI_xQueueGiveMutexRecursive( xMutex )
+#endif
+
+#ifndef traceRETURN_xQueueGiveMutexRecursive
+    #define traceRETURN_xQueueGiveMutexRecursive( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueTakeMutexRecursive
+    #define traceAPI_xQueueTakeMutexRecursive( xMutex, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xQueueTakeMutexRecursive
+    #define traceRETURN_xQueueTakeMutexRecursive( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueCreateCountingSemaphoreStatic
+    #define traceAPI_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue )
+#endif
+
+#ifndef traceRETURN_xQueueCreateCountingSemaphoreStatic
+    #define traceRETURN_xQueueCreateCountingSemaphoreStatic( xHandle )
+#endif
+
+#ifndef traceAPI_xQueueCreateCountingSemaphore
+    #define traceAPI_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount )
+#endif
+
+#ifndef traceRETURN_xQueueCreateCountingSemaphore
+    #define traceRETURN_xQueueCreateCountingSemaphore( xHandle )
+#endif
+
+#ifndef traceAPI_xQueueGenericSend
+    #define traceAPI_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition )
+#endif
+
+#ifndef traceRETURN_xQueueGenericSend
+    #define traceRETURN_xQueueGenericSend( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueGenericSendFromISR
+    #define traceAPI_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition )
+#endif
+
+#ifndef traceRETURN_xQueueGenericSendFromISR
+    #define traceRETURN_xQueueGenericSendFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueGiveFromISR
+    #define traceAPI_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceRETURN_xQueueGiveFromISR
+    #define traceRETURN_xQueueGiveFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueReceive
+    #define traceAPI_xQueueReceive( xQueue, pvBuffer, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xQueueReceive
+    #define traceRETURN_xQueueReceive( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueSemaphoreTake
+    #define traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xQueueSemaphoreTake
+    #define traceRETURN_xQueueSemaphoreTake( xReturn )
+#endif
+
+#ifndef traceAPI_xQueuePeek
+    #define traceAPI_xQueuePeek( xQueue, pvBuffer, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xQueuePeek
+    #define traceRETURN_xQueuePeek( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueReceiveFromISR
+    #define traceAPI_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceRETURN_xQueueReceiveFromISR
+    #define traceRETURN_xQueueReceiveFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xQueuePeekFromISR
+    #define traceAPI_xQueuePeekFromISR( xQueue, pvBuffer )
+#endif
+
+#ifndef traceRETURN_xQueuePeekFromISR
+    #define traceRETURN_xQueuePeekFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_uxQueueMessagesWaiting
+    #define traceAPI_uxQueueMessagesWaiting( xQueue )
+#endif
+
+#ifndef traceRETURN_uxQueueMessagesWaiting
+    #define traceRETURN_uxQueueMessagesWaiting( uxReturn )
+#endif
+
+#ifndef traceAPI_uxQueueSpacesAvailable
+    #define traceAPI_uxQueueSpacesAvailable( xQueue )
+#endif
+
+#ifndef traceRETURN_uxQueueSpacesAvailable
+    #define traceRETURN_uxQueueSpacesAvailable( uxReturn )
+#endif
+
+#ifndef traceAPI_uxQueueMessagesWaitingFromISR
+    #define traceAPI_uxQueueMessagesWaitingFromISR( xQueue )
+#endif
+
+#ifndef traceRETURN_uxQueueMessagesWaitingFromISR
+    #define traceRETURN_uxQueueMessagesWaitingFromISR( uxReturn )
+#endif
+
+#ifndef traceAPI_vQueueDelete
+    #define traceAPI_vQueueDelete( xQueue )
+#endif
+
+#ifndef traceRETURN_vQueueDelete
+    #define traceRETURN_vQueueDelete()
+#endif
+
+#ifndef traceAPI_uxQueueGetQueueNumber
+    #define traceAPI_uxQueueGetQueueNumber( xQueue )
+#endif
+
+#ifndef traceRETURN_uxQueueGetQueueNumber
+    #define traceRETURN_uxQueueGetQueueNumber( uxQueueNumber )
+#endif
+
+#ifndef traceAPI_vQueueSetQueueNumber
+    #define traceAPI_vQueueSetQueueNumber( xQueue, uxQueueNumber )
+#endif
+
+#ifndef traceRETURN_vQueueSetQueueNumber
+    #define traceRETURN_vQueueSetQueueNumber()
+#endif
+
+#ifndef traceAPI_ucQueueGetQueueType
+    #define traceAPI_ucQueueGetQueueType( xQueue )
+#endif
+
+#ifndef traceRETURN_ucQueueGetQueueType
+    #define traceRETURN_ucQueueGetQueueType( ucQueueType )
+#endif
+
+#ifndef traceAPI_uxQueueGetQueueItemSize
+    #define traceAPI_uxQueueGetQueueItemSize( xQueue )
+#endif
+
+#ifndef traceRETURN_uxQueueGetQueueItemSize
+    #define traceRETURN_uxQueueGetQueueItemSize( uxItemSize )
+#endif
+
+#ifndef traceAPI_uxQueueGetQueueLength
+    #define traceAPI_uxQueueGetQueueLength( xQueue )
+#endif
+
+#ifndef traceRETURN_uxQueueGetQueueLength
+    #define traceRETURN_uxQueueGetQueueLength( uxLength )
+#endif
+
+#ifndef traceAPI_xQueueIsQueueEmptyFromISR
+    #define traceAPI_xQueueIsQueueEmptyFromISR( xQueue )
+#endif
+
+#ifndef traceRETURN_xQueueIsQueueEmptyFromISR
+    #define traceRETURN_xQueueIsQueueEmptyFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueIsQueueFullFromISR
+    #define traceAPI_xQueueIsQueueFullFromISR( xQueue )
+#endif
+
+#ifndef traceRETURN_xQueueIsQueueFullFromISR
+    #define traceRETURN_xQueueIsQueueFullFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueCRSend
+    #define traceAPI_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xQueueCRSend
+    #define traceRETURN_xQueueCRSend( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueCRReceive
+    #define traceAPI_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xQueueCRReceive
+    #define traceRETURN_xQueueCRReceive( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueCRSendFromISR
+    #define traceAPI_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken )
+#endif
+
+#ifndef traceRETURN_xQueueCRSendFromISR
+    #define traceRETURN_xQueueCRSendFromISR( xCoRoutinePreviouslyWoken )
+#endif
+
+#ifndef traceAPI_xQueueCRReceiveFromISR
+    #define traceAPI_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken )
+#endif
+
+#ifndef traceRETURN_xQueueCRReceiveFromISR
+    #define traceRETURN_xQueueCRReceiveFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_vQueueAddToRegistry
+    #define traceAPI_vQueueAddToRegistry( xQueue, pcQueueName )
+#endif
+
+#ifndef traceRETURN_vQueueAddToRegistry
+    #define traceRETURN_vQueueAddToRegistry()
+#endif
+
+#ifndef traceAPI_pcQueueGetName
+    #define traceAPI_pcQueueGetName( xQueue )
+#endif
+
+#ifndef traceRETURN_pcQueueGetName
+    #define traceRETURN_pcQueueGetName( pcReturn )
+#endif
+
+#ifndef traceAPI_vQueueUnregisterQueue
+    #define traceAPI_vQueueUnregisterQueue( xQueue )
+#endif
+
+#ifndef traceRETURN_vQueueUnregisterQueue
+    #define traceRETURN_vQueueUnregisterQueue()
+#endif
+
+#ifndef traceAPI_vQueueWaitForMessageRestricted
+    #define traceAPI_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely )
+#endif
+
+#ifndef traceRETURN_vQueueWaitForMessageRestricted
+    #define traceRETURN_vQueueWaitForMessageRestricted()
+#endif
+
+#ifndef traceAPI_xQueueCreateSet
+    #define traceAPI_xQueueCreateSet( uxEventQueueLength )
+#endif
+
+#ifndef traceRETURN_xQueueCreateSet
+    #define traceRETURN_xQueueCreateSet( pxQueue )
+#endif
+
+#ifndef traceAPI_xQueueAddToSet
+    #define traceAPI_xQueueAddToSet( xQueueOrSemaphore, xQueueSet )
+#endif
+
+#ifndef traceRETURN_xQueueAddToSet
+    #define traceRETURN_xQueueAddToSet( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueRemoveFromSet
+    #define traceAPI_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet )
+#endif
+
+#ifndef traceRETURN_xQueueRemoveFromSet
+    #define traceRETURN_xQueueRemoveFromSet( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueSelectFromSet
+    #define traceAPI_xQueueSelectFromSet( xQueueSet, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xQueueSelectFromSet
+    #define traceRETURN_xQueueSelectFromSet( xReturn )
+#endif
+
+#ifndef traceAPI_xQueueSelectFromSetFromISR
+    #define traceAPI_xQueueSelectFromSetFromISR( xQueueSet )
+#endif
+
+#ifndef traceRETURN_xQueueSelectFromSetFromISR
+    #define traceRETURN_xQueueSelectFromSetFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xTimerCreateTimerTask
+    #define traceAPI_xTimerCreateTimerTask()
+#endif
+
+#ifndef traceRETURN_xTimerCreateTimerTask
+    #define traceRETURN_xTimerCreateTimerTask( xReturn )
+#endif
+
+#ifndef traceAPI_xTimerCreate
+    #define traceAPI_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction )
+#endif
+
+#ifndef traceRETURN_xTimerCreate
+    #define traceRETURN_xTimerCreate( pxNewTimer )
+#endif
+
+#ifndef traceAPI_xTimerCreateStatic
+    #define traceAPI_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer )
+#endif
+
+#ifndef traceRETURN_xTimerCreateStatic
+    #define traceRETURN_xTimerCreateStatic( pxNewTimer )
+#endif
+
+#ifndef traceAPI_xTimerGenericCommandFromTask
+    #define traceAPI_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xTimerGenericCommandFromTask
+    #define traceRETURN_xTimerGenericCommandFromTask( xReturn )
+#endif
+
+#ifndef traceAPI_xTimerGenericCommandFromISR
+    #define traceAPI_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xTimerGenericCommandFromISR
+    #define traceRETURN_xTimerGenericCommandFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xTimerGetTimerDaemonTaskHandle
+    #define traceAPI_xTimerGetTimerDaemonTaskHandle()
+#endif
+
+#ifndef traceRETURN_xTimerGetTimerDaemonTaskHandle
+    #define traceRETURN_xTimerGetTimerDaemonTaskHandle( xTimerTaskHandle )
+#endif
+
+#ifndef traceAPI_xTimerGetPeriod
+    #define traceAPI_xTimerGetPeriod( xTimer )
+#endif
+
+#ifndef traceRETURN_xTimerGetPeriod
+    #define traceRETURN_xTimerGetPeriod( xTimerPeriodInTicks )
+#endif
+
+#ifndef traceAPI_vTimerSetReloadMode
+    #define traceAPI_vTimerSetReloadMode( xTimer, xAutoReload )
+#endif
+
+#ifndef traceRETURN_vTimerSetReloadMode
+    #define traceRETURN_vTimerSetReloadMode()
+#endif
+
+#ifndef traceAPI_xTimerGetReloadMode
+    #define traceAPI_xTimerGetReloadMode( xTimer )
+#endif
+
+#ifndef traceRETURN_xTimerGetReloadMode
+    #define traceRETURN_xTimerGetReloadMode( xReturn )
+#endif
+
+#ifndef traceAPI_uxTimerGetReloadMode
+    #define traceAPI_uxTimerGetReloadMode( xTimer )
+#endif
+
+#ifndef traceRETURN_uxTimerGetReloadMode
+    #define traceRETURN_uxTimerGetReloadMode( uxReturn )
+#endif
+
+#ifndef traceAPI_xTimerGetExpiryTime
+    #define traceAPI_xTimerGetExpiryTime( xTimer )
+#endif
+
+#ifndef traceRETURN_xTimerGetExpiryTime
+    #define traceRETURN_xTimerGetExpiryTime( xReturn )
+#endif
+
+#ifndef traceAPI_xTimerGetStaticBuffer
+    #define traceAPI_xTimerGetStaticBuffer( xTimer, ppxTimerBuffer )
+#endif
+
+#ifndef traceRETURN_xTimerGetStaticBuffer
+    #define traceRETURN_xTimerGetStaticBuffer( xReturn )
+#endif
+
+#ifndef traceAPI_pcTimerGetName
+    #define traceAPI_pcTimerGetName( xTimer )
+#endif
+
+#ifndef traceRETURN_pcTimerGetName
+    #define traceRETURN_pcTimerGetName( pcTimerName )
+#endif
+
+#ifndef traceAPI_xTimerIsTimerActive
+    #define traceAPI_xTimerIsTimerActive( xTimer )
+#endif
+
+#ifndef traceRETURN_xTimerIsTimerActive
+    #define traceRETURN_xTimerIsTimerActive( xReturn )
+#endif
+
+#ifndef traceAPI_pvTimerGetTimerID
+    #define traceAPI_pvTimerGetTimerID( xTimer )
+#endif
+
+#ifndef traceRETURN_pvTimerGetTimerID
+    #define traceRETURN_pvTimerGetTimerID( pvReturn )
+#endif
+
+#ifndef traceAPI_vTimerSetTimerID
+    #define traceAPI_vTimerSetTimerID( xTimer, pvNewID )
+#endif
+
+#ifndef traceRETURN_vTimerSetTimerID
+    #define traceRETURN_vTimerSetTimerID()
+#endif
+
+#ifndef traceAPI_xTimerPendFunctionCallFromISR
+    #define traceAPI_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceRETURN_xTimerPendFunctionCallFromISR
+    #define traceRETURN_xTimerPendFunctionCallFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xTimerPendFunctionCall
+    #define traceAPI_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xTimerPendFunctionCall
+    #define traceRETURN_xTimerPendFunctionCall( xReturn )
+#endif
+
+#ifndef traceAPI_uxTimerGetTimerNumber
+    #define traceAPI_uxTimerGetTimerNumber( xTimer )
+#endif
+
+#ifndef traceRETURN_uxTimerGetTimerNumber
+    #define traceRETURN_uxTimerGetTimerNumber( uxTimerNumber )
+#endif
+
+#ifndef traceAPI_vTimerSetTimerNumber
+    #define traceAPI_vTimerSetTimerNumber( xTimer, uxTimerNumber )
+#endif
+
+#ifndef traceRETURN_vTimerSetTimerNumber
+    #define traceRETURN_vTimerSetTimerNumber()
+#endif
+
+#ifndef traceAPI_xTaskCreateStatic
+    #define traceAPI_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer )
+#endif
+
+#ifndef traceRETURN_xTaskCreateStatic
+    #define traceRETURN_xTaskCreateStatic( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskCreateRestrictedStatic
+    #define traceAPI_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask )
+#endif
+
+#ifndef traceRETURN_xTaskCreateRestrictedStatic
+    #define traceRETURN_xTaskCreateRestrictedStatic( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskCreateRestricted
+    #define traceAPI_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask )
+#endif
+
+#ifndef traceRETURN_xTaskCreateRestricted
+    #define traceRETURN_xTaskCreateRestricted( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskCreate
+    #define traceAPI_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask )
+#endif
+
+#ifndef traceRETURN_xTaskCreate
+    #define traceRETURN_xTaskCreate( xReturn )
+#endif
+
+#ifndef traceAPI_vTaskDelete
+    #define traceAPI_vTaskDelete( xTaskToDelete )
+#endif
+
+#ifndef traceRETURN_vTaskDelete
+    #define traceRETURN_vTaskDelete()
+#endif
+
+#ifndef traceAPI_xTaskDelayUntil
+    #define traceAPI_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )
+#endif
+
+#ifndef traceRETURN_xTaskDelayUntil
+    #define traceRETURN_xTaskDelayUntil( xShouldDelay )
+#endif
+
+#ifndef traceAPI_vTaskDelay
+    #define traceAPI_vTaskDelay( xTicksToDelay )
+#endif
+
+#ifndef traceRETURN_vTaskDelay
+    #define traceRETURN_vTaskDelay()
+#endif
+
+#ifndef traceAPI_eTaskGetState
+    #define traceAPI_eTaskGetState( xTask )
+#endif
+
+#ifndef traceRETURN_eTaskGetState
+    #define traceRETURN_eTaskGetState( eReturn )
+#endif
+
+#ifndef traceAPI_uxTaskPriorityGet
+    #define traceAPI_uxTaskPriorityGet( xTask )
+#endif
+
+#ifndef traceRETURN_uxTaskPriorityGet
+    #define traceRETURN_uxTaskPriorityGet( uxReturn )
+#endif
+
+#ifndef traceAPI_uxTaskPriorityGetFromISR
+    #define traceAPI_uxTaskPriorityGetFromISR( xTask )
+#endif
+
+#ifndef traceRETURN_uxTaskPriorityGetFromISR
+    #define traceRETURN_uxTaskPriorityGetFromISR( uxReturn )
+#endif
+
+#ifndef traceAPI_vTaskPrioritySet
+    #define traceAPI_vTaskPrioritySet( xTask, uxNewPriority )
+#endif
+
+#ifndef traceRETURN_vTaskPrioritySet
+    #define traceRETURN_vTaskPrioritySet()
+#endif
+
+#ifndef traceAPI_vTaskCoreAffinitySet
+    #define traceAPI_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask )
+#endif
+
+#ifndef traceRETURN_vTaskCoreAffinitySet
+    #define traceRETURN_vTaskCoreAffinitySet()
+#endif
+
+#ifndef traceAPI_vTaskCoreAffinityGet
+    #define traceAPI_vTaskCoreAffinityGet( xTask )
+#endif
+
+#ifndef traceRETURN_vTaskCoreAffinityGet
+    #define traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask )
+#endif
+
+#ifndef traceAPI_vTaskPreemptionDisable
+    #define traceAPI_vTaskPreemptionDisable( xTask )
+#endif
+
+#ifndef traceRETURN_vTaskPreemptionDisable
+    #define traceRETURN_vTaskPreemptionDisable()
+#endif
+
+#ifndef traceAPI_vTaskPreemptionEnable
+    #define traceAPI_vTaskPreemptionEnable( xTask )
+#endif
+
+#ifndef traceRETURN_vTaskPreemptionEnable
+    #define traceRETURN_vTaskPreemptionEnable()
+#endif
+
+#ifndef traceAPI_vTaskSuspend
+    #define traceAPI_vTaskSuspend( xTaskToSuspend )
+#endif
+
+#ifndef traceRETURN_vTaskSuspend
+    #define traceRETURN_vTaskSuspend()
+#endif
+
+#ifndef traceAPI_vTaskResume
+    #define traceAPI_vTaskResume( xTaskToResume )
+#endif
+
+#ifndef traceRETURN_vTaskResume
+    #define traceRETURN_vTaskResume()
+#endif
+
+#ifndef traceAPI_xTaskResumeFromISR
+    #define traceAPI_xTaskResumeFromISR( xTaskToResume )
+#endif
+
+#ifndef traceRETURN_xTaskResumeFromISR
+    #define traceRETURN_xTaskResumeFromISR( xYieldRequired )
+#endif
+
+#ifndef traceAPI_vTaskStartScheduler
+    #define traceAPI_vTaskStartScheduler()
+#endif
+
+#ifndef traceRETURN_vTaskStartScheduler
+    #define traceRETURN_vTaskStartScheduler()
+#endif
+
+#ifndef traceAPI_vTaskEndScheduler
+    #define traceAPI_vTaskEndScheduler()
+#endif
+
+#ifndef traceRETURN_vTaskEndScheduler
+    #define traceRETURN_vTaskEndScheduler()
+#endif
+
+#ifndef traceAPI_vTaskSuspendAll
+    #define traceAPI_vTaskSuspendAll()
+#endif
+
+#ifndef traceRETURN_vTaskSuspendAll
+    #define traceRETURN_vTaskSuspendAll()
+#endif
+
+#ifndef traceAPI_xTaskResumeAll
+    #define traceAPI_xTaskResumeAll()
+#endif
+
+#ifndef traceRETURN_xTaskResumeAll
+    #define traceRETURN_xTaskResumeAll( xAlreadyYielded )
+#endif
+
+#ifndef traceAPI_xTaskGetTickCount
+    #define traceAPI_xTaskGetTickCount()
+#endif
+
+#ifndef traceRETURN_xTaskGetTickCount
+    #define traceRETURN_xTaskGetTickCount( xTicks )
+#endif
+
+#ifndef traceAPI_xTaskGetTickCountFromISR
+    #define traceAPI_xTaskGetTickCountFromISR()
+#endif
+
+#ifndef traceRETURN_xTaskGetTickCountFromISR
+    #define traceRETURN_xTaskGetTickCountFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_uxTaskGetNumberOfTasks
+    #define traceAPI_uxTaskGetNumberOfTasks()
+#endif
+
+#ifndef traceRETURN_uxTaskGetNumberOfTasks
+    #define traceRETURN_uxTaskGetNumberOfTasks( uxCurrentNumberOfTasks )
+#endif
+
+#ifndef traceAPI_pcTaskGetName
+    #define traceAPI_pcTaskGetName( xTaskToQuery )
+#endif
+
+#ifndef traceRETURN_pcTaskGetName
+    #define traceRETURN_pcTaskGetName( pcTaskName )
+#endif
+
+#ifndef traceAPI_xTaskGetHandle
+    #define traceAPI_xTaskGetHandle( pcNameToQuery )
+#endif
+
+#ifndef traceRETURN_xTaskGetHandle
+    #define traceRETURN_xTaskGetHandle( pxTCB )
+#endif
+
+#ifndef traceAPI_xTaskGetStaticBuffers
+    #define traceAPI_xTaskGetStaticBuffers( xTask, ppuxStackBuffer, ppxTaskBuffer )
+#endif
+
+#ifndef traceRETURN_xTaskGetStaticBuffers
+    #define traceRETURN_xTaskGetStaticBuffers( xReturn )
+#endif
+
+#ifndef traceAPI_uxTaskGetSystemState
+    #define traceAPI_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime )
+#endif
+
+#ifndef traceRETURN_uxTaskGetSystemState
+    #define traceRETURN_uxTaskGetSystemState( uxTask )
+#endif
+
+#ifndef traceAPI_xTaskGetIdleTaskHandle
+    #define traceAPI_xTaskGetIdleTaskHandle()
+#endif
+
+#ifndef traceRETURN_xTaskGetIdleTaskHandle
+    #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
+#endif
+
+#ifndef traceAPI_vTaskStepTick
+    #define traceAPI_vTaskStepTick( xTicksToJump )
+#endif
+
+#ifndef traceRETURN_vTaskStepTick
+    #define traceRETURN_vTaskStepTick()
+#endif
+
+#ifndef traceAPI_xTaskCatchUpTicks
+    #define traceAPI_xTaskCatchUpTicks( xTicksToCatchUp )
+#endif
+
+#ifndef traceRETURN_xTaskCatchUpTicks
+    #define traceRETURN_xTaskCatchUpTicks( xYieldOccurred )
+#endif
+
+#ifndef traceAPI_xTaskAbortDelay
+    #define traceAPI_xTaskAbortDelay( xTask )
+#endif
+
+#ifndef traceRETURN_xTaskAbortDelay
+    #define traceRETURN_xTaskAbortDelay( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskIncrementTick
+    #define traceAPI_xTaskIncrementTick()
+#endif
+
+#ifndef traceRETURN_xTaskIncrementTick
+    #define traceRETURN_xTaskIncrementTick( xSwitchRequired )
+#endif
+
+#ifndef traceAPI_vTaskSetApplicationTaskTag
+    #define traceAPI_vTaskSetApplicationTaskTag( xTask, pxHookFunction )
+#endif
+
+#ifndef traceRETURN_vTaskSetApplicationTaskTag
+    #define traceRETURN_vTaskSetApplicationTaskTag()
+#endif
+
+#ifndef traceAPI_xTaskGetApplicationTaskTag
+    #define traceAPI_xTaskGetApplicationTaskTag( xTask )
+#endif
+
+#ifndef traceRETURN_xTaskGetApplicationTaskTag
+    #define traceRETURN_xTaskGetApplicationTaskTag( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskGetApplicationTaskTagFromISR
+    #define traceAPI_xTaskGetApplicationTaskTagFromISR( xTask )
+#endif
+
+#ifndef traceRETURN_xTaskGetApplicationTaskTagFromISR
+    #define traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskCallApplicationTaskHook
+    #define traceAPI_xTaskCallApplicationTaskHook( xTask, pvParameter )
+#endif
+
+#ifndef traceRETURN_xTaskCallApplicationTaskHook
+    #define traceRETURN_xTaskCallApplicationTaskHook( xReturn )
+#endif
+
+#ifndef traceAPI_vTaskSwitchContext
+    #define traceAPI_vTaskSwitchContext()
+#endif
+
+#ifndef traceRETURN_vTaskSwitchContext
+    #define traceRETURN_vTaskSwitchContext()
+#endif
+
+#ifndef traceAPI_vTaskPlaceOnEventList
+    #define traceAPI_vTaskPlaceOnEventList( pxEventList, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_vTaskPlaceOnEventList
+    #define traceRETURN_vTaskPlaceOnEventList()
+#endif
+
+#ifndef traceAPI_vTaskPlaceOnUnorderedEventList
+    #define traceAPI_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_vTaskPlaceOnUnorderedEventList
+    #define traceRETURN_vTaskPlaceOnUnorderedEventList()
+#endif
+
+#ifndef traceAPI_vTaskPlaceOnEventListRestricted
+    #define traceAPI_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely )
+#endif
+
+#ifndef traceRETURN_vTaskPlaceOnEventListRestricted
+    #define traceRETURN_vTaskPlaceOnEventListRestricted()
+#endif
+
+#ifndef traceAPI_xTaskRemoveFromEventList
+    #define traceAPI_xTaskRemoveFromEventList( pxEventList )
+#endif
+
+#ifndef traceRETURN_xTaskRemoveFromEventList
+    #define traceRETURN_xTaskRemoveFromEventList( xReturn )
+#endif
+
+#ifndef traceAPI_vTaskRemoveFromUnorderedEventList
+    #define traceAPI_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue )
+#endif
+
+#ifndef traceRETURN_vTaskRemoveFromUnorderedEventList
+    #define traceRETURN_vTaskRemoveFromUnorderedEventList()
+#endif
+
+#ifndef traceAPI_vTaskSetTimeOutState
+    #define traceAPI_vTaskSetTimeOutState( pxTimeOut )
+#endif
+
+#ifndef traceRETURN_vTaskSetTimeOutState
+    #define traceRETURN_vTaskSetTimeOutState()
+#endif
+
+#ifndef traceAPI_vTaskInternalSetTimeOutState
+    #define traceAPI_vTaskInternalSetTimeOutState( pxTimeOut )
+#endif
+
+#ifndef traceRETURN_vTaskInternalSetTimeOutState
+    #define traceRETURN_vTaskInternalSetTimeOutState()
+#endif
+
+#ifndef traceAPI_xTaskCheckForTimeOut
+    #define traceAPI_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait )
+#endif
+
+#ifndef traceRETURN_xTaskCheckForTimeOut
+    #define traceRETURN_xTaskCheckForTimeOut( xReturn )
+#endif
+
+#ifndef traceAPI_vTaskMissedYield
+    #define traceAPI_vTaskMissedYield()
+#endif
+
+#ifndef traceRETURN_vTaskMissedYield
+    #define traceRETURN_vTaskMissedYield()
+#endif
+
+#ifndef traceAPI_uxTaskGetTaskNumber
+    #define traceAPI_uxTaskGetTaskNumber( xTask )
+#endif
+
+#ifndef traceRETURN_uxTaskGetTaskNumber
+    #define traceRETURN_uxTaskGetTaskNumber( uxReturn )
+#endif
+
+#ifndef traceAPI_vTaskSetTaskNumber
+    #define traceAPI_vTaskSetTaskNumber( xTask, uxHandle )
+#endif
+
+#ifndef traceRETURN_vTaskSetTaskNumber
+    #define traceRETURN_vTaskSetTaskNumber()
+#endif
+
+#ifndef traceAPI_eTaskConfirmSleepModeStatus
+    #define traceAPI_eTaskConfirmSleepModeStatus()
+#endif
+
+#ifndef traceRETURN_eTaskConfirmSleepModeStatus
+    #define traceRETURN_eTaskConfirmSleepModeStatus( eReturn )
+#endif
+
+#ifndef traceAPI_vTaskSetThreadLocalStoragePointer
+    #define traceAPI_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue )
+#endif
+
+#ifndef traceRETURN_vTaskSetThreadLocalStoragePointer
+    #define traceRETURN_vTaskSetThreadLocalStoragePointer()
+#endif
+
+#ifndef traceAPI_pvTaskGetThreadLocalStoragePointer
+    #define traceAPI_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex )
+#endif
+
+#ifndef traceRETURN_pvTaskGetThreadLocalStoragePointer
+    #define traceRETURN_pvTaskGetThreadLocalStoragePointer( pvReturn )
+#endif
+
+#ifndef traceAPI_vTaskAllocateMPURegions
+    #define traceAPI_vTaskAllocateMPURegions( xTaskToModify, pxRegions )
+#endif
+
+#ifndef traceRETURN_vTaskAllocateMPURegions
+    #define traceRETURN_vTaskAllocateMPURegions()
+#endif
+
+#ifndef traceAPI_vTaskGetInfo
+    #define traceAPI_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState )
+#endif
+
+#ifndef traceRETURN_vTaskGetInfo
+    #define traceRETURN_vTaskGetInfo()
+#endif
+
+#ifndef traceAPI_uxTaskGetStackHighWaterMark2
+    #define traceAPI_uxTaskGetStackHighWaterMark2( xTask )
+#endif
+
+#ifndef traceRETURN_uxTaskGetStackHighWaterMark2
+    #define traceRETURN_uxTaskGetStackHighWaterMark2( uxReturn )
+#endif
+
+#ifndef traceAPI_uxTaskGetStackHighWaterMark
+    #define traceAPI_uxTaskGetStackHighWaterMark( xTask )
+#endif
+
+#ifndef traceRETURN_uxTaskGetStackHighWaterMark
+    #define traceRETURN_uxTaskGetStackHighWaterMark( uxReturn )
+#endif
+
+#ifndef traceAPI_xTaskGetCurrentTaskHandle
+    #define traceAPI_xTaskGetCurrentTaskHandle()
+#endif
+
+#ifndef traceRETURN_xTaskGetCurrentTaskHandle
+    #define traceRETURN_xTaskGetCurrentTaskHandle( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskGetCurrentTaskHandleCPU
+    #define traceAPI_xTaskGetCurrentTaskHandleCPU( xCoreID )
+#endif
+
+#ifndef traceRETURN_xTaskGetCurrentTaskHandleCPU
+    #define traceRETURN_xTaskGetCurrentTaskHandleCPU( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskGetSchedulerState
+    #define traceAPI_xTaskGetSchedulerState()
+#endif
+
+#ifndef traceRETURN_xTaskGetSchedulerState
+    #define traceRETURN_xTaskGetSchedulerState( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskPriorityInherit
+    #define traceAPI_xTaskPriorityInherit( pxMutexHolder )
+#endif
+
+#ifndef traceRETURN_xTaskPriorityInherit
+    #define traceRETURN_xTaskPriorityInherit( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskPriorityDisinherit
+    #define traceAPI_xTaskPriorityDisinherit( pxMutexHolder )
+#endif
+
+#ifndef traceRETURN_xTaskPriorityDisinherit
+    #define traceRETURN_xTaskPriorityDisinherit( xReturn )
+#endif
+
+#ifndef traceAPI_vTaskPriorityDisinheritAfterTimeout
+    #define traceAPI_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask )
+#endif
+
+#ifndef traceRETURN_vTaskPriorityDisinheritAfterTimeout
+    #define traceRETURN_vTaskPriorityDisinheritAfterTimeout()
+#endif
+
+#ifndef traceAPI_vTaskYieldWithinAPI
+    #define traceAPI_vTaskYieldWithinAPI()
+#endif
+
+#ifndef traceRETURN_vTaskYieldWithinAPI
+    #define traceRETURN_vTaskYieldWithinAPI()
+#endif
+
+#ifndef traceAPI_vTaskEnterCritical
+    #define traceAPI_vTaskEnterCritical()
+#endif
+
+#ifndef traceRETURN_vTaskEnterCritical
+    #define traceRETURN_vTaskEnterCritical()
+#endif
+
+#ifndef traceAPI_vTaskEnterCriticalFromISR
+    #define traceAPI_vTaskEnterCriticalFromISR()
+#endif
+
+#ifndef traceRETURN_vTaskEnterCriticalFromISR
+    #define traceRETURN_vTaskEnterCriticalFromISR( uxSavedInterruptStatus )
+#endif
+
+#ifndef traceAPI_vTaskExitCritical
+    #define traceAPI_vTaskExitCritical()
+#endif
+
+#ifndef traceRETURN_vTaskExitCritical
+    #define traceRETURN_vTaskExitCritical()
+#endif
+
+#ifndef traceAPI_vTaskExitCriticalFromISR
+    #define traceAPI_vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#endif
+
+#ifndef traceRETURN_vTaskExitCriticalFromISR
+    #define traceRETURN_vTaskExitCriticalFromISR()
+#endif
+
+#ifndef traceAPI_vTaskList
+    #define traceAPI_vTaskList( pcWriteBuffer )
+#endif
+
+#ifndef traceRETURN_vTaskList
+    #define traceRETURN_vTaskList()
+#endif
+
+#ifndef traceAPI_vTaskGetRunTimeStats
+    #define traceAPI_vTaskGetRunTimeStats( pcWriteBuffer )
+#endif
+
+#ifndef traceRETURN_vTaskGetRunTimeStats
+    #define traceRETURN_vTaskGetRunTimeStats()
+#endif
+
+#ifndef traceAPI_uxTaskResetEventItemValue
+    #define traceAPI_uxTaskResetEventItemValue()
+#endif
+
+#ifndef traceRETURN_uxTaskResetEventItemValue
+    #define traceRETURN_uxTaskResetEventItemValue( uxReturn )
+#endif
+
+#ifndef traceAPI_pvTaskIncrementMutexHeldCount
+    #define traceAPI_pvTaskIncrementMutexHeldCount()
+#endif
+
+#ifndef traceRETURN_pvTaskIncrementMutexHeldCount
+    #define traceRETURN_pvTaskIncrementMutexHeldCount( pxTCB )
+#endif
+
+#ifndef traceAPI_ulTaskGenericNotifyTake
+    #define traceAPI_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_ulTaskGenericNotifyTake
+    #define traceRETURN_ulTaskGenericNotifyTake( ulReturn )
+#endif
+
+#ifndef traceAPI_xTaskGenericNotifyWait
+    #define traceAPI_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait )
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotifyWait
+    #define traceRETURN_xTaskGenericNotifyWait( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskGenericNotify
+    #define traceAPI_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue )
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotify
+    #define traceRETURN_xTaskGenericNotify( xReturn )
+#endif
+
+#ifndef traceAPI_xTaskGenericNotifyFromISR
+    #define traceAPI_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotifyFromISR
+    #define traceRETURN_xTaskGenericNotifyFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_vTaskGenericNotifyGiveFromISR
+    #define traceAPI_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken )
+#endif
+
+#ifndef traceRETURN_vTaskGenericNotifyGiveFromISR
+    #define traceRETURN_vTaskGenericNotifyGiveFromISR()
+#endif
+
+#ifndef traceAPI_xTaskGenericNotifyStateClear
+    #define traceAPI_xTaskGenericNotifyStateClear( xTask, uxIndexToClear )
+#endif
+
+#ifndef traceRETURN_xTaskGenericNotifyStateClear
+    #define traceRETURN_xTaskGenericNotifyStateClear( xReturn )
+#endif
+
+#ifndef traceAPI_ulTaskGenericNotifyValueClear
+    #define traceAPI_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear )
+#endif
+
+#ifndef traceRETURN_ulTaskGenericNotifyValueClear
+    #define traceRETURN_ulTaskGenericNotifyValueClear( ulReturn )
+#endif
+
+#ifndef traceAPI_ulTaskGetRunTimeCounter
+    #define traceAPI_ulTaskGetRunTimeCounter( xTask )
+#endif
+
+#ifndef traceRETURN_ulTaskGetRunTimeCounter
+    #define traceRETURN_ulTaskGetRunTimeCounter( ulRunTimeCounter )
+#endif
+
+#ifndef traceAPI_ulTaskGetRunTimePercent
+    #define traceAPI_ulTaskGetRunTimePercent( xTask )
+#endif
+
+#ifndef traceRETURN_ulTaskGetRunTimePercent
+    #define traceRETURN_ulTaskGetRunTimePercent( ulReturn )
+#endif
+
+#ifndef traceAPI_ulTaskGetIdleRunTimeCounter
+    #define traceAPI_ulTaskGetIdleRunTimeCounter()
+#endif
+
+#ifndef traceRETURN_ulTaskGetIdleRunTimeCounter
+    #define traceRETURN_ulTaskGetIdleRunTimeCounter( ulReturn )
+#endif
+
+#ifndef traceAPI_ulTaskGetIdleRunTimePercent
+    #define traceAPI_ulTaskGetIdleRunTimePercent()
+#endif
+
+#ifndef traceRETURN_ulTaskGetIdleRunTimePercent
+    #define traceRETURN_ulTaskGetIdleRunTimePercent( ulReturn )
+#endif
+
+#ifndef traceAPI_xTaskGetMPUSettings
+    #define traceAPI_xTaskGetMPUSettings( xTask )
+#endif
+
+#ifndef traceRETURN_xTaskGetMPUSettings
+    #define traceRETURN_xTaskGetMPUSettings( xMPUSettings )
+#endif
+
+#ifndef traceAPI_xStreamBufferGenericCreate
+    #define traceAPI_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
+#endif
+
 #ifndef traceRETURN_xStreamBufferGenericCreate
-    #define traceRETURN_xStreamBufferGenericCreate( pucAllocatedMemory )
+    #define traceRETURN_xStreamBufferGenericCreate( pvAllocatedMemory )
+#endif
+
+#ifndef traceAPI_xStreamBufferGenericCreateStatic
+    #define traceAPI_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
 #endif
 
 #ifndef traceRETURN_xStreamBufferGenericCreateStatic
     #define traceRETURN_xStreamBufferGenericCreateStatic( xReturn )
 #endif
 
+#ifndef traceAPI_xStreamBufferGetStaticBuffers
+    #define traceAPI_xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer )
+#endif
+
+#ifndef traceRETURN_xStreamBufferGetStaticBuffers
+    #define traceRETURN_xStreamBufferGetStaticBuffers( xReturn )
+#endif
+
+#ifndef traceAPI_vStreamBufferDelete
+    #define traceAPI_vStreamBufferDelete( xStreamBuffer )
+#endif
+
 #ifndef traceRETURN_vStreamBufferDelete
     #define traceRETURN_vStreamBufferDelete()
+#endif
+
+#ifndef traceAPI_xStreamBufferReset
+    #define traceAPI_xStreamBufferReset( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReset
     #define traceRETURN_xStreamBufferReset( xReturn )
 #endif
 
+#ifndef traceAPI_xStreamBufferSetTriggerLevel
+    #define traceAPI_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel )
+#endif
+
 #ifndef traceRETURN_xStreamBufferSetTriggerLevel
     #define traceRETURN_xStreamBufferSetTriggerLevel( xReturn )
+#endif
+
+#ifndef traceAPI_xStreamBufferSpacesAvailable
+    #define traceAPI_xStreamBufferSpacesAvailable( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferSpacesAvailable
     #define traceRETURN_xStreamBufferSpacesAvailable( xSpace )
 #endif
 
+#ifndef traceAPI_xStreamBufferBytesAvailable
+    #define traceAPI_xStreamBufferBytesAvailable( xStreamBuffer )
+#endif
+
 #ifndef traceRETURN_xStreamBufferBytesAvailable
     #define traceRETURN_xStreamBufferBytesAvailable( xReturn )
+#endif
+
+#ifndef traceAPI_xStreamBufferSend
+    #define traceAPI_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xStreamBufferSend
     #define traceRETURN_xStreamBufferSend( xReturn )
 #endif
 
+#ifndef traceAPI_xStreamBufferSendFromISR
+    #define traceAPI_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken )
+#endif
+
 #ifndef traceRETURN_xStreamBufferSendFromISR
     #define traceRETURN_xStreamBufferSendFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xStreamBufferReceive
+    #define traceAPI_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReceive
     #define traceRETURN_xStreamBufferReceive( xReceivedLength )
 #endif
 
+#ifndef traceAPI_xStreamBufferNextMessageLengthBytes
+    #define traceAPI_xStreamBufferNextMessageLengthBytes( xStreamBuffer )
+#endif
+
 #ifndef traceRETURN_xStreamBufferNextMessageLengthBytes
     #define traceRETURN_xStreamBufferNextMessageLengthBytes( xReturn )
+#endif
+
+#ifndef traceAPI_xStreamBufferReceiveFromISR
+    #define traceAPI_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReceiveFromISR
     #define traceRETURN_xStreamBufferReceiveFromISR( xReceivedLength )
 #endif
 
+#ifndef traceAPI_xStreamBufferIsEmpty
+    #define traceAPI_xStreamBufferIsEmpty( xStreamBuffer )
+#endif
+
 #ifndef traceRETURN_xStreamBufferIsEmpty
     #define traceRETURN_xStreamBufferIsEmpty( xReturn )
+#endif
+
+#ifndef traceAPI_xStreamBufferIsFull
+    #define traceAPI_xStreamBufferIsFull( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferIsFull
     #define traceRETURN_xStreamBufferIsFull( xReturn )
 #endif
 
+#ifndef traceAPI_xStreamBufferSendCompletedFromISR
+    #define traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
+#endif
+
 #ifndef traceRETURN_xStreamBufferSendCompletedFromISR
     #define traceRETURN_xStreamBufferSendCompletedFromISR( xReturn )
+#endif
+
+#ifndef traceAPI_xStreamBufferReceiveCompletedFromISR
+    #define traceAPI_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReceiveCompletedFromISR
     #define traceRETURN_xStreamBufferReceiveCompletedFromISR( xReturn )
 #endif
 
+#ifndef traceAPI_uxStreamBufferGetStreamBufferNumber
+    #define traceAPI_uxStreamBufferGetStreamBufferNumber( xStreamBuffer )
+#endif
+
 #ifndef traceRETURN_uxStreamBufferGetStreamBufferNumber
     #define traceRETURN_uxStreamBufferGetStreamBufferNumber( uxStreamBufferNumber )
+#endif
+
+#ifndef traceAPI_vStreamBufferSetStreamBufferNumber
+    #define traceAPI_vStreamBufferSetStreamBufferNumber( xStreamBuffer, uxStreamBufferNumber )
 #endif
 
 #ifndef traceRETURN_vStreamBufferSetStreamBufferNumber
     #define traceRETURN_vStreamBufferSetStreamBufferNumber()
 #endif
 
+#ifndef traceAPI_ucStreamBufferGetStreamBufferType
+    #define traceAPI_ucStreamBufferGetStreamBufferType( xStreamBuffer )
+#endif
+
 #ifndef traceRETURN_ucStreamBufferGetStreamBufferType
-    #define traceRETURN_ucStreamBufferGetStreamBufferType( ucFlags )
+    #define traceRETURN_ucStreamBufferGetStreamBufferType( ucStreamBufferType )
+#endif
+
+#ifndef traceAPI_vListInitialise
+    #define traceAPI_vListInitialise( pxList )
+#endif
+
+#ifndef traceRETURN_vListInitialise
+    #define traceRETURN_vListInitialise()
+#endif
+
+#ifndef traceAPI_vListInitialiseItem
+    #define traceAPI_vListInitialiseItem( pxItem )
+#endif
+
+#ifndef traceRETURN_vListInitialiseItem
+    #define traceRETURN_vListInitialiseItem()
+#endif
+
+#ifndef traceAPI_vListInsertEnd
+    #define traceAPI_vListInsertEnd( pxList, pxNewListItem )
+#endif
+
+#ifndef traceRETURN_vListInsertEnd
+    #define traceRETURN_vListInsertEnd()
+#endif
+
+#ifndef traceAPI_vListInsert
+    #define traceAPI_vListInsert( pxList, pxNewListItem )
+#endif
+
+#ifndef traceRETURN_vListInsert
+    #define traceRETURN_vListInsert()
+#endif
+
+#ifndef traceAPI_uxListRemove
+    #define traceAPI_uxListRemove( pxItemToRemove )
+#endif
+
+#ifndef traceRETURN_uxListRemove
+    #define traceRETURN_uxListRemove( uxNumberOfItems )
+#endif
+
+#ifndef traceAPI_xCoRoutineCreate
+    #define traceAPI_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex )
+#endif
+
+#ifndef traceRETURN_xCoRoutineCreate
+    #define traceRETURN_xCoRoutineCreate( xReturn )
+#endif
+
+#ifndef traceAPI_vCoRoutineAddToDelayedList
+    #define traceAPI_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList )
+#endif
+
+#ifndef traceRETURN_vCoRoutineAddToDelayedList
+    #define traceRETURN_vCoRoutineAddToDelayedList()
+#endif
+
+#ifndef traceAPI_vCoRoutineSchedule
+    #define traceAPI_vCoRoutineSchedule()
+#endif
+
+#ifndef traceRETURN_vCoRoutineSchedule
+    #define traceRETURN_vCoRoutineSchedule()
+#endif
+
+#ifndef traceAPI_xCoRoutineRemoveFromEventList
+    #define traceAPI_xCoRoutineRemoveFromEventList( pxEventList )
+#endif
+
+#ifndef traceRETURN_xCoRoutineRemoveFromEventList
+    #define traceRETURN_xCoRoutineRemoveFromEventList( xReturn )
 #endif
 
 #ifndef configGENERATE_RUN_TIME_STATS

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1678,7 +1678,7 @@
 #endif
 
 #ifndef traceAPI_xStreamBufferSendCompletedFromISR
-    #define traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer,pxHigherPriorityTaskWoken )
+    #define traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceAPI_xStreamBufferReceiveCompletedFromISR

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -978,1536 +978,1536 @@
     #define traceSTREAM_BUFFER_RECEIVE_FROM_ISR( xStreamBuffer, xReceivedLength )
 #endif
 
-#ifndef traceAPI_xEventGroupCreateStatic
-    #define traceAPI_xEventGroupCreateStatic( pxEventGroupBuffer )
+#ifndef traceENTER_xEventGroupCreateStatic
+    #define traceENTER_xEventGroupCreateStatic( pxEventGroupBuffer )
 #endif
 
 #ifndef traceRETURN_xEventGroupCreateStatic
     #define traceRETURN_xEventGroupCreateStatic( pxEventBits )
 #endif
 
-#ifndef traceAPI_xEventGroupCreate
-    #define traceAPI_xEventGroupCreate()
+#ifndef traceENTER_xEventGroupCreate
+    #define traceENTER_xEventGroupCreate()
 #endif
 
 #ifndef traceRETURN_xEventGroupCreate
     #define traceRETURN_xEventGroupCreate( pxEventBits )
 #endif
 
-#ifndef traceAPI_xEventGroupSync
-    #define traceAPI_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait )
+#ifndef traceENTER_xEventGroupSync
+    #define traceENTER_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xEventGroupSync
     #define traceRETURN_xEventGroupSync( uxReturn )
 #endif
 
-#ifndef traceAPI_xEventGroupWaitBits
-    #define traceAPI_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait )
+#ifndef traceENTER_xEventGroupWaitBits
+    #define traceENTER_xEventGroupWaitBits( xEventGroup, uxBitsToWaitFor, xClearOnExit, xWaitForAllBits, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xEventGroupWaitBits
     #define traceRETURN_xEventGroupWaitBits( uxReturn )
 #endif
 
-#ifndef traceAPI_xEventGroupClearBits
-    #define traceAPI_xEventGroupClearBits( xEventGroup, uxBitsToClear )
+#ifndef traceENTER_xEventGroupClearBits
+    #define traceENTER_xEventGroupClearBits( xEventGroup, uxBitsToClear )
 #endif
 
 #ifndef traceRETURN_xEventGroupClearBits
     #define traceRETURN_xEventGroupClearBits( uxReturn )
 #endif
 
-#ifndef traceAPI_xEventGroupClearBitsFromISR
-    #define traceAPI_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear )
+#ifndef traceENTER_xEventGroupClearBitsFromISR
+    #define traceENTER_xEventGroupClearBitsFromISR( xEventGroup, uxBitsToClear )
 #endif
 
 #ifndef traceRETURN_xEventGroupClearBitsFromISR
     #define traceRETURN_xEventGroupClearBitsFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xEventGroupGetBitsFromISR
-    #define traceAPI_xEventGroupGetBitsFromISR( xEventGroup )
+#ifndef traceENTER_xEventGroupGetBitsFromISR
+    #define traceENTER_xEventGroupGetBitsFromISR( xEventGroup )
 #endif
 
 #ifndef traceRETURN_xEventGroupGetBitsFromISR
     #define traceRETURN_xEventGroupGetBitsFromISR( uxReturn )
 #endif
 
-#ifndef traceAPI_xEventGroupSetBits
-    #define traceAPI_xEventGroupSetBits( xEventGroup, uxBitsToSet )
+#ifndef traceENTER_xEventGroupSetBits
+    #define traceENTER_xEventGroupSetBits( xEventGroup, uxBitsToSet )
 #endif
 
 #ifndef traceRETURN_xEventGroupSetBits
     #define traceRETURN_xEventGroupSetBits( uxEventBits )
 #endif
 
-#ifndef traceAPI_vEventGroupDelete
-    #define traceAPI_vEventGroupDelete( xEventGroup )
+#ifndef traceENTER_vEventGroupDelete
+    #define traceENTER_vEventGroupDelete( xEventGroup )
 #endif
 
 #ifndef traceRETURN_vEventGroupDelete
     #define traceRETURN_vEventGroupDelete()
 #endif
 
-#ifndef traceAPI_xEventGroupGetStaticBuffer
-    #define traceAPI_xEventGroupGetStaticBuffer( xEventGroup, ppxEventGroupBuffer )
+#ifndef traceENTER_xEventGroupGetStaticBuffer
+    #define traceENTER_xEventGroupGetStaticBuffer( xEventGroup, ppxEventGroupBuffer )
 #endif
 
 #ifndef traceRETURN_xEventGroupGetStaticBuffer
     #define traceRETURN_xEventGroupGetStaticBuffer( xReturn )
 #endif
 
-#ifndef traceAPI_vEventGroupSetBitsCallback
-    #define traceAPI_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet )
+#ifndef traceENTER_vEventGroupSetBitsCallback
+    #define traceENTER_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet )
 #endif
 
 #ifndef traceRETURN_vEventGroupSetBitsCallback
     #define traceRETURN_vEventGroupSetBitsCallback()
 #endif
 
-#ifndef traceAPI_vEventGroupClearBitsCallback
-    #define traceAPI_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear )
+#ifndef traceENTER_vEventGroupClearBitsCallback
+    #define traceENTER_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear )
 #endif
 
 #ifndef traceRETURN_vEventGroupClearBitsCallback
     #define traceRETURN_vEventGroupClearBitsCallback()
 #endif
 
-#ifndef traceAPI_xEventGroupSetBitsFromISR
-    #define traceAPI_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xEventGroupSetBitsFromISR
+    #define traceENTER_xEventGroupSetBitsFromISR( xEventGroup, uxBitsToSet, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xEventGroupSetBitsFromISR
     #define traceRETURN_xEventGroupSetBitsFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_uxEventGroupGetNumber
-    #define traceAPI_uxEventGroupGetNumber( xEventGroup )
+#ifndef traceENTER_uxEventGroupGetNumber
+    #define traceENTER_uxEventGroupGetNumber( xEventGroup )
 #endif
 
 #ifndef traceRETURN_uxEventGroupGetNumber
     #define traceRETURN_uxEventGroupGetNumber( xReturn )
 #endif
 
-#ifndef traceAPI_vEventGroupSetNumber
-    #define traceAPI_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber )
+#ifndef traceENTER_vEventGroupSetNumber
+    #define traceENTER_vEventGroupSetNumber( xEventGroup, uxEventGroupNumber )
 #endif
 
 #ifndef traceRETURN_vEventGroupSetNumber
     #define traceRETURN_vEventGroupSetNumber()
 #endif
 
-#ifndef traceAPI_xQueueGenericReset
-    #define traceAPI_xQueueGenericReset( xQueue, xNewQueue )
+#ifndef traceENTER_xQueueGenericReset
+    #define traceENTER_xQueueGenericReset( xQueue, xNewQueue )
 #endif
 
 #ifndef traceRETURN_xQueueGenericReset
     #define traceRETURN_xQueueGenericReset( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueGenericCreateStatic
-    #define traceAPI_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType )
+#ifndef traceENTER_xQueueGenericCreateStatic
+    #define traceENTER_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType )
 #endif
 
 #ifndef traceRETURN_xQueueGenericCreateStatic
     #define traceRETURN_xQueueGenericCreateStatic( pxNewQueue )
 #endif
 
-#ifndef traceAPI_xQueueGenericGetStaticBuffers
-    #define traceAPI_xQueueGenericGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue )
+#ifndef traceENTER_xQueueGenericGetStaticBuffers
+    #define traceENTER_xQueueGenericGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue )
 #endif
 
 #ifndef traceRETURN_xQueueGenericGetStaticBuffers
     #define traceRETURN_xQueueGenericGetStaticBuffers( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueGenericCreate
-    #define traceAPI_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType )
+#ifndef traceENTER_xQueueGenericCreate
+    #define traceENTER_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType )
 #endif
 
 #ifndef traceRETURN_xQueueGenericCreate
     #define traceRETURN_xQueueGenericCreate( pxNewQueue )
 #endif
 
-#ifndef traceAPI_xQueueCreateMutex
-    #define traceAPI_xQueueCreateMutex( ucQueueType )
+#ifndef traceENTER_xQueueCreateMutex
+    #define traceENTER_xQueueCreateMutex( ucQueueType )
 #endif
 
 #ifndef traceRETURN_xQueueCreateMutex
     #define traceRETURN_xQueueCreateMutex( xNewQueue )
 #endif
 
-#ifndef traceAPI_xQueueCreateMutexStatic
-    #define traceAPI_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue )
+#ifndef traceENTER_xQueueCreateMutexStatic
+    #define traceENTER_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue )
 #endif
 
 #ifndef traceRETURN_xQueueCreateMutexStatic
     #define traceRETURN_xQueueCreateMutexStatic( xNewQueue )
 #endif
 
-#ifndef traceAPI_xQueueGetMutexHolder
-    #define traceAPI_xQueueGetMutexHolder( xSemaphore )
+#ifndef traceENTER_xQueueGetMutexHolder
+    #define traceENTER_xQueueGetMutexHolder( xSemaphore )
 #endif
 
 #ifndef traceRETURN_xQueueGetMutexHolder
     #define traceRETURN_xQueueGetMutexHolder( pxReturn )
 #endif
 
-#ifndef traceAPI_xQueueGetMutexHolderFromISR
-    #define traceAPI_xQueueGetMutexHolderFromISR( xSemaphore )
+#ifndef traceENTER_xQueueGetMutexHolderFromISR
+    #define traceENTER_xQueueGetMutexHolderFromISR( xSemaphore )
 #endif
 
 #ifndef traceRETURN_xQueueGetMutexHolderFromISR
     #define traceRETURN_xQueueGetMutexHolderFromISR( pxReturn )
 #endif
 
-#ifndef traceAPI_xQueueGiveMutexRecursive
-    #define traceAPI_xQueueGiveMutexRecursive( xMutex )
+#ifndef traceENTER_xQueueGiveMutexRecursive
+    #define traceENTER_xQueueGiveMutexRecursive( xMutex )
 #endif
 
 #ifndef traceRETURN_xQueueGiveMutexRecursive
     #define traceRETURN_xQueueGiveMutexRecursive( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueTakeMutexRecursive
-    #define traceAPI_xQueueTakeMutexRecursive( xMutex, xTicksToWait )
+#ifndef traceENTER_xQueueTakeMutexRecursive
+    #define traceENTER_xQueueTakeMutexRecursive( xMutex, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xQueueTakeMutexRecursive
     #define traceRETURN_xQueueTakeMutexRecursive( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueCreateCountingSemaphoreStatic
-    #define traceAPI_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue )
+#ifndef traceENTER_xQueueCreateCountingSemaphoreStatic
+    #define traceENTER_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue )
 #endif
 
 #ifndef traceRETURN_xQueueCreateCountingSemaphoreStatic
     #define traceRETURN_xQueueCreateCountingSemaphoreStatic( xHandle )
 #endif
 
-#ifndef traceAPI_xQueueCreateCountingSemaphore
-    #define traceAPI_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount )
+#ifndef traceENTER_xQueueCreateCountingSemaphore
+    #define traceENTER_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount )
 #endif
 
 #ifndef traceRETURN_xQueueCreateCountingSemaphore
     #define traceRETURN_xQueueCreateCountingSemaphore( xHandle )
 #endif
 
-#ifndef traceAPI_xQueueGenericSend
-    #define traceAPI_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition )
+#ifndef traceENTER_xQueueGenericSend
+    #define traceENTER_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition )
 #endif
 
 #ifndef traceRETURN_xQueueGenericSend
     #define traceRETURN_xQueueGenericSend( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueGenericSendFromISR
-    #define traceAPI_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition )
+#ifndef traceENTER_xQueueGenericSendFromISR
+    #define traceENTER_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition )
 #endif
 
 #ifndef traceRETURN_xQueueGenericSendFromISR
     #define traceRETURN_xQueueGenericSendFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueGiveFromISR
-    #define traceAPI_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xQueueGiveFromISR
+    #define traceENTER_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xQueueGiveFromISR
     #define traceRETURN_xQueueGiveFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueReceive
-    #define traceAPI_xQueueReceive( xQueue, pvBuffer, xTicksToWait )
+#ifndef traceENTER_xQueueReceive
+    #define traceENTER_xQueueReceive( xQueue, pvBuffer, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xQueueReceive
     #define traceRETURN_xQueueReceive( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueSemaphoreTake
-    #define traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait )
+#ifndef traceENTER_xQueueSemaphoreTake
+    #define traceENTER_xQueueSemaphoreTake( xQueue, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xQueueSemaphoreTake
     #define traceRETURN_xQueueSemaphoreTake( xReturn )
 #endif
 
-#ifndef traceAPI_xQueuePeek
-    #define traceAPI_xQueuePeek( xQueue, pvBuffer, xTicksToWait )
+#ifndef traceENTER_xQueuePeek
+    #define traceENTER_xQueuePeek( xQueue, pvBuffer, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xQueuePeek
     #define traceRETURN_xQueuePeek( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueReceiveFromISR
-    #define traceAPI_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xQueueReceiveFromISR
+    #define traceENTER_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xQueueReceiveFromISR
     #define traceRETURN_xQueueReceiveFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xQueuePeekFromISR
-    #define traceAPI_xQueuePeekFromISR( xQueue, pvBuffer )
+#ifndef traceENTER_xQueuePeekFromISR
+    #define traceENTER_xQueuePeekFromISR( xQueue, pvBuffer )
 #endif
 
 #ifndef traceRETURN_xQueuePeekFromISR
     #define traceRETURN_xQueuePeekFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_uxQueueMessagesWaiting
-    #define traceAPI_uxQueueMessagesWaiting( xQueue )
+#ifndef traceENTER_uxQueueMessagesWaiting
+    #define traceENTER_uxQueueMessagesWaiting( xQueue )
 #endif
 
 #ifndef traceRETURN_uxQueueMessagesWaiting
     #define traceRETURN_uxQueueMessagesWaiting( uxReturn )
 #endif
 
-#ifndef traceAPI_uxQueueSpacesAvailable
-    #define traceAPI_uxQueueSpacesAvailable( xQueue )
+#ifndef traceENTER_uxQueueSpacesAvailable
+    #define traceENTER_uxQueueSpacesAvailable( xQueue )
 #endif
 
 #ifndef traceRETURN_uxQueueSpacesAvailable
     #define traceRETURN_uxQueueSpacesAvailable( uxReturn )
 #endif
 
-#ifndef traceAPI_uxQueueMessagesWaitingFromISR
-    #define traceAPI_uxQueueMessagesWaitingFromISR( xQueue )
+#ifndef traceENTER_uxQueueMessagesWaitingFromISR
+    #define traceENTER_uxQueueMessagesWaitingFromISR( xQueue )
 #endif
 
 #ifndef traceRETURN_uxQueueMessagesWaitingFromISR
     #define traceRETURN_uxQueueMessagesWaitingFromISR( uxReturn )
 #endif
 
-#ifndef traceAPI_vQueueDelete
-    #define traceAPI_vQueueDelete( xQueue )
+#ifndef traceENTER_vQueueDelete
+    #define traceENTER_vQueueDelete( xQueue )
 #endif
 
 #ifndef traceRETURN_vQueueDelete
     #define traceRETURN_vQueueDelete()
 #endif
 
-#ifndef traceAPI_uxQueueGetQueueNumber
-    #define traceAPI_uxQueueGetQueueNumber( xQueue )
+#ifndef traceENTER_uxQueueGetQueueNumber
+    #define traceENTER_uxQueueGetQueueNumber( xQueue )
 #endif
 
 #ifndef traceRETURN_uxQueueGetQueueNumber
     #define traceRETURN_uxQueueGetQueueNumber( uxQueueNumber )
 #endif
 
-#ifndef traceAPI_vQueueSetQueueNumber
-    #define traceAPI_vQueueSetQueueNumber( xQueue, uxQueueNumber )
+#ifndef traceENTER_vQueueSetQueueNumber
+    #define traceENTER_vQueueSetQueueNumber( xQueue, uxQueueNumber )
 #endif
 
 #ifndef traceRETURN_vQueueSetQueueNumber
     #define traceRETURN_vQueueSetQueueNumber()
 #endif
 
-#ifndef traceAPI_ucQueueGetQueueType
-    #define traceAPI_ucQueueGetQueueType( xQueue )
+#ifndef traceENTER_ucQueueGetQueueType
+    #define traceENTER_ucQueueGetQueueType( xQueue )
 #endif
 
 #ifndef traceRETURN_ucQueueGetQueueType
     #define traceRETURN_ucQueueGetQueueType( ucQueueType )
 #endif
 
-#ifndef traceAPI_uxQueueGetQueueItemSize
-    #define traceAPI_uxQueueGetQueueItemSize( xQueue )
+#ifndef traceENTER_uxQueueGetQueueItemSize
+    #define traceENTER_uxQueueGetQueueItemSize( xQueue )
 #endif
 
 #ifndef traceRETURN_uxQueueGetQueueItemSize
     #define traceRETURN_uxQueueGetQueueItemSize( uxItemSize )
 #endif
 
-#ifndef traceAPI_uxQueueGetQueueLength
-    #define traceAPI_uxQueueGetQueueLength( xQueue )
+#ifndef traceENTER_uxQueueGetQueueLength
+    #define traceENTER_uxQueueGetQueueLength( xQueue )
 #endif
 
 #ifndef traceRETURN_uxQueueGetQueueLength
     #define traceRETURN_uxQueueGetQueueLength( uxLength )
 #endif
 
-#ifndef traceAPI_xQueueIsQueueEmptyFromISR
-    #define traceAPI_xQueueIsQueueEmptyFromISR( xQueue )
+#ifndef traceENTER_xQueueIsQueueEmptyFromISR
+    #define traceENTER_xQueueIsQueueEmptyFromISR( xQueue )
 #endif
 
 #ifndef traceRETURN_xQueueIsQueueEmptyFromISR
     #define traceRETURN_xQueueIsQueueEmptyFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueIsQueueFullFromISR
-    #define traceAPI_xQueueIsQueueFullFromISR( xQueue )
+#ifndef traceENTER_xQueueIsQueueFullFromISR
+    #define traceENTER_xQueueIsQueueFullFromISR( xQueue )
 #endif
 
 #ifndef traceRETURN_xQueueIsQueueFullFromISR
     #define traceRETURN_xQueueIsQueueFullFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueCRSend
-    #define traceAPI_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait )
+#ifndef traceENTER_xQueueCRSend
+    #define traceENTER_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xQueueCRSend
     #define traceRETURN_xQueueCRSend( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueCRReceive
-    #define traceAPI_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait )
+#ifndef traceENTER_xQueueCRReceive
+    #define traceENTER_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xQueueCRReceive
     #define traceRETURN_xQueueCRReceive( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueCRSendFromISR
-    #define traceAPI_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken )
+#ifndef traceENTER_xQueueCRSendFromISR
+    #define traceENTER_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken )
 #endif
 
 #ifndef traceRETURN_xQueueCRSendFromISR
     #define traceRETURN_xQueueCRSendFromISR( xCoRoutinePreviouslyWoken )
 #endif
 
-#ifndef traceAPI_xQueueCRReceiveFromISR
-    #define traceAPI_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken )
+#ifndef traceENTER_xQueueCRReceiveFromISR
+    #define traceENTER_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken )
 #endif
 
 #ifndef traceRETURN_xQueueCRReceiveFromISR
     #define traceRETURN_xQueueCRReceiveFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_vQueueAddToRegistry
-    #define traceAPI_vQueueAddToRegistry( xQueue, pcQueueName )
+#ifndef traceENTER_vQueueAddToRegistry
+    #define traceENTER_vQueueAddToRegistry( xQueue, pcQueueName )
 #endif
 
 #ifndef traceRETURN_vQueueAddToRegistry
     #define traceRETURN_vQueueAddToRegistry()
 #endif
 
-#ifndef traceAPI_pcQueueGetName
-    #define traceAPI_pcQueueGetName( xQueue )
+#ifndef traceENTER_pcQueueGetName
+    #define traceENTER_pcQueueGetName( xQueue )
 #endif
 
 #ifndef traceRETURN_pcQueueGetName
     #define traceRETURN_pcQueueGetName( pcReturn )
 #endif
 
-#ifndef traceAPI_vQueueUnregisterQueue
-    #define traceAPI_vQueueUnregisterQueue( xQueue )
+#ifndef traceENTER_vQueueUnregisterQueue
+    #define traceENTER_vQueueUnregisterQueue( xQueue )
 #endif
 
 #ifndef traceRETURN_vQueueUnregisterQueue
     #define traceRETURN_vQueueUnregisterQueue()
 #endif
 
-#ifndef traceAPI_vQueueWaitForMessageRestricted
-    #define traceAPI_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely )
+#ifndef traceENTER_vQueueWaitForMessageRestricted
+    #define traceENTER_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely )
 #endif
 
 #ifndef traceRETURN_vQueueWaitForMessageRestricted
     #define traceRETURN_vQueueWaitForMessageRestricted()
 #endif
 
-#ifndef traceAPI_xQueueCreateSet
-    #define traceAPI_xQueueCreateSet( uxEventQueueLength )
+#ifndef traceENTER_xQueueCreateSet
+    #define traceENTER_xQueueCreateSet( uxEventQueueLength )
 #endif
 
 #ifndef traceRETURN_xQueueCreateSet
     #define traceRETURN_xQueueCreateSet( pxQueue )
 #endif
 
-#ifndef traceAPI_xQueueAddToSet
-    #define traceAPI_xQueueAddToSet( xQueueOrSemaphore, xQueueSet )
+#ifndef traceENTER_xQueueAddToSet
+    #define traceENTER_xQueueAddToSet( xQueueOrSemaphore, xQueueSet )
 #endif
 
 #ifndef traceRETURN_xQueueAddToSet
     #define traceRETURN_xQueueAddToSet( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueRemoveFromSet
-    #define traceAPI_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet )
+#ifndef traceENTER_xQueueRemoveFromSet
+    #define traceENTER_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet )
 #endif
 
 #ifndef traceRETURN_xQueueRemoveFromSet
     #define traceRETURN_xQueueRemoveFromSet( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueSelectFromSet
-    #define traceAPI_xQueueSelectFromSet( xQueueSet, xTicksToWait )
+#ifndef traceENTER_xQueueSelectFromSet
+    #define traceENTER_xQueueSelectFromSet( xQueueSet, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xQueueSelectFromSet
     #define traceRETURN_xQueueSelectFromSet( xReturn )
 #endif
 
-#ifndef traceAPI_xQueueSelectFromSetFromISR
-    #define traceAPI_xQueueSelectFromSetFromISR( xQueueSet )
+#ifndef traceENTER_xQueueSelectFromSetFromISR
+    #define traceENTER_xQueueSelectFromSetFromISR( xQueueSet )
 #endif
 
 #ifndef traceRETURN_xQueueSelectFromSetFromISR
     #define traceRETURN_xQueueSelectFromSetFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xTimerCreateTimerTask
-    #define traceAPI_xTimerCreateTimerTask()
+#ifndef traceENTER_xTimerCreateTimerTask
+    #define traceENTER_xTimerCreateTimerTask()
 #endif
 
 #ifndef traceRETURN_xTimerCreateTimerTask
     #define traceRETURN_xTimerCreateTimerTask( xReturn )
 #endif
 
-#ifndef traceAPI_xTimerCreate
-    #define traceAPI_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction )
+#ifndef traceENTER_xTimerCreate
+    #define traceENTER_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction )
 #endif
 
 #ifndef traceRETURN_xTimerCreate
     #define traceRETURN_xTimerCreate( pxNewTimer )
 #endif
 
-#ifndef traceAPI_xTimerCreateStatic
-    #define traceAPI_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer )
+#ifndef traceENTER_xTimerCreateStatic
+    #define traceENTER_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer )
 #endif
 
 #ifndef traceRETURN_xTimerCreateStatic
     #define traceRETURN_xTimerCreateStatic( pxNewTimer )
 #endif
 
-#ifndef traceAPI_xTimerGenericCommandFromTask
-    #define traceAPI_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
+#ifndef traceENTER_xTimerGenericCommandFromTask
+    #define traceENTER_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xTimerGenericCommandFromTask
     #define traceRETURN_xTimerGenericCommandFromTask( xReturn )
 #endif
 
-#ifndef traceAPI_xTimerGenericCommandFromISR
-    #define traceAPI_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
+#ifndef traceENTER_xTimerGenericCommandFromISR
+    #define traceENTER_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xTimerGenericCommandFromISR
     #define traceRETURN_xTimerGenericCommandFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xTimerGetTimerDaemonTaskHandle
-    #define traceAPI_xTimerGetTimerDaemonTaskHandle()
+#ifndef traceENTER_xTimerGetTimerDaemonTaskHandle
+    #define traceENTER_xTimerGetTimerDaemonTaskHandle()
 #endif
 
 #ifndef traceRETURN_xTimerGetTimerDaemonTaskHandle
     #define traceRETURN_xTimerGetTimerDaemonTaskHandle( xTimerTaskHandle )
 #endif
 
-#ifndef traceAPI_xTimerGetPeriod
-    #define traceAPI_xTimerGetPeriod( xTimer )
+#ifndef traceENTER_xTimerGetPeriod
+    #define traceENTER_xTimerGetPeriod( xTimer )
 #endif
 
 #ifndef traceRETURN_xTimerGetPeriod
     #define traceRETURN_xTimerGetPeriod( xTimerPeriodInTicks )
 #endif
 
-#ifndef traceAPI_vTimerSetReloadMode
-    #define traceAPI_vTimerSetReloadMode( xTimer, xAutoReload )
+#ifndef traceENTER_vTimerSetReloadMode
+    #define traceENTER_vTimerSetReloadMode( xTimer, xAutoReload )
 #endif
 
 #ifndef traceRETURN_vTimerSetReloadMode
     #define traceRETURN_vTimerSetReloadMode()
 #endif
 
-#ifndef traceAPI_xTimerGetReloadMode
-    #define traceAPI_xTimerGetReloadMode( xTimer )
+#ifndef traceENTER_xTimerGetReloadMode
+    #define traceENTER_xTimerGetReloadMode( xTimer )
 #endif
 
 #ifndef traceRETURN_xTimerGetReloadMode
     #define traceRETURN_xTimerGetReloadMode( xReturn )
 #endif
 
-#ifndef traceAPI_uxTimerGetReloadMode
-    #define traceAPI_uxTimerGetReloadMode( xTimer )
+#ifndef traceENTER_uxTimerGetReloadMode
+    #define traceENTER_uxTimerGetReloadMode( xTimer )
 #endif
 
 #ifndef traceRETURN_uxTimerGetReloadMode
     #define traceRETURN_uxTimerGetReloadMode( uxReturn )
 #endif
 
-#ifndef traceAPI_xTimerGetExpiryTime
-    #define traceAPI_xTimerGetExpiryTime( xTimer )
+#ifndef traceENTER_xTimerGetExpiryTime
+    #define traceENTER_xTimerGetExpiryTime( xTimer )
 #endif
 
 #ifndef traceRETURN_xTimerGetExpiryTime
     #define traceRETURN_xTimerGetExpiryTime( xReturn )
 #endif
 
-#ifndef traceAPI_xTimerGetStaticBuffer
-    #define traceAPI_xTimerGetStaticBuffer( xTimer, ppxTimerBuffer )
+#ifndef traceENTER_xTimerGetStaticBuffer
+    #define traceENTER_xTimerGetStaticBuffer( xTimer, ppxTimerBuffer )
 #endif
 
 #ifndef traceRETURN_xTimerGetStaticBuffer
     #define traceRETURN_xTimerGetStaticBuffer( xReturn )
 #endif
 
-#ifndef traceAPI_pcTimerGetName
-    #define traceAPI_pcTimerGetName( xTimer )
+#ifndef traceENTER_pcTimerGetName
+    #define traceENTER_pcTimerGetName( xTimer )
 #endif
 
 #ifndef traceRETURN_pcTimerGetName
     #define traceRETURN_pcTimerGetName( pcTimerName )
 #endif
 
-#ifndef traceAPI_xTimerIsTimerActive
-    #define traceAPI_xTimerIsTimerActive( xTimer )
+#ifndef traceENTER_xTimerIsTimerActive
+    #define traceENTER_xTimerIsTimerActive( xTimer )
 #endif
 
 #ifndef traceRETURN_xTimerIsTimerActive
     #define traceRETURN_xTimerIsTimerActive( xReturn )
 #endif
 
-#ifndef traceAPI_pvTimerGetTimerID
-    #define traceAPI_pvTimerGetTimerID( xTimer )
+#ifndef traceENTER_pvTimerGetTimerID
+    #define traceENTER_pvTimerGetTimerID( xTimer )
 #endif
 
 #ifndef traceRETURN_pvTimerGetTimerID
     #define traceRETURN_pvTimerGetTimerID( pvReturn )
 #endif
 
-#ifndef traceAPI_vTimerSetTimerID
-    #define traceAPI_vTimerSetTimerID( xTimer, pvNewID )
+#ifndef traceENTER_vTimerSetTimerID
+    #define traceENTER_vTimerSetTimerID( xTimer, pvNewID )
 #endif
 
 #ifndef traceRETURN_vTimerSetTimerID
     #define traceRETURN_vTimerSetTimerID()
 #endif
 
-#ifndef traceAPI_xTimerPendFunctionCallFromISR
-    #define traceAPI_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xTimerPendFunctionCallFromISR
+    #define traceENTER_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xTimerPendFunctionCallFromISR
     #define traceRETURN_xTimerPendFunctionCallFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xTimerPendFunctionCall
-    #define traceAPI_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait )
+#ifndef traceENTER_xTimerPendFunctionCall
+    #define traceENTER_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xTimerPendFunctionCall
     #define traceRETURN_xTimerPendFunctionCall( xReturn )
 #endif
 
-#ifndef traceAPI_uxTimerGetTimerNumber
-    #define traceAPI_uxTimerGetTimerNumber( xTimer )
+#ifndef traceENTER_uxTimerGetTimerNumber
+    #define traceENTER_uxTimerGetTimerNumber( xTimer )
 #endif
 
 #ifndef traceRETURN_uxTimerGetTimerNumber
     #define traceRETURN_uxTimerGetTimerNumber( uxTimerNumber )
 #endif
 
-#ifndef traceAPI_vTimerSetTimerNumber
-    #define traceAPI_vTimerSetTimerNumber( xTimer, uxTimerNumber )
+#ifndef traceENTER_vTimerSetTimerNumber
+    #define traceENTER_vTimerSetTimerNumber( xTimer, uxTimerNumber )
 #endif
 
 #ifndef traceRETURN_vTimerSetTimerNumber
     #define traceRETURN_vTimerSetTimerNumber()
 #endif
 
-#ifndef traceAPI_xTaskCreateStatic
-    #define traceAPI_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer )
+#ifndef traceENTER_xTaskCreateStatic
+    #define traceENTER_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer )
 #endif
 
 #ifndef traceRETURN_xTaskCreateStatic
     #define traceRETURN_xTaskCreateStatic( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskCreateRestrictedStatic
-    #define traceAPI_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask )
+#ifndef traceENTER_xTaskCreateRestrictedStatic
+    #define traceENTER_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask )
 #endif
 
 #ifndef traceRETURN_xTaskCreateRestrictedStatic
     #define traceRETURN_xTaskCreateRestrictedStatic( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskCreateRestricted
-    #define traceAPI_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask )
+#ifndef traceENTER_xTaskCreateRestricted
+    #define traceENTER_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask )
 #endif
 
 #ifndef traceRETURN_xTaskCreateRestricted
     #define traceRETURN_xTaskCreateRestricted( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskCreate
-    #define traceAPI_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask )
+#ifndef traceENTER_xTaskCreate
+    #define traceENTER_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask )
 #endif
 
 #ifndef traceRETURN_xTaskCreate
     #define traceRETURN_xTaskCreate( xReturn )
 #endif
 
-#ifndef traceAPI_vTaskDelete
-    #define traceAPI_vTaskDelete( xTaskToDelete )
+#ifndef traceENTER_vTaskDelete
+    #define traceENTER_vTaskDelete( xTaskToDelete )
 #endif
 
 #ifndef traceRETURN_vTaskDelete
     #define traceRETURN_vTaskDelete()
 #endif
 
-#ifndef traceAPI_xTaskDelayUntil
-    #define traceAPI_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )
+#ifndef traceENTER_xTaskDelayUntil
+    #define traceENTER_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement )
 #endif
 
 #ifndef traceRETURN_xTaskDelayUntil
     #define traceRETURN_xTaskDelayUntil( xShouldDelay )
 #endif
 
-#ifndef traceAPI_vTaskDelay
-    #define traceAPI_vTaskDelay( xTicksToDelay )
+#ifndef traceENTER_vTaskDelay
+    #define traceENTER_vTaskDelay( xTicksToDelay )
 #endif
 
 #ifndef traceRETURN_vTaskDelay
     #define traceRETURN_vTaskDelay()
 #endif
 
-#ifndef traceAPI_eTaskGetState
-    #define traceAPI_eTaskGetState( xTask )
+#ifndef traceENTER_eTaskGetState
+    #define traceENTER_eTaskGetState( xTask )
 #endif
 
 #ifndef traceRETURN_eTaskGetState
     #define traceRETURN_eTaskGetState( eReturn )
 #endif
 
-#ifndef traceAPI_uxTaskPriorityGet
-    #define traceAPI_uxTaskPriorityGet( xTask )
+#ifndef traceENTER_uxTaskPriorityGet
+    #define traceENTER_uxTaskPriorityGet( xTask )
 #endif
 
 #ifndef traceRETURN_uxTaskPriorityGet
     #define traceRETURN_uxTaskPriorityGet( uxReturn )
 #endif
 
-#ifndef traceAPI_uxTaskPriorityGetFromISR
-    #define traceAPI_uxTaskPriorityGetFromISR( xTask )
+#ifndef traceENTER_uxTaskPriorityGetFromISR
+    #define traceENTER_uxTaskPriorityGetFromISR( xTask )
 #endif
 
 #ifndef traceRETURN_uxTaskPriorityGetFromISR
     #define traceRETURN_uxTaskPriorityGetFromISR( uxReturn )
 #endif
 
-#ifndef traceAPI_vTaskPrioritySet
-    #define traceAPI_vTaskPrioritySet( xTask, uxNewPriority )
+#ifndef traceENTER_vTaskPrioritySet
+    #define traceENTER_vTaskPrioritySet( xTask, uxNewPriority )
 #endif
 
 #ifndef traceRETURN_vTaskPrioritySet
     #define traceRETURN_vTaskPrioritySet()
 #endif
 
-#ifndef traceAPI_vTaskCoreAffinitySet
-    #define traceAPI_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask )
+#ifndef traceENTER_vTaskCoreAffinitySet
+    #define traceENTER_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask )
 #endif
 
 #ifndef traceRETURN_vTaskCoreAffinitySet
     #define traceRETURN_vTaskCoreAffinitySet()
 #endif
 
-#ifndef traceAPI_vTaskCoreAffinityGet
-    #define traceAPI_vTaskCoreAffinityGet( xTask )
+#ifndef traceENTER_vTaskCoreAffinityGet
+    #define traceENTER_vTaskCoreAffinityGet( xTask )
 #endif
 
 #ifndef traceRETURN_vTaskCoreAffinityGet
     #define traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask )
 #endif
 
-#ifndef traceAPI_vTaskPreemptionDisable
-    #define traceAPI_vTaskPreemptionDisable( xTask )
+#ifndef traceENTER_vTaskPreemptionDisable
+    #define traceENTER_vTaskPreemptionDisable( xTask )
 #endif
 
 #ifndef traceRETURN_vTaskPreemptionDisable
     #define traceRETURN_vTaskPreemptionDisable()
 #endif
 
-#ifndef traceAPI_vTaskPreemptionEnable
-    #define traceAPI_vTaskPreemptionEnable( xTask )
+#ifndef traceENTER_vTaskPreemptionEnable
+    #define traceENTER_vTaskPreemptionEnable( xTask )
 #endif
 
 #ifndef traceRETURN_vTaskPreemptionEnable
     #define traceRETURN_vTaskPreemptionEnable()
 #endif
 
-#ifndef traceAPI_vTaskSuspend
-    #define traceAPI_vTaskSuspend( xTaskToSuspend )
+#ifndef traceENTER_vTaskSuspend
+    #define traceENTER_vTaskSuspend( xTaskToSuspend )
 #endif
 
 #ifndef traceRETURN_vTaskSuspend
     #define traceRETURN_vTaskSuspend()
 #endif
 
-#ifndef traceAPI_vTaskResume
-    #define traceAPI_vTaskResume( xTaskToResume )
+#ifndef traceENTER_vTaskResume
+    #define traceENTER_vTaskResume( xTaskToResume )
 #endif
 
 #ifndef traceRETURN_vTaskResume
     #define traceRETURN_vTaskResume()
 #endif
 
-#ifndef traceAPI_xTaskResumeFromISR
-    #define traceAPI_xTaskResumeFromISR( xTaskToResume )
+#ifndef traceENTER_xTaskResumeFromISR
+    #define traceENTER_xTaskResumeFromISR( xTaskToResume )
 #endif
 
 #ifndef traceRETURN_xTaskResumeFromISR
     #define traceRETURN_xTaskResumeFromISR( xYieldRequired )
 #endif
 
-#ifndef traceAPI_vTaskStartScheduler
-    #define traceAPI_vTaskStartScheduler()
+#ifndef traceENTER_vTaskStartScheduler
+    #define traceENTER_vTaskStartScheduler()
 #endif
 
 #ifndef traceRETURN_vTaskStartScheduler
     #define traceRETURN_vTaskStartScheduler()
 #endif
 
-#ifndef traceAPI_vTaskEndScheduler
-    #define traceAPI_vTaskEndScheduler()
+#ifndef traceENTER_vTaskEndScheduler
+    #define traceENTER_vTaskEndScheduler()
 #endif
 
 #ifndef traceRETURN_vTaskEndScheduler
     #define traceRETURN_vTaskEndScheduler()
 #endif
 
-#ifndef traceAPI_vTaskSuspendAll
-    #define traceAPI_vTaskSuspendAll()
+#ifndef traceENTER_vTaskSuspendAll
+    #define traceENTER_vTaskSuspendAll()
 #endif
 
 #ifndef traceRETURN_vTaskSuspendAll
     #define traceRETURN_vTaskSuspendAll()
 #endif
 
-#ifndef traceAPI_xTaskResumeAll
-    #define traceAPI_xTaskResumeAll()
+#ifndef traceENTER_xTaskResumeAll
+    #define traceENTER_xTaskResumeAll()
 #endif
 
 #ifndef traceRETURN_xTaskResumeAll
     #define traceRETURN_xTaskResumeAll( xAlreadyYielded )
 #endif
 
-#ifndef traceAPI_xTaskGetTickCount
-    #define traceAPI_xTaskGetTickCount()
+#ifndef traceENTER_xTaskGetTickCount
+    #define traceENTER_xTaskGetTickCount()
 #endif
 
 #ifndef traceRETURN_xTaskGetTickCount
     #define traceRETURN_xTaskGetTickCount( xTicks )
 #endif
 
-#ifndef traceAPI_xTaskGetTickCountFromISR
-    #define traceAPI_xTaskGetTickCountFromISR()
+#ifndef traceENTER_xTaskGetTickCountFromISR
+    #define traceENTER_xTaskGetTickCountFromISR()
 #endif
 
 #ifndef traceRETURN_xTaskGetTickCountFromISR
     #define traceRETURN_xTaskGetTickCountFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_uxTaskGetNumberOfTasks
-    #define traceAPI_uxTaskGetNumberOfTasks()
+#ifndef traceENTER_uxTaskGetNumberOfTasks
+    #define traceENTER_uxTaskGetNumberOfTasks()
 #endif
 
 #ifndef traceRETURN_uxTaskGetNumberOfTasks
     #define traceRETURN_uxTaskGetNumberOfTasks( uxCurrentNumberOfTasks )
 #endif
 
-#ifndef traceAPI_pcTaskGetName
-    #define traceAPI_pcTaskGetName( xTaskToQuery )
+#ifndef traceENTER_pcTaskGetName
+    #define traceENTER_pcTaskGetName( xTaskToQuery )
 #endif
 
 #ifndef traceRETURN_pcTaskGetName
     #define traceRETURN_pcTaskGetName( pcTaskName )
 #endif
 
-#ifndef traceAPI_xTaskGetHandle
-    #define traceAPI_xTaskGetHandle( pcNameToQuery )
+#ifndef traceENTER_xTaskGetHandle
+    #define traceENTER_xTaskGetHandle( pcNameToQuery )
 #endif
 
 #ifndef traceRETURN_xTaskGetHandle
     #define traceRETURN_xTaskGetHandle( pxTCB )
 #endif
 
-#ifndef traceAPI_xTaskGetStaticBuffers
-    #define traceAPI_xTaskGetStaticBuffers( xTask, ppuxStackBuffer, ppxTaskBuffer )
+#ifndef traceENTER_xTaskGetStaticBuffers
+    #define traceENTER_xTaskGetStaticBuffers( xTask, ppuxStackBuffer, ppxTaskBuffer )
 #endif
 
 #ifndef traceRETURN_xTaskGetStaticBuffers
     #define traceRETURN_xTaskGetStaticBuffers( xReturn )
 #endif
 
-#ifndef traceAPI_uxTaskGetSystemState
-    #define traceAPI_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime )
+#ifndef traceENTER_uxTaskGetSystemState
+    #define traceENTER_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime )
 #endif
 
 #ifndef traceRETURN_uxTaskGetSystemState
     #define traceRETURN_uxTaskGetSystemState( uxTask )
 #endif
 
-#ifndef traceAPI_xTaskGetIdleTaskHandle
-    #define traceAPI_xTaskGetIdleTaskHandle()
+#ifndef traceENTER_xTaskGetIdleTaskHandle
+    #define traceENTER_xTaskGetIdleTaskHandle()
 #endif
 
 #ifndef traceRETURN_xTaskGetIdleTaskHandle
     #define traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandle )
 #endif
 
-#ifndef traceAPI_vTaskStepTick
-    #define traceAPI_vTaskStepTick( xTicksToJump )
+#ifndef traceENTER_vTaskStepTick
+    #define traceENTER_vTaskStepTick( xTicksToJump )
 #endif
 
 #ifndef traceRETURN_vTaskStepTick
     #define traceRETURN_vTaskStepTick()
 #endif
 
-#ifndef traceAPI_xTaskCatchUpTicks
-    #define traceAPI_xTaskCatchUpTicks( xTicksToCatchUp )
+#ifndef traceENTER_xTaskCatchUpTicks
+    #define traceENTER_xTaskCatchUpTicks( xTicksToCatchUp )
 #endif
 
 #ifndef traceRETURN_xTaskCatchUpTicks
     #define traceRETURN_xTaskCatchUpTicks( xYieldOccurred )
 #endif
 
-#ifndef traceAPI_xTaskAbortDelay
-    #define traceAPI_xTaskAbortDelay( xTask )
+#ifndef traceENTER_xTaskAbortDelay
+    #define traceENTER_xTaskAbortDelay( xTask )
 #endif
 
 #ifndef traceRETURN_xTaskAbortDelay
     #define traceRETURN_xTaskAbortDelay( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskIncrementTick
-    #define traceAPI_xTaskIncrementTick()
+#ifndef traceENTER_xTaskIncrementTick
+    #define traceENTER_xTaskIncrementTick()
 #endif
 
 #ifndef traceRETURN_xTaskIncrementTick
     #define traceRETURN_xTaskIncrementTick( xSwitchRequired )
 #endif
 
-#ifndef traceAPI_vTaskSetApplicationTaskTag
-    #define traceAPI_vTaskSetApplicationTaskTag( xTask, pxHookFunction )
+#ifndef traceENTER_vTaskSetApplicationTaskTag
+    #define traceENTER_vTaskSetApplicationTaskTag( xTask, pxHookFunction )
 #endif
 
 #ifndef traceRETURN_vTaskSetApplicationTaskTag
     #define traceRETURN_vTaskSetApplicationTaskTag()
 #endif
 
-#ifndef traceAPI_xTaskGetApplicationTaskTag
-    #define traceAPI_xTaskGetApplicationTaskTag( xTask )
+#ifndef traceENTER_xTaskGetApplicationTaskTag
+    #define traceENTER_xTaskGetApplicationTaskTag( xTask )
 #endif
 
 #ifndef traceRETURN_xTaskGetApplicationTaskTag
     #define traceRETURN_xTaskGetApplicationTaskTag( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskGetApplicationTaskTagFromISR
-    #define traceAPI_xTaskGetApplicationTaskTagFromISR( xTask )
+#ifndef traceENTER_xTaskGetApplicationTaskTagFromISR
+    #define traceENTER_xTaskGetApplicationTaskTagFromISR( xTask )
 #endif
 
 #ifndef traceRETURN_xTaskGetApplicationTaskTagFromISR
     #define traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskCallApplicationTaskHook
-    #define traceAPI_xTaskCallApplicationTaskHook( xTask, pvParameter )
+#ifndef traceENTER_xTaskCallApplicationTaskHook
+    #define traceENTER_xTaskCallApplicationTaskHook( xTask, pvParameter )
 #endif
 
 #ifndef traceRETURN_xTaskCallApplicationTaskHook
     #define traceRETURN_xTaskCallApplicationTaskHook( xReturn )
 #endif
 
-#ifndef traceAPI_vTaskSwitchContext
-    #define traceAPI_vTaskSwitchContext()
+#ifndef traceENTER_vTaskSwitchContext
+    #define traceENTER_vTaskSwitchContext()
 #endif
 
 #ifndef traceRETURN_vTaskSwitchContext
     #define traceRETURN_vTaskSwitchContext()
 #endif
 
-#ifndef traceAPI_vTaskPlaceOnEventList
-    #define traceAPI_vTaskPlaceOnEventList( pxEventList, xTicksToWait )
+#ifndef traceENTER_vTaskPlaceOnEventList
+    #define traceENTER_vTaskPlaceOnEventList( pxEventList, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_vTaskPlaceOnEventList
     #define traceRETURN_vTaskPlaceOnEventList()
 #endif
 
-#ifndef traceAPI_vTaskPlaceOnUnorderedEventList
-    #define traceAPI_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait )
+#ifndef traceENTER_vTaskPlaceOnUnorderedEventList
+    #define traceENTER_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_vTaskPlaceOnUnorderedEventList
     #define traceRETURN_vTaskPlaceOnUnorderedEventList()
 #endif
 
-#ifndef traceAPI_vTaskPlaceOnEventListRestricted
-    #define traceAPI_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely )
+#ifndef traceENTER_vTaskPlaceOnEventListRestricted
+    #define traceENTER_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely )
 #endif
 
 #ifndef traceRETURN_vTaskPlaceOnEventListRestricted
     #define traceRETURN_vTaskPlaceOnEventListRestricted()
 #endif
 
-#ifndef traceAPI_xTaskRemoveFromEventList
-    #define traceAPI_xTaskRemoveFromEventList( pxEventList )
+#ifndef traceENTER_xTaskRemoveFromEventList
+    #define traceENTER_xTaskRemoveFromEventList( pxEventList )
 #endif
 
 #ifndef traceRETURN_xTaskRemoveFromEventList
     #define traceRETURN_xTaskRemoveFromEventList( xReturn )
 #endif
 
-#ifndef traceAPI_vTaskRemoveFromUnorderedEventList
-    #define traceAPI_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue )
+#ifndef traceENTER_vTaskRemoveFromUnorderedEventList
+    #define traceENTER_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue )
 #endif
 
 #ifndef traceRETURN_vTaskRemoveFromUnorderedEventList
     #define traceRETURN_vTaskRemoveFromUnorderedEventList()
 #endif
 
-#ifndef traceAPI_vTaskSetTimeOutState
-    #define traceAPI_vTaskSetTimeOutState( pxTimeOut )
+#ifndef traceENTER_vTaskSetTimeOutState
+    #define traceENTER_vTaskSetTimeOutState( pxTimeOut )
 #endif
 
 #ifndef traceRETURN_vTaskSetTimeOutState
     #define traceRETURN_vTaskSetTimeOutState()
 #endif
 
-#ifndef traceAPI_vTaskInternalSetTimeOutState
-    #define traceAPI_vTaskInternalSetTimeOutState( pxTimeOut )
+#ifndef traceENTER_vTaskInternalSetTimeOutState
+    #define traceENTER_vTaskInternalSetTimeOutState( pxTimeOut )
 #endif
 
 #ifndef traceRETURN_vTaskInternalSetTimeOutState
     #define traceRETURN_vTaskInternalSetTimeOutState()
 #endif
 
-#ifndef traceAPI_xTaskCheckForTimeOut
-    #define traceAPI_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait )
+#ifndef traceENTER_xTaskCheckForTimeOut
+    #define traceENTER_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait )
 #endif
 
 #ifndef traceRETURN_xTaskCheckForTimeOut
     #define traceRETURN_xTaskCheckForTimeOut( xReturn )
 #endif
 
-#ifndef traceAPI_vTaskMissedYield
-    #define traceAPI_vTaskMissedYield()
+#ifndef traceENTER_vTaskMissedYield
+    #define traceENTER_vTaskMissedYield()
 #endif
 
 #ifndef traceRETURN_vTaskMissedYield
     #define traceRETURN_vTaskMissedYield()
 #endif
 
-#ifndef traceAPI_uxTaskGetTaskNumber
-    #define traceAPI_uxTaskGetTaskNumber( xTask )
+#ifndef traceENTER_uxTaskGetTaskNumber
+    #define traceENTER_uxTaskGetTaskNumber( xTask )
 #endif
 
 #ifndef traceRETURN_uxTaskGetTaskNumber
     #define traceRETURN_uxTaskGetTaskNumber( uxReturn )
 #endif
 
-#ifndef traceAPI_vTaskSetTaskNumber
-    #define traceAPI_vTaskSetTaskNumber( xTask, uxHandle )
+#ifndef traceENTER_vTaskSetTaskNumber
+    #define traceENTER_vTaskSetTaskNumber( xTask, uxHandle )
 #endif
 
 #ifndef traceRETURN_vTaskSetTaskNumber
     #define traceRETURN_vTaskSetTaskNumber()
 #endif
 
-#ifndef traceAPI_eTaskConfirmSleepModeStatus
-    #define traceAPI_eTaskConfirmSleepModeStatus()
+#ifndef traceENTER_eTaskConfirmSleepModeStatus
+    #define traceENTER_eTaskConfirmSleepModeStatus()
 #endif
 
 #ifndef traceRETURN_eTaskConfirmSleepModeStatus
     #define traceRETURN_eTaskConfirmSleepModeStatus( eReturn )
 #endif
 
-#ifndef traceAPI_vTaskSetThreadLocalStoragePointer
-    #define traceAPI_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue )
+#ifndef traceENTER_vTaskSetThreadLocalStoragePointer
+    #define traceENTER_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue )
 #endif
 
 #ifndef traceRETURN_vTaskSetThreadLocalStoragePointer
     #define traceRETURN_vTaskSetThreadLocalStoragePointer()
 #endif
 
-#ifndef traceAPI_pvTaskGetThreadLocalStoragePointer
-    #define traceAPI_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex )
+#ifndef traceENTER_pvTaskGetThreadLocalStoragePointer
+    #define traceENTER_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex )
 #endif
 
 #ifndef traceRETURN_pvTaskGetThreadLocalStoragePointer
     #define traceRETURN_pvTaskGetThreadLocalStoragePointer( pvReturn )
 #endif
 
-#ifndef traceAPI_vTaskAllocateMPURegions
-    #define traceAPI_vTaskAllocateMPURegions( xTaskToModify, pxRegions )
+#ifndef traceENTER_vTaskAllocateMPURegions
+    #define traceENTER_vTaskAllocateMPURegions( xTaskToModify, pxRegions )
 #endif
 
 #ifndef traceRETURN_vTaskAllocateMPURegions
     #define traceRETURN_vTaskAllocateMPURegions()
 #endif
 
-#ifndef traceAPI_vTaskGetInfo
-    #define traceAPI_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState )
+#ifndef traceENTER_vTaskGetInfo
+    #define traceENTER_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState )
 #endif
 
 #ifndef traceRETURN_vTaskGetInfo
     #define traceRETURN_vTaskGetInfo()
 #endif
 
-#ifndef traceAPI_uxTaskGetStackHighWaterMark2
-    #define traceAPI_uxTaskGetStackHighWaterMark2( xTask )
+#ifndef traceENTER_uxTaskGetStackHighWaterMark2
+    #define traceENTER_uxTaskGetStackHighWaterMark2( xTask )
 #endif
 
 #ifndef traceRETURN_uxTaskGetStackHighWaterMark2
     #define traceRETURN_uxTaskGetStackHighWaterMark2( uxReturn )
 #endif
 
-#ifndef traceAPI_uxTaskGetStackHighWaterMark
-    #define traceAPI_uxTaskGetStackHighWaterMark( xTask )
+#ifndef traceENTER_uxTaskGetStackHighWaterMark
+    #define traceENTER_uxTaskGetStackHighWaterMark( xTask )
 #endif
 
 #ifndef traceRETURN_uxTaskGetStackHighWaterMark
     #define traceRETURN_uxTaskGetStackHighWaterMark( uxReturn )
 #endif
 
-#ifndef traceAPI_xTaskGetCurrentTaskHandle
-    #define traceAPI_xTaskGetCurrentTaskHandle()
+#ifndef traceENTER_xTaskGetCurrentTaskHandle
+    #define traceENTER_xTaskGetCurrentTaskHandle()
 #endif
 
 #ifndef traceRETURN_xTaskGetCurrentTaskHandle
     #define traceRETURN_xTaskGetCurrentTaskHandle( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskGetCurrentTaskHandleCPU
-    #define traceAPI_xTaskGetCurrentTaskHandleCPU( xCoreID )
+#ifndef traceENTER_xTaskGetCurrentTaskHandleCPU
+    #define traceENTER_xTaskGetCurrentTaskHandleCPU( xCoreID )
 #endif
 
 #ifndef traceRETURN_xTaskGetCurrentTaskHandleCPU
     #define traceRETURN_xTaskGetCurrentTaskHandleCPU( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskGetSchedulerState
-    #define traceAPI_xTaskGetSchedulerState()
+#ifndef traceENTER_xTaskGetSchedulerState
+    #define traceENTER_xTaskGetSchedulerState()
 #endif
 
 #ifndef traceRETURN_xTaskGetSchedulerState
     #define traceRETURN_xTaskGetSchedulerState( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskPriorityInherit
-    #define traceAPI_xTaskPriorityInherit( pxMutexHolder )
+#ifndef traceENTER_xTaskPriorityInherit
+    #define traceENTER_xTaskPriorityInherit( pxMutexHolder )
 #endif
 
 #ifndef traceRETURN_xTaskPriorityInherit
     #define traceRETURN_xTaskPriorityInherit( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskPriorityDisinherit
-    #define traceAPI_xTaskPriorityDisinherit( pxMutexHolder )
+#ifndef traceENTER_xTaskPriorityDisinherit
+    #define traceENTER_xTaskPriorityDisinherit( pxMutexHolder )
 #endif
 
 #ifndef traceRETURN_xTaskPriorityDisinherit
     #define traceRETURN_xTaskPriorityDisinherit( xReturn )
 #endif
 
-#ifndef traceAPI_vTaskPriorityDisinheritAfterTimeout
-    #define traceAPI_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask )
+#ifndef traceENTER_vTaskPriorityDisinheritAfterTimeout
+    #define traceENTER_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask )
 #endif
 
 #ifndef traceRETURN_vTaskPriorityDisinheritAfterTimeout
     #define traceRETURN_vTaskPriorityDisinheritAfterTimeout()
 #endif
 
-#ifndef traceAPI_vTaskYieldWithinAPI
-    #define traceAPI_vTaskYieldWithinAPI()
+#ifndef traceENTER_vTaskYieldWithinAPI
+    #define traceENTER_vTaskYieldWithinAPI()
 #endif
 
 #ifndef traceRETURN_vTaskYieldWithinAPI
     #define traceRETURN_vTaskYieldWithinAPI()
 #endif
 
-#ifndef traceAPI_vTaskEnterCritical
-    #define traceAPI_vTaskEnterCritical()
+#ifndef traceENTER_vTaskEnterCritical
+    #define traceENTER_vTaskEnterCritical()
 #endif
 
 #ifndef traceRETURN_vTaskEnterCritical
     #define traceRETURN_vTaskEnterCritical()
 #endif
 
-#ifndef traceAPI_vTaskEnterCriticalFromISR
-    #define traceAPI_vTaskEnterCriticalFromISR()
+#ifndef traceENTER_vTaskEnterCriticalFromISR
+    #define traceENTER_vTaskEnterCriticalFromISR()
 #endif
 
 #ifndef traceRETURN_vTaskEnterCriticalFromISR
     #define traceRETURN_vTaskEnterCriticalFromISR( uxSavedInterruptStatus )
 #endif
 
-#ifndef traceAPI_vTaskExitCritical
-    #define traceAPI_vTaskExitCritical()
+#ifndef traceENTER_vTaskExitCritical
+    #define traceENTER_vTaskExitCritical()
 #endif
 
 #ifndef traceRETURN_vTaskExitCritical
     #define traceRETURN_vTaskExitCritical()
 #endif
 
-#ifndef traceAPI_vTaskExitCriticalFromISR
-    #define traceAPI_vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#ifndef traceENTER_vTaskExitCriticalFromISR
+    #define traceENTER_vTaskExitCriticalFromISR( uxSavedInterruptStatus )
 #endif
 
 #ifndef traceRETURN_vTaskExitCriticalFromISR
     #define traceRETURN_vTaskExitCriticalFromISR()
 #endif
 
-#ifndef traceAPI_vTaskList
-    #define traceAPI_vTaskList( pcWriteBuffer )
+#ifndef traceENTER_vTaskList
+    #define traceENTER_vTaskList( pcWriteBuffer )
 #endif
 
 #ifndef traceRETURN_vTaskList
     #define traceRETURN_vTaskList()
 #endif
 
-#ifndef traceAPI_vTaskGetRunTimeStats
-    #define traceAPI_vTaskGetRunTimeStats( pcWriteBuffer )
+#ifndef traceENTER_vTaskGetRunTimeStats
+    #define traceENTER_vTaskGetRunTimeStats( pcWriteBuffer )
 #endif
 
 #ifndef traceRETURN_vTaskGetRunTimeStats
     #define traceRETURN_vTaskGetRunTimeStats()
 #endif
 
-#ifndef traceAPI_uxTaskResetEventItemValue
-    #define traceAPI_uxTaskResetEventItemValue()
+#ifndef traceENTER_uxTaskResetEventItemValue
+    #define traceENTER_uxTaskResetEventItemValue()
 #endif
 
 #ifndef traceRETURN_uxTaskResetEventItemValue
     #define traceRETURN_uxTaskResetEventItemValue( uxReturn )
 #endif
 
-#ifndef traceAPI_pvTaskIncrementMutexHeldCount
-    #define traceAPI_pvTaskIncrementMutexHeldCount()
+#ifndef traceENTER_pvTaskIncrementMutexHeldCount
+    #define traceENTER_pvTaskIncrementMutexHeldCount()
 #endif
 
 #ifndef traceRETURN_pvTaskIncrementMutexHeldCount
     #define traceRETURN_pvTaskIncrementMutexHeldCount( pxTCB )
 #endif
 
-#ifndef traceAPI_ulTaskGenericNotifyTake
-    #define traceAPI_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait )
+#ifndef traceENTER_ulTaskGenericNotifyTake
+    #define traceENTER_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_ulTaskGenericNotifyTake
     #define traceRETURN_ulTaskGenericNotifyTake( ulReturn )
 #endif
 
-#ifndef traceAPI_xTaskGenericNotifyWait
-    #define traceAPI_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait )
+#ifndef traceENTER_xTaskGenericNotifyWait
+    #define traceENTER_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xTaskGenericNotifyWait
     #define traceRETURN_xTaskGenericNotifyWait( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskGenericNotify
-    #define traceAPI_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue )
+#ifndef traceENTER_xTaskGenericNotify
+    #define traceENTER_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue )
 #endif
 
 #ifndef traceRETURN_xTaskGenericNotify
     #define traceRETURN_xTaskGenericNotify( xReturn )
 #endif
 
-#ifndef traceAPI_xTaskGenericNotifyFromISR
-    #define traceAPI_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xTaskGenericNotifyFromISR
+    #define traceENTER_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xTaskGenericNotifyFromISR
     #define traceRETURN_xTaskGenericNotifyFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_vTaskGenericNotifyGiveFromISR
-    #define traceAPI_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_vTaskGenericNotifyGiveFromISR
+    #define traceENTER_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_vTaskGenericNotifyGiveFromISR
     #define traceRETURN_vTaskGenericNotifyGiveFromISR()
 #endif
 
-#ifndef traceAPI_xTaskGenericNotifyStateClear
-    #define traceAPI_xTaskGenericNotifyStateClear( xTask, uxIndexToClear )
+#ifndef traceENTER_xTaskGenericNotifyStateClear
+    #define traceENTER_xTaskGenericNotifyStateClear( xTask, uxIndexToClear )
 #endif
 
 #ifndef traceRETURN_xTaskGenericNotifyStateClear
     #define traceRETURN_xTaskGenericNotifyStateClear( xReturn )
 #endif
 
-#ifndef traceAPI_ulTaskGenericNotifyValueClear
-    #define traceAPI_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear )
+#ifndef traceENTER_ulTaskGenericNotifyValueClear
+    #define traceENTER_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear )
 #endif
 
 #ifndef traceRETURN_ulTaskGenericNotifyValueClear
     #define traceRETURN_ulTaskGenericNotifyValueClear( ulReturn )
 #endif
 
-#ifndef traceAPI_ulTaskGetRunTimeCounter
-    #define traceAPI_ulTaskGetRunTimeCounter( xTask )
+#ifndef traceENTER_ulTaskGetRunTimeCounter
+    #define traceENTER_ulTaskGetRunTimeCounter( xTask )
 #endif
 
 #ifndef traceRETURN_ulTaskGetRunTimeCounter
     #define traceRETURN_ulTaskGetRunTimeCounter( ulRunTimeCounter )
 #endif
 
-#ifndef traceAPI_ulTaskGetRunTimePercent
-    #define traceAPI_ulTaskGetRunTimePercent( xTask )
+#ifndef traceENTER_ulTaskGetRunTimePercent
+    #define traceENTER_ulTaskGetRunTimePercent( xTask )
 #endif
 
 #ifndef traceRETURN_ulTaskGetRunTimePercent
     #define traceRETURN_ulTaskGetRunTimePercent( ulReturn )
 #endif
 
-#ifndef traceAPI_ulTaskGetIdleRunTimeCounter
-    #define traceAPI_ulTaskGetIdleRunTimeCounter()
+#ifndef traceENTER_ulTaskGetIdleRunTimeCounter
+    #define traceENTER_ulTaskGetIdleRunTimeCounter()
 #endif
 
 #ifndef traceRETURN_ulTaskGetIdleRunTimeCounter
     #define traceRETURN_ulTaskGetIdleRunTimeCounter( ulReturn )
 #endif
 
-#ifndef traceAPI_ulTaskGetIdleRunTimePercent
-    #define traceAPI_ulTaskGetIdleRunTimePercent()
+#ifndef traceENTER_ulTaskGetIdleRunTimePercent
+    #define traceENTER_ulTaskGetIdleRunTimePercent()
 #endif
 
 #ifndef traceRETURN_ulTaskGetIdleRunTimePercent
     #define traceRETURN_ulTaskGetIdleRunTimePercent( ulReturn )
 #endif
 
-#ifndef traceAPI_xTaskGetMPUSettings
-    #define traceAPI_xTaskGetMPUSettings( xTask )
+#ifndef traceENTER_xTaskGetMPUSettings
+    #define traceENTER_xTaskGetMPUSettings( xTask )
 #endif
 
 #ifndef traceRETURN_xTaskGetMPUSettings
     #define traceRETURN_xTaskGetMPUSettings( xMPUSettings )
 #endif
 
-#ifndef traceAPI_xStreamBufferGenericCreate
-    #define traceAPI_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
+#ifndef traceENTER_xStreamBufferGenericCreate
+    #define traceENTER_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
 #endif
 
 #ifndef traceRETURN_xStreamBufferGenericCreate
     #define traceRETURN_xStreamBufferGenericCreate( pvAllocatedMemory )
 #endif
 
-#ifndef traceAPI_xStreamBufferGenericCreateStatic
-    #define traceAPI_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
+#ifndef traceENTER_xStreamBufferGenericCreateStatic
+    #define traceENTER_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback )
 #endif
 
 #ifndef traceRETURN_xStreamBufferGenericCreateStatic
     #define traceRETURN_xStreamBufferGenericCreateStatic( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferGetStaticBuffers
-    #define traceAPI_xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer )
+#ifndef traceENTER_xStreamBufferGetStaticBuffers
+    #define traceENTER_xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferGetStaticBuffers
     #define traceRETURN_xStreamBufferGetStaticBuffers( xReturn )
 #endif
 
-#ifndef traceAPI_vStreamBufferDelete
-    #define traceAPI_vStreamBufferDelete( xStreamBuffer )
+#ifndef traceENTER_vStreamBufferDelete
+    #define traceENTER_vStreamBufferDelete( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_vStreamBufferDelete
     #define traceRETURN_vStreamBufferDelete()
 #endif
 
-#ifndef traceAPI_xStreamBufferReset
-    #define traceAPI_xStreamBufferReset( xStreamBuffer )
+#ifndef traceENTER_xStreamBufferReset
+    #define traceENTER_xStreamBufferReset( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReset
     #define traceRETURN_xStreamBufferReset( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferSetTriggerLevel
-    #define traceAPI_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel )
+#ifndef traceENTER_xStreamBufferSetTriggerLevel
+    #define traceENTER_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel )
 #endif
 
 #ifndef traceRETURN_xStreamBufferSetTriggerLevel
     #define traceRETURN_xStreamBufferSetTriggerLevel( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferSpacesAvailable
-    #define traceAPI_xStreamBufferSpacesAvailable( xStreamBuffer )
+#ifndef traceENTER_xStreamBufferSpacesAvailable
+    #define traceENTER_xStreamBufferSpacesAvailable( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferSpacesAvailable
     #define traceRETURN_xStreamBufferSpacesAvailable( xSpace )
 #endif
 
-#ifndef traceAPI_xStreamBufferBytesAvailable
-    #define traceAPI_xStreamBufferBytesAvailable( xStreamBuffer )
+#ifndef traceENTER_xStreamBufferBytesAvailable
+    #define traceENTER_xStreamBufferBytesAvailable( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferBytesAvailable
     #define traceRETURN_xStreamBufferBytesAvailable( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferSend
-    #define traceAPI_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait )
+#ifndef traceENTER_xStreamBufferSend
+    #define traceENTER_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xStreamBufferSend
     #define traceRETURN_xStreamBufferSend( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferSendFromISR
-    #define traceAPI_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xStreamBufferSendFromISR
+    #define traceENTER_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xStreamBufferSendFromISR
     #define traceRETURN_xStreamBufferSendFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferReceive
-    #define traceAPI_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait )
+#ifndef traceENTER_xStreamBufferReceive
+    #define traceENTER_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReceive
     #define traceRETURN_xStreamBufferReceive( xReceivedLength )
 #endif
 
-#ifndef traceAPI_xStreamBufferNextMessageLengthBytes
-    #define traceAPI_xStreamBufferNextMessageLengthBytes( xStreamBuffer )
+#ifndef traceENTER_xStreamBufferNextMessageLengthBytes
+    #define traceENTER_xStreamBufferNextMessageLengthBytes( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferNextMessageLengthBytes
     #define traceRETURN_xStreamBufferNextMessageLengthBytes( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferReceiveFromISR
-    #define traceAPI_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xStreamBufferReceiveFromISR
+    #define traceENTER_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReceiveFromISR
     #define traceRETURN_xStreamBufferReceiveFromISR( xReceivedLength )
 #endif
 
-#ifndef traceAPI_xStreamBufferIsEmpty
-    #define traceAPI_xStreamBufferIsEmpty( xStreamBuffer )
+#ifndef traceENTER_xStreamBufferIsEmpty
+    #define traceENTER_xStreamBufferIsEmpty( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferIsEmpty
     #define traceRETURN_xStreamBufferIsEmpty( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferIsFull
-    #define traceAPI_xStreamBufferIsFull( xStreamBuffer )
+#ifndef traceENTER_xStreamBufferIsFull
+    #define traceENTER_xStreamBufferIsFull( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_xStreamBufferIsFull
     #define traceRETURN_xStreamBufferIsFull( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferSendCompletedFromISR
-    #define traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xStreamBufferSendCompletedFromISR
+    #define traceENTER_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xStreamBufferSendCompletedFromISR
     #define traceRETURN_xStreamBufferSendCompletedFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_xStreamBufferReceiveCompletedFromISR
-    #define traceAPI_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
+#ifndef traceENTER_xStreamBufferReceiveCompletedFromISR
+    #define traceENTER_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken )
 #endif
 
 #ifndef traceRETURN_xStreamBufferReceiveCompletedFromISR
     #define traceRETURN_xStreamBufferReceiveCompletedFromISR( xReturn )
 #endif
 
-#ifndef traceAPI_uxStreamBufferGetStreamBufferNumber
-    #define traceAPI_uxStreamBufferGetStreamBufferNumber( xStreamBuffer )
+#ifndef traceENTER_uxStreamBufferGetStreamBufferNumber
+    #define traceENTER_uxStreamBufferGetStreamBufferNumber( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_uxStreamBufferGetStreamBufferNumber
     #define traceRETURN_uxStreamBufferGetStreamBufferNumber( uxStreamBufferNumber )
 #endif
 
-#ifndef traceAPI_vStreamBufferSetStreamBufferNumber
-    #define traceAPI_vStreamBufferSetStreamBufferNumber( xStreamBuffer, uxStreamBufferNumber )
+#ifndef traceENTER_vStreamBufferSetStreamBufferNumber
+    #define traceENTER_vStreamBufferSetStreamBufferNumber( xStreamBuffer, uxStreamBufferNumber )
 #endif
 
 #ifndef traceRETURN_vStreamBufferSetStreamBufferNumber
     #define traceRETURN_vStreamBufferSetStreamBufferNumber()
 #endif
 
-#ifndef traceAPI_ucStreamBufferGetStreamBufferType
-    #define traceAPI_ucStreamBufferGetStreamBufferType( xStreamBuffer )
+#ifndef traceENTER_ucStreamBufferGetStreamBufferType
+    #define traceENTER_ucStreamBufferGetStreamBufferType( xStreamBuffer )
 #endif
 
 #ifndef traceRETURN_ucStreamBufferGetStreamBufferType
     #define traceRETURN_ucStreamBufferGetStreamBufferType( ucStreamBufferType )
 #endif
 
-#ifndef traceAPI_vListInitialise
-    #define traceAPI_vListInitialise( pxList )
+#ifndef traceENTER_vListInitialise
+    #define traceENTER_vListInitialise( pxList )
 #endif
 
 #ifndef traceRETURN_vListInitialise
     #define traceRETURN_vListInitialise()
 #endif
 
-#ifndef traceAPI_vListInitialiseItem
-    #define traceAPI_vListInitialiseItem( pxItem )
+#ifndef traceENTER_vListInitialiseItem
+    #define traceENTER_vListInitialiseItem( pxItem )
 #endif
 
 #ifndef traceRETURN_vListInitialiseItem
     #define traceRETURN_vListInitialiseItem()
 #endif
 
-#ifndef traceAPI_vListInsertEnd
-    #define traceAPI_vListInsertEnd( pxList, pxNewListItem )
+#ifndef traceENTER_vListInsertEnd
+    #define traceENTER_vListInsertEnd( pxList, pxNewListItem )
 #endif
 
 #ifndef traceRETURN_vListInsertEnd
     #define traceRETURN_vListInsertEnd()
 #endif
 
-#ifndef traceAPI_vListInsert
-    #define traceAPI_vListInsert( pxList, pxNewListItem )
+#ifndef traceENTER_vListInsert
+    #define traceENTER_vListInsert( pxList, pxNewListItem )
 #endif
 
 #ifndef traceRETURN_vListInsert
     #define traceRETURN_vListInsert()
 #endif
 
-#ifndef traceAPI_uxListRemove
-    #define traceAPI_uxListRemove( pxItemToRemove )
+#ifndef traceENTER_uxListRemove
+    #define traceENTER_uxListRemove( pxItemToRemove )
 #endif
 
 #ifndef traceRETURN_uxListRemove
     #define traceRETURN_uxListRemove( uxNumberOfItems )
 #endif
 
-#ifndef traceAPI_xCoRoutineCreate
-    #define traceAPI_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex )
+#ifndef traceENTER_xCoRoutineCreate
+    #define traceENTER_xCoRoutineCreate( pxCoRoutineCode, uxPriority, uxIndex )
 #endif
 
 #ifndef traceRETURN_xCoRoutineCreate
     #define traceRETURN_xCoRoutineCreate( xReturn )
 #endif
 
-#ifndef traceAPI_vCoRoutineAddToDelayedList
-    #define traceAPI_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList )
+#ifndef traceENTER_vCoRoutineAddToDelayedList
+    #define traceENTER_vCoRoutineAddToDelayedList( xTicksToDelay, pxEventList )
 #endif
 
 #ifndef traceRETURN_vCoRoutineAddToDelayedList
     #define traceRETURN_vCoRoutineAddToDelayedList()
 #endif
 
-#ifndef traceAPI_vCoRoutineSchedule
-    #define traceAPI_vCoRoutineSchedule()
+#ifndef traceENTER_vCoRoutineSchedule
+    #define traceENTER_vCoRoutineSchedule()
 #endif
 
 #ifndef traceRETURN_vCoRoutineSchedule
     #define traceRETURN_vCoRoutineSchedule()
 #endif
 
-#ifndef traceAPI_xCoRoutineRemoveFromEventList
-    #define traceAPI_xCoRoutineRemoveFromEventList( pxEventList )
+#ifndef traceENTER_xCoRoutineRemoveFromEventList
+    #define traceENTER_xCoRoutineRemoveFromEventList( pxEventList )
 #endif
 
 #ifndef traceRETURN_xCoRoutineRemoveFromEventList

--- a/list.c
+++ b/list.c
@@ -242,6 +242,7 @@ UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
     ( pxList->uxNumberOfItems )--;
 
     traceRETURN_uxListRemove( pxList->uxNumberOfItems );
+
     return pxList->uxNumberOfItems;
 }
 /*-----------------------------------------------------------*/

--- a/list.c
+++ b/list.c
@@ -214,11 +214,13 @@ void vListInsert( List_t * const pxList,
 
 UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
 {
+    /* The list item knows which list it is in.  Obtain the list from the list
+     * item. */
+    List_t * const pxList = pxItemToRemove->pxContainer;
+
     traceAPI_uxListRemove( pxItemToRemove );
 
-/* The list item knows which list it is in.  Obtain the list from the list
- * item. */
-    List_t * const pxList = pxItemToRemove->pxContainer;
+
 
     pxItemToRemove->pxNext->pxPrevious = pxItemToRemove->pxPrevious;
     pxItemToRemove->pxPrevious->pxNext = pxItemToRemove->pxNext;

--- a/list.c
+++ b/list.c
@@ -49,7 +49,7 @@
 
 void vListInitialise( List_t * const pxList )
 {
-    traceAPI_vListInitialise( pxList );
+    traceENTER_vListInitialise( pxList );
 
     /* The list structure contains a list item which is used to mark the
      * end of the list.  To initialise the list the list end is inserted
@@ -89,7 +89,7 @@ void vListInitialise( List_t * const pxList )
 
 void vListInitialiseItem( ListItem_t * const pxItem )
 {
-    traceAPI_vListInitialiseItem( pxItem );
+    traceENTER_vListInitialiseItem( pxItem );
 
     /* Make sure the list item is not recorded as being on a list. */
     pxItem->pxContainer = NULL;
@@ -108,7 +108,7 @@ void vListInsertEnd( List_t * const pxList,
 {
     ListItem_t * const pxIndex = pxList->pxIndex;
 
-    traceAPI_vListInsertEnd( pxList, pxNewListItem );
+    traceENTER_vListInsertEnd( pxList, pxNewListItem );
 
     /* Only effective when configASSERT() is also defined, these tests may catch
      * the list data structures being overwritten in memory.  They will not catch
@@ -143,7 +143,7 @@ void vListInsert( List_t * const pxList,
     ListItem_t * pxIterator;
     const TickType_t xValueOfInsertion = pxNewListItem->xItemValue;
 
-    traceAPI_vListInsert( pxList, pxNewListItem );
+    traceENTER_vListInsert( pxList, pxNewListItem );
 
     /* Only effective when configASSERT() is also defined, these tests may catch
      * the list data structures being overwritten in memory.  They will not catch
@@ -218,7 +218,7 @@ UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
      * item. */
     List_t * const pxList = pxItemToRemove->pxContainer;
 
-    traceAPI_uxListRemove( pxItemToRemove );
+    traceENTER_uxListRemove( pxItemToRemove );
 
 
 

--- a/list.c
+++ b/list.c
@@ -49,6 +49,8 @@
 
 void vListInitialise( List_t * const pxList )
 {
+    traceAPI_vListInitialise( pxList );
+
     /* The list structure contains a list item which is used to mark the
      * end of the list.  To initialise the list the list end is inserted
      * as the only list entry. */
@@ -80,11 +82,15 @@ void vListInitialise( List_t * const pxList )
      * configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
     listSET_LIST_INTEGRITY_CHECK_1_VALUE( pxList );
     listSET_LIST_INTEGRITY_CHECK_2_VALUE( pxList );
+
+    traceRETURN_vListInitialise();
 }
 /*-----------------------------------------------------------*/
 
 void vListInitialiseItem( ListItem_t * const pxItem )
 {
+    traceAPI_vListInitialiseItem( pxItem );
+
     /* Make sure the list item is not recorded as being on a list. */
     pxItem->pxContainer = NULL;
 
@@ -92,6 +98,8 @@ void vListInitialiseItem( ListItem_t * const pxItem )
      * configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
     listSET_FIRST_LIST_ITEM_INTEGRITY_CHECK_VALUE( pxItem );
     listSET_SECOND_LIST_ITEM_INTEGRITY_CHECK_VALUE( pxItem );
+
+    traceRETURN_vListInitialiseItem();
 }
 /*-----------------------------------------------------------*/
 
@@ -99,6 +107,8 @@ void vListInsertEnd( List_t * const pxList,
                      ListItem_t * const pxNewListItem )
 {
     ListItem_t * const pxIndex = pxList->pxIndex;
+
+    traceAPI_vListInsertEnd( pxList, pxNewListItem );
 
     /* Only effective when configASSERT() is also defined, these tests may catch
      * the list data structures being overwritten in memory.  They will not catch
@@ -122,6 +132,8 @@ void vListInsertEnd( List_t * const pxList,
     pxNewListItem->pxContainer = pxList;
 
     ( pxList->uxNumberOfItems )++;
+
+    traceRETURN_vListInsertEnd();
 }
 /*-----------------------------------------------------------*/
 
@@ -130,6 +142,8 @@ void vListInsert( List_t * const pxList,
 {
     ListItem_t * pxIterator;
     const TickType_t xValueOfInsertion = pxNewListItem->xItemValue;
+
+    traceAPI_vListInsert( pxList, pxNewListItem );
 
     /* Only effective when configASSERT() is also defined, these tests may catch
      * the list data structures being overwritten in memory.  They will not catch
@@ -193,11 +207,15 @@ void vListInsert( List_t * const pxList,
     pxNewListItem->pxContainer = pxList;
 
     ( pxList->uxNumberOfItems )++;
+
+    traceRETURN_vListInsert();
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
 {
+    traceAPI_uxListRemove( pxItemToRemove );
+
 /* The list item knows which list it is in.  Obtain the list from the list
  * item. */
     List_t * const pxList = pxItemToRemove->pxContainer;
@@ -221,6 +239,7 @@ UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
     pxItemToRemove->pxContainer = NULL;
     ( pxList->uxNumberOfItems )--;
 
+    traceRETURN_uxListRemove( pxList->uxNumberOfItems );
     return pxList->uxNumberOfItems;
 }
 /*-----------------------------------------------------------*/

--- a/queue.c
+++ b/queue.c
@@ -303,7 +303,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     BaseType_t xReturn = pdPASS;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueGenericReset( xQueue, xNewQueue );
+    traceENTER_xQueueGenericReset( xQueue, xNewQueue );
 
     configASSERT( pxQueue );
 
@@ -378,7 +378,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     {
         Queue_t * pxNewQueue = NULL;
 
-        traceAPI_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType );
+        traceENTER_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType );
 
         /* The StaticQueue_t structure and the queue storage area must be
          * supplied. */
@@ -444,7 +444,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
 
-        traceAPI_xQueueGenericGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue );
+        traceENTER_xQueueGenericGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue );
 
         configASSERT( pxQueue );
         configASSERT( ppxStaticQueue );
@@ -498,7 +498,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         size_t xQueueSizeInBytes;
         uint8_t * pucQueueStorage;
 
-        traceAPI_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
+        traceENTER_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
 
         if( ( uxQueueLength > ( UBaseType_t ) 0 ) &&
             /* Check for multiplication overflow. */
@@ -643,7 +643,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         QueueHandle_t xNewQueue;
         const UBaseType_t uxMutexLength = ( UBaseType_t ) 1, uxMutexSize = ( UBaseType_t ) 0;
 
-        traceAPI_xQueueCreateMutex( ucQueueType );
+        traceENTER_xQueueCreateMutex( ucQueueType );
 
         xNewQueue = xQueueGenericCreate( uxMutexLength, uxMutexSize, ucQueueType );
         prvInitialiseMutex( ( Queue_t * ) xNewQueue );
@@ -664,7 +664,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         QueueHandle_t xNewQueue;
         const UBaseType_t uxMutexLength = ( UBaseType_t ) 1, uxMutexSize = ( UBaseType_t ) 0;
 
-        traceAPI_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue );
+        traceENTER_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue );
 
         /* Prevent compiler warnings about unused parameters if
          * configUSE_TRACE_FACILITY does not equal 1. */
@@ -688,7 +688,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         TaskHandle_t pxReturn;
         Queue_t * const pxSemaphore = ( Queue_t * ) xSemaphore;
 
-        traceAPI_xQueueGetMutexHolder( xSemaphore );
+        traceENTER_xQueueGetMutexHolder( xSemaphore );
 
         configASSERT( xSemaphore );
 
@@ -724,7 +724,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
     {
         TaskHandle_t pxReturn;
 
-        traceAPI_xQueueGetMutexHolderFromISR( xSemaphore );
+        traceENTER_xQueueGetMutexHolderFromISR( xSemaphore );
 
         configASSERT( xSemaphore );
 
@@ -755,7 +755,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         BaseType_t xReturn;
         Queue_t * const pxMutex = ( Queue_t * ) xMutex;
 
-        traceAPI_xQueueGiveMutexRecursive( xMutex );
+        traceENTER_xQueueGiveMutexRecursive( xMutex );
 
         configASSERT( pxMutex );
 
@@ -815,7 +815,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         BaseType_t xReturn;
         Queue_t * const pxMutex = ( Queue_t * ) xMutex;
 
-        traceAPI_xQueueTakeMutexRecursive( xMutex, xTicksToWait );
+        traceENTER_xQueueTakeMutexRecursive( xMutex, xTicksToWait );
 
         configASSERT( pxMutex );
 
@@ -862,7 +862,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
     {
         QueueHandle_t xHandle = NULL;
 
-        traceAPI_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue );
+        traceENTER_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue );
 
         if( ( uxMaxCount != 0 ) &&
             ( uxInitialCount <= uxMaxCount ) )
@@ -901,7 +901,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
     {
         QueueHandle_t xHandle = NULL;
 
-        traceAPI_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount );
+        traceENTER_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount );
 
         if( ( uxMaxCount != 0 ) &&
             ( uxInitialCount <= uxMaxCount ) )
@@ -942,7 +942,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
     TimeOut_t xTimeOut;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
+    traceENTER_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -1171,7 +1171,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition );
+    traceENTER_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -1338,7 +1338,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken );
+    traceENTER_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken );
 
     /* Similar to xQueueGenericSendFromISR() but used with semaphores where the
      * item size is 0.  Don't directly wake a task that was blocked on a queue
@@ -1509,7 +1509,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
     TimeOut_t xTimeOut;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueReceive( xQueue, pvBuffer, xTicksToWait );
+    traceENTER_xQueueReceive( xQueue, pvBuffer, xTicksToWait );
 
     /* Check the pointer is not NULL. */
     configASSERT( ( pxQueue ) );
@@ -1673,7 +1673,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
         BaseType_t xInheritanceOccurred = pdFALSE;
     #endif
 
-    traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait );
+    traceENTER_xQueueSemaphoreTake( xQueue, xTicksToWait );
 
     /* Check the queue pointer is not NULL. */
     configASSERT( ( pxQueue ) );
@@ -1899,7 +1899,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
     int8_t * pcOriginalReadPosition;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueuePeek( xQueue, pvBuffer, xTicksToWait );
+    traceENTER_xQueuePeek( xQueue, pvBuffer, xTicksToWait );
 
     /* Check the pointer is not NULL. */
     configASSERT( ( pxQueue ) );
@@ -2067,7 +2067,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken );
+    traceENTER_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvBuffer == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -2164,7 +2164,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
     int8_t * pcOriginalReadPosition;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueuePeekFromISR( xQueue, pvBuffer );
+    traceENTER_xQueuePeekFromISR( xQueue, pvBuffer );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvBuffer == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -2219,7 +2219,7 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
 {
     UBaseType_t uxReturn;
 
-    traceAPI_uxQueueMessagesWaiting( xQueue );
+    traceENTER_uxQueueMessagesWaiting( xQueue );
 
     configASSERT( xQueue );
 
@@ -2240,7 +2240,7 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
     UBaseType_t uxReturn;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_uxQueueSpacesAvailable( xQueue );
+    traceENTER_uxQueueSpacesAvailable( xQueue );
 
     configASSERT( pxQueue );
 
@@ -2261,7 +2261,7 @@ UBaseType_t uxQueueMessagesWaitingFromISR( const QueueHandle_t xQueue )
     UBaseType_t uxReturn;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_uxQueueMessagesWaitingFromISR( xQueue );
+    traceENTER_uxQueueMessagesWaitingFromISR( xQueue );
 
     configASSERT( pxQueue );
     uxReturn = pxQueue->uxMessagesWaiting;
@@ -2276,7 +2276,7 @@ void vQueueDelete( QueueHandle_t xQueue )
 {
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_vQueueDelete( xQueue );
+    traceENTER_vQueueDelete( xQueue );
 
     configASSERT( pxQueue );
     traceQUEUE_DELETE( pxQueue );
@@ -2322,7 +2322,7 @@ void vQueueDelete( QueueHandle_t xQueue )
 
     UBaseType_t uxQueueGetQueueNumber( QueueHandle_t xQueue )
     {
-        traceAPI_uxQueueGetQueueNumber( xQueue );
+        traceENTER_uxQueueGetQueueNumber( xQueue );
 
         traceRETURN_uxQueueGetQueueNumber( ( ( Queue_t * ) xQueue )->uxQueueNumber );
 
@@ -2337,7 +2337,7 @@ void vQueueDelete( QueueHandle_t xQueue )
     void vQueueSetQueueNumber( QueueHandle_t xQueue,
                                UBaseType_t uxQueueNumber )
     {
-        traceAPI_vQueueSetQueueNumber( xQueue, uxQueueNumber );
+        traceENTER_vQueueSetQueueNumber( xQueue, uxQueueNumber );
 
         ( ( Queue_t * ) xQueue )->uxQueueNumber = uxQueueNumber;
 
@@ -2351,7 +2351,7 @@ void vQueueDelete( QueueHandle_t xQueue )
 
     uint8_t ucQueueGetQueueType( QueueHandle_t xQueue )
     {
-        traceAPI_ucQueueGetQueueType( xQueue );
+        traceENTER_ucQueueGetQueueType( xQueue );
 
         traceRETURN_ucQueueGetQueueType( ( ( Queue_t * ) xQueue )->ucQueueType );
 
@@ -2363,7 +2363,7 @@ void vQueueDelete( QueueHandle_t xQueue )
 
 UBaseType_t uxQueueGetQueueItemSize( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTION */
 {
-    traceAPI_uxQueueGetQueueItemSize( xQueue );
+    traceENTER_uxQueueGetQueueItemSize( xQueue );
 
     traceRETURN_uxQueueGetQueueItemSize( ( ( Queue_t * ) xQueue )->uxItemSize );
 
@@ -2373,7 +2373,7 @@ UBaseType_t uxQueueGetQueueItemSize( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTI
 
 UBaseType_t uxQueueGetQueueLength( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTION */
 {
-    traceAPI_uxQueueGetQueueLength( xQueue );
+    traceENTER_uxQueueGetQueueLength( xQueue );
 
     traceRETURN_uxQueueGetQueueLength( ( ( Queue_t * ) xQueue )->uxLength );
 
@@ -2658,7 +2658,7 @@ BaseType_t xQueueIsQueueEmptyFromISR( const QueueHandle_t xQueue )
     BaseType_t xReturn;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueIsQueueEmptyFromISR( xQueue );
+    traceENTER_xQueueIsQueueEmptyFromISR( xQueue );
 
     configASSERT( pxQueue );
 
@@ -2703,7 +2703,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     BaseType_t xReturn;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueIsQueueFullFromISR( xQueue );
+    traceENTER_xQueueIsQueueFullFromISR( xQueue );
 
     configASSERT( pxQueue );
 
@@ -2731,7 +2731,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
 
-        traceAPI_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait );
+        traceENTER_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait );
 
         /* If the queue is already full we may have to block.  A critical section
          * is required to prevent an interrupt removing something from the queue
@@ -2814,7 +2814,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
 
-        traceAPI_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait );
+        traceENTER_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait );
 
         /* If the queue is already empty we may have to block.  A critical section
          * is required to prevent an interrupt adding something to the queue
@@ -2911,7 +2911,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         Queue_t * const pxQueue = xQueue;
 
-        traceAPI_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken );
+        traceENTER_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken );
 
         /* Cannot block within an ISR so if there is no space on the queue then
          * exit without doing anything. */
@@ -2966,7 +2966,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
 
-        traceAPI_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken );
+        traceENTER_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken );
 
         /* We cannot block from an ISR, so check there is data available. If
          * not then just leave without doing anything. */
@@ -3033,7 +3033,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         UBaseType_t ux;
         QueueRegistryItem_t * pxEntryToWrite = NULL;
 
-        traceAPI_vQueueAddToRegistry( xQueue, pcQueueName );
+        traceENTER_vQueueAddToRegistry( xQueue, pcQueueName );
 
         configASSERT( xQueue );
 
@@ -3083,7 +3083,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         UBaseType_t ux;
         const char * pcReturn = NULL; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
 
-        traceAPI_pcQueueGetName( xQueue );
+        traceENTER_pcQueueGetName( xQueue );
 
         configASSERT( xQueue );
 
@@ -3117,7 +3117,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         UBaseType_t ux;
 
-        traceAPI_vQueueUnregisterQueue( xQueue );
+        traceENTER_vQueueUnregisterQueue( xQueue );
 
         configASSERT( xQueue );
 
@@ -3156,7 +3156,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         Queue_t * const pxQueue = xQueue;
 
-        traceAPI_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely );
+        traceENTER_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely );
 
         /* This function should not be called by application code hence the
          * 'Restricted' in its name.  It is not part of the public API.  It is
@@ -3198,7 +3198,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         QueueSetHandle_t pxQueue;
 
-        traceAPI_xQueueCreateSet( uxEventQueueLength );
+        traceENTER_xQueueCreateSet( uxEventQueueLength );
 
         pxQueue = xQueueGenericCreate( uxEventQueueLength, ( UBaseType_t ) sizeof( Queue_t * ), queueQUEUE_TYPE_SET );
 
@@ -3217,7 +3217,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         BaseType_t xReturn;
 
-        traceAPI_xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
+        traceENTER_xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
 
         taskENTER_CRITICAL();
         {
@@ -3256,7 +3256,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         BaseType_t xReturn;
         Queue_t * const pxQueueOrSemaphore = ( Queue_t * ) xQueueOrSemaphore;
 
-        traceAPI_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet );
+        traceENTER_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet );
 
         if( pxQueueOrSemaphore->pxQueueSetContainer != xQueueSet )
         {
@@ -3296,7 +3296,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         QueueSetMemberHandle_t xReturn = NULL;
 
-        traceAPI_xQueueSelectFromSet( xQueueSet, xTicksToWait );
+        traceENTER_xQueueSelectFromSet( xQueueSet, xTicksToWait );
 
         ( void ) xQueueReceive( ( QueueHandle_t ) xQueueSet, &xReturn, xTicksToWait ); /*lint !e961 Casting from one typedef to another is not redundant. */
 
@@ -3314,7 +3314,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         QueueSetMemberHandle_t xReturn = NULL;
 
-        traceAPI_xQueueSelectFromSetFromISR( xQueueSet );
+        traceENTER_xQueueSelectFromSetFromISR( xQueueSet );
 
         ( void ) xQueueReceiveFromISR( ( QueueHandle_t ) xQueueSet, &xReturn, NULL ); /*lint !e961 Casting from one typedef to another is not redundant. */
 

--- a/queue.c
+++ b/queue.c
@@ -363,6 +363,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     /* A value is returned for calling semantic consistency with previous
      * versions. */
     traceRETURN_xQueueGenericReset( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -427,6 +428,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         }
 
         traceRETURN_xQueueGenericCreateStatic( pxNewQueue );
+
         return pxNewQueue;
     }
 
@@ -441,6 +443,8 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     {
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
+
+        traceAPI_xQueueGenericGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue );
 
         configASSERT( pxQueue );
         configASSERT( ppxStaticQueue );
@@ -475,6 +479,8 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
             xReturn = pdTRUE;
         }
         #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+        traceRETURN_xQueueGenericGetStaticBuffers( xReturn );
 
         return xReturn;
     }
@@ -547,6 +553,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         }
 
         traceRETURN_xQueueGenericCreate( pxNewQueue );
+
         return pxNewQueue;
     }
 
@@ -642,6 +649,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         prvInitialiseMutex( ( Queue_t * ) xNewQueue );
 
         traceRETURN_xQueueCreateMutex( xNewQueue );
+
         return xNewQueue;
     }
 
@@ -666,6 +674,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         prvInitialiseMutex( ( Queue_t * ) xNewQueue );
 
         traceRETURN_xQueueCreateMutexStatic( xNewQueue );
+
         return xNewQueue;
     }
 
@@ -702,6 +711,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         taskEXIT_CRITICAL();
 
         traceRETURN_xQueueGetMutexHolder( pxReturn );
+
         return pxReturn;
     } /*lint !e818 xSemaphore cannot be a pointer to const because it is a typedef. */
 
@@ -731,6 +741,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
 
         traceRETURN_xQueueGetMutexHolderFromISR( pxReturn );
+
         return pxReturn;
     } /*lint !e818 xSemaphore cannot be a pointer to const because it is a typedef. */
 
@@ -789,6 +800,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
 
         traceRETURN_xQueueGiveMutexRecursive( xReturn );
+
         return xReturn;
     }
 
@@ -835,6 +847,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
 
         traceRETURN_xQueueTakeMutexRecursive( xReturn );
+
         return xReturn;
     }
 
@@ -874,6 +887,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
 
         traceRETURN_xQueueCreateCountingSemaphoreStatic( xHandle );
+
         return xHandle;
     }
 
@@ -912,6 +926,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
 
         traceRETURN_xQueueCreateCountingSemaphore( xHandle );
+
         return xHandle;
     }
 
@@ -1050,7 +1065,9 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 #endif /* configUSE_QUEUE_SETS */
 
                 taskEXIT_CRITICAL();
+
                 traceRETURN_xQueueGenericSend( pdPASS );
+
                 return pdPASS;
             }
             else
@@ -1065,6 +1082,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                      * the function. */
                     traceQUEUE_SEND_FAILED( pxQueue );
                     traceRETURN_xQueueGenericSend( errQUEUE_FULL );
+
                     return errQUEUE_FULL;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -1137,6 +1155,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
 
             traceQUEUE_SEND_FAILED( pxQueue );
             traceRETURN_xQueueGenericSend( errQUEUE_FULL );
+
             return errQUEUE_FULL;
         }
     } /*lint -restore */
@@ -1307,6 +1326,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xQueueGenericSendFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1476,6 +1496,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xQueueGiveFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1542,7 +1563,9 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 }
 
                 taskEXIT_CRITICAL();
+
                 traceRETURN_xQueueReceive( pdPASS );
+
                 return pdPASS;
             }
             else
@@ -1552,8 +1575,10 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                     /* The queue was empty and no block time is specified (or
                      * the block time has expired) so leave now. */
                     taskEXIT_CRITICAL();
+
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
                     traceRETURN_xQueueReceive( errQUEUE_EMPTY );
+
                     return errQUEUE_EMPTY;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -1625,6 +1650,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
             {
                 traceQUEUE_RECEIVE_FAILED( pxQueue );
                 traceRETURN_xQueueReceive( errQUEUE_EMPTY );
+
                 return errQUEUE_EMPTY;
             }
             else
@@ -1718,7 +1744,9 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 }
 
                 taskEXIT_CRITICAL();
+
                 traceRETURN_xQueueSemaphoreTake( pdPASS );
+
                 return pdPASS;
             }
             else
@@ -1728,8 +1756,10 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                     /* The semaphore count was 0 and no block time is specified
                      * (or the block time has expired) so exit now. */
                     taskEXIT_CRITICAL();
+
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
                     traceRETURN_xQueueSemaphoreTake( errQUEUE_EMPTY );
+
                     return errQUEUE_EMPTY;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -1848,6 +1878,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
 
                 traceQUEUE_RECEIVE_FAILED( pxQueue );
                 traceRETURN_xQueueSemaphoreTake( errQUEUE_EMPTY );
+
                 return errQUEUE_EMPTY;
             }
             else
@@ -1928,7 +1959,9 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                 }
 
                 taskEXIT_CRITICAL();
+
                 traceRETURN_xQueuePeek( pdPASS );
+
                 return pdPASS;
             }
             else
@@ -1938,8 +1971,10 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                     /* The queue was empty and no block time is specified (or
                      * the block time has expired) so leave now. */
                     taskEXIT_CRITICAL();
+
                     traceQUEUE_PEEK_FAILED( pxQueue );
                     traceRETURN_xQueuePeek( errQUEUE_EMPTY );
+
                     return errQUEUE_EMPTY;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -2012,6 +2047,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
             {
                 traceQUEUE_PEEK_FAILED( pxQueue );
                 traceRETURN_xQueuePeek( errQUEUE_EMPTY );
+
                 return errQUEUE_EMPTY;
             }
             else
@@ -2115,6 +2151,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xQueueReceiveFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -2173,6 +2210,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xQueuePeekFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -2192,6 +2230,7 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
     taskEXIT_CRITICAL();
 
     traceRETURN_uxQueueMessagesWaiting( uxReturn );
+
     return uxReturn;
 } /*lint !e818 Pointer cannot be declared const as xQueue is a typedef not pointer. */
 /*-----------------------------------------------------------*/
@@ -2212,6 +2251,7 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
     taskEXIT_CRITICAL();
 
     traceRETURN_uxQueueSpacesAvailable( uxReturn );
+
     return uxReturn;
 } /*lint !e818 Pointer cannot be declared const as xQueue is a typedef not pointer. */
 /*-----------------------------------------------------------*/
@@ -2227,6 +2267,7 @@ UBaseType_t uxQueueMessagesWaitingFromISR( const QueueHandle_t xQueue )
     uxReturn = pxQueue->uxMessagesWaiting;
 
     traceRETURN_uxQueueMessagesWaitingFromISR( uxReturn );
+
     return uxReturn;
 } /*lint !e818 Pointer cannot be declared const as xQueue is a typedef not pointer. */
 /*-----------------------------------------------------------*/
@@ -2282,7 +2323,9 @@ void vQueueDelete( QueueHandle_t xQueue )
     UBaseType_t uxQueueGetQueueNumber( QueueHandle_t xQueue )
     {
         traceAPI_uxQueueGetQueueNumber( xQueue );
+
         traceRETURN_uxQueueGetQueueNumber( ( ( Queue_t * ) xQueue )->uxQueueNumber );
+
         return ( ( Queue_t * ) xQueue )->uxQueueNumber;
     }
 
@@ -2309,7 +2352,9 @@ void vQueueDelete( QueueHandle_t xQueue )
     uint8_t ucQueueGetQueueType( QueueHandle_t xQueue )
     {
         traceAPI_ucQueueGetQueueType( xQueue );
+
         traceRETURN_ucQueueGetQueueType( ( ( Queue_t * ) xQueue )->ucQueueType );
+
         return ( ( Queue_t * ) xQueue )->ucQueueType;
     }
 
@@ -2318,12 +2363,20 @@ void vQueueDelete( QueueHandle_t xQueue )
 
 UBaseType_t uxQueueGetQueueItemSize( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTION */
 {
+    traceAPI_uxQueueGetQueueItemSize( xQueue );
+
+    traceRETURN_uxQueueGetQueueItemSize( ( ( Queue_t * ) xQueue )->uxItemSize );
+
     return ( ( Queue_t * ) xQueue )->uxItemSize;
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t uxQueueGetQueueLength( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTION */
 {
+    traceAPI_uxQueueGetQueueLength( xQueue );
+
+    traceRETURN_uxQueueGetQueueLength( ( ( Queue_t * ) xQueue )->uxLength );
+
     return ( ( Queue_t * ) xQueue )->uxLength;
 }
 /*-----------------------------------------------------------*/
@@ -2619,6 +2672,7 @@ BaseType_t xQueueIsQueueEmptyFromISR( const QueueHandle_t xQueue )
     }
 
     traceRETURN_xQueueIsQueueEmptyFromISR( xReturn );
+
     return xReturn;
 } /*lint !e818 xQueue could not be pointer to const because it is a typedef. */
 /*-----------------------------------------------------------*/
@@ -2663,6 +2717,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     }
 
     traceRETURN_xQueueIsQueueFullFromISR( xReturn );
+
     return xReturn;
 } /*lint !e818 xQueue could not be pointer to const because it is a typedef. */
 /*-----------------------------------------------------------*/
@@ -2743,6 +2798,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         portENABLE_INTERRUPTS();
 
         traceRETURN_xQueueCRSend( xReturn );
+
         return xReturn;
     }
 
@@ -2840,6 +2896,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         portENABLE_INTERRUPTS();
 
         traceRETURN_xQueueCRReceive( xReturn );
+
         return xReturn;
     }
 
@@ -2893,6 +2950,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
 
         traceRETURN_xQueueCRSendFromISR( xCoRoutinePreviouslyWoken );
+
         return xCoRoutinePreviouslyWoken;
     }
 
@@ -2960,6 +3018,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
 
         traceRETURN_xQueueCRReceiveFromISR( xReturn );
+
         return xReturn;
     }
 
@@ -3045,6 +3104,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
 
         traceRETURN_pcQueueGetName( pcReturn );
+
         return pcReturn;
     } /*lint !e818 xQueue cannot be a pointer to const because it is a typedef. */
 
@@ -3143,6 +3203,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         pxQueue = xQueueGenericCreate( uxEventQueueLength, ( UBaseType_t ) sizeof( Queue_t * ), queueQUEUE_TYPE_SET );
 
         traceRETURN_xQueueCreateSet( pxQueue );
+
         return pxQueue;
     }
 
@@ -3180,6 +3241,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         taskEXIT_CRITICAL();
 
         traceRETURN_xQueueAddToSet( xReturn );
+
         return xReturn;
     }
 
@@ -3220,6 +3282,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
 
         traceRETURN_xQueueRemoveFromSet( xReturn );
+
         return xReturn;
     } /*lint !e818 xQueueSet could not be declared as pointing to const as it is a typedef. */
 
@@ -3234,8 +3297,11 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         QueueSetMemberHandle_t xReturn = NULL;
 
         traceAPI_xQueueSelectFromSet( xQueueSet, xTicksToWait );
+
         ( void ) xQueueReceive( ( QueueHandle_t ) xQueueSet, &xReturn, xTicksToWait ); /*lint !e961 Casting from one typedef to another is not redundant. */
+
         traceRETURN_xQueueSelectFromSet( xReturn );
+
         return xReturn;
     }
 
@@ -3249,8 +3315,11 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         QueueSetMemberHandle_t xReturn = NULL;
 
         traceAPI_xQueueSelectFromSetFromISR( xQueueSet );
+
         ( void ) xQueueReceiveFromISR( ( QueueHandle_t ) xQueueSet, &xReturn, NULL ); /*lint !e961 Casting from one typedef to another is not redundant. */
+
         traceRETURN_xQueueSelectFromSetFromISR( xReturn );
+
         return xReturn;
     }
 

--- a/queue.c
+++ b/queue.c
@@ -1643,11 +1643,11 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
     TimeOut_t xTimeOut;
     Queue_t * const pxQueue = xQueue;
 
-    traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait );
-
     #if ( configUSE_MUTEXES == 1 )
         BaseType_t xInheritanceOccurred = pdFALSE;
     #endif
+
+    traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait );
 
     /* Check the queue pointer is not NULL. */
     configASSERT( ( pxQueue ) );

--- a/queue.c
+++ b/queue.c
@@ -303,6 +303,8 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
     BaseType_t xReturn = pdPASS;
     Queue_t * const pxQueue = xQueue;
 
+    traceAPI_xQueueGenericReset( xQueue, xNewQueue );
+
     configASSERT( pxQueue );
 
     if( ( pxQueue != NULL ) &&
@@ -360,6 +362,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
     /* A value is returned for calling semantic consistency with previous
      * versions. */
+    traceRETURN_xQueueGenericReset( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -373,6 +376,8 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
                                              const uint8_t ucQueueType )
     {
         Queue_t * pxNewQueue = NULL;
+
+        traceAPI_xQueueGenericCreateStatic( uxQueueLength, uxItemSize, pucQueueStorage, pxStaticQueue, ucQueueType );
 
         /* The StaticQueue_t structure and the queue storage area must be
          * supplied. */
@@ -421,6 +426,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xQueueGenericCreateStatic( pxNewQueue );
         return pxNewQueue;
     }
 
@@ -486,6 +492,8 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         size_t xQueueSizeInBytes;
         uint8_t * pucQueueStorage;
 
+        traceAPI_xQueueGenericCreate( uxQueueLength, uxItemSize, ucQueueType );
+
         if( ( uxQueueLength > ( UBaseType_t ) 0 ) &&
             /* Check for multiplication overflow. */
             ( ( SIZE_MAX / uxQueueLength ) >= uxItemSize ) &&
@@ -538,6 +546,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xQueueGenericCreate( pxNewQueue );
         return pxNewQueue;
     }
 
@@ -627,9 +636,12 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         QueueHandle_t xNewQueue;
         const UBaseType_t uxMutexLength = ( UBaseType_t ) 1, uxMutexSize = ( UBaseType_t ) 0;
 
+        traceAPI_xQueueCreateMutex( ucQueueType );
+
         xNewQueue = xQueueGenericCreate( uxMutexLength, uxMutexSize, ucQueueType );
         prvInitialiseMutex( ( Queue_t * ) xNewQueue );
 
+        traceRETURN_xQueueCreateMutex( xNewQueue );
         return xNewQueue;
     }
 
@@ -644,6 +656,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         QueueHandle_t xNewQueue;
         const UBaseType_t uxMutexLength = ( UBaseType_t ) 1, uxMutexSize = ( UBaseType_t ) 0;
 
+        traceAPI_xQueueCreateMutexStatic( ucQueueType, pxStaticQueue );
+
         /* Prevent compiler warnings about unused parameters if
          * configUSE_TRACE_FACILITY does not equal 1. */
         ( void ) ucQueueType;
@@ -651,6 +665,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         xNewQueue = xQueueGenericCreateStatic( uxMutexLength, uxMutexSize, NULL, pxStaticQueue, ucQueueType );
         prvInitialiseMutex( ( Queue_t * ) xNewQueue );
 
+        traceRETURN_xQueueCreateMutexStatic( xNewQueue );
         return xNewQueue;
     }
 
@@ -663,6 +678,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
     {
         TaskHandle_t pxReturn;
         Queue_t * const pxSemaphore = ( Queue_t * ) xSemaphore;
+
+        traceAPI_xQueueGetMutexHolder( xSemaphore );
 
         configASSERT( xSemaphore );
 
@@ -684,6 +701,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xQueueGetMutexHolder( pxReturn );
         return pxReturn;
     } /*lint !e818 xSemaphore cannot be a pointer to const because it is a typedef. */
 
@@ -695,6 +713,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
     TaskHandle_t xQueueGetMutexHolderFromISR( QueueHandle_t xSemaphore )
     {
         TaskHandle_t pxReturn;
+
+        traceAPI_xQueueGetMutexHolderFromISR( xSemaphore );
 
         configASSERT( xSemaphore );
 
@@ -710,6 +730,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             pxReturn = NULL;
         }
 
+        traceRETURN_xQueueGetMutexHolderFromISR( pxReturn );
         return pxReturn;
     } /*lint !e818 xSemaphore cannot be a pointer to const because it is a typedef. */
 
@@ -722,6 +743,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
     {
         BaseType_t xReturn;
         Queue_t * const pxMutex = ( Queue_t * ) xMutex;
+
+        traceAPI_xQueueGiveMutexRecursive( xMutex );
 
         configASSERT( pxMutex );
 
@@ -765,6 +788,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             traceGIVE_MUTEX_RECURSIVE_FAILED( pxMutex );
         }
 
+        traceRETURN_xQueueGiveMutexRecursive( xReturn );
         return xReturn;
     }
 
@@ -778,6 +802,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
     {
         BaseType_t xReturn;
         Queue_t * const pxMutex = ( Queue_t * ) xMutex;
+
+        traceAPI_xQueueTakeMutexRecursive( xMutex, xTicksToWait );
 
         configASSERT( pxMutex );
 
@@ -808,6 +834,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             }
         }
 
+        traceRETURN_xQueueTakeMutexRecursive( xReturn );
         return xReturn;
     }
 
@@ -821,6 +848,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
                                                        StaticQueue_t * pxStaticQueue )
     {
         QueueHandle_t xHandle = NULL;
+
+        traceAPI_xQueueCreateCountingSemaphoreStatic( uxMaxCount, uxInitialCount, pxStaticQueue );
 
         if( ( uxMaxCount != 0 ) &&
             ( uxInitialCount <= uxMaxCount ) )
@@ -844,6 +873,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xQueueCreateCountingSemaphoreStatic( xHandle );
         return xHandle;
     }
 
@@ -856,6 +886,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
                                                  const UBaseType_t uxInitialCount )
     {
         QueueHandle_t xHandle = NULL;
+
+        traceAPI_xQueueCreateCountingSemaphore( uxMaxCount, uxInitialCount );
 
         if( ( uxMaxCount != 0 ) &&
             ( uxInitialCount <= uxMaxCount ) )
@@ -879,6 +911,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xQueueCreateCountingSemaphore( xHandle );
         return xHandle;
     }
 
@@ -893,6 +926,8 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
     BaseType_t xEntryTimeSet = pdFALSE, xYieldRequired;
     TimeOut_t xTimeOut;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -1015,6 +1050,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 #endif /* configUSE_QUEUE_SETS */
 
                 taskEXIT_CRITICAL();
+                traceRETURN_xQueueGenericSend( pdPASS );
                 return pdPASS;
             }
             else
@@ -1028,6 +1064,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                     /* Return to the original privilege level before exiting
                      * the function. */
                     traceQUEUE_SEND_FAILED( pxQueue );
+                    traceRETURN_xQueueGenericSend( errQUEUE_FULL );
                     return errQUEUE_FULL;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -1099,6 +1136,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
             ( void ) xTaskResumeAll();
 
             traceQUEUE_SEND_FAILED( pxQueue );
+            traceRETURN_xQueueGenericSend( errQUEUE_FULL );
             return errQUEUE_FULL;
         }
     } /*lint -restore */
@@ -1113,6 +1151,8 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
     BaseType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -1266,6 +1306,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
     }
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xQueueGenericSendFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1276,6 +1317,8 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
     BaseType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueueGiveFromISR( xQueue, pxHigherPriorityTaskWoken );
 
     /* Similar to xQueueGenericSendFromISR() but used with semaphores where the
      * item size is 0.  Don't directly wake a task that was blocked on a queue
@@ -1432,6 +1475,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
     }
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xQueueGiveFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1443,6 +1487,8 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
     BaseType_t xEntryTimeSet = pdFALSE;
     TimeOut_t xTimeOut;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueueReceive( xQueue, pvBuffer, xTicksToWait );
 
     /* Check the pointer is not NULL. */
     configASSERT( ( pxQueue ) );
@@ -1496,6 +1542,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 }
 
                 taskEXIT_CRITICAL();
+                traceRETURN_xQueueReceive( pdPASS );
                 return pdPASS;
             }
             else
@@ -1506,6 +1553,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                      * the block time has expired) so leave now. */
                     taskEXIT_CRITICAL();
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
+                    traceRETURN_xQueueReceive( errQUEUE_EMPTY );
                     return errQUEUE_EMPTY;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -1576,6 +1624,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
             if( prvIsQueueEmpty( pxQueue ) != pdFALSE )
             {
                 traceQUEUE_RECEIVE_FAILED( pxQueue );
+                traceRETURN_xQueueReceive( errQUEUE_EMPTY );
                 return errQUEUE_EMPTY;
             }
             else
@@ -1593,6 +1642,8 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
     BaseType_t xEntryTimeSet = pdFALSE;
     TimeOut_t xTimeOut;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueueSemaphoreTake( xQueue, xTicksToWait );
 
     #if ( configUSE_MUTEXES == 1 )
         BaseType_t xInheritanceOccurred = pdFALSE;
@@ -1667,6 +1718,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 }
 
                 taskEXIT_CRITICAL();
+                traceRETURN_xQueueSemaphoreTake( pdPASS );
                 return pdPASS;
             }
             else
@@ -1677,6 +1729,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                      * (or the block time has expired) so exit now. */
                     taskEXIT_CRITICAL();
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
+                    traceRETURN_xQueueSemaphoreTake( errQUEUE_EMPTY );
                     return errQUEUE_EMPTY;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -1794,6 +1847,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 #endif /* configUSE_MUTEXES */
 
                 traceQUEUE_RECEIVE_FAILED( pxQueue );
+                traceRETURN_xQueueSemaphoreTake( errQUEUE_EMPTY );
                 return errQUEUE_EMPTY;
             }
             else
@@ -1813,6 +1867,8 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
     TimeOut_t xTimeOut;
     int8_t * pcOriginalReadPosition;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueuePeek( xQueue, pvBuffer, xTicksToWait );
 
     /* Check the pointer is not NULL. */
     configASSERT( ( pxQueue ) );
@@ -1872,6 +1928,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                 }
 
                 taskEXIT_CRITICAL();
+                traceRETURN_xQueuePeek( pdPASS );
                 return pdPASS;
             }
             else
@@ -1882,6 +1939,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                      * the block time has expired) so leave now. */
                     taskEXIT_CRITICAL();
                     traceQUEUE_PEEK_FAILED( pxQueue );
+                    traceRETURN_xQueuePeek( errQUEUE_EMPTY );
                     return errQUEUE_EMPTY;
                 }
                 else if( xEntryTimeSet == pdFALSE )
@@ -1953,6 +2011,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
             if( prvIsQueueEmpty( pxQueue ) != pdFALSE )
             {
                 traceQUEUE_PEEK_FAILED( pxQueue );
+                traceRETURN_xQueuePeek( errQUEUE_EMPTY );
                 return errQUEUE_EMPTY;
             }
             else
@@ -1971,6 +2030,8 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
     BaseType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvBuffer == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -2053,6 +2114,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
     }
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xQueueReceiveFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -2064,6 +2126,8 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
     UBaseType_t uxSavedInterruptStatus;
     int8_t * pcOriginalReadPosition;
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_xQueuePeekFromISR( xQueue, pvBuffer );
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvBuffer == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
@@ -2108,6 +2172,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
     }
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xQueuePeekFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -2115,6 +2180,8 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
 UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
 {
     UBaseType_t uxReturn;
+
+    traceAPI_uxQueueMessagesWaiting( xQueue );
 
     configASSERT( xQueue );
 
@@ -2124,6 +2191,7 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
     }
     taskEXIT_CRITICAL();
 
+    traceRETURN_uxQueueMessagesWaiting( uxReturn );
     return uxReturn;
 } /*lint !e818 Pointer cannot be declared const as xQueue is a typedef not pointer. */
 /*-----------------------------------------------------------*/
@@ -2133,6 +2201,8 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
     UBaseType_t uxReturn;
     Queue_t * const pxQueue = xQueue;
 
+    traceAPI_uxQueueSpacesAvailable( xQueue );
+
     configASSERT( pxQueue );
 
     taskENTER_CRITICAL();
@@ -2141,6 +2211,7 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
     }
     taskEXIT_CRITICAL();
 
+    traceRETURN_uxQueueSpacesAvailable( uxReturn );
     return uxReturn;
 } /*lint !e818 Pointer cannot be declared const as xQueue is a typedef not pointer. */
 /*-----------------------------------------------------------*/
@@ -2150,9 +2221,12 @@ UBaseType_t uxQueueMessagesWaitingFromISR( const QueueHandle_t xQueue )
     UBaseType_t uxReturn;
     Queue_t * const pxQueue = xQueue;
 
+    traceAPI_uxQueueMessagesWaitingFromISR( xQueue );
+
     configASSERT( pxQueue );
     uxReturn = pxQueue->uxMessagesWaiting;
 
+    traceRETURN_uxQueueMessagesWaitingFromISR( uxReturn );
     return uxReturn;
 } /*lint !e818 Pointer cannot be declared const as xQueue is a typedef not pointer. */
 /*-----------------------------------------------------------*/
@@ -2160,6 +2234,8 @@ UBaseType_t uxQueueMessagesWaitingFromISR( const QueueHandle_t xQueue )
 void vQueueDelete( QueueHandle_t xQueue )
 {
     Queue_t * const pxQueue = xQueue;
+
+    traceAPI_vQueueDelete( xQueue );
 
     configASSERT( pxQueue );
     traceQUEUE_DELETE( pxQueue );
@@ -2196,6 +2272,8 @@ void vQueueDelete( QueueHandle_t xQueue )
         ( void ) pxQueue;
     }
     #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+    traceRETURN_vQueueDelete();
 }
 /*-----------------------------------------------------------*/
 
@@ -2203,6 +2281,8 @@ void vQueueDelete( QueueHandle_t xQueue )
 
     UBaseType_t uxQueueGetQueueNumber( QueueHandle_t xQueue )
     {
+        traceAPI_uxQueueGetQueueNumber( xQueue );
+        traceRETURN_uxQueueGetQueueNumber( ( ( Queue_t * ) xQueue )->uxQueueNumber );
         return ( ( Queue_t * ) xQueue )->uxQueueNumber;
     }
 
@@ -2214,7 +2294,11 @@ void vQueueDelete( QueueHandle_t xQueue )
     void vQueueSetQueueNumber( QueueHandle_t xQueue,
                                UBaseType_t uxQueueNumber )
     {
+        traceAPI_vQueueSetQueueNumber( xQueue, uxQueueNumber );
+
         ( ( Queue_t * ) xQueue )->uxQueueNumber = uxQueueNumber;
+
+        traceRETURN_vQueueSetQueueNumber();
     }
 
 #endif /* configUSE_TRACE_FACILITY */
@@ -2224,6 +2308,8 @@ void vQueueDelete( QueueHandle_t xQueue )
 
     uint8_t ucQueueGetQueueType( QueueHandle_t xQueue )
     {
+        traceAPI_ucQueueGetQueueType( xQueue );
+        traceRETURN_ucQueueGetQueueType( ( ( Queue_t * ) xQueue )->ucQueueType );
         return ( ( Queue_t * ) xQueue )->ucQueueType;
     }
 
@@ -2519,6 +2605,8 @@ BaseType_t xQueueIsQueueEmptyFromISR( const QueueHandle_t xQueue )
     BaseType_t xReturn;
     Queue_t * const pxQueue = xQueue;
 
+    traceAPI_xQueueIsQueueEmptyFromISR( xQueue );
+
     configASSERT( pxQueue );
 
     if( pxQueue->uxMessagesWaiting == ( UBaseType_t ) 0 )
@@ -2530,6 +2618,7 @@ BaseType_t xQueueIsQueueEmptyFromISR( const QueueHandle_t xQueue )
         xReturn = pdFALSE;
     }
 
+    traceRETURN_xQueueIsQueueEmptyFromISR( xReturn );
     return xReturn;
 } /*lint !e818 xQueue could not be pointer to const because it is a typedef. */
 /*-----------------------------------------------------------*/
@@ -2560,6 +2649,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     BaseType_t xReturn;
     Queue_t * const pxQueue = xQueue;
 
+    traceAPI_xQueueIsQueueFullFromISR( xQueue );
+
     configASSERT( pxQueue );
 
     if( pxQueue->uxMessagesWaiting == pxQueue->uxLength )
@@ -2571,6 +2662,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         xReturn = pdFALSE;
     }
 
+    traceRETURN_xQueueIsQueueFullFromISR( xReturn );
     return xReturn;
 } /*lint !e818 xQueue could not be pointer to const because it is a typedef. */
 /*-----------------------------------------------------------*/
@@ -2583,6 +2675,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
+
+        traceAPI_xQueueCRSend( xQueue, pvItemToQueue, xTicksToWait );
 
         /* If the queue is already full we may have to block.  A critical section
          * is required to prevent an interrupt removing something from the queue
@@ -2648,6 +2742,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
         portENABLE_INTERRUPTS();
 
+        traceRETURN_xQueueCRSend( xReturn );
         return xReturn;
     }
 
@@ -2662,6 +2757,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
+
+        traceAPI_xQueueCRReceive( xQueue, pvBuffer, xTicksToWait );
 
         /* If the queue is already empty we may have to block.  A critical section
          * is required to prevent an interrupt adding something to the queue
@@ -2742,6 +2839,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
         portENABLE_INTERRUPTS();
 
+        traceRETURN_xQueueCRReceive( xReturn );
         return xReturn;
     }
 
@@ -2755,6 +2853,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                                     BaseType_t xCoRoutinePreviouslyWoken )
     {
         Queue_t * const pxQueue = xQueue;
+
+        traceAPI_xQueueCRSendFromISR( xQueue, pvItemToQueue, xCoRoutinePreviouslyWoken );
 
         /* Cannot block within an ISR so if there is no space on the queue then
          * exit without doing anything. */
@@ -2792,6 +2892,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xQueueCRSendFromISR( xCoRoutinePreviouslyWoken );
         return xCoRoutinePreviouslyWoken;
     }
 
@@ -2806,6 +2907,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         BaseType_t xReturn;
         Queue_t * const pxQueue = xQueue;
+
+        traceAPI_xQueueCRReceiveFromISR( xQueue, pvBuffer, pxCoRoutineWoken );
 
         /* We cannot block from an ISR, so check there is data available. If
          * not then just leave without doing anything. */
@@ -2856,6 +2959,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             xReturn = pdFAIL;
         }
 
+        traceRETURN_xQueueCRReceiveFromISR( xReturn );
         return xReturn;
     }
 
@@ -2869,6 +2973,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         UBaseType_t ux;
         QueueRegistryItem_t * pxEntryToWrite = NULL;
+
+        traceAPI_vQueueAddToRegistry( xQueue, pcQueueName );
 
         configASSERT( xQueue );
 
@@ -2904,6 +3010,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
             traceQUEUE_REGISTRY_ADD( xQueue, pcQueueName );
         }
+
+        traceRETURN_vQueueAddToRegistry();
     }
 
 #endif /* configQUEUE_REGISTRY_SIZE */
@@ -2915,6 +3023,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         UBaseType_t ux;
         const char * pcReturn = NULL; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+
+        traceAPI_pcQueueGetName( xQueue );
 
         configASSERT( xQueue );
 
@@ -2934,6 +3044,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             }
         }
 
+        traceRETURN_pcQueueGetName( pcReturn );
         return pcReturn;
     } /*lint !e818 xQueue cannot be a pointer to const because it is a typedef. */
 
@@ -2945,6 +3056,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     void vQueueUnregisterQueue( QueueHandle_t xQueue )
     {
         UBaseType_t ux;
+
+        traceAPI_vQueueUnregisterQueue( xQueue );
 
         configASSERT( xQueue );
 
@@ -2968,6 +3081,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
+
+        traceRETURN_vQueueUnregisterQueue();
     } /*lint !e818 xQueue could not be pointer to const because it is a typedef. */
 
 #endif /* configQUEUE_REGISTRY_SIZE */
@@ -2980,6 +3095,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                                          const BaseType_t xWaitIndefinitely )
     {
         Queue_t * const pxQueue = xQueue;
+
+        traceAPI_vQueueWaitForMessageRestricted( xQueue, xTicksToWait, xWaitIndefinitely );
 
         /* This function should not be called by application code hence the
          * 'Restricted' in its name.  It is not part of the public API.  It is
@@ -3008,6 +3125,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
 
         prvUnlockQueue( pxQueue );
+
+        traceRETURN_vQueueWaitForMessageRestricted();
     }
 
 #endif /* configUSE_TIMERS */
@@ -3019,8 +3138,11 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         QueueSetHandle_t pxQueue;
 
+        traceAPI_xQueueCreateSet( uxEventQueueLength );
+
         pxQueue = xQueueGenericCreate( uxEventQueueLength, ( UBaseType_t ) sizeof( Queue_t * ), queueQUEUE_TYPE_SET );
 
+        traceRETURN_xQueueCreateSet( pxQueue );
         return pxQueue;
     }
 
@@ -3033,6 +3155,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                                QueueSetHandle_t xQueueSet )
     {
         BaseType_t xReturn;
+
+        traceAPI_xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
 
         taskENTER_CRITICAL();
         {
@@ -3055,6 +3179,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xQueueAddToSet( xReturn );
         return xReturn;
     }
 
@@ -3068,6 +3193,8 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         BaseType_t xReturn;
         Queue_t * const pxQueueOrSemaphore = ( Queue_t * ) xQueueOrSemaphore;
+
+        traceAPI_xQueueRemoveFromSet( xQueueOrSemaphore, xQueueSet );
 
         if( pxQueueOrSemaphore->pxQueueSetContainer != xQueueSet )
         {
@@ -3092,6 +3219,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             xReturn = pdPASS;
         }
 
+        traceRETURN_xQueueRemoveFromSet( xReturn );
         return xReturn;
     } /*lint !e818 xQueueSet could not be declared as pointing to const as it is a typedef. */
 
@@ -3105,7 +3233,9 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         QueueSetMemberHandle_t xReturn = NULL;
 
+        traceAPI_xQueueSelectFromSet( xQueueSet, xTicksToWait );
         ( void ) xQueueReceive( ( QueueHandle_t ) xQueueSet, &xReturn, xTicksToWait ); /*lint !e961 Casting from one typedef to another is not redundant. */
+        traceRETURN_xQueueSelectFromSet( xReturn );
         return xReturn;
     }
 
@@ -3118,7 +3248,9 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
     {
         QueueSetMemberHandle_t xReturn = NULL;
 
+        traceAPI_xQueueSelectFromSetFromISR( xQueueSet );
         ( void ) xQueueReceiveFromISR( ( QueueHandle_t ) xQueueSet, &xReturn, NULL ); /*lint !e961 Casting from one typedef to another is not redundant. */
+        traceRETURN_xQueueSelectFromSetFromISR( xReturn );
         return xReturn;
     }
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -390,6 +390,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         }
 
         traceRETURN_xStreamBufferGenericCreate( pvAllocatedMemory );
+
         return ( StreamBufferHandle_t ) pvAllocatedMemory; /*lint !e9087 !e826 Safe cast as allocated memory is aligned. */
     }
 #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
@@ -474,6 +475,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         }
 
         traceRETURN_xStreamBufferGenericCreateStatic( xReturn );
+
         return xReturn;
     }
 #endif /* ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
@@ -486,6 +488,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
     {
         BaseType_t xReturn;
         StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
+
+        traceAPI_xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer );
 
         configASSERT( pxStreamBuffer );
         configASSERT( ppucStreamBufferStorageArea );
@@ -501,6 +505,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         {
             xReturn = pdFALSE;
         }
+
+        traceRETURN_xStreamBufferGetStaticBuffers( xReturn );
 
         return xReturn;
     }
@@ -600,6 +606,7 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
     taskEXIT_CRITICAL();
 
     traceRETURN_xStreamBufferReset( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -633,6 +640,7 @@ BaseType_t xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
     }
 
     traceRETURN_xStreamBufferSetTriggerLevel( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -669,6 +677,7 @@ size_t xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer )
     }
 
     traceRETURN_xStreamBufferSpacesAvailable( xSpace );
+
     return xSpace;
 }
 /*-----------------------------------------------------------*/
@@ -683,7 +692,9 @@ size_t xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer )
     configASSERT( pxStreamBuffer );
 
     xReturn = prvBytesInBuffer( pxStreamBuffer );
+
     traceRETURN_xStreamBufferBytesAvailable( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -818,6 +829,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
     }
 
     traceRETURN_xStreamBufferSend( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -871,6 +883,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
 
     traceSTREAM_BUFFER_SEND_FROM_ISR( xStreamBuffer, xReturn );
     traceRETURN_xStreamBufferSendFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1028,6 +1041,7 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
     }
 
     traceRETURN_xStreamBufferReceive( xReceivedLength );
+
     return xReceivedLength;
 }
 /*-----------------------------------------------------------*/
@@ -1071,6 +1085,7 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
     }
 
     traceRETURN_xStreamBufferNextMessageLengthBytes( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1130,6 +1145,7 @@ size_t xStreamBufferReceiveFromISR( StreamBufferHandle_t xStreamBuffer,
 
     traceSTREAM_BUFFER_RECEIVE_FROM_ISR( xStreamBuffer, xReceivedLength );
     traceRETURN_xStreamBufferReceiveFromISR( xReceivedLength );
+
     return xReceivedLength;
 }
 /*-----------------------------------------------------------*/
@@ -1209,6 +1225,7 @@ BaseType_t xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer )
     }
 
     traceRETURN_xStreamBufferIsEmpty( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1247,6 +1264,7 @@ BaseType_t xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer )
     }
 
     traceRETURN_xStreamBufferIsFull( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1281,6 +1299,7 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xStreamBufferSendCompletedFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1315,6 +1334,7 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xStreamBufferReceiveCompletedFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1474,7 +1494,9 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
     UBaseType_t uxStreamBufferGetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer )
     {
         traceAPI_uxStreamBufferGetStreamBufferNumber( xStreamBuffer );
+
         traceRETURN_uxStreamBufferGetStreamBufferNumber( xStreamBuffer->uxStreamBufferNumber );
+
         return xStreamBuffer->uxStreamBufferNumber;
     }
 
@@ -1486,8 +1508,10 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
     void vStreamBufferSetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer,
                                              UBaseType_t uxStreamBufferNumber )
     {
-        traceAPI_vStreamBufferSetStreamBufferNumber();
+        traceAPI_vStreamBufferSetStreamBufferNumber( xStreamBuffer, uxStreamBufferNumber );
+
         xStreamBuffer->uxStreamBufferNumber = uxStreamBufferNumber;
+
         traceRETURN_vStreamBufferSetStreamBufferNumber();
     }
 
@@ -1499,7 +1523,9 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
     uint8_t ucStreamBufferGetStreamBufferType( StreamBufferHandle_t xStreamBuffer )
     {
         traceAPI_ucStreamBufferGetStreamBufferType( xStreamBuffer );
+
         traceRETURN_ucStreamBufferGetStreamBufferType( ( uint8_t ) ( xStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) );
+
         return( ( uint8_t ) ( xStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) );
     }
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -326,7 +326,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         void * pvAllocatedMemory;
         uint8_t ucFlags;
 
-        traceAPI_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback );
+        traceENTER_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback );
 
         /* In case the stream buffer is going to be used as a message buffer
          * (that is, it will hold discrete messages with a little meta data that
@@ -410,7 +410,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         StreamBufferHandle_t xReturn;
         uint8_t ucFlags;
 
-        traceAPI_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback );
+        traceENTER_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback );
 
         configASSERT( pucStreamBufferStorageArea );
         configASSERT( pxStaticStreamBuffer );
@@ -489,7 +489,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         BaseType_t xReturn;
         StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
 
-        traceAPI_xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer );
+        traceENTER_xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer );
 
         configASSERT( pxStreamBuffer );
         configASSERT( ppucStreamBufferStorageArea );
@@ -517,7 +517,7 @@ void vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer )
 {
     StreamBuffer_t * pxStreamBuffer = xStreamBuffer;
 
-    traceAPI_vStreamBufferDelete( xStreamBuffer );
+    traceENTER_vStreamBufferDelete( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -560,7 +560,7 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
         UBaseType_t uxStreamBufferNumber;
     #endif
 
-    traceAPI_xStreamBufferReset( xStreamBuffer );
+    traceENTER_xStreamBufferReset( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -617,7 +617,7 @@ BaseType_t xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     BaseType_t xReturn;
 
-    traceAPI_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
+    traceENTER_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
 
     configASSERT( pxStreamBuffer );
 
@@ -651,7 +651,7 @@ size_t xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer )
     size_t xSpace;
     size_t xOriginalTail;
 
-    traceAPI_xStreamBufferSpacesAvailable( xStreamBuffer );
+    traceENTER_xStreamBufferSpacesAvailable( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -687,7 +687,7 @@ size_t xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer )
     const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReturn;
 
-    traceAPI_xStreamBufferBytesAvailable( xStreamBuffer );
+    traceENTER_xStreamBufferBytesAvailable( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -710,7 +710,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
     TimeOut_t xTimeOut;
     size_t xMaxReportedSpace = 0;
 
-    traceAPI_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
+    traceENTER_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
 
     configASSERT( pvTxData );
     configASSERT( pxStreamBuffer );
@@ -843,7 +843,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
     size_t xReturn, xSpace;
     size_t xRequiredSpace = xDataLengthBytes;
 
-    traceAPI_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken );
+    traceENTER_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken );
 
     configASSERT( pvTxData );
     configASSERT( pxStreamBuffer );
@@ -946,7 +946,7 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReceivedLength = 0, xBytesAvailable, xBytesToStoreMessageLength;
 
-    traceAPI_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
+    traceENTER_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
 
     configASSERT( pvRxData );
     configASSERT( pxStreamBuffer );
@@ -1052,7 +1052,7 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
     size_t xReturn, xBytesAvailable;
     configMESSAGE_BUFFER_LENGTH_TYPE xTempReturn;
 
-    traceAPI_xStreamBufferNextMessageLengthBytes( xStreamBuffer );
+    traceENTER_xStreamBufferNextMessageLengthBytes( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -1098,7 +1098,7 @@ size_t xStreamBufferReceiveFromISR( StreamBufferHandle_t xStreamBuffer,
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReceivedLength = 0, xBytesAvailable, xBytesToStoreMessageLength;
 
-    traceAPI_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken );
+    traceENTER_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken );
 
     configASSERT( pvRxData );
     configASSERT( pxStreamBuffer );
@@ -1208,7 +1208,7 @@ BaseType_t xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer )
     BaseType_t xReturn;
     size_t xTail;
 
-    traceAPI_xStreamBufferIsEmpty( xStreamBuffer );
+    traceENTER_xStreamBufferIsEmpty( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -1236,7 +1236,7 @@ BaseType_t xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer )
     size_t xBytesToStoreMessageLength;
     const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
 
-    traceAPI_xStreamBufferIsFull( xStreamBuffer );
+    traceENTER_xStreamBufferIsFull( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -1276,7 +1276,7 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
     BaseType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
 
-    traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
+    traceENTER_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
 
     configASSERT( pxStreamBuffer );
 
@@ -1311,7 +1311,7 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
     BaseType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
 
-    traceAPI_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
+    traceENTER_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
 
     configASSERT( pxStreamBuffer );
 
@@ -1493,7 +1493,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
     UBaseType_t uxStreamBufferGetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer )
     {
-        traceAPI_uxStreamBufferGetStreamBufferNumber( xStreamBuffer );
+        traceENTER_uxStreamBufferGetStreamBufferNumber( xStreamBuffer );
 
         traceRETURN_uxStreamBufferGetStreamBufferNumber( xStreamBuffer->uxStreamBufferNumber );
 
@@ -1508,7 +1508,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
     void vStreamBufferSetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer,
                                              UBaseType_t uxStreamBufferNumber )
     {
-        traceAPI_vStreamBufferSetStreamBufferNumber( xStreamBuffer, uxStreamBufferNumber );
+        traceENTER_vStreamBufferSetStreamBufferNumber( xStreamBuffer, uxStreamBufferNumber );
 
         xStreamBuffer->uxStreamBufferNumber = uxStreamBufferNumber;
 
@@ -1522,7 +1522,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
     uint8_t ucStreamBufferGetStreamBufferType( StreamBufferHandle_t xStreamBuffer )
     {
-        traceAPI_ucStreamBufferGetStreamBufferType( xStreamBuffer );
+        traceENTER_ucStreamBufferGetStreamBufferType( xStreamBuffer );
 
         traceRETURN_ucStreamBufferGetStreamBufferType( ( uint8_t ) ( xStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) );
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -326,6 +326,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         void * pvAllocatedMemory;
         uint8_t ucFlags;
 
+        traceAPI_xStreamBufferGenericCreate( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback );
+
         /* In case the stream buffer is going to be used as a message buffer
          * (that is, it will hold discrete messages with a little meta data that
          * says how big the next message is) check the buffer will be large enough
@@ -387,6 +389,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             traceSTREAM_BUFFER_CREATE_FAILED( xIsMessageBuffer );
         }
 
+        traceRETURN_xStreamBufferGenericCreate( pvAllocatedMemory );
         return ( StreamBufferHandle_t ) pvAllocatedMemory; /*lint !e9087 !e826 Safe cast as allocated memory is aligned. */
     }
 #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
@@ -405,6 +408,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         StreamBuffer_t * const pxStreamBuffer = ( StreamBuffer_t * ) pxStaticStreamBuffer; /*lint !e740 !e9087 Safe cast as StaticStreamBuffer_t is opaque Streambuffer_t. */
         StreamBufferHandle_t xReturn;
         uint8_t ucFlags;
+
+        traceAPI_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback );
 
         configASSERT( pucStreamBufferStorageArea );
         configASSERT( pxStaticStreamBuffer );
@@ -468,6 +473,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             traceSTREAM_BUFFER_CREATE_STATIC_FAILED( xReturn, xIsMessageBuffer );
         }
 
+        traceRETURN_xStreamBufferGenericCreateStatic( xReturn );
         return xReturn;
     }
 #endif /* ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
@@ -505,6 +511,8 @@ void vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer )
 {
     StreamBuffer_t * pxStreamBuffer = xStreamBuffer;
 
+    traceAPI_vStreamBufferDelete( xStreamBuffer );
+
     configASSERT( pxStreamBuffer );
 
     traceSTREAM_BUFFER_DELETE( xStreamBuffer );
@@ -531,6 +539,8 @@ void vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer )
          * freed - just scrub the structure so future use will assert. */
         ( void ) memset( pxStreamBuffer, 0x00, sizeof( StreamBuffer_t ) );
     }
+
+    traceRETURN_vStreamBufferDelete();
 }
 /*-----------------------------------------------------------*/
 
@@ -539,6 +549,8 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     BaseType_t xReturn = pdFAIL;
     StreamBufferCallbackFunction_t pxSendCallback = NULL, pxReceiveCallback = NULL;
+
+    traceAPI_xStreamBufferReset( xStreamBuffer );
 
     #if ( configUSE_TRACE_FACILITY == 1 )
         UBaseType_t uxStreamBufferNumber;
@@ -587,6 +599,7 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
     }
     taskEXIT_CRITICAL();
 
+    traceRETURN_xStreamBufferReset( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -596,6 +609,8 @@ BaseType_t xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
 {
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     BaseType_t xReturn;
+
+    traceAPI_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
 
     configASSERT( pxStreamBuffer );
 
@@ -617,6 +632,7 @@ BaseType_t xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
         xReturn = pdFALSE;
     }
 
+    traceRETURN_xStreamBufferSetTriggerLevel( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -626,6 +642,8 @@ size_t xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer )
     const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xSpace;
     size_t xOriginalTail;
+
+    traceAPI_xStreamBufferSpacesAvailable( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -650,6 +668,7 @@ size_t xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer )
         mtCOVERAGE_TEST_MARKER();
     }
 
+    traceRETURN_xStreamBufferSpacesAvailable( xSpace );
     return xSpace;
 }
 /*-----------------------------------------------------------*/
@@ -659,9 +678,12 @@ size_t xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer )
     const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReturn;
 
+    traceAPI_xStreamBufferBytesAvailable( xStreamBuffer );
+
     configASSERT( pxStreamBuffer );
 
     xReturn = prvBytesInBuffer( pxStreamBuffer );
+    traceRETURN_xStreamBufferBytesAvailable( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -676,6 +698,8 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
     size_t xRequiredSpace = xDataLengthBytes;
     TimeOut_t xTimeOut;
     size_t xMaxReportedSpace = 0;
+
+    traceAPI_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
 
     configASSERT( pvTxData );
     configASSERT( pxStreamBuffer );
@@ -793,6 +817,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
         traceSTREAM_BUFFER_SEND_FAILED( xStreamBuffer );
     }
 
+    traceRETURN_xStreamBufferSend( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -805,6 +830,8 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReturn, xSpace;
     size_t xRequiredSpace = xDataLengthBytes;
+
+    traceAPI_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken );
 
     configASSERT( pvTxData );
     configASSERT( pxStreamBuffer );
@@ -843,7 +870,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
     }
 
     traceSTREAM_BUFFER_SEND_FROM_ISR( xStreamBuffer, xReturn );
-
+    traceRETURN_xStreamBufferSendFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -905,6 +932,8 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
 {
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReceivedLength = 0, xBytesAvailable, xBytesToStoreMessageLength;
+
+    traceAPI_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
 
     configASSERT( pvRxData );
     configASSERT( pxStreamBuffer );
@@ -998,6 +1027,7 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
         mtCOVERAGE_TEST_MARKER();
     }
 
+    traceRETURN_xStreamBufferReceive( xReceivedLength );
     return xReceivedLength;
 }
 /*-----------------------------------------------------------*/
@@ -1007,6 +1037,8 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReturn, xBytesAvailable;
     configMESSAGE_BUFFER_LENGTH_TYPE xTempReturn;
+
+    traceAPI_xStreamBufferNextMessageLengthBytes( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -1038,6 +1070,7 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
         xReturn = 0;
     }
 
+    traceRETURN_xStreamBufferNextMessageLengthBytes( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1049,6 +1082,8 @@ size_t xStreamBufferReceiveFromISR( StreamBufferHandle_t xStreamBuffer,
 {
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     size_t xReceivedLength = 0, xBytesAvailable, xBytesToStoreMessageLength;
+
+    traceAPI_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken );
 
     configASSERT( pvRxData );
     configASSERT( pxStreamBuffer );
@@ -1094,7 +1129,7 @@ size_t xStreamBufferReceiveFromISR( StreamBufferHandle_t xStreamBuffer,
     }
 
     traceSTREAM_BUFFER_RECEIVE_FROM_ISR( xStreamBuffer, xReceivedLength );
-
+    traceRETURN_xStreamBufferReceiveFromISR( xReceivedLength );
     return xReceivedLength;
 }
 /*-----------------------------------------------------------*/
@@ -1157,6 +1192,8 @@ BaseType_t xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer )
     BaseType_t xReturn;
     size_t xTail;
 
+    traceAPI_xStreamBufferIsEmpty( xStreamBuffer );
+
     configASSERT( pxStreamBuffer );
 
     /* True if no bytes are available. */
@@ -1171,6 +1208,7 @@ BaseType_t xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer )
         xReturn = pdFALSE;
     }
 
+    traceRETURN_xStreamBufferIsEmpty( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1180,6 +1218,8 @@ BaseType_t xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer )
     BaseType_t xReturn;
     size_t xBytesToStoreMessageLength;
     const StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
+
+    traceAPI_xStreamBufferIsFull( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 
@@ -1206,6 +1246,7 @@ BaseType_t xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer )
         xReturn = pdFALSE;
     }
 
+    traceRETURN_xStreamBufferIsFull( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1216,6 +1257,8 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     BaseType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
+
+    traceAPI_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
 
     configASSERT( pxStreamBuffer );
 
@@ -1237,6 +1280,7 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
     }
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xStreamBufferSendCompletedFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1247,6 +1291,8 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
     StreamBuffer_t * const pxStreamBuffer = xStreamBuffer;
     BaseType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
+
+    traceAPI_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
 
     configASSERT( pxStreamBuffer );
 
@@ -1268,6 +1314,7 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
     }
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xStreamBufferReceiveCompletedFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -1426,6 +1473,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
     UBaseType_t uxStreamBufferGetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer )
     {
+        traceAPI_uxStreamBufferGetStreamBufferNumber( xStreamBuffer );
+        traceRETURN_uxStreamBufferGetStreamBufferNumber( xStreamBuffer->uxStreamBufferNumber );
         return xStreamBuffer->uxStreamBufferNumber;
     }
 
@@ -1437,7 +1486,9 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
     void vStreamBufferSetStreamBufferNumber( StreamBufferHandle_t xStreamBuffer,
                                              UBaseType_t uxStreamBufferNumber )
     {
+        traceAPI_vStreamBufferSetStreamBufferNumber();
         xStreamBuffer->uxStreamBufferNumber = uxStreamBufferNumber;
+        traceRETURN_vStreamBufferSetStreamBufferNumber();
     }
 
 #endif /* configUSE_TRACE_FACILITY */
@@ -1447,6 +1498,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
     uint8_t ucStreamBufferGetStreamBufferType( StreamBufferHandle_t xStreamBuffer )
     {
+        traceAPI_ucStreamBufferGetStreamBufferType( xStreamBuffer );
+        traceRETURN_ucStreamBufferGetStreamBufferType( ( uint8_t ) ( xStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) );
         return( ( uint8_t ) ( xStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) );
     }
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -550,11 +550,11 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
     BaseType_t xReturn = pdFAIL;
     StreamBufferCallbackFunction_t pxSendCallback = NULL, pxReceiveCallback = NULL;
 
-    traceAPI_xStreamBufferReset( xStreamBuffer );
-
     #if ( configUSE_TRACE_FACILITY == 1 )
         UBaseType_t uxStreamBufferNumber;
     #endif
+
+    traceAPI_xStreamBufferReset( xStreamBuffer );
 
     configASSERT( pxStreamBuffer );
 

--- a/tasks.c
+++ b/tasks.c
@@ -1171,6 +1171,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         TCB_t * pxNewTCB;
         TaskHandle_t xReturn;
 
+        traceAPI_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
+
         configASSERT( puxStackBuffer != NULL );
         configASSERT( pxTaskBuffer != NULL );
 
@@ -1217,6 +1219,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             xReturn = NULL;
         }
 
+        traceRETURN_xTaskCreateStatic( xReturn );
         return xReturn;
     }
 
@@ -1239,6 +1242,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         TCB_t * pxNewTCB;
         BaseType_t xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
+
+        traceAPI_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask );
 
         configASSERT( pxTaskDefinition->puxStackBuffer != NULL );
         configASSERT( pxTaskDefinition->pxTaskBuffer != NULL );
@@ -1281,6 +1286,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             xReturn = pdPASS;
         }
 
+        traceRETURN_xTaskCreateRestrictedStatic( xReturn );
         return xReturn;
     }
 
@@ -1303,6 +1309,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         TCB_t * pxNewTCB;
         BaseType_t xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
+
+        traceAPI_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask );
 
         configASSERT( pxTaskDefinition->puxStackBuffer );
 
@@ -1346,6 +1354,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             }
         }
 
+        traceRETURN_xTaskCreateRestricted( xReturn );
         return xReturn;
     }
 
@@ -1376,6 +1385,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         TCB_t * pxNewTCB;
         BaseType_t xReturn;
+
+        traceAPI_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
 
         /* If the stack grows down then allocate the stack then the TCB so the stack
          * does not grow into the TCB.  Likewise if the stack grows up then allocate
@@ -1464,6 +1475,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
         }
 
+        traceRETURN_xTaskCreate( xReturn );
         return xReturn;
     }
 
@@ -1880,6 +1892,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * pxTCB;
 
+        traceAPI_vTaskDelete( xTaskToDelete );
+
         taskENTER_CRITICAL();
         {
             /* If null is passed in here then it is the calling task that is
@@ -2010,6 +2024,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             taskEXIT_CRITICAL();
         }
         #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+        traceRETURN_vTaskDelete();
     }
 
 #endif /* INCLUDE_vTaskDelete */
@@ -2022,6 +2038,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TickType_t xTimeToWake;
         BaseType_t xAlreadyYielded, xShouldDelay = pdFALSE;
+
+        traceAPI_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
 
         configASSERT( pxPreviousWakeTime );
         configASSERT( ( xTimeIncrement > 0U ) );
@@ -2101,6 +2119,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xTaskDelayUntil( xShouldDelay );
         return xShouldDelay;
     }
 
@@ -2112,6 +2131,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     void vTaskDelay( const TickType_t xTicksToDelay )
     {
         BaseType_t xAlreadyYielded = pdFALSE;
+
+        traceAPI_vTaskDelay( xTicksToDelay );
 
         /* A delay time of zero just forces a reschedule. */
         if( xTicksToDelay > ( TickType_t ) 0U )
@@ -2152,6 +2173,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskDelay();
     }
 
 #endif /* INCLUDE_vTaskDelay */
@@ -2167,6 +2190,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         List_t const * pxDelayedList;
         List_t const * pxOverflowedDelayedList;
         const TCB_t * const pxTCB = xTask;
+
+        traceAPI_eTaskGetState( xTask );
 
         configASSERT( pxTCB );
 
@@ -2279,6 +2304,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
 
+        traceRETURN_eTaskGetState( eReturn );
         return eReturn;
     } /*lint !e818 xTask cannot be a pointer to const because it is a typedef. */
 
@@ -2292,6 +2318,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t const * pxTCB;
         UBaseType_t uxReturn;
 
+        traceAPI_uxTaskPriorityGet( xTask );
+
         taskENTER_CRITICAL();
         {
             /* If null is passed in here then it is the priority of the task
@@ -2301,6 +2329,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_uxTaskPriorityGet( uxReturn );
         return uxReturn;
     }
 
@@ -2314,6 +2343,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t const * pxTCB;
         UBaseType_t uxReturn;
         UBaseType_t uxSavedInterruptStatus;
+
+        traceAPI_uxTaskPriorityGetFromISR( xTask );
 
         /* RTOS ports that support interrupt nesting have the concept of a
          * maximum  system call (or maximum API call) interrupt priority.
@@ -2342,6 +2373,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+        traceRETURN_uxTaskPriorityGetFromISR( uxReturn );
         return uxReturn;
     }
 
@@ -2356,6 +2388,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t * pxTCB;
         UBaseType_t uxCurrentBasePriority, uxPriorityUsedOnEntry;
         BaseType_t xYieldRequired = pdFALSE;
+
+        traceAPI_vTaskPrioritySet( xTask, uxNewPriority );
 
         #if ( configNUMBER_OF_CORES > 1 )
             BaseType_t xYieldForTask = pdFALSE;
@@ -2563,6 +2597,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
         taskEXIT_CRITICAL();
+        traceRETURN_vTaskPrioritySet();
     }
 
 #endif /* INCLUDE_vTaskPrioritySet */
@@ -2579,6 +2614,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         #if ( configUSE_PREEMPTION == 1 )
             UBaseType_t uxPrevNotAllowedCores;
         #endif
+
+        traceAPI_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask );
 
         taskENTER_CRITICAL();
         {
@@ -2625,6 +2662,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
         taskEXIT_CRITICAL();
+        traceRETURN_vTaskCoreAffinitySet();
     }
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
 /*-----------------------------------------------------------*/
@@ -2635,6 +2673,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         const TCB_t * pxTCB;
         UBaseType_t uxCoreAffinityMask;
 
+        traceAPI_vTaskCoreAffinityGet( xTask );
+
         taskENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
@@ -2642,6 +2682,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask );
         return uxCoreAffinityMask;
     }
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
@@ -2654,6 +2695,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * pxTCB;
 
+        traceAPI_vTaskPreemptionDisable( xTask );
+
         taskENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
@@ -2661,6 +2704,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             pxTCB->xPreemptionDisable = pdTRUE;
         }
         taskEXIT_CRITICAL();
+        traceRETURN_vTaskPreemptionDisable();
     }
 
 #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
@@ -2673,6 +2717,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t * pxTCB;
         BaseType_t xCoreID;
 
+        traceAPI_vTaskPreemptionEnable( xTask );
         taskENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
@@ -2689,6 +2734,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
         taskEXIT_CRITICAL();
+        traceRETURN_vTaskPreemptionEnable();
     }
 
 #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
@@ -2704,6 +2750,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             BaseType_t xTaskRunningOnCore;
         #endif
 
+        traceAPI_vTaskSuspend( xTaskToSuspend );
         taskENTER_CRITICAL();
         {
             /* If null is passed in here then it is the running task that is
@@ -2853,6 +2900,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             taskEXIT_CRITICAL();
         }
         #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+        traceRETURN_vTaskSuspend();
     }
 
 #endif /* INCLUDE_vTaskSuspend */
@@ -2909,6 +2958,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     void vTaskResume( TaskHandle_t xTaskToResume )
     {
         TCB_t * const pxTCB = xTaskToResume;
+
+        traceAPI_vTaskResume( xTaskToResume );
 
         /* It does not make sense to resume the calling task. */
         configASSERT( xTaskToResume );
@@ -2975,6 +3026,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskResume();
     }
 
 #endif /* INCLUDE_vTaskSuspend */
@@ -2988,6 +3041,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         BaseType_t xYieldRequired = pdFALSE;
         TCB_t * const pxTCB = xTaskToResume;
         UBaseType_t uxSavedInterruptStatus;
+
+        traceAPI_xTaskResumeFromISR( xTaskToResume );
 
         configASSERT( xTaskToResume );
 
@@ -3067,6 +3122,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+        traceRETURN_xTaskResumeFromISR( xYieldRequired );
         return xYieldRequired;
     }
 
@@ -3250,6 +3306,8 @@ void vTaskStartScheduler( void )
 {
     BaseType_t xReturn;
 
+    traceAPI_vTaskStartScheduler();
+
     #if ( configUSE_CORE_AFFINITY == 1 ) && ( configNUMBER_OF_CORES > 1 )
     {
         /* Sanity check that the UBaseType_t must have greater than or equal to
@@ -3339,22 +3397,30 @@ void vTaskStartScheduler( void )
     /* OpenOCD makes use of uxTopUsedPriority for thread debugging. Prevent uxTopUsedPriority
      * from getting optimized out as it is no longer used by the kernel. */
     ( void ) uxTopUsedPriority;
+
+    traceRETURN_vTaskStartScheduler();
 }
 /*-----------------------------------------------------------*/
 
 void vTaskEndScheduler( void )
 {
+    traceAPI_vTaskEndScheduler();
+
     /* Stop the scheduler interrupts and call the portable scheduler end
      * routine so the original ISRs can be restored if necessary.  The port
      * layer must ensure interrupts enable  bit is left in the correct state. */
     portDISABLE_INTERRUPTS();
     xSchedulerRunning = pdFALSE;
     vPortEndScheduler();
+
+    traceRETURN_vTaskEndScheduler();
 }
 /*----------------------------------------------------------*/
 
 void vTaskSuspendAll( void )
 {
+    traceAPI_vTaskSuspendAll();
+
     #if ( configNUMBER_OF_CORES == 1 )
     {
         /* A critical section is not required as the variable is of type
@@ -3430,6 +3496,8 @@ void vTaskSuspendAll( void )
         }
     }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+    traceRETURN_vTaskSuspendAll();
 }
 
 /*----------------------------------------------------------*/
@@ -3501,6 +3569,8 @@ BaseType_t xTaskResumeAll( void )
 {
     TCB_t * pxTCB = NULL;
     BaseType_t xAlreadyYielded = pdFALSE;
+
+    traceAPI_xTaskResumeAll();
 
     #if ( configNUMBER_OF_CORES > 1 )
         if( xSchedulerRunning != pdFALSE )
@@ -3636,6 +3706,7 @@ BaseType_t xTaskResumeAll( void )
         taskEXIT_CRITICAL();
     }
 
+    traceRETURN_xTaskResumeAll( xAlreadyYielded );
     return xAlreadyYielded;
 }
 /*-----------------------------------------------------------*/
@@ -3644,6 +3715,8 @@ TickType_t xTaskGetTickCount( void )
 {
     TickType_t xTicks;
 
+    traceAPI_xTaskGetTickCount();
+
     /* Critical section required if running on a 16 bit processor. */
     portTICK_TYPE_ENTER_CRITICAL();
     {
@@ -3651,6 +3724,7 @@ TickType_t xTaskGetTickCount( void )
     }
     portTICK_TYPE_EXIT_CRITICAL();
 
+    traceRETURN_xTaskGetTickCount( xTicks );
     return xTicks;
 }
 /*-----------------------------------------------------------*/
@@ -3659,6 +3733,8 @@ TickType_t xTaskGetTickCountFromISR( void )
 {
     TickType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
+
+    traceAPI_xTaskGetTickCountFromISR();
 
     /* RTOS ports that support interrupt nesting have the concept of a maximum
      * system call (or maximum API call) interrupt priority.  Interrupts that are
@@ -3682,14 +3758,18 @@ TickType_t xTaskGetTickCountFromISR( void )
     }
     portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
 
+    traceRETURN_xTaskGetTickCountFromISR( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 UBaseType_t uxTaskGetNumberOfTasks( void )
 {
+    traceAPI_uxTaskGetNumberOfTasks();
+
     /* A critical section is not required because the variables are of type
      * BaseType_t. */
+    traceRETURN_uxTaskGetNumberOfTasks( uxCurrentNumberOfTasks );
     return uxCurrentNumberOfTasks;
 }
 /*-----------------------------------------------------------*/
@@ -3698,10 +3778,13 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 {
     TCB_t * pxTCB;
 
+    traceAPI_pcTaskGetName( xTaskToQuery );
+
     /* If null is passed in here then the name of the calling task is being
      * queried. */
     pxTCB = prvGetTCBFromHandle( xTaskToQuery );
     configASSERT( pxTCB );
+    traceRETURN_pcTaskGetName( &( pxTCB->pcTaskName[ 0 ] ) );
     return &( pxTCB->pcTaskName[ 0 ] );
 }
 /*-----------------------------------------------------------*/
@@ -3850,6 +3933,8 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         UBaseType_t uxQueue = configMAX_PRIORITIES;
         TCB_t * pxTCB;
 
+        traceAPI_xTaskGetHandle( pcNameToQuery );
+
         /* Task names will be truncated to configMAX_TASK_NAME_LEN - 1 bytes. */
         configASSERT( strlen( pcNameToQuery ) < configMAX_TASK_NAME_LEN );
 
@@ -3901,6 +3986,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         }
         ( void ) xTaskResumeAll();
 
+        traceRETURN_xTaskGetHandle( pxTCB );
         return pxTCB;
     }
 
@@ -3961,6 +4047,8 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
     {
         UBaseType_t uxTask = 0, uxQueue = configMAX_PRIORITIES;
+
+        traceAPI_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
 
         vTaskSuspendAll();
         {
@@ -4023,6 +4111,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         }
         ( void ) xTaskResumeAll();
 
+        traceRETURN_uxTaskGetSystemState( uxTask );
         return uxTask;
     }
 
@@ -4035,9 +4124,12 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
  * Consider to add another function to return the idle task handles. */
     TaskHandle_t xTaskGetIdleTaskHandle( void )
     {
+        traceAPI_xTaskGetIdleTaskHandle();
+
         /* If xTaskGetIdleTaskHandle() is called before the scheduler has been
          * started, then xIdleTaskHandles will be NULL. */
         configASSERT( ( xIdleTaskHandles[ 0 ] != NULL ) );
+        traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandles[ 0 ] );
         return xIdleTaskHandles[ 0 ];
     }
 
@@ -4052,6 +4144,8 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 
     void vTaskStepTick( TickType_t xTicksToJump )
     {
+        traceAPI_vTaskStepTick( xTicksToJump );
+
         /* Correct the tick count value after a period during which the tick
          * was suppressed.  Note this does *not* call the tick hook function for
          * each stepped tick. */
@@ -4080,6 +4174,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 
         xTickCount += xTicksToJump;
         traceINCREASE_TICK_COUNT( xTicksToJump );
+        traceRETURN_vTaskStepTick();
     }
 
 #endif /* configUSE_TICKLESS_IDLE */
@@ -4088,6 +4183,8 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
 {
     BaseType_t xYieldOccurred;
+
+    traceAPI_xTaskCatchUpTicks( xTicksToCatchUp );
 
     /* Must not be called with the scheduler suspended as the implementation
      * relies on xPendedTicks being wound down to 0 in xTaskResumeAll(). */
@@ -4105,6 +4202,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
     taskEXIT_CRITICAL();
     xYieldOccurred = xTaskResumeAll();
 
+    traceRETURN_xTaskCatchUpTicks( xYieldOccurred );
     return xYieldOccurred;
 }
 /*----------------------------------------------------------*/
@@ -4115,6 +4213,8 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
     {
         TCB_t * pxTCB = xTask;
         BaseType_t xReturn;
+
+        traceAPI_xTaskAbortDelay( xTask );
 
         configASSERT( pxTCB );
 
@@ -4195,6 +4295,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
         }
         ( void ) xTaskResumeAll();
 
+        traceRETURN_xTaskAbortDelay( xReturn );
         return xReturn;
     }
 
@@ -4206,6 +4307,8 @@ BaseType_t xTaskIncrementTick( void )
     TCB_t * pxTCB;
     TickType_t xItemValue;
     BaseType_t xSwitchRequired = pdFALSE;
+
+    traceAPI_xTaskIncrementTick();
 
     #if ( configUSE_PREEMPTION == 1 ) && ( configNUMBER_OF_CORES > 1 )
     BaseType_t xYieldRequiredForCore[ configNUMBER_OF_CORES ] = { pdFALSE };
@@ -4444,6 +4547,7 @@ BaseType_t xTaskIncrementTick( void )
         #endif
     }
 
+    traceRETURN_xTaskIncrementTick( xSwitchRequired );
     return xSwitchRequired;
 }
 /*-----------------------------------------------------------*/
@@ -4454,6 +4558,8 @@ BaseType_t xTaskIncrementTick( void )
                                      TaskHookFunction_t pxHookFunction )
     {
         TCB_t * xTCB;
+
+        traceAPI_vTaskSetApplicationTaskTag( xTask, pxHookFunction );
 
         /* If xTask is NULL then it is the task hook of the calling task that is
          * getting set. */
@@ -4473,6 +4579,7 @@ BaseType_t xTaskIncrementTick( void )
             xTCB->pxTaskTag = pxHookFunction;
         }
         taskEXIT_CRITICAL();
+        traceRETURN_vTaskSetApplicationTaskTag();
     }
 
 #endif /* configUSE_APPLICATION_TASK_TAG */
@@ -4485,6 +4592,8 @@ BaseType_t xTaskIncrementTick( void )
         TCB_t * pxTCB;
         TaskHookFunction_t xReturn;
 
+        traceAPI_xTaskGetApplicationTaskTag( xTask );
+
         /* If xTask is NULL then set the calling task's hook. */
         pxTCB = prvGetTCBFromHandle( xTask );
 
@@ -4496,6 +4605,7 @@ BaseType_t xTaskIncrementTick( void )
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xTaskGetApplicationTaskTag( xReturn );
         return xReturn;
     }
 
@@ -4510,6 +4620,8 @@ BaseType_t xTaskIncrementTick( void )
         TaskHookFunction_t xReturn;
         UBaseType_t uxSavedInterruptStatus;
 
+        traceAPI_xTaskGetApplicationTaskTagFromISR( xTask );
+
         /* If xTask is NULL then set the calling task's hook. */
         pxTCB = prvGetTCBFromHandle( xTask );
 
@@ -4521,6 +4633,7 @@ BaseType_t xTaskIncrementTick( void )
         }
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+        traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn );
         return xReturn;
     }
 
@@ -4534,6 +4647,8 @@ BaseType_t xTaskIncrementTick( void )
     {
         TCB_t * xTCB;
         BaseType_t xReturn;
+
+        traceAPI_xTaskCallApplicationTaskHook( xTask, pvParameter );
 
         /* If xTask is NULL then we are calling our own task hook. */
         if( xTask == NULL )
@@ -4554,6 +4669,7 @@ BaseType_t xTaskIncrementTick( void )
             xReturn = pdFAIL;
         }
 
+        traceRETURN_xTaskCallApplicationTaskHook( xReturn );
         return xReturn;
     }
 
@@ -4730,6 +4846,8 @@ BaseType_t xTaskIncrementTick( void )
 void vTaskPlaceOnEventList( List_t * const pxEventList,
                             const TickType_t xTicksToWait )
 {
+    traceAPI_vTaskPlaceOnEventList( pxEventList, xTicksToWait );
+
     configASSERT( pxEventList );
 
     /* THIS FUNCTION MUST BE CALLED WITH EITHER INTERRUPTS DISABLED OR THE
@@ -4749,6 +4867,8 @@ void vTaskPlaceOnEventList( List_t * const pxEventList,
     vListInsert( pxEventList, &( pxCurrentTCB->xEventListItem ) );
 
     prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
+
+    traceRETURN_vTaskPlaceOnEventList();
 }
 /*-----------------------------------------------------------*/
 
@@ -4756,6 +4876,8 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
                                      const TickType_t xItemValue,
                                      const TickType_t xTicksToWait )
 {
+    traceAPI_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait );
+
     configASSERT( pxEventList );
 
     /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
@@ -4775,6 +4897,8 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
     listINSERT_END( pxEventList, &( pxCurrentTCB->xEventListItem ) );
 
     prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
+
+    traceRETURN_vTaskPlaceOnUnorderedEventList();
 }
 /*-----------------------------------------------------------*/
 
@@ -4784,6 +4908,8 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
                                           TickType_t xTicksToWait,
                                           const BaseType_t xWaitIndefinitely )
     {
+        traceAPI_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely );
+
         configASSERT( pxEventList );
 
         /* This function should not be called by application code hence the
@@ -4808,6 +4934,8 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
         traceTASK_DELAY_UNTIL( ( xTickCount + xTicksToWait ) );
         prvAddCurrentTaskToDelayedList( xTicksToWait, xWaitIndefinitely );
+
+        traceRETURN_vTaskPlaceOnEventListRestricted();
     }
 
 #endif /* configUSE_TIMERS */
@@ -4817,6 +4945,8 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
 {
     TCB_t * pxUnblockedTCB;
     BaseType_t xReturn;
+
+    traceAPI_xTaskRemoveFromEventList( pxEventList );
 
     /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
      * called from a critical section within an ISR. */
@@ -4896,6 +5026,7 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
     }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
+    traceRETURN_xTaskRemoveFromEventList( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -4904,6 +5035,8 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
                                         const TickType_t xItemValue )
 {
     TCB_t * pxUnblockedTCB;
+
+    traceAPI_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue );
 
     /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
      * the event flags implementation. */
@@ -4962,11 +5095,15 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
         #endif
     }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+    traceRETURN_vTaskRemoveFromUnorderedEventList();
 }
 /*-----------------------------------------------------------*/
 
 void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
 {
+    traceAPI_vTaskSetTimeOutState( pxTimeOut );
+
     configASSERT( pxTimeOut );
     taskENTER_CRITICAL();
     {
@@ -4974,14 +5111,19 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
         pxTimeOut->xTimeOnEntering = xTickCount;
     }
     taskEXIT_CRITICAL();
+    traceRETURN_vTaskSetTimeOutState();
 }
 /*-----------------------------------------------------------*/
 
 void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 {
+    traceAPI_vTaskInternalSetTimeOutState( pxTimeOut );
+
     /* For internal use only as it does not use a critical section. */
     pxTimeOut->xOverflowCount = xNumOfOverflows;
     pxTimeOut->xTimeOnEntering = xTickCount;
+
+    traceRETURN_vTaskInternalSetTimeOutState();
 }
 /*-----------------------------------------------------------*/
 
@@ -4989,6 +5131,8 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
                                  TickType_t * const pxTicksToWait )
 {
     BaseType_t xReturn;
+
+    traceAPI_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
 
     configASSERT( pxTimeOut );
     configASSERT( pxTicksToWait );
@@ -5046,14 +5190,19 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
     }
     taskEXIT_CRITICAL();
 
+    traceRETURN_xTaskCheckForTimeOut( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void vTaskMissedYield( void )
 {
+    traceAPI_vTaskMissedYield();
+
     /* Must be called from within a critical section. */
     xYieldPendings[ portGET_CORE_ID() ] = pdTRUE;
+
+    traceRETURN_vTaskMissedYield();
 }
 /*-----------------------------------------------------------*/
 
@@ -5063,6 +5212,8 @@ void vTaskMissedYield( void )
     {
         UBaseType_t uxReturn;
         TCB_t const * pxTCB;
+
+        traceAPI_uxTaskGetTaskNumber( xTask );
 
         if( xTask != NULL )
         {
@@ -5074,6 +5225,7 @@ void vTaskMissedYield( void )
             uxReturn = 0U;
         }
 
+        traceRETURN_uxTaskGetTaskNumber( uxReturn );
         return uxReturn;
     }
 
@@ -5087,11 +5239,15 @@ void vTaskMissedYield( void )
     {
         TCB_t * pxTCB;
 
+        traceAPI_vTaskSetTaskNumber( xTask, uxHandle );
+
         if( xTask != NULL )
         {
             pxTCB = xTask;
             pxTCB->uxTaskNumber = uxHandle;
         }
+
+        traceRETURN_vTaskSetTaskNumber();
     }
 
 #endif /* configUSE_TRACE_FACILITY */
@@ -5326,6 +5482,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             const UBaseType_t uxNonApplicationTasks = 1;
         #endif /* INCLUDE_vTaskSuspend */
 
+        traceAPI_eTaskConfirmSleepModeStatus();
+
         eSleepModeStatus eReturn = eStandardSleep;
 
         /* This function must be called from a critical section. */
@@ -5362,6 +5520,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_eTaskConfirmSleepModeStatus( eReturn );
         return eReturn;
     }
 
@@ -5376,6 +5535,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     {
         TCB_t * pxTCB;
 
+        traceAPI_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue );
+
         if( ( xIndex >= 0 ) &&
             ( xIndex < ( BaseType_t ) configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
         {
@@ -5383,6 +5544,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             configASSERT( pxTCB != NULL );
             pxTCB->pvThreadLocalStoragePointers[ xIndex ] = pvValue;
         }
+
+        traceRETURN_vTaskSetThreadLocalStoragePointer();
     }
 
 #endif /* configNUM_THREAD_LOCAL_STORAGE_POINTERS */
@@ -5396,6 +5559,8 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
         void * pvReturn = NULL;
         TCB_t * pxTCB;
 
+        traceAPI_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex );
+
         if( ( xIndex >= 0 ) &&
             ( xIndex < ( BaseType_t ) configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
         {
@@ -5407,6 +5572,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             pvReturn = NULL;
         }
 
+        traceRETURN_pvTaskGetThreadLocalStoragePointer( pvReturn );
         return pvReturn;
     }
 
@@ -5420,11 +5586,15 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     {
         TCB_t * pxTCB;
 
+        traceAPI_vTaskAllocateMPURegions( xTaskToModify, xRegions );
+
         /* If null is passed in here then we are modifying the MPU settings of
          * the calling task. */
         pxTCB = prvGetTCBFromHandle( xTaskToModify );
 
         vPortStoreTaskMPUSettings( &( pxTCB->xMPUSettings ), pxRegions, NULL, 0 );
+
+        traceRETURN_vTaskAllocateMPURegions();
     }
 
 #endif /* portUSING_MPU_WRAPPERS */
@@ -5541,6 +5711,8 @@ static void prvCheckTasksWaitingTermination( void )
     {
         TCB_t * pxTCB;
 
+        traceAPI_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState );
+
         /* xTask is NULL then get the state of the calling task. */
         pxTCB = prvGetTCBFromHandle( xTask );
 
@@ -5648,6 +5820,8 @@ static void prvCheckTasksWaitingTermination( void )
         {
             pxTaskStatus->usStackHighWaterMark = 0;
         }
+
+        traceRETURN_vTaskGetInfo();
     }
 
 #endif /* configUSE_TRACE_FACILITY */
@@ -5722,6 +5896,8 @@ static void prvCheckTasksWaitingTermination( void )
         uint8_t * pucEndOfStack;
         configSTACK_DEPTH_TYPE uxReturn;
 
+        traceAPI_uxTaskGetStackHighWaterMark2( xTask );
+
         /* uxTaskGetStackHighWaterMark() and uxTaskGetStackHighWaterMark2() are
          * the same except for their return type.  Using configSTACK_DEPTH_TYPE
          * allows the user to determine the return type.  It gets around the
@@ -5743,6 +5919,7 @@ static void prvCheckTasksWaitingTermination( void )
 
         uxReturn = prvTaskCheckFreeStackSpace( pucEndOfStack );
 
+        traceRETURN_uxTaskGetStackHighWaterMark2( uxReturn );
         return uxReturn;
     }
 
@@ -5756,6 +5933,8 @@ static void prvCheckTasksWaitingTermination( void )
         TCB_t * pxTCB;
         uint8_t * pucEndOfStack;
         UBaseType_t uxReturn;
+
+        traceAPI_uxTaskGetStackHighWaterMark( xTask );
 
         pxTCB = prvGetTCBFromHandle( xTask );
 
@@ -5771,6 +5950,7 @@ static void prvCheckTasksWaitingTermination( void )
 
         uxReturn = ( UBaseType_t ) prvTaskCheckFreeStackSpace( pucEndOfStack );
 
+        traceRETURN_uxTaskGetStackHighWaterMark( uxReturn );
         return uxReturn;
     }
 
@@ -5860,11 +6040,14 @@ static void prvResetNextTaskUnblockTime( void )
         {
             TaskHandle_t xReturn;
 
+            traceAPI_xTaskGetCurrentTaskHandle();
+
             /* A critical section is not required as this is not called from
              * an interrupt and the current TCB will always be the same for any
              * individual execution thread. */
             xReturn = pxCurrentTCB;
 
+            traceRETURN_xTaskGetCurrentTaskHandle( xReturn );
             return xReturn;
         }
     #else /* #if ( configNUMBER_OF_CORES == 1 ) */
@@ -5872,6 +6055,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             TaskHandle_t xReturn;
             UBaseType_t uxSavedInterruptStatus;
+
+            traceAPI_xTaskGetCurrentTaskHandle();
 
             uxSavedInterruptStatus = portSET_INTERRUPT_MASK();
             {
@@ -5891,6 +6076,7 @@ static void prvResetNextTaskUnblockTime( void )
                 xReturn = pxCurrentTCBs[ xCoreID ];
             }
 
+            traceRETURN_xTaskGetCurrentTaskHandle( xReturn );
             return xReturn;
         }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
@@ -5903,6 +6089,8 @@ static void prvResetNextTaskUnblockTime( void )
     BaseType_t xTaskGetSchedulerState( void )
     {
         BaseType_t xReturn;
+
+        traceAPI_xTaskGetSchedulerState();
 
         if( xSchedulerRunning == pdFALSE )
         {
@@ -5928,6 +6116,7 @@ static void prvResetNextTaskUnblockTime( void )
             #endif
         }
 
+        traceRETURN_xTaskGetSchedulerState( xReturn );
         return xReturn;
     }
 
@@ -5940,6 +6129,8 @@ static void prvResetNextTaskUnblockTime( void )
     {
         TCB_t * const pxMutexHolderTCB = pxMutexHolder;
         BaseType_t xReturn = pdFALSE;
+
+        traceAPI_xTaskPriorityInherit( pxMutexHolder );
 
         /* If the mutex was given back by an interrupt while the queue was
          * locked then the mutex holder might now be NULL.  _RB_ Is this still
@@ -6028,6 +6219,7 @@ static void prvResetNextTaskUnblockTime( void )
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xTaskPriorityInherit( xReturn );
         return xReturn;
     }
 
@@ -6040,6 +6232,8 @@ static void prvResetNextTaskUnblockTime( void )
     {
         TCB_t * const pxTCB = pxMutexHolder;
         BaseType_t xReturn = pdFALSE;
+
+        traceAPI_xTaskPriorityDisinherit( pxMutexHolder );
 
         if( pxMutexHolder != NULL )
         {
@@ -6118,6 +6312,7 @@ static void prvResetNextTaskUnblockTime( void )
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xTaskPriorityDisinherit( xReturn );
         return xReturn;
     }
 
@@ -6132,6 +6327,8 @@ static void prvResetNextTaskUnblockTime( void )
         TCB_t * const pxTCB = pxMutexHolder;
         UBaseType_t uxPriorityUsedOnEntry, uxPriorityToUse;
         const UBaseType_t uxOnlyOneMutexHeld = ( UBaseType_t ) 1;
+
+        traceAPI_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask );
 
         if( pxMutexHolder != NULL )
         {
@@ -6235,6 +6432,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskPriorityDisinheritAfterTimeout();
     }
 
 #endif /* configUSE_MUTEXES */
@@ -6248,6 +6447,8 @@ static void prvResetNextTaskUnblockTime( void )
  */
     void vTaskYieldWithinAPI( void )
     {
+        traceAPI_vTaskYieldWithinAPI();
+
         if( portGET_CRITICAL_NESTING_COUNT() == 0U )
         {
             portYIELD();
@@ -6256,6 +6457,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             xYieldPendings[ portGET_CORE_ID() ] = pdTRUE;
         }
+
+        traceRETURN_vTaskYieldWithinAPI();
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
@@ -6265,6 +6468,8 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskEnterCritical( void )
     {
+        traceAPI_vTaskEnterCritical();
+
         portDISABLE_INTERRUPTS();
 
         if( xSchedulerRunning != pdFALSE )
@@ -6286,6 +6491,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskEnterCritical();
     }
 
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
@@ -6295,6 +6502,8 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskEnterCritical( void )
     {
+        traceAPI_vTaskEnterCritical();
+
         portDISABLE_INTERRUPTS();
 
         if( xSchedulerRunning != pdFALSE )
@@ -6331,6 +6540,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskEnterCritical();
     }
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -6342,6 +6553,8 @@ static void prvResetNextTaskUnblockTime( void )
     UBaseType_t vTaskEnterCriticalFromISR( void )
     {
         UBaseType_t uxSavedInterruptStatus = 0;
+
+        traceAPI_vTaskEnterCriticalFromISR();
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -6359,6 +6572,7 @@ static void prvResetNextTaskUnblockTime( void )
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_vTaskEnterCriticalFromISR( uxSavedInterruptStatus );
         return uxSavedInterruptStatus;
     }
 
@@ -6369,6 +6583,8 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCritical( void )
     {
+        traceAPI_vTaskExitCritical();
+
         if( xSchedulerRunning != pdFALSE )
         {
             /* If pxCurrentTCB->uxCriticalNesting is zero then this function
@@ -6401,6 +6617,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskExitCritical();
     }
 
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
@@ -6410,6 +6628,8 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCritical( void )
     {
+        traceAPI_vTaskExitCritical();
+
         if( xSchedulerRunning != pdFALSE )
         {
             /* If critical nesting count is zero then this function
@@ -6458,6 +6678,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskExitCritical();
     }
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -6467,6 +6689,8 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
+        traceAPI_vTaskExitCriticalFromISR( uxSavedInterruptStatus );
+
         if( xSchedulerRunning != pdFALSE )
         {
             /* If critical nesting count is zero then this function
@@ -6496,6 +6720,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskExitCriticalFromISR();
     }
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -6535,6 +6761,8 @@ static void prvResetNextTaskUnblockTime( void )
         TaskStatus_t * pxTaskStatusArray;
         UBaseType_t uxArraySize, x;
         char cStatus;
+
+        traceAPI_vTaskList( pcWriteBuffer );
 
         /*
          * PLEASE NOTE:
@@ -6629,6 +6857,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskList();
     }
 
 #endif /* ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
@@ -6641,6 +6871,8 @@ static void prvResetNextTaskUnblockTime( void )
         TaskStatus_t * pxTaskStatusArray;
         UBaseType_t uxArraySize, x;
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulStatsAsPercentage;
+
+        traceAPI_vTaskGetRunTimeStats( pcWriteBuffer );
 
         /*
          * PLEASE NOTE:
@@ -6750,6 +6982,8 @@ static void prvResetNextTaskUnblockTime( void )
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        traceRETURN_vTaskGetRunTimeStats();
     }
 
 #endif /* ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
@@ -6759,12 +6993,15 @@ TickType_t uxTaskResetEventItemValue( void )
 {
     TickType_t uxReturn;
 
+    traceAPI_uxTaskResetEventItemValue();
+
     uxReturn = listGET_LIST_ITEM_VALUE( &( pxCurrentTCB->xEventListItem ) );
 
     /* Reset the event list item to its normal value - so it can be used with
      * queues and semaphores. */
     listSET_LIST_ITEM_VALUE( &( pxCurrentTCB->xEventListItem ), ( ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxCurrentTCB->uxPriority ) ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
+    traceRETURN_uxTaskResetEventItemValue( uxReturn );
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -6775,6 +7012,8 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         TCB_t * pxTCB;
 
+        traceAPI_pvTaskIncrementMutexHeldCount();
+
         pxTCB = pxCurrentTCB;
 
         /* If xSemaphoreCreateMutex() is called before any tasks have been created
@@ -6784,6 +7023,7 @@ TickType_t uxTaskResetEventItemValue( void )
             ( pxTCB->uxMutexesHeld )++;
         }
 
+        traceRETURN_pvTaskIncrementMutexHeldCount( pxTCB );
         return pxTCB;
     }
 
@@ -6797,6 +7037,8 @@ TickType_t uxTaskResetEventItemValue( void )
                                       TickType_t xTicksToWait )
     {
         uint32_t ulReturn;
+
+        traceAPI_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait );
 
         configASSERT( uxIndexToWaitOn < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -6864,6 +7106,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_ulTaskGenericNotifyTake( ulReturn );
         return ulReturn;
     }
 
@@ -6879,6 +7122,8 @@ TickType_t uxTaskResetEventItemValue( void )
                                        TickType_t xTicksToWait )
     {
         BaseType_t xReturn;
+
+        traceAPI_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait );
 
         configASSERT( uxIndexToWaitOn < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -6958,6 +7203,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xTaskGenericNotifyWait( xReturn );
         return xReturn;
     }
 
@@ -6975,6 +7221,8 @@ TickType_t uxTaskResetEventItemValue( void )
         TCB_t * pxTCB;
         BaseType_t xReturn = pdPASS;
         uint8_t ucOriginalNotifyState;
+
+        traceAPI_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
 
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
         configASSERT( xTaskToNotify );
@@ -7093,6 +7341,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xTaskGenericNotify( xReturn );
         return xReturn;
     }
 
@@ -7112,6 +7361,8 @@ TickType_t uxTaskResetEventItemValue( void )
         uint8_t ucOriginalNotifyState;
         BaseType_t xReturn = pdPASS;
         UBaseType_t uxSavedInterruptStatus;
+
+        traceAPI_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken );
 
         configASSERT( xTaskToNotify );
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
@@ -7252,6 +7503,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
+        traceRETURN_xTaskGenericNotifyFromISR( xReturn );
         return xReturn;
     }
 
@@ -7267,6 +7519,8 @@ TickType_t uxTaskResetEventItemValue( void )
         TCB_t * pxTCB;
         uint8_t ucOriginalNotifyState;
         UBaseType_t uxSavedInterruptStatus;
+
+        traceAPI_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken );
 
         configASSERT( xTaskToNotify );
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
@@ -7362,6 +7616,7 @@ TickType_t uxTaskResetEventItemValue( void )
             }
         }
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        traceRETURN_vTaskGenericNotifyGiveFromISR();
     }
 
 #endif /* configUSE_TASK_NOTIFICATIONS */
@@ -7374,6 +7629,8 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         TCB_t * pxTCB;
         BaseType_t xReturn;
+
+        traceAPI_xTaskGenericNotifyStateClear( xTask, uxIndexToClear );
 
         configASSERT( uxIndexToClear < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -7395,6 +7652,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xTaskGenericNotifyStateClear( xReturn );
         return xReturn;
     }
 
@@ -7409,6 +7667,8 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         TCB_t * pxTCB;
         uint32_t ulReturn;
+
+        traceAPI_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear );
 
         configASSERT( uxIndexToClear < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -7425,6 +7685,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_ulTaskGenericNotifyValueClear( ulReturn );
         return ulReturn;
     }
 
@@ -7437,8 +7698,11 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         TCB_t * pxTCB;
 
+        traceAPI_ulTaskGetRunTimeCounter( xTask );
+
         pxTCB = prvGetTCBFromHandle( xTask );
 
+        traceRETURN_ulTaskGetRunTimeCounter( pxTCB->ulRunTimeCounter );
         return pxTCB->ulRunTimeCounter;
     }
 
@@ -7451,6 +7715,8 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         TCB_t * pxTCB;
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulReturn;
+
+        traceAPI_ulTaskGetIdleRunTimePercent();
 
         ulTotalTime = ( configRUN_TIME_COUNTER_TYPE ) portGET_RUN_TIME_COUNTER_VALUE();
 
@@ -7468,6 +7734,7 @@ TickType_t uxTaskResetEventItemValue( void )
             ulReturn = 0;
         }
 
+        traceRETURN_ulTaskGetIdleRunTimePercent( ulReturn );
         return ulReturn;
     }
 
@@ -7481,11 +7748,14 @@ TickType_t uxTaskResetEventItemValue( void )
         configRUN_TIME_COUNTER_TYPE ulReturn = 0;
         BaseType_t i;
 
+        traceAPI_ulTaskGetIdleRunTimeCounter();
+
         for( i = 0; i < ( BaseType_t ) configNUMBER_OF_CORES; i++ )
         {
             ulReturn += xIdleTaskHandles[ i ]->ulRunTimeCounter;
         }
 
+        traceRETURN_ulTaskGetIdleRunTimeCounter( ulReturn );
         return ulReturn;
     }
 

--- a/tasks.c
+++ b/tasks.c
@@ -1253,6 +1253,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         }
 
         traceRETURN_xTaskCreateStatic( xReturn );
+
         return xReturn;
     }
 
@@ -1320,6 +1321,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         }
 
         traceRETURN_xTaskCreateRestrictedStatic( xReturn );
+
         return xReturn;
     }
 
@@ -1388,6 +1390,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         }
 
         traceRETURN_xTaskCreateRestricted( xReturn );
+
         return xReturn;
     }
 
@@ -1509,6 +1512,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         }
 
         traceRETURN_xTaskCreate( xReturn );
+
         return xReturn;
     }
 
@@ -2144,6 +2148,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
 
         traceRETURN_xTaskDelayUntil( xShouldDelay );
+
         return xShouldDelay;
     }
 
@@ -2329,6 +2334,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
 
         traceRETURN_eTaskGetState( eReturn );
+
         return eReturn;
     } /*lint !e818 xTask cannot be a pointer to const because it is a typedef. */
 
@@ -2354,6 +2360,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         taskEXIT_CRITICAL();
 
         traceRETURN_uxTaskPriorityGet( uxReturn );
+
         return uxReturn;
     }
 
@@ -2398,6 +2405,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_uxTaskPriorityGetFromISR( uxReturn );
+
         return uxReturn;
     }
 
@@ -2611,6 +2619,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
         taskEXIT_CRITICAL();
+
         traceRETURN_vTaskPrioritySet();
     }
 
@@ -2676,6 +2685,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
         taskEXIT_CRITICAL();
+
         traceRETURN_vTaskCoreAffinitySet();
     }
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
@@ -2697,6 +2707,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         taskEXIT_CRITICAL();
 
         traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask );
+
         return uxCoreAffinityMask;
     }
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
@@ -2718,6 +2729,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             pxTCB->xPreemptionDisable = pdTRUE;
         }
         taskEXIT_CRITICAL();
+
         traceRETURN_vTaskPreemptionDisable();
     }
 
@@ -2732,6 +2744,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         BaseType_t xCoreID;
 
         traceAPI_vTaskPreemptionEnable( xTask );
+
         taskENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
@@ -2748,6 +2761,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
         taskEXIT_CRITICAL();
+
         traceRETURN_vTaskPreemptionEnable();
     }
 
@@ -2765,6 +2779,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         #endif
 
         traceAPI_vTaskSuspend( xTaskToSuspend );
+
         taskENTER_CRITICAL();
         {
             /* If null is passed in here then it is the running task that is
@@ -3117,6 +3132,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskResumeFromISR( xYieldRequired );
+
         return xYieldRequired;
     }
 
@@ -3701,6 +3717,7 @@ BaseType_t xTaskResumeAll( void )
     }
 
     traceRETURN_xTaskResumeAll( xAlreadyYielded );
+
     return xAlreadyYielded;
 }
 /*-----------------------------------------------------------*/
@@ -3719,6 +3736,7 @@ TickType_t xTaskGetTickCount( void )
     portTICK_TYPE_EXIT_CRITICAL();
 
     traceRETURN_xTaskGetTickCount( xTicks );
+
     return xTicks;
 }
 /*-----------------------------------------------------------*/
@@ -3753,6 +3771,7 @@ TickType_t xTaskGetTickCountFromISR( void )
     portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
 
     traceRETURN_xTaskGetTickCountFromISR( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -3764,6 +3783,7 @@ UBaseType_t uxTaskGetNumberOfTasks( void )
     /* A critical section is not required because the variables are of type
      * BaseType_t. */
     traceRETURN_uxTaskGetNumberOfTasks( uxCurrentNumberOfTasks );
+
     return uxCurrentNumberOfTasks;
 }
 /*-----------------------------------------------------------*/
@@ -3778,7 +3798,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
      * queried. */
     pxTCB = prvGetTCBFromHandle( xTaskToQuery );
     configASSERT( pxTCB );
+
     traceRETURN_pcTaskGetName( &( pxTCB->pcTaskName[ 0 ] ) );
+
     return &( pxTCB->pcTaskName[ 0 ] );
 }
 /*-----------------------------------------------------------*/
@@ -3981,6 +4003,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         ( void ) xTaskResumeAll();
 
         traceRETURN_xTaskGetHandle( pxTCB );
+
         return pxTCB;
     }
 
@@ -3995,6 +4018,8 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
     {
         BaseType_t xReturn;
         TCB_t * pxTCB;
+
+        traceAPI_xTaskGetStaticBuffers( xTask, ppuxStackBuffer, ppxTaskBuffer );
 
         configASSERT( ppuxStackBuffer != NULL );
         configASSERT( ppxTaskBuffer != NULL );
@@ -4027,6 +4052,8 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
             xReturn = pdTRUE;
         }
         #endif /* tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE == 1 */
+
+        traceRETURN_xTaskGetStaticBuffers( xReturn );
 
         return xReturn;
     }
@@ -4106,6 +4133,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         ( void ) xTaskResumeAll();
 
         traceRETURN_uxTaskGetSystemState( uxTask );
+
         return uxTask;
     }
 
@@ -4123,7 +4151,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         /* If xTaskGetIdleTaskHandle() is called before the scheduler has been
          * started, then xIdleTaskHandles will be NULL. */
         configASSERT( ( xIdleTaskHandles[ 0 ] != NULL ) );
+
         traceRETURN_xTaskGetIdleTaskHandle( xIdleTaskHandles[ 0 ] );
+
         return xIdleTaskHandles[ 0 ];
     }
 
@@ -4167,6 +4197,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         }
 
         xTickCount += xTicksToJump;
+
         traceINCREASE_TICK_COUNT( xTicksToJump );
         traceRETURN_vTaskStepTick();
     }
@@ -4197,6 +4228,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
     xYieldOccurred = xTaskResumeAll();
 
     traceRETURN_xTaskCatchUpTicks( xYieldOccurred );
+
     return xYieldOccurred;
 }
 /*----------------------------------------------------------*/
@@ -4290,6 +4322,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
         ( void ) xTaskResumeAll();
 
         traceRETURN_xTaskAbortDelay( xReturn );
+
         return xReturn;
     }
 
@@ -4542,6 +4575,7 @@ BaseType_t xTaskIncrementTick( void )
     }
 
     traceRETURN_xTaskIncrementTick( xSwitchRequired );
+
     return xSwitchRequired;
 }
 /*-----------------------------------------------------------*/
@@ -4573,6 +4607,7 @@ BaseType_t xTaskIncrementTick( void )
             xTCB->pxTaskTag = pxHookFunction;
         }
         taskEXIT_CRITICAL();
+
         traceRETURN_vTaskSetApplicationTaskTag();
     }
 
@@ -4600,6 +4635,7 @@ BaseType_t xTaskIncrementTick( void )
         taskEXIT_CRITICAL();
 
         traceRETURN_xTaskGetApplicationTaskTag( xReturn );
+
         return xReturn;
     }
 
@@ -4628,6 +4664,7 @@ BaseType_t xTaskIncrementTick( void )
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn );
+
         return xReturn;
     }
 
@@ -4664,6 +4701,7 @@ BaseType_t xTaskIncrementTick( void )
         }
 
         traceRETURN_xTaskCallApplicationTaskHook( xReturn );
+
         return xReturn;
     }
 
@@ -4673,6 +4711,8 @@ BaseType_t xTaskIncrementTick( void )
 #if ( configNUMBER_OF_CORES == 1 )
     void vTaskSwitchContext( void )
     {
+        traceAPI_vTaskSwitchContext();
+
         if( uxSchedulerSuspended != ( UBaseType_t ) 0U )
         {
             /* The scheduler is currently suspended - do not allow a context
@@ -4742,10 +4782,14 @@ BaseType_t xTaskIncrementTick( void )
             }
             #endif
         }
+
+        traceRETURN_vTaskSwitchContext();
     }
 #else /* if ( configNUMBER_OF_CORES == 1 ) */
     void vTaskSwitchContext( BaseType_t xCoreID )
     {
+        traceAPI_vTaskSwitchContext();
+
         /* Acquire both locks:
          * - The ISR lock protects the ready list from simultaneous access by
          *   both other ISRs and tasks.
@@ -4833,6 +4877,8 @@ BaseType_t xTaskIncrementTick( void )
         }
         portRELEASE_ISR_LOCK();
         portRELEASE_TASK_LOCK();
+
+        traceRETURN_vTaskSwitchContext();
     }
 #endif /* if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
@@ -5105,6 +5151,7 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
         pxTimeOut->xTimeOnEntering = xTickCount;
     }
     taskEXIT_CRITICAL();
+
     traceRETURN_vTaskSetTimeOutState();
 }
 /*-----------------------------------------------------------*/
@@ -5185,6 +5232,7 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
     taskEXIT_CRITICAL();
 
     traceRETURN_xTaskCheckForTimeOut( xReturn );
+
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -5220,6 +5268,7 @@ void vTaskMissedYield( void )
         }
 
         traceRETURN_uxTaskGetTaskNumber( uxReturn );
+
         return uxReturn;
     }
 
@@ -5515,6 +5564,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
         }
 
         traceRETURN_eTaskConfirmSleepModeStatus( eReturn );
+
         return eReturn;
     }
 
@@ -5567,6 +5617,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
         }
 
         traceRETURN_pvTaskGetThreadLocalStoragePointer( pvReturn );
+
         return pvReturn;
     }
 
@@ -5580,7 +5631,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     {
         TCB_t * pxTCB;
 
-        traceAPI_vTaskAllocateMPURegions( xTaskToModify, xRegions );
+        traceAPI_vTaskAllocateMPURegions( xTaskToModify, pxRegions );
 
         /* If null is passed in here then we are modifying the MPU settings of
          * the calling task. */
@@ -5914,6 +5965,7 @@ static void prvCheckTasksWaitingTermination( void )
         uxReturn = prvTaskCheckFreeStackSpace( pucEndOfStack );
 
         traceRETURN_uxTaskGetStackHighWaterMark2( uxReturn );
+
         return uxReturn;
     }
 
@@ -5945,6 +5997,7 @@ static void prvCheckTasksWaitingTermination( void )
         uxReturn = ( UBaseType_t ) prvTaskCheckFreeStackSpace( pucEndOfStack );
 
         traceRETURN_uxTaskGetStackHighWaterMark( uxReturn );
+
         return uxReturn;
     }
 
@@ -6042,6 +6095,7 @@ static void prvResetNextTaskUnblockTime( void )
             xReturn = pxCurrentTCB;
 
             traceRETURN_xTaskGetCurrentTaskHandle( xReturn );
+
             return xReturn;
         }
     #else /* #if ( configNUMBER_OF_CORES == 1 ) */
@@ -6058,6 +6112,8 @@ static void prvResetNextTaskUnblockTime( void )
             }
             portCLEAR_INTERRUPT_MASK( uxSavedInterruptStatus );
 
+            traceRETURN_xTaskGetCurrentTaskHandle( xReturn );
+
             return xReturn;
         }
 
@@ -6065,12 +6121,15 @@ static void prvResetNextTaskUnblockTime( void )
         {
             TaskHandle_t xReturn = NULL;
 
+             traceAPI_xTaskGetCurrentTaskHandleCPU( xCoreID );
+
             if( taskVALID_CORE_ID( xCoreID ) != pdFALSE )
             {
                 xReturn = pxCurrentTCBs[ xCoreID ];
             }
 
-            traceRETURN_xTaskGetCurrentTaskHandle( xReturn );
+            traceRETURN_xTaskGetCurrentTaskHandleCPU( xReturn );
+
             return xReturn;
         }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
@@ -6111,6 +6170,7 @@ static void prvResetNextTaskUnblockTime( void )
         }
 
         traceRETURN_xTaskGetSchedulerState( xReturn );
+
         return xReturn;
     }
 
@@ -6214,6 +6274,7 @@ static void prvResetNextTaskUnblockTime( void )
         }
 
         traceRETURN_xTaskPriorityInherit( xReturn );
+
         return xReturn;
     }
 
@@ -6307,6 +6368,7 @@ static void prvResetNextTaskUnblockTime( void )
         }
 
         traceRETURN_xTaskPriorityDisinherit( xReturn );
+
         return xReturn;
     }
 
@@ -6567,6 +6629,7 @@ static void prvResetNextTaskUnblockTime( void )
         }
 
         traceRETURN_vTaskEnterCriticalFromISR( uxSavedInterruptStatus );
+
         return uxSavedInterruptStatus;
     }
 
@@ -6996,6 +7059,7 @@ TickType_t uxTaskResetEventItemValue( void )
     listSET_LIST_ITEM_VALUE( &( pxCurrentTCB->xEventListItem ), ( ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxCurrentTCB->uxPriority ) ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 
     traceRETURN_uxTaskResetEventItemValue( uxReturn );
+
     return uxReturn;
 }
 /*-----------------------------------------------------------*/
@@ -7018,6 +7082,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
 
         traceRETURN_pvTaskIncrementMutexHeldCount( pxTCB );
+
         return pxTCB;
     }
 
@@ -7101,6 +7166,7 @@ TickType_t uxTaskResetEventItemValue( void )
         taskEXIT_CRITICAL();
 
         traceRETURN_ulTaskGenericNotifyTake( ulReturn );
+
         return ulReturn;
     }
 
@@ -7198,6 +7264,7 @@ TickType_t uxTaskResetEventItemValue( void )
         taskEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotifyWait( xReturn );
+
         return xReturn;
     }
 
@@ -7317,6 +7384,7 @@ TickType_t uxTaskResetEventItemValue( void )
         taskEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotify( xReturn );
+
         return xReturn;
     }
 
@@ -7479,6 +7547,7 @@ TickType_t uxTaskResetEventItemValue( void )
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskGenericNotifyFromISR( xReturn );
+
         return xReturn;
     }
 
@@ -7591,6 +7660,7 @@ TickType_t uxTaskResetEventItemValue( void )
             }
         }
         taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+
         traceRETURN_vTaskGenericNotifyGiveFromISR();
     }
 
@@ -7628,6 +7698,7 @@ TickType_t uxTaskResetEventItemValue( void )
         taskEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotifyStateClear( xReturn );
+
         return xReturn;
     }
 
@@ -7661,6 +7732,7 @@ TickType_t uxTaskResetEventItemValue( void )
         taskEXIT_CRITICAL();
 
         traceRETURN_ulTaskGenericNotifyValueClear( ulReturn );
+
         return ulReturn;
     }
 
@@ -7678,6 +7750,7 @@ TickType_t uxTaskResetEventItemValue( void )
         pxTCB = prvGetTCBFromHandle( xTask );
 
         traceRETURN_ulTaskGetRunTimeCounter( pxTCB->ulRunTimeCounter );
+
         return pxTCB->ulRunTimeCounter;
     }
 
@@ -7691,7 +7764,7 @@ TickType_t uxTaskResetEventItemValue( void )
         TCB_t * pxTCB;
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulReturn;
 
-        traceAPI_ulTaskGetIdleRunTimePercent();
+        traceAPI_ulTaskGetRunTimePercent( xTask );
 
         ulTotalTime = ( configRUN_TIME_COUNTER_TYPE ) portGET_RUN_TIME_COUNTER_VALUE();
 
@@ -7709,7 +7782,8 @@ TickType_t uxTaskResetEventItemValue( void )
             ulReturn = 0;
         }
 
-        traceRETURN_ulTaskGetIdleRunTimePercent( ulReturn );
+        traceRETURN_ulTaskGetRunTimePercent( ulReturn );
+
         return ulReturn;
     }
 
@@ -7731,6 +7805,7 @@ TickType_t uxTaskResetEventItemValue( void )
         }
 
         traceRETURN_ulTaskGetIdleRunTimeCounter( ulReturn );
+
         return ulReturn;
     }
 
@@ -7744,6 +7819,8 @@ TickType_t uxTaskResetEventItemValue( void )
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulReturn;
         configRUN_TIME_COUNTER_TYPE ulRunTimeCounter = 0;
         BaseType_t i;
+
+        traceAPI_ulTaskGetIdleRunTimePercent();
 
         ulTotalTime = portGET_RUN_TIME_COUNTER_VALUE() * configNUMBER_OF_CORES;
 
@@ -7764,6 +7841,8 @@ TickType_t uxTaskResetEventItemValue( void )
         {
             ulReturn = 0;
         }
+
+        traceRETURN_ulTaskGetIdleRunTimePercent( ulReturn );
 
         return ulReturn;
     }
@@ -7894,7 +7973,11 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
     {
         TCB_t * pxTCB;
 
+        traceAPI_xTaskGetMPUSettings( xTask );
+
         pxTCB = prvGetTCBFromHandle( xTask );
+
+        traceRETURN_xTaskGetMPUSettings( &( pxTCB->xMPUSettings ) );
 
         return &( pxTCB->xMPUSettings );
     }

--- a/tasks.c
+++ b/tasks.c
@@ -6121,7 +6121,7 @@ static void prvResetNextTaskUnblockTime( void )
         {
             TaskHandle_t xReturn = NULL;
 
-             traceAPI_xTaskGetCurrentTaskHandleCPU( xCoreID );
+            traceAPI_xTaskGetCurrentTaskHandleCPU( xCoreID );
 
             if( taskVALID_CORE_ID( xCoreID ) != pdFALSE )
             {

--- a/tasks.c
+++ b/tasks.c
@@ -1204,7 +1204,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         TCB_t * pxNewTCB;
         TaskHandle_t xReturn;
 
-        traceAPI_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
+        traceENTER_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
 
         configASSERT( puxStackBuffer != NULL );
         configASSERT( pxTaskBuffer != NULL );
@@ -1277,7 +1277,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         TCB_t * pxNewTCB;
         BaseType_t xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
 
-        traceAPI_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask );
+        traceENTER_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask );
 
         configASSERT( pxTaskDefinition->puxStackBuffer != NULL );
         configASSERT( pxTaskDefinition->pxTaskBuffer != NULL );
@@ -1345,7 +1345,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         TCB_t * pxNewTCB;
         BaseType_t xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
 
-        traceAPI_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask );
+        traceENTER_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask );
 
         configASSERT( pxTaskDefinition->puxStackBuffer );
 
@@ -1422,7 +1422,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         TCB_t * pxNewTCB;
         BaseType_t xReturn;
 
-        traceAPI_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
+        traceENTER_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
 
         /* If the stack grows down then allocate the stack then the TCB so the stack
          * does not grow into the TCB.  Likewise if the stack grows up then allocate
@@ -1920,7 +1920,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * pxTCB;
 
-        traceAPI_vTaskDelete( xTaskToDelete );
+        traceENTER_vTaskDelete( xTaskToDelete );
 
         taskENTER_CRITICAL();
         {
@@ -2067,7 +2067,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TickType_t xTimeToWake;
         BaseType_t xAlreadyYielded, xShouldDelay = pdFALSE;
 
-        traceAPI_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
+        traceENTER_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
 
         configASSERT( pxPreviousWakeTime );
         configASSERT( ( xTimeIncrement > 0U ) );
@@ -2161,7 +2161,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         BaseType_t xAlreadyYielded = pdFALSE;
 
-        traceAPI_vTaskDelay( xTicksToDelay );
+        traceENTER_vTaskDelay( xTicksToDelay );
 
         /* A delay time of zero just forces a reschedule. */
         if( xTicksToDelay > ( TickType_t ) 0U )
@@ -2220,7 +2220,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         List_t const * pxOverflowedDelayedList;
         const TCB_t * const pxTCB = xTask;
 
-        traceAPI_eTaskGetState( xTask );
+        traceENTER_eTaskGetState( xTask );
 
         configASSERT( pxTCB );
 
@@ -2348,7 +2348,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t const * pxTCB;
         UBaseType_t uxReturn;
 
-        traceAPI_uxTaskPriorityGet( xTask );
+        traceENTER_uxTaskPriorityGet( xTask );
 
         taskENTER_CRITICAL();
         {
@@ -2375,7 +2375,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         UBaseType_t uxReturn;
         UBaseType_t uxSavedInterruptStatus;
 
-        traceAPI_uxTaskPriorityGetFromISR( xTask );
+        traceENTER_uxTaskPriorityGetFromISR( xTask );
 
         /* RTOS ports that support interrupt nesting have the concept of a
          * maximum  system call (or maximum API call) interrupt priority.
@@ -2421,7 +2421,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         UBaseType_t uxCurrentBasePriority, uxPriorityUsedOnEntry;
         BaseType_t xYieldRequired = pdFALSE;
 
-        traceAPI_vTaskPrioritySet( xTask, uxNewPriority );
+        traceENTER_vTaskPrioritySet( xTask, uxNewPriority );
 
         #if ( configNUMBER_OF_CORES > 1 )
             BaseType_t xYieldForTask = pdFALSE;
@@ -2638,7 +2638,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             UBaseType_t uxPrevNotAllowedCores;
         #endif
 
-        traceAPI_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask );
+        traceENTER_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask );
 
         taskENTER_CRITICAL();
         {
@@ -2697,7 +2697,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         const TCB_t * pxTCB;
         UBaseType_t uxCoreAffinityMask;
 
-        traceAPI_vTaskCoreAffinityGet( xTask );
+        traceENTER_vTaskCoreAffinityGet( xTask );
 
         taskENTER_CRITICAL();
         {
@@ -2720,7 +2720,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * pxTCB;
 
-        traceAPI_vTaskPreemptionDisable( xTask );
+        traceENTER_vTaskPreemptionDisable( xTask );
 
         taskENTER_CRITICAL();
         {
@@ -2743,7 +2743,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t * pxTCB;
         BaseType_t xCoreID;
 
-        traceAPI_vTaskPreemptionEnable( xTask );
+        traceENTER_vTaskPreemptionEnable( xTask );
 
         taskENTER_CRITICAL();
         {
@@ -2778,7 +2778,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             BaseType_t xTaskRunningOnCore;
         #endif
 
-        traceAPI_vTaskSuspend( xTaskToSuspend );
+        traceENTER_vTaskSuspend( xTaskToSuspend );
 
         taskENTER_CRITICAL();
         {
@@ -2988,7 +2988,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * const pxTCB = xTaskToResume;
 
-        traceAPI_vTaskResume( xTaskToResume );
+        traceENTER_vTaskResume( xTaskToResume );
 
         /* It does not make sense to resume the calling task. */
         configASSERT( xTaskToResume );
@@ -3051,7 +3051,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t * const pxTCB = xTaskToResume;
         UBaseType_t uxSavedInterruptStatus;
 
-        traceAPI_xTaskResumeFromISR( xTaskToResume );
+        traceENTER_xTaskResumeFromISR( xTaskToResume );
 
         configASSERT( xTaskToResume );
 
@@ -3316,7 +3316,7 @@ void vTaskStartScheduler( void )
 {
     BaseType_t xReturn;
 
-    traceAPI_vTaskStartScheduler();
+    traceENTER_vTaskStartScheduler();
 
     #if ( configUSE_CORE_AFFINITY == 1 ) && ( configNUMBER_OF_CORES > 1 )
     {
@@ -3414,7 +3414,7 @@ void vTaskStartScheduler( void )
 
 void vTaskEndScheduler( void )
 {
-    traceAPI_vTaskEndScheduler();
+    traceENTER_vTaskEndScheduler();
 
     /* Stop the scheduler interrupts and call the portable scheduler end
      * routine so the original ISRs can be restored if necessary.  The port
@@ -3429,7 +3429,7 @@ void vTaskEndScheduler( void )
 
 void vTaskSuspendAll( void )
 {
-    traceAPI_vTaskSuspendAll();
+    traceENTER_vTaskSuspendAll();
 
     #if ( configNUMBER_OF_CORES == 1 )
     {
@@ -3580,7 +3580,7 @@ BaseType_t xTaskResumeAll( void )
     TCB_t * pxTCB = NULL;
     BaseType_t xAlreadyYielded = pdFALSE;
 
-    traceAPI_xTaskResumeAll();
+    traceENTER_xTaskResumeAll();
 
     #if ( configNUMBER_OF_CORES > 1 )
         if( xSchedulerRunning != pdFALSE )
@@ -3726,7 +3726,7 @@ TickType_t xTaskGetTickCount( void )
 {
     TickType_t xTicks;
 
-    traceAPI_xTaskGetTickCount();
+    traceENTER_xTaskGetTickCount();
 
     /* Critical section required if running on a 16 bit processor. */
     portTICK_TYPE_ENTER_CRITICAL();
@@ -3746,7 +3746,7 @@ TickType_t xTaskGetTickCountFromISR( void )
     TickType_t xReturn;
     UBaseType_t uxSavedInterruptStatus;
 
-    traceAPI_xTaskGetTickCountFromISR();
+    traceENTER_xTaskGetTickCountFromISR();
 
     /* RTOS ports that support interrupt nesting have the concept of a maximum
      * system call (or maximum API call) interrupt priority.  Interrupts that are
@@ -3778,7 +3778,7 @@ TickType_t xTaskGetTickCountFromISR( void )
 
 UBaseType_t uxTaskGetNumberOfTasks( void )
 {
-    traceAPI_uxTaskGetNumberOfTasks();
+    traceENTER_uxTaskGetNumberOfTasks();
 
     /* A critical section is not required because the variables are of type
      * BaseType_t. */
@@ -3792,7 +3792,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 {
     TCB_t * pxTCB;
 
-    traceAPI_pcTaskGetName( xTaskToQuery );
+    traceENTER_pcTaskGetName( xTaskToQuery );
 
     /* If null is passed in here then the name of the calling task is being
      * queried. */
@@ -3949,7 +3949,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         UBaseType_t uxQueue = configMAX_PRIORITIES;
         TCB_t * pxTCB;
 
-        traceAPI_xTaskGetHandle( pcNameToQuery );
+        traceENTER_xTaskGetHandle( pcNameToQuery );
 
         /* Task names will be truncated to configMAX_TASK_NAME_LEN - 1 bytes. */
         configASSERT( strlen( pcNameToQuery ) < configMAX_TASK_NAME_LEN );
@@ -4019,7 +4019,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
         BaseType_t xReturn;
         TCB_t * pxTCB;
 
-        traceAPI_xTaskGetStaticBuffers( xTask, ppuxStackBuffer, ppxTaskBuffer );
+        traceENTER_xTaskGetStaticBuffers( xTask, ppuxStackBuffer, ppxTaskBuffer );
 
         configASSERT( ppuxStackBuffer != NULL );
         configASSERT( ppxTaskBuffer != NULL );
@@ -4069,7 +4069,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
     {
         UBaseType_t uxTask = 0, uxQueue = configMAX_PRIORITIES;
 
-        traceAPI_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
+        traceENTER_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
 
         vTaskSuspendAll();
         {
@@ -4146,7 +4146,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
  * Consider to add another function to return the idle task handles. */
     TaskHandle_t xTaskGetIdleTaskHandle( void )
     {
-        traceAPI_xTaskGetIdleTaskHandle();
+        traceENTER_xTaskGetIdleTaskHandle();
 
         /* If xTaskGetIdleTaskHandle() is called before the scheduler has been
          * started, then xIdleTaskHandles will be NULL. */
@@ -4168,7 +4168,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
 
     void vTaskStepTick( TickType_t xTicksToJump )
     {
-        traceAPI_vTaskStepTick( xTicksToJump );
+        traceENTER_vTaskStepTick( xTicksToJump );
 
         /* Correct the tick count value after a period during which the tick
          * was suppressed.  Note this does *not* call the tick hook function for
@@ -4209,7 +4209,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
 {
     BaseType_t xYieldOccurred;
 
-    traceAPI_xTaskCatchUpTicks( xTicksToCatchUp );
+    traceENTER_xTaskCatchUpTicks( xTicksToCatchUp );
 
     /* Must not be called with the scheduler suspended as the implementation
      * relies on xPendedTicks being wound down to 0 in xTaskResumeAll(). */
@@ -4240,7 +4240,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
         TCB_t * pxTCB = xTask;
         BaseType_t xReturn;
 
-        traceAPI_xTaskAbortDelay( xTask );
+        traceENTER_xTaskAbortDelay( xTask );
 
         configASSERT( pxTCB );
 
@@ -4335,7 +4335,7 @@ BaseType_t xTaskIncrementTick( void )
     TickType_t xItemValue;
     BaseType_t xSwitchRequired = pdFALSE;
 
-    traceAPI_xTaskIncrementTick();
+    traceENTER_xTaskIncrementTick();
 
     #if ( configUSE_PREEMPTION == 1 ) && ( configNUMBER_OF_CORES > 1 )
     BaseType_t xYieldRequiredForCore[ configNUMBER_OF_CORES ] = { pdFALSE };
@@ -4587,7 +4587,7 @@ BaseType_t xTaskIncrementTick( void )
     {
         TCB_t * xTCB;
 
-        traceAPI_vTaskSetApplicationTaskTag( xTask, pxHookFunction );
+        traceENTER_vTaskSetApplicationTaskTag( xTask, pxHookFunction );
 
         /* If xTask is NULL then it is the task hook of the calling task that is
          * getting set. */
@@ -4621,7 +4621,7 @@ BaseType_t xTaskIncrementTick( void )
         TCB_t * pxTCB;
         TaskHookFunction_t xReturn;
 
-        traceAPI_xTaskGetApplicationTaskTag( xTask );
+        traceENTER_xTaskGetApplicationTaskTag( xTask );
 
         /* If xTask is NULL then set the calling task's hook. */
         pxTCB = prvGetTCBFromHandle( xTask );
@@ -4650,7 +4650,7 @@ BaseType_t xTaskIncrementTick( void )
         TaskHookFunction_t xReturn;
         UBaseType_t uxSavedInterruptStatus;
 
-        traceAPI_xTaskGetApplicationTaskTagFromISR( xTask );
+        traceENTER_xTaskGetApplicationTaskTagFromISR( xTask );
 
         /* If xTask is NULL then set the calling task's hook. */
         pxTCB = prvGetTCBFromHandle( xTask );
@@ -4679,7 +4679,7 @@ BaseType_t xTaskIncrementTick( void )
         TCB_t * xTCB;
         BaseType_t xReturn;
 
-        traceAPI_xTaskCallApplicationTaskHook( xTask, pvParameter );
+        traceENTER_xTaskCallApplicationTaskHook( xTask, pvParameter );
 
         /* If xTask is NULL then we are calling our own task hook. */
         if( xTask == NULL )
@@ -4711,7 +4711,7 @@ BaseType_t xTaskIncrementTick( void )
 #if ( configNUMBER_OF_CORES == 1 )
     void vTaskSwitchContext( void )
     {
-        traceAPI_vTaskSwitchContext();
+        traceENTER_vTaskSwitchContext();
 
         if( uxSchedulerSuspended != ( UBaseType_t ) 0U )
         {
@@ -4788,7 +4788,7 @@ BaseType_t xTaskIncrementTick( void )
 #else /* if ( configNUMBER_OF_CORES == 1 ) */
     void vTaskSwitchContext( BaseType_t xCoreID )
     {
-        traceAPI_vTaskSwitchContext();
+        traceENTER_vTaskSwitchContext();
 
         /* Acquire both locks:
          * - The ISR lock protects the ready list from simultaneous access by
@@ -4886,7 +4886,7 @@ BaseType_t xTaskIncrementTick( void )
 void vTaskPlaceOnEventList( List_t * const pxEventList,
                             const TickType_t xTicksToWait )
 {
-    traceAPI_vTaskPlaceOnEventList( pxEventList, xTicksToWait );
+    traceENTER_vTaskPlaceOnEventList( pxEventList, xTicksToWait );
 
     configASSERT( pxEventList );
 
@@ -4916,7 +4916,7 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
                                      const TickType_t xItemValue,
                                      const TickType_t xTicksToWait )
 {
-    traceAPI_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait );
+    traceENTER_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait );
 
     configASSERT( pxEventList );
 
@@ -4948,7 +4948,7 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
                                           TickType_t xTicksToWait,
                                           const BaseType_t xWaitIndefinitely )
     {
-        traceAPI_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely );
+        traceENTER_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely );
 
         configASSERT( pxEventList );
 
@@ -4986,7 +4986,7 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
     TCB_t * pxUnblockedTCB;
     BaseType_t xReturn;
 
-    traceAPI_xTaskRemoveFromEventList( pxEventList );
+    traceENTER_xTaskRemoveFromEventList( pxEventList );
 
     /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
      * called from a critical section within an ISR. */
@@ -5076,7 +5076,7 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
 {
     TCB_t * pxUnblockedTCB;
 
-    traceAPI_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue );
+    traceENTER_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue );
 
     /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
      * the event flags implementation. */
@@ -5142,7 +5142,7 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
 
 void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
 {
-    traceAPI_vTaskSetTimeOutState( pxTimeOut );
+    traceENTER_vTaskSetTimeOutState( pxTimeOut );
 
     configASSERT( pxTimeOut );
     taskENTER_CRITICAL();
@@ -5158,7 +5158,7 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
 
 void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 {
-    traceAPI_vTaskInternalSetTimeOutState( pxTimeOut );
+    traceENTER_vTaskInternalSetTimeOutState( pxTimeOut );
 
     /* For internal use only as it does not use a critical section. */
     pxTimeOut->xOverflowCount = xNumOfOverflows;
@@ -5173,7 +5173,7 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
 {
     BaseType_t xReturn;
 
-    traceAPI_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
+    traceENTER_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
 
     configASSERT( pxTimeOut );
     configASSERT( pxTicksToWait );
@@ -5239,7 +5239,7 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
 
 void vTaskMissedYield( void )
 {
-    traceAPI_vTaskMissedYield();
+    traceENTER_vTaskMissedYield();
 
     /* Must be called from within a critical section. */
     xYieldPendings[ portGET_CORE_ID() ] = pdTRUE;
@@ -5255,7 +5255,7 @@ void vTaskMissedYield( void )
         UBaseType_t uxReturn;
         TCB_t const * pxTCB;
 
-        traceAPI_uxTaskGetTaskNumber( xTask );
+        traceENTER_uxTaskGetTaskNumber( xTask );
 
         if( xTask != NULL )
         {
@@ -5282,7 +5282,7 @@ void vTaskMissedYield( void )
     {
         TCB_t * pxTCB;
 
-        traceAPI_vTaskSetTaskNumber( xTask, uxHandle );
+        traceENTER_vTaskSetTaskNumber( xTask, uxHandle );
 
         if( xTask != NULL )
         {
@@ -5525,7 +5525,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             const UBaseType_t uxNonApplicationTasks = 1;
         #endif /* INCLUDE_vTaskSuspend */
 
-        traceAPI_eTaskConfirmSleepModeStatus();
+        traceENTER_eTaskConfirmSleepModeStatus();
 
         eSleepModeStatus eReturn = eStandardSleep;
 
@@ -5579,7 +5579,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     {
         TCB_t * pxTCB;
 
-        traceAPI_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue );
+        traceENTER_vTaskSetThreadLocalStoragePointer( xTaskToSet, xIndex, pvValue );
 
         if( ( xIndex >= 0 ) &&
             ( xIndex < ( BaseType_t ) configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
@@ -5603,7 +5603,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
         void * pvReturn = NULL;
         TCB_t * pxTCB;
 
-        traceAPI_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex );
+        traceENTER_pvTaskGetThreadLocalStoragePointer( xTaskToQuery, xIndex );
 
         if( ( xIndex >= 0 ) &&
             ( xIndex < ( BaseType_t ) configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
@@ -5631,7 +5631,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
     {
         TCB_t * pxTCB;
 
-        traceAPI_vTaskAllocateMPURegions( xTaskToModify, pxRegions );
+        traceENTER_vTaskAllocateMPURegions( xTaskToModify, pxRegions );
 
         /* If null is passed in here then we are modifying the MPU settings of
          * the calling task. */
@@ -5756,7 +5756,7 @@ static void prvCheckTasksWaitingTermination( void )
     {
         TCB_t * pxTCB;
 
-        traceAPI_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState );
+        traceENTER_vTaskGetInfo( xTask, pxTaskStatus, xGetFreeStackSpace, eState );
 
         /* xTask is NULL then get the state of the calling task. */
         pxTCB = prvGetTCBFromHandle( xTask );
@@ -5941,7 +5941,7 @@ static void prvCheckTasksWaitingTermination( void )
         uint8_t * pucEndOfStack;
         configSTACK_DEPTH_TYPE uxReturn;
 
-        traceAPI_uxTaskGetStackHighWaterMark2( xTask );
+        traceENTER_uxTaskGetStackHighWaterMark2( xTask );
 
         /* uxTaskGetStackHighWaterMark() and uxTaskGetStackHighWaterMark2() are
          * the same except for their return type.  Using configSTACK_DEPTH_TYPE
@@ -5980,7 +5980,7 @@ static void prvCheckTasksWaitingTermination( void )
         uint8_t * pucEndOfStack;
         UBaseType_t uxReturn;
 
-        traceAPI_uxTaskGetStackHighWaterMark( xTask );
+        traceENTER_uxTaskGetStackHighWaterMark( xTask );
 
         pxTCB = prvGetTCBFromHandle( xTask );
 
@@ -6087,7 +6087,7 @@ static void prvResetNextTaskUnblockTime( void )
         {
             TaskHandle_t xReturn;
 
-            traceAPI_xTaskGetCurrentTaskHandle();
+            traceENTER_xTaskGetCurrentTaskHandle();
 
             /* A critical section is not required as this is not called from
              * an interrupt and the current TCB will always be the same for any
@@ -6104,7 +6104,7 @@ static void prvResetNextTaskUnblockTime( void )
             TaskHandle_t xReturn;
             UBaseType_t uxSavedInterruptStatus;
 
-            traceAPI_xTaskGetCurrentTaskHandle();
+            traceENTER_xTaskGetCurrentTaskHandle();
 
             uxSavedInterruptStatus = portSET_INTERRUPT_MASK();
             {
@@ -6121,7 +6121,7 @@ static void prvResetNextTaskUnblockTime( void )
         {
             TaskHandle_t xReturn = NULL;
 
-            traceAPI_xTaskGetCurrentTaskHandleCPU( xCoreID );
+            traceENTER_xTaskGetCurrentTaskHandleCPU( xCoreID );
 
             if( taskVALID_CORE_ID( xCoreID ) != pdFALSE )
             {
@@ -6143,7 +6143,7 @@ static void prvResetNextTaskUnblockTime( void )
     {
         BaseType_t xReturn;
 
-        traceAPI_xTaskGetSchedulerState();
+        traceENTER_xTaskGetSchedulerState();
 
         if( xSchedulerRunning == pdFALSE )
         {
@@ -6184,7 +6184,7 @@ static void prvResetNextTaskUnblockTime( void )
         TCB_t * const pxMutexHolderTCB = pxMutexHolder;
         BaseType_t xReturn = pdFALSE;
 
-        traceAPI_xTaskPriorityInherit( pxMutexHolder );
+        traceENTER_xTaskPriorityInherit( pxMutexHolder );
 
         /* If the mutex was given back by an interrupt while the queue was
          * locked then the mutex holder might now be NULL.  _RB_ Is this still
@@ -6288,7 +6288,7 @@ static void prvResetNextTaskUnblockTime( void )
         TCB_t * const pxTCB = pxMutexHolder;
         BaseType_t xReturn = pdFALSE;
 
-        traceAPI_xTaskPriorityDisinherit( pxMutexHolder );
+        traceENTER_xTaskPriorityDisinherit( pxMutexHolder );
 
         if( pxMutexHolder != NULL )
         {
@@ -6384,7 +6384,7 @@ static void prvResetNextTaskUnblockTime( void )
         UBaseType_t uxPriorityUsedOnEntry, uxPriorityToUse;
         const UBaseType_t uxOnlyOneMutexHeld = ( UBaseType_t ) 1;
 
-        traceAPI_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask );
+        traceENTER_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask );
 
         if( pxMutexHolder != NULL )
         {
@@ -6503,7 +6503,7 @@ static void prvResetNextTaskUnblockTime( void )
  */
     void vTaskYieldWithinAPI( void )
     {
-        traceAPI_vTaskYieldWithinAPI();
+        traceENTER_vTaskYieldWithinAPI();
 
         if( portGET_CRITICAL_NESTING_COUNT() == 0U )
         {
@@ -6524,7 +6524,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskEnterCritical( void )
     {
-        traceAPI_vTaskEnterCritical();
+        traceENTER_vTaskEnterCritical();
 
         portDISABLE_INTERRUPTS();
 
@@ -6558,7 +6558,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskEnterCritical( void )
     {
-        traceAPI_vTaskEnterCritical();
+        traceENTER_vTaskEnterCritical();
 
         portDISABLE_INTERRUPTS();
 
@@ -6610,7 +6610,7 @@ static void prvResetNextTaskUnblockTime( void )
     {
         UBaseType_t uxSavedInterruptStatus = 0;
 
-        traceAPI_vTaskEnterCriticalFromISR();
+        traceENTER_vTaskEnterCriticalFromISR();
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -6640,7 +6640,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCritical( void )
     {
-        traceAPI_vTaskExitCritical();
+        traceENTER_vTaskExitCritical();
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -6685,7 +6685,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCritical( void )
     {
-        traceAPI_vTaskExitCritical();
+        traceENTER_vTaskExitCritical();
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -6746,7 +6746,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
-        traceAPI_vTaskExitCriticalFromISR( uxSavedInterruptStatus );
+        traceENTER_vTaskExitCriticalFromISR( uxSavedInterruptStatus );
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -6819,7 +6819,7 @@ static void prvResetNextTaskUnblockTime( void )
         UBaseType_t uxArraySize, x;
         char cStatus;
 
-        traceAPI_vTaskList( pcWriteBuffer );
+        traceENTER_vTaskList( pcWriteBuffer );
 
         /*
          * PLEASE NOTE:
@@ -6929,7 +6929,7 @@ static void prvResetNextTaskUnblockTime( void )
         UBaseType_t uxArraySize, x;
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulStatsAsPercentage;
 
-        traceAPI_vTaskGetRunTimeStats( pcWriteBuffer );
+        traceENTER_vTaskGetRunTimeStats( pcWriteBuffer );
 
         /*
          * PLEASE NOTE:
@@ -7050,7 +7050,7 @@ TickType_t uxTaskResetEventItemValue( void )
 {
     TickType_t uxReturn;
 
-    traceAPI_uxTaskResetEventItemValue();
+    traceENTER_uxTaskResetEventItemValue();
 
     uxReturn = listGET_LIST_ITEM_VALUE( &( pxCurrentTCB->xEventListItem ) );
 
@@ -7070,7 +7070,7 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         TCB_t * pxTCB;
 
-        traceAPI_pvTaskIncrementMutexHeldCount();
+        traceENTER_pvTaskIncrementMutexHeldCount();
 
         pxTCB = pxCurrentTCB;
 
@@ -7097,7 +7097,7 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         uint32_t ulReturn;
 
-        traceAPI_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait );
+        traceENTER_ulTaskGenericNotifyTake( uxIndexToWaitOn, xClearCountOnExit, xTicksToWait );
 
         configASSERT( uxIndexToWaitOn < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -7183,7 +7183,7 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         BaseType_t xReturn;
 
-        traceAPI_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait );
+        traceENTER_xTaskGenericNotifyWait( uxIndexToWaitOn, ulBitsToClearOnEntry, ulBitsToClearOnExit, pulNotificationValue, xTicksToWait );
 
         configASSERT( uxIndexToWaitOn < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -7283,7 +7283,7 @@ TickType_t uxTaskResetEventItemValue( void )
         BaseType_t xReturn = pdPASS;
         uint8_t ucOriginalNotifyState;
 
-        traceAPI_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
+        traceENTER_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
 
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
         configASSERT( xTaskToNotify );
@@ -7405,7 +7405,7 @@ TickType_t uxTaskResetEventItemValue( void )
         BaseType_t xReturn = pdPASS;
         UBaseType_t uxSavedInterruptStatus;
 
-        traceAPI_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken );
+        traceENTER_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken );
 
         configASSERT( xTaskToNotify );
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
@@ -7564,7 +7564,7 @@ TickType_t uxTaskResetEventItemValue( void )
         uint8_t ucOriginalNotifyState;
         UBaseType_t uxSavedInterruptStatus;
 
-        traceAPI_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken );
+        traceENTER_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken );
 
         configASSERT( xTaskToNotify );
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
@@ -7675,7 +7675,7 @@ TickType_t uxTaskResetEventItemValue( void )
         TCB_t * pxTCB;
         BaseType_t xReturn;
 
-        traceAPI_xTaskGenericNotifyStateClear( xTask, uxIndexToClear );
+        traceENTER_xTaskGenericNotifyStateClear( xTask, uxIndexToClear );
 
         configASSERT( uxIndexToClear < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -7714,7 +7714,7 @@ TickType_t uxTaskResetEventItemValue( void )
         TCB_t * pxTCB;
         uint32_t ulReturn;
 
-        traceAPI_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear );
+        traceENTER_ulTaskGenericNotifyValueClear( xTask, uxIndexToClear, ulBitsToClear );
 
         configASSERT( uxIndexToClear < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
@@ -7745,7 +7745,7 @@ TickType_t uxTaskResetEventItemValue( void )
     {
         TCB_t * pxTCB;
 
-        traceAPI_ulTaskGetRunTimeCounter( xTask );
+        traceENTER_ulTaskGetRunTimeCounter( xTask );
 
         pxTCB = prvGetTCBFromHandle( xTask );
 
@@ -7764,7 +7764,7 @@ TickType_t uxTaskResetEventItemValue( void )
         TCB_t * pxTCB;
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulReturn;
 
-        traceAPI_ulTaskGetRunTimePercent( xTask );
+        traceENTER_ulTaskGetRunTimePercent( xTask );
 
         ulTotalTime = ( configRUN_TIME_COUNTER_TYPE ) portGET_RUN_TIME_COUNTER_VALUE();
 
@@ -7797,7 +7797,7 @@ TickType_t uxTaskResetEventItemValue( void )
         configRUN_TIME_COUNTER_TYPE ulReturn = 0;
         BaseType_t i;
 
-        traceAPI_ulTaskGetIdleRunTimeCounter();
+        traceENTER_ulTaskGetIdleRunTimeCounter();
 
         for( i = 0; i < ( BaseType_t ) configNUMBER_OF_CORES; i++ )
         {
@@ -7820,7 +7820,7 @@ TickType_t uxTaskResetEventItemValue( void )
         configRUN_TIME_COUNTER_TYPE ulRunTimeCounter = 0;
         BaseType_t i;
 
-        traceAPI_ulTaskGetIdleRunTimePercent();
+        traceENTER_ulTaskGetIdleRunTimePercent();
 
         ulTotalTime = portGET_RUN_TIME_COUNTER_VALUE() * configNUMBER_OF_CORES;
 
@@ -7973,7 +7973,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
     {
         TCB_t * pxTCB;
 
-        traceAPI_xTaskGetMPUSettings( xTask );
+        traceENTER_xTaskGetMPUSettings( xTask );
 
         pxTCB = prvGetTCBFromHandle( xTask );
 

--- a/timers.c
+++ b/timers.c
@@ -235,6 +235,8 @@
     {
         BaseType_t xReturn = pdFAIL;
 
+        traceAPI_xTimerCreateTimerTask();
+
         /* This function is called when the scheduler is started if
          * configUSE_TIMERS is set to 1.  Check that the infrastructure used by the
          * timer service task has been created/initialised.  If timers have already
@@ -280,6 +282,8 @@
         }
 
         configASSERT( xReturn );
+
+        traceRETURN_xTimerCreateTimerTask( xReturn );
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -294,6 +298,8 @@
         {
             Timer_t * pxNewTimer;
 
+            traceAPI_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction );
+
             pxNewTimer = ( Timer_t * ) pvPortMalloc( sizeof( Timer_t ) ); /*lint !e9087 !e9079 All values returned by pvPortMalloc() have at least the alignment required by the MCU's stack, and the first member of Timer_t is always a pointer to the timer's name. */
 
             if( pxNewTimer != NULL )
@@ -305,6 +311,7 @@
                 prvInitialiseNewTimer( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxNewTimer );
             }
 
+            traceRETURN_xTimerCreate( pxNewTimer );
             return pxNewTimer;
         }
 
@@ -321,6 +328,8 @@
                                           StaticTimer_t * pxTimerBuffer )
         {
             Timer_t * pxNewTimer;
+
+            traceAPI_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
 
             #if ( configASSERT_DEFINED == 1 )
             {
@@ -347,6 +356,7 @@
                 prvInitialiseNewTimer( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxNewTimer );
             }
 
+            traceRETURN_xTimerCreateStatic( pxNewTimer );
             return pxNewTimer;
         }
 
@@ -395,6 +405,8 @@
 
         ( void ) pxHigherPriorityTaskWoken;
 
+        traceAPI_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+
         configASSERT( xTimer );
 
         /* Send a message to the timer service task to perform a particular action
@@ -427,6 +439,7 @@
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xTimerGenericCommandFromTask( xReturn );
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -441,6 +454,8 @@
         DaemonTaskMessage_t xMessage;
 
         ( void ) xTicksToWait;
+
+        traceAPI_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
 
         configASSERT( xTimer );
 
@@ -467,15 +482,20 @@
             mtCOVERAGE_TEST_MARKER();
         }
 
+        traceRETURN_xTimerGenericCommandFromISR( xReturn );
         return xReturn;
     }
 /*-----------------------------------------------------------*/
 
     TaskHandle_t xTimerGetTimerDaemonTaskHandle( void )
     {
+        traceAPI_xTimerGetTimerDaemonTaskHandle();
+
         /* If xTimerGetTimerDaemonTaskHandle() is called before the scheduler has been
          * started, then xTimerTaskHandle will be NULL. */
         configASSERT( ( xTimerTaskHandle != NULL ) );
+
+        traceRETURN_xTimerGetTimerDaemonTaskHandle( xTimerTaskHandle );
         return xTimerTaskHandle;
     }
 /*-----------------------------------------------------------*/
@@ -484,7 +504,11 @@
     {
         Timer_t * pxTimer = xTimer;
 
+        traceAPI_xTimerGetPeriod( xTimer );
+
         configASSERT( xTimer );
+
+        traceRETURN_xTimerGetPeriod( pxTimer->xTimerPeriodInTicks );
         return pxTimer->xTimerPeriodInTicks;
     }
 /*-----------------------------------------------------------*/
@@ -493,6 +517,8 @@
                               const BaseType_t xAutoReload )
     {
         Timer_t * pxTimer = xTimer;
+
+        traceAPI_vTimerSetReloadMode( xTimer, xAutoReload );
 
         configASSERT( xTimer );
         taskENTER_CRITICAL();
@@ -507,6 +533,7 @@
             }
         }
         taskEXIT_CRITICAL();
+        traceRETURN_vTimerSetReloadMode();
     }
 /*-----------------------------------------------------------*/
 
@@ -514,6 +541,8 @@
     {
         Timer_t * pxTimer = xTimer;
         BaseType_t xReturn;
+
+        traceAPI_xTimerGetReloadMode( xTimer );
 
         configASSERT( xTimer );
         taskENTER_CRITICAL();
@@ -531,6 +560,7 @@
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xTimerGetReloadMode( xReturn );
         return xReturn;
     }
 
@@ -545,8 +575,10 @@
         Timer_t * pxTimer = xTimer;
         TickType_t xReturn;
 
+        traceAPI_xTimerGetExpiryTime( xTimer );
         configASSERT( xTimer );
         xReturn = listGET_LIST_ITEM_VALUE( &( pxTimer->xTimerListItem ) );
+        traceRETURN_xTimerGetExpiryTime( xReturn );
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -579,7 +611,11 @@
     {
         Timer_t * pxTimer = xTimer;
 
+        traceAPI_pcTimerGetName( xTimer );
+
         configASSERT( xTimer );
+
+        traceRETURN_pcTimerGetName( pxTimer->pcTimerName );
         return pxTimer->pcTimerName;
     }
 /*-----------------------------------------------------------*/
@@ -1057,6 +1093,8 @@
         BaseType_t xReturn;
         Timer_t * pxTimer = xTimer;
 
+        traceAPI_xTimerIsTimerActive( xTimer );
+
         configASSERT( xTimer );
 
         /* Is the timer in the list of active timers? */
@@ -1073,6 +1111,7 @@
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_xTimerIsTimerActive( xReturn );
         return xReturn;
     } /*lint !e818 Can't be pointer to const due to the typedef. */
 /*-----------------------------------------------------------*/
@@ -1082,6 +1121,8 @@
         Timer_t * const pxTimer = xTimer;
         void * pvReturn;
 
+        traceAPI_pvTimerGetTimerID( xTimer );
+
         configASSERT( xTimer );
 
         taskENTER_CRITICAL();
@@ -1090,6 +1131,7 @@
         }
         taskEXIT_CRITICAL();
 
+        traceRETURN_pvTimerGetTimerID( pvReturn );
         return pvReturn;
     }
 /*-----------------------------------------------------------*/
@@ -1099,6 +1141,8 @@
     {
         Timer_t * const pxTimer = xTimer;
 
+        traceAPI_vTimerSetTimerID( xTimer, pvNewID );
+
         configASSERT( xTimer );
 
         taskENTER_CRITICAL();
@@ -1106,6 +1150,7 @@
             pxTimer->pvTimerID = pvNewID;
         }
         taskEXIT_CRITICAL();
+        traceRETURN_vTimerSetTimerID();
     }
 /*-----------------------------------------------------------*/
 
@@ -1119,6 +1164,8 @@
             DaemonTaskMessage_t xMessage;
             BaseType_t xReturn;
 
+            traceAPI_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken );
+
             /* Complete the message with the function parameters and post it to the
              * daemon task. */
             xMessage.xMessageID = tmrCOMMAND_EXECUTE_CALLBACK_FROM_ISR;
@@ -1129,7 +1176,7 @@
             xReturn = xQueueSendFromISR( xTimerQueue, &xMessage, pxHigherPriorityTaskWoken );
 
             tracePEND_FUNC_CALL_FROM_ISR( xFunctionToPend, pvParameter1, ulParameter2, xReturn );
-
+            traceRETURN_xTimerPendFunctionCallFromISR( xReturn );
             return xReturn;
         }
 
@@ -1146,6 +1193,8 @@
             DaemonTaskMessage_t xMessage;
             BaseType_t xReturn;
 
+            traceAPI_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
+
             /* This function can only be called after a timer has been created or
              * after the scheduler has been started because, until then, the timer
              * queue does not exist. */
@@ -1161,7 +1210,7 @@
             xReturn = xQueueSendToBack( xTimerQueue, &xMessage, xTicksToWait );
 
             tracePEND_FUNC_CALL( xFunctionToPend, pvParameter1, ulParameter2, xReturn );
-
+            traceRETURN_xTimerPendFunctionCall( xReturn );
             return xReturn;
         }
 
@@ -1172,6 +1221,8 @@
 
         UBaseType_t uxTimerGetTimerNumber( TimerHandle_t xTimer )
         {
+            traceAPI_uxTimerGetTimerNumber( xTimer );
+            traceRETURN_uxTimerGetTimerNumber( ( ( Timer_t * ) xTimer )->uxTimerNumber );
             return ( ( Timer_t * ) xTimer )->uxTimerNumber;
         }
 
@@ -1183,7 +1234,9 @@
         void vTimerSetTimerNumber( TimerHandle_t xTimer,
                                    UBaseType_t uxTimerNumber )
         {
+            traceAPI_vTimerSetTimerNumber( xTimer, uxTimerNumber );
             ( ( Timer_t * ) xTimer )->uxTimerNumber = uxTimerNumber;
+            traceRETURN_vTimerSetTimerNumber();
         }
 
     #endif /* configUSE_TRACE_FACILITY */

--- a/timers.c
+++ b/timers.c
@@ -235,7 +235,7 @@
     {
         BaseType_t xReturn = pdFAIL;
 
-        traceAPI_xTimerCreateTimerTask();
+        traceENTER_xTimerCreateTimerTask();
 
         /* This function is called when the scheduler is started if
          * configUSE_TIMERS is set to 1.  Check that the infrastructure used by the
@@ -299,7 +299,7 @@
         {
             Timer_t * pxNewTimer;
 
-            traceAPI_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction );
+            traceENTER_xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction );
 
             pxNewTimer = ( Timer_t * ) pvPortMalloc( sizeof( Timer_t ) ); /*lint !e9087 !e9079 All values returned by pvPortMalloc() have at least the alignment required by the MCU's stack, and the first member of Timer_t is always a pointer to the timer's name. */
 
@@ -331,7 +331,7 @@
         {
             Timer_t * pxNewTimer;
 
-            traceAPI_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
+            traceENTER_xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, pxCallbackFunction, pxTimerBuffer );
 
             #if ( configASSERT_DEFINED == 1 )
             {
@@ -408,7 +408,7 @@
 
         ( void ) pxHigherPriorityTaskWoken;
 
-        traceAPI_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+        traceENTER_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
 
         configASSERT( xTimer );
 
@@ -459,7 +459,7 @@
 
         ( void ) xTicksToWait;
 
-        traceAPI_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
+        traceENTER_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
 
         configASSERT( xTimer );
 
@@ -494,7 +494,7 @@
 
     TaskHandle_t xTimerGetTimerDaemonTaskHandle( void )
     {
-        traceAPI_xTimerGetTimerDaemonTaskHandle();
+        traceENTER_xTimerGetTimerDaemonTaskHandle();
 
         /* If xTimerGetTimerDaemonTaskHandle() is called before the scheduler has been
          * started, then xTimerTaskHandle will be NULL. */
@@ -510,7 +510,7 @@
     {
         Timer_t * pxTimer = xTimer;
 
-        traceAPI_xTimerGetPeriod( xTimer );
+        traceENTER_xTimerGetPeriod( xTimer );
 
         configASSERT( xTimer );
 
@@ -525,7 +525,7 @@
     {
         Timer_t * pxTimer = xTimer;
 
-        traceAPI_vTimerSetReloadMode( xTimer, xAutoReload );
+        traceENTER_vTimerSetReloadMode( xTimer, xAutoReload );
 
         configASSERT( xTimer );
         taskENTER_CRITICAL();
@@ -550,7 +550,7 @@
         Timer_t * pxTimer = xTimer;
         BaseType_t xReturn;
 
-        traceAPI_xTimerGetReloadMode( xTimer );
+        traceENTER_xTimerGetReloadMode( xTimer );
 
         configASSERT( xTimer );
         taskENTER_CRITICAL();
@@ -577,7 +577,7 @@
     {
         UBaseType_t uxReturn;
 
-        traceAPI_uxTimerGetReloadMode( xTimer );
+        traceENTER_uxTimerGetReloadMode( xTimer );
 
         uxReturn = ( UBaseType_t ) xTimerGetReloadMode( xTimer );
 
@@ -592,7 +592,7 @@
         Timer_t * pxTimer = xTimer;
         TickType_t xReturn;
 
-        traceAPI_xTimerGetExpiryTime( xTimer );
+        traceENTER_xTimerGetExpiryTime( xTimer );
 
         configASSERT( xTimer );
         xReturn = listGET_LIST_ITEM_VALUE( &( pxTimer->xTimerListItem ) );
@@ -610,7 +610,7 @@
             BaseType_t xReturn;
             Timer_t * pxTimer = xTimer;
 
-            traceAPI_xTimerGetStaticBuffer( xTimer, ppxTimerBuffer );
+            traceENTER_xTimerGetStaticBuffer( xTimer, ppxTimerBuffer );
 
             configASSERT( ppxTimerBuffer != NULL );
 
@@ -635,7 +635,7 @@
     {
         Timer_t * pxTimer = xTimer;
 
-        traceAPI_pcTimerGetName( xTimer );
+        traceENTER_pcTimerGetName( xTimer );
 
         configASSERT( xTimer );
 
@@ -1118,7 +1118,7 @@
         BaseType_t xReturn;
         Timer_t * pxTimer = xTimer;
 
-        traceAPI_xTimerIsTimerActive( xTimer );
+        traceENTER_xTimerIsTimerActive( xTimer );
 
         configASSERT( xTimer );
 
@@ -1147,7 +1147,7 @@
         Timer_t * const pxTimer = xTimer;
         void * pvReturn;
 
-        traceAPI_pvTimerGetTimerID( xTimer );
+        traceENTER_pvTimerGetTimerID( xTimer );
 
         configASSERT( xTimer );
 
@@ -1168,7 +1168,7 @@
     {
         Timer_t * const pxTimer = xTimer;
 
-        traceAPI_vTimerSetTimerID( xTimer, pvNewID );
+        traceENTER_vTimerSetTimerID( xTimer, pvNewID );
 
         configASSERT( xTimer );
 
@@ -1192,7 +1192,7 @@
             DaemonTaskMessage_t xMessage;
             BaseType_t xReturn;
 
-            traceAPI_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken );
+            traceENTER_xTimerPendFunctionCallFromISR( xFunctionToPend, pvParameter1, ulParameter2, pxHigherPriorityTaskWoken );
 
             /* Complete the message with the function parameters and post it to the
              * daemon task. */
@@ -1222,7 +1222,7 @@
             DaemonTaskMessage_t xMessage;
             BaseType_t xReturn;
 
-            traceAPI_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
+            traceENTER_xTimerPendFunctionCall( xFunctionToPend, pvParameter1, ulParameter2, xTicksToWait );
 
             /* This function can only be called after a timer has been created or
              * after the scheduler has been started because, until then, the timer
@@ -1251,7 +1251,7 @@
 
         UBaseType_t uxTimerGetTimerNumber( TimerHandle_t xTimer )
         {
-            traceAPI_uxTimerGetTimerNumber( xTimer );
+            traceENTER_uxTimerGetTimerNumber( xTimer );
 
             traceRETURN_uxTimerGetTimerNumber( ( ( Timer_t * ) xTimer )->uxTimerNumber );
 
@@ -1266,7 +1266,7 @@
         void vTimerSetTimerNumber( TimerHandle_t xTimer,
                                    UBaseType_t uxTimerNumber )
         {
-            traceAPI_vTimerSetTimerNumber( xTimer, uxTimerNumber );
+            traceENTER_vTimerSetTimerNumber( xTimer, uxTimerNumber );
 
             ( ( Timer_t * ) xTimer )->uxTimerNumber = uxTimerNumber;
 

--- a/timers.c
+++ b/timers.c
@@ -284,6 +284,7 @@
         configASSERT( xReturn );
 
         traceRETURN_xTimerCreateTimerTask( xReturn );
+
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -312,6 +313,7 @@
             }
 
             traceRETURN_xTimerCreate( pxNewTimer );
+
             return pxNewTimer;
         }
 
@@ -357,6 +359,7 @@
             }
 
             traceRETURN_xTimerCreateStatic( pxNewTimer );
+
             return pxNewTimer;
         }
 
@@ -440,6 +443,7 @@
         }
 
         traceRETURN_xTimerGenericCommandFromTask( xReturn );
+
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -483,6 +487,7 @@
         }
 
         traceRETURN_xTimerGenericCommandFromISR( xReturn );
+
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -496,6 +501,7 @@
         configASSERT( ( xTimerTaskHandle != NULL ) );
 
         traceRETURN_xTimerGetTimerDaemonTaskHandle( xTimerTaskHandle );
+
         return xTimerTaskHandle;
     }
 /*-----------------------------------------------------------*/
@@ -509,6 +515,7 @@
         configASSERT( xTimer );
 
         traceRETURN_xTimerGetPeriod( pxTimer->xTimerPeriodInTicks );
+
         return pxTimer->xTimerPeriodInTicks;
     }
 /*-----------------------------------------------------------*/
@@ -533,6 +540,7 @@
             }
         }
         taskEXIT_CRITICAL();
+
         traceRETURN_vTimerSetReloadMode();
     }
 /*-----------------------------------------------------------*/
@@ -561,12 +569,21 @@
         taskEXIT_CRITICAL();
 
         traceRETURN_xTimerGetReloadMode( xReturn );
+
         return xReturn;
     }
 
     UBaseType_t uxTimerGetReloadMode( TimerHandle_t xTimer )
     {
-        return ( UBaseType_t ) xTimerGetReloadMode( xTimer );
+        UBaseType_t uxReturn;
+
+        traceAPI_uxTimerGetReloadMode( xTimer );
+
+        uxReturn = ( UBaseType_t ) xTimerGetReloadMode( xTimer );
+
+        traceRETURN_uxTimerGetReloadMode( uxReturn );
+
+        return uxReturn;
     }
 /*-----------------------------------------------------------*/
 
@@ -576,9 +593,12 @@
         TickType_t xReturn;
 
         traceAPI_xTimerGetExpiryTime( xTimer );
+
         configASSERT( xTimer );
         xReturn = listGET_LIST_ITEM_VALUE( &( pxTimer->xTimerListItem ) );
+
         traceRETURN_xTimerGetExpiryTime( xReturn );
+
         return xReturn;
     }
 /*-----------------------------------------------------------*/
@@ -589,6 +609,8 @@
         {
             BaseType_t xReturn;
             Timer_t * pxTimer = xTimer;
+
+            traceAPI_xTimerGetStaticBuffer( xTimer, ppxTimerBuffer );
 
             configASSERT( ppxTimerBuffer != NULL );
 
@@ -601,6 +623,8 @@
             {
                 xReturn = pdFALSE;
             }
+
+            traceRETURN_xTimerGetStaticBuffer( xReturn );
 
             return xReturn;
         }
@@ -616,6 +640,7 @@
         configASSERT( xTimer );
 
         traceRETURN_pcTimerGetName( pxTimer->pcTimerName );
+
         return pxTimer->pcTimerName;
     }
 /*-----------------------------------------------------------*/
@@ -1112,6 +1137,7 @@
         taskEXIT_CRITICAL();
 
         traceRETURN_xTimerIsTimerActive( xReturn );
+
         return xReturn;
     } /*lint !e818 Can't be pointer to const due to the typedef. */
 /*-----------------------------------------------------------*/
@@ -1132,6 +1158,7 @@
         taskEXIT_CRITICAL();
 
         traceRETURN_pvTimerGetTimerID( pvReturn );
+
         return pvReturn;
     }
 /*-----------------------------------------------------------*/
@@ -1150,6 +1177,7 @@
             pxTimer->pvTimerID = pvNewID;
         }
         taskEXIT_CRITICAL();
+
         traceRETURN_vTimerSetTimerID();
     }
 /*-----------------------------------------------------------*/
@@ -1177,6 +1205,7 @@
 
             tracePEND_FUNC_CALL_FROM_ISR( xFunctionToPend, pvParameter1, ulParameter2, xReturn );
             traceRETURN_xTimerPendFunctionCallFromISR( xReturn );
+
             return xReturn;
         }
 
@@ -1211,6 +1240,7 @@
 
             tracePEND_FUNC_CALL( xFunctionToPend, pvParameter1, ulParameter2, xReturn );
             traceRETURN_xTimerPendFunctionCall( xReturn );
+
             return xReturn;
         }
 
@@ -1222,7 +1252,9 @@
         UBaseType_t uxTimerGetTimerNumber( TimerHandle_t xTimer )
         {
             traceAPI_uxTimerGetTimerNumber( xTimer );
+
             traceRETURN_uxTimerGetTimerNumber( ( ( Timer_t * ) xTimer )->uxTimerNumber );
+
             return ( ( Timer_t * ) xTimer )->uxTimerNumber;
         }
 
@@ -1235,7 +1267,9 @@
                                    UBaseType_t uxTimerNumber )
         {
             traceAPI_vTimerSetTimerNumber( xTimer, uxTimerNumber );
+
             ( ( Timer_t * ) xTimer )->uxTimerNumber = uxTimerNumber;
+
             traceRETURN_vTimerSetTimerNumber();
         }
 


### PR DESCRIPTION
Add Trace Hook Macros to all API calls

Description
-----------
This pull-request adds out-of-the-box support for different tracing tools.
For more information see following forum post: https://forums.freertos.org/t/add-tracing-functionality-for-all-api-calls/18007.

New trace hook macros have been added for all public API functions, one for each function entry and one for each exit.
There are no functional changes, as the macros are by default empty.

Test Steps
-----------
N/A

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.