### PR TITLE
Separate the task create function for core affinity

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1618,12 +1618,28 @@
     #define traceRETURN_xTaskCreateStatic( xReturn )
 #endif
 
+#ifndef traceENTER_xTaskCreateStaticAffinitySet
+    #define traceENTER_xTaskCreateStaticAffinitySet( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer, uxCoreAffinityMask )
+#endif
+
+#ifndef traceRETURN_xTaskCreateStaticAffinitySet
+    #define traceRETURN_xTaskCreateStaticAffinitySet( xReturn )
+#endif
+
 #ifndef traceENTER_xTaskCreateRestrictedStatic
     #define traceENTER_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask )
 #endif
 
 #ifndef traceRETURN_xTaskCreateRestrictedStatic
     #define traceRETURN_xTaskCreateRestrictedStatic( xReturn )
+#endif
+
+#ifndef traceENTER_xTaskCreateRestrictedStaticAffinitySet
+    #define traceENTER_xTaskCreateRestrictedStaticAffinitySet( pxTaskDefinition, uxCoreAffinityMask, pxCreatedTask )
+#endif
+
+#ifndef traceRETURN_xTaskCreateRestrictedStaticAffinitySet
+    #define traceRETURN_xTaskCreateRestrictedStaticAffinitySet( xReturn )
 #endif
 
 #ifndef traceENTER_xTaskCreateRestricted
@@ -1634,12 +1650,28 @@
     #define traceRETURN_xTaskCreateRestricted( xReturn )
 #endif
 
+#ifndef traceENTER_xTaskCreateRestrictedAffinitySet
+    #define traceENTER_xTaskCreateRestrictedAffinitySet( pxTaskDefinition, uxCoreAffinityMask, pxCreatedTask )
+#endif
+
+#ifndef traceRETURN_xTaskCreateRestrictedAffinitySet
+    #define traceRETURN_xTaskCreateRestrictedAffinitySet( xReturn )
+#endif
+
 #ifndef traceENTER_xTaskCreate
     #define traceENTER_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask )
 #endif
 
 #ifndef traceRETURN_xTaskCreate
     #define traceRETURN_xTaskCreate( xReturn )
+#endif
+
+#ifndef traceENTER_xTaskCreateAffinitySet
+    #define traceENTER_xTaskCreateAffinitySet( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, uxCoreAffinityMask, pxCreatedTask )
+#endif
+
+#ifndef traceRETURN_xTaskCreateAffinitySet
+    #define traceRETURN_xTaskCreateAffinitySet( xReturn )
 #endif
 
 #ifndef traceENTER_vTaskDelete

--- a/tasks.c
+++ b/tasks.c
@@ -705,8 +705,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
 /*
- * Create a task with static buffer. Returning a handle to the task if it is created
- * successfully. Otherwise, NULL is returned.
+ * Create a task with static buffer for both TCB and stack. Returns a handle to
+ * the task if it is created successfully. Otherwise, returns NULL.
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     static TCB_t * prvCreateStaticTask( TaskFunction_t pxTaskCode,
@@ -720,8 +720,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 
 /*
- * Create a restricted task with static buffer. Returning a handle to the task if
- * it is created successfully. Otherwise, NULL is returned.
+ * Create a restricted task with static buffer for both TCB and stack. Returns
+ * a handle to the task if it is created successfully. Otherwise, returns NULL.
  */
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
     static TCB_t * prvCreateRestrictedStaticTask( const TaskParameters_t * const pxTaskDefinition,
@@ -729,8 +729,9 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
 
 /*
- * Create a restricted task with a TCB_t. Returning a handle to the task if it is
- * created successfully. Otherwise, NULL is returned.
+ * Create a restricted task with static buffer for task stack and allocated buffer
+ * for TCB. Returns a handle to the task if it is created successfully. Otherwise,
+ * returns NULL.
  */
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     static TCB_t * prvCreateRestrictedTask( const TaskParameters_t * const pxTaskDefinition,
@@ -738,8 +739,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
 
 /*
- * Create a task with allocated buffer. Returning a handle to the task if it is created
- * successfully. Otherwise, NULL is returned.
+ * Create a task with allocated buffer for both TCB and stack. Returns a handle to
+ * the task if it is created successfully. Otherwise, returns NULL.
  */
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     static TCB_t * prvCreateTask( TaskFunction_t pxTaskCode,
@@ -1236,8 +1237,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         TCB_t * pxNewTCB;
 
-        traceENTER_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
-
         configASSERT( puxStackBuffer != NULL );
         configASSERT( pxTaskBuffer != NULL );
 
@@ -1277,6 +1276,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return pxNewTCB;
     }
+/*-----------------------------------------------------------*/
 
     TaskHandle_t xTaskCreateStatic( TaskFunction_t pxTaskCode,
                                     const char * const pcName, /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
@@ -1288,6 +1288,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         TaskHandle_t xReturn = NULL;
         TCB_t * pxNewTCB;
+
+        traceENTER_xTaskCreateStatic( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer );
 
         pxNewTCB = prvCreateStaticTask( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer, &xReturn );
 
@@ -1311,6 +1313,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return xReturn;
     }
+/*-----------------------------------------------------------*/
 
     #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
         TaskHandle_t xTaskCreateStaticAffinitySet( TaskFunction_t pxTaskCode,
@@ -1324,6 +1327,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         {
             TaskHandle_t xReturn = NULL;
             TCB_t * pxNewTCB;
+
+            traceENTER_xTaskCreateStaticAffinitySet( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer, uxCoreAffinityMask );
 
             pxNewTCB = prvCreateStaticTask( pxTaskCode, pcName, ulStackDepth, pvParameters, uxPriority, puxStackBuffer, pxTaskBuffer, &xReturn );
 
@@ -1339,6 +1344,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                 mtCOVERAGE_TEST_MARKER();
             }
 
+            traceRETURN_xTaskCreateStaticAffinitySet( xReturn );
+
             return xReturn;
         }
     #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
@@ -1351,8 +1358,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                                   TaskHandle_t * const pxCreatedTask )
     {
         TCB_t * pxNewTCB;
-
-        traceENTER_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask );
 
         configASSERT( pxTaskDefinition->puxStackBuffer != NULL );
         configASSERT( pxTaskDefinition->pxTaskBuffer != NULL );
@@ -1391,12 +1396,15 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return pxNewTCB;
     }
+/*-----------------------------------------------------------*/
 
     BaseType_t xTaskCreateRestrictedStatic( const TaskParameters_t * const pxTaskDefinition,
                                             TaskHandle_t * pxCreatedTask )
     {
         TCB_t * pxNewTCB;
         BaseType_t xReturn;
+
+        traceENTER_xTaskCreateRestrictedStatic( pxTaskDefinition, pxCreatedTask );
 
         configASSERT( pxTaskDefinition != NULL );
 
@@ -1423,6 +1431,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return xReturn;
     }
+/*-----------------------------------------------------------*/
 
     #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
         BaseType_t xTaskCreateRestrictedStaticAffinitySet( const TaskParameters_t * const pxTaskDefinition,
@@ -1431,6 +1440,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         {
             TCB_t * pxNewTCB;
             BaseType_t xReturn;
+
+            traceENTER_xTaskCreateRestrictedStaticAffinitySet( pxTaskDefinition, uxCoreAffinityMask, pxCreatedTask );
 
             configASSERT( pxTaskDefinition != NULL );
 
@@ -1449,6 +1460,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                 xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
             }
 
+            traceRETURN_xTaskCreateRestrictedStaticAffinitySet( xReturn );
+
             return xReturn;
         }
     #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
@@ -1461,8 +1474,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                             TaskHandle_t * const pxCreatedTask )
     {
         TCB_t * pxNewTCB;
-
-        traceENTER_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask );
 
         configASSERT( pxTaskDefinition->puxStackBuffer );
 
@@ -1502,12 +1513,15 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return pxNewTCB;
     }
+/*-----------------------------------------------------------*/
 
     BaseType_t xTaskCreateRestricted( const TaskParameters_t * const pxTaskDefinition,
                                       TaskHandle_t * pxCreatedTask )
     {
         TCB_t * pxNewTCB;
         BaseType_t xReturn;
+
+        traceENTER_xTaskCreateRestricted( pxTaskDefinition, pxCreatedTask );
 
         pxNewTCB = prvCreateRestrictedTask( pxTaskDefinition, pxCreatedTask );
 
@@ -1533,6 +1547,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return xReturn;
     }
+/*-----------------------------------------------------------*/
 
     #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
         BaseType_t xTaskCreateRestrictedAffinitySet( const TaskParameters_t * const pxTaskDefinition,
@@ -1541,6 +1556,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         {
             TCB_t * pxNewTCB;
             BaseType_t xReturn;
+
+            traceENTER_xTaskCreateRestrictedAffinitySet( pxTaskDefinition, uxCoreAffinityMask, pxCreatedTask );
 
             pxNewTCB = prvCreateRestrictedTask( pxTaskDefinition, pxCreatedTask );
 
@@ -1557,6 +1574,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             {
                 xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
             }
+
+            traceRETURN_xTaskCreateRestrictedAffinitySet( xReturn );
 
             return xReturn;
         }
@@ -1575,8 +1594,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                   TaskHandle_t * const pxCreatedTask )
     {
         TCB_t * pxNewTCB;
-
-        traceENTER_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
 
         /* If the stack grows down then allocate the stack then the TCB so the stack
          * does not grow into the TCB.  Likewise if the stack grows up then allocate
@@ -1653,6 +1670,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return pxNewTCB;
     }
+/*-----------------------------------------------------------*/
 
     BaseType_t xTaskCreate( TaskFunction_t pxTaskCode,
                             const char * const pcName, /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
@@ -1663,6 +1681,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         TCB_t * pxNewTCB;
         BaseType_t xReturn;
+
+        traceENTER_xTaskCreate( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
 
         pxNewTCB = prvCreateTask( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
 
@@ -1687,6 +1707,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         return xReturn;
     }
+/*-----------------------------------------------------------*/
 
     #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
         BaseType_t xTaskCreateAffinitySet( TaskFunction_t pxTaskCode,
@@ -1699,6 +1720,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         {
             TCB_t * pxNewTCB;
             BaseType_t xReturn;
+
+            traceENTER_xTaskCreateAffinitySet( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, uxCoreAffinityMask, pxCreatedTask );
 
             pxNewTCB = prvCreateTask( pxTaskCode, pcName, usStackDepth, pvParameters, uxPriority, pxCreatedTask );
 
@@ -1714,6 +1737,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             {
                 xReturn = errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY;
             }
+
+            traceRETURN_xTaskCreateAffinitySet( xReturn );
 
             return xReturn;
         }

--- a/tasks.c
+++ b/tasks.c
@@ -671,8 +671,11 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
  */
 static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
+/*
+ * Create a task with static buffer. Returning a handle to the task if it is created
+ * successfully. Otherwise, NULL is returned.
+ */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-
     static TCB_t * prvCreateStaticTask( TaskFunction_t pxTaskCode,
                                         const char * const pcName, /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
                                         const uint32_t ulStackDepth,
@@ -680,27 +683,39 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                         UBaseType_t uxPriority,
                                         StackType_t * const puxStackBuffer,
                                         StaticTask_t * const pxTaskBuffer,
-                                        TaskHandle_t * const pxCreatedTask );
-#endif
+                                        TaskHandle_t * const pxCreatedTask ) PRIVILEGED_FUNCTION;
+#endif /* #if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 
+/*
+ * Create a restricted task with static buffer. Returning a handle to the task if
+ * it is created successfully. Otherwise, NULL is returned.
+ */
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
     static TCB_t * prvCreateRestrictedStaticTask( const TaskParameters_t * const pxTaskDefinition,
-                                                  TaskHandle_t * const pxCreatedTask );
-#endif
+                                                  TaskHandle_t * const pxCreatedTask ) PRIVILEGED_FUNCTION;
+#endif /* #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
 
+/*
+ * Create a restricted task with a TCB_t. Returning a handle to the task if it is
+ * created successfully. Otherwise, NULL is returned.
+ */
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
     static TCB_t * prvCreateRestrictedTask( const TaskParameters_t * const pxTaskDefinition,
-                                            TaskHandle_t * const pxCreatedTask );
-#endif
+                                            TaskHandle_t * const pxCreatedTask ) PRIVILEGED_FUNCTION;
+#endif /* #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
 
+/*
+ * Create a task with allocated buffer. Returning a handle to the task if it is created
+ * successfully. Otherwise, NULL is returned.
+ */
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     static TCB_t * prvCreateTask( TaskFunction_t pxTaskCode,
                                   const char * const pcName, /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
                                   const configSTACK_DEPTH_TYPE usStackDepth,
                                   void * const pvParameters,
                                   UBaseType_t uxPriority,
-                                  TaskHandle_t * const pxCreatedTask );
-#endif
+                                  TaskHandle_t * const pxCreatedTask ) PRIVILEGED_FUNCTION;
+#endif /* #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) */
 
 /*
  * freertos_tasks_c_additions_init() should only be called if the user definable


### PR DESCRIPTION
Separate the task create function for core affinity

Description
-----------
Create the following private function to create task:
* prvCreateStaticTask
* prvCreateRestrictedStaticTask
* prvCreateRestrictedTask
* prvCreateTask

uxCoreAffinityMask and prvAddNewTaskToReadyList are still required to be called to setup core affinity and add the task to ready list.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
Address #750 in comment 1151, 1625


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
