### PR TITLE
Add default implementations of vApplicationGetIdleTaskMemory and vApplicationGetTimerTaskMemory

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1127,7 +1127,7 @@
 #endif
 
 #ifndef configKERNEL_PROVIDED_STATIC_MEMORY
-    #define configKERNEL_PROVIDED_STATIC_MEMORY 0
+    #define configKERNEL_PROVIDED_STATIC_MEMORY    0
 #endif
 
 #ifndef configSUPPORT_DYNAMIC_ALLOCATION

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1126,6 +1126,10 @@
     #define configSUPPORT_STATIC_ALLOCATION    0
 #endif
 
+#ifndef configKERNEL_PROVIDED_STATIC_MEMORY
+    #define configKERNEL_PROVIDED_STATIC_MEMORY 0
+#endif
+
 #ifndef configSUPPORT_DYNAMIC_ALLOCATION
     /* Defaults to 1 for backward compatibility. */
     #define configSUPPORT_DYNAMIC_ALLOCATION    1

--- a/tasks.c
+++ b/tasks.c
@@ -7655,7 +7655,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
 #endif /* if ( configINCLUDE_FREERTOS_TASK_C_ADDITIONS_H == 1 ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) )
+#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) && ( portUSING_MPU_WRAPPERS == 0 ) )
 
 /*
  * This is the kernel provided implementation of vApplicationGetIdleTaskMemory()
@@ -7668,18 +7668,18 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
                                         StackType_t ** ppxIdleTaskStackBuffer,
                                         uint32_t * pulIdleTaskStackSize )
     {
-        PRIVILEGED_DATA static StaticTask_t xIdleTaskTCB;
-        PRIVILEGED_DATA static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+        static StaticTask_t xIdleTaskTCB;
+        static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
         *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
         *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
         *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
     }
 
-#endif /* #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) ) */
+#endif /* #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) && ( portUSING_MPU_WRAPPERS == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) )
+#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) && ( portUSING_MPU_WRAPPERS == 0 ) )
 
 /*
  * This is the kernel provided implementation of vApplicationGetTimerTaskMemory()
@@ -7692,13 +7692,13 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
                                          StackType_t ** ppxTimerTaskStackBuffer,
                                          uint32_t * pulTimerTaskStackSize )
     {
-        PRIVILEGED_DATA static StaticTask_t xTimerTaskTCB;
-        PRIVILEGED_DATA static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+        static StaticTask_t xTimerTaskTCB;
+        static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 
         *ppxTimerTaskTCBBuffer = &( xTimerTaskTCB );
         *ppxTimerTaskStackBuffer = &( uxTimerTaskStack[ 0 ] );
         *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
     }
 
-#endif /* #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) ) */
+#endif /* #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) && ( portUSING_MPU_WRAPPERS == 0 ) ) */
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -7681,41 +7681,41 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
 /*-----------------------------------------------------------*/
 
 /*
-  vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
-  equals to 1 and is required for static memory allocation support.
-  This definition can be overwritten. 
-*/
+ * vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+ * equals to 1 and is required for static memory allocation support.
+ * This definition can be overwritten.
+ */
 
-#if (configSUPPORT_STATIC_ALLOCATION == 1)
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
 
-__attribute__((__weak__)) void vApplicationGetIdleTaskMemory (StaticTask_t **ppxIdleTaskTCBBuffer,
-                                                             StackType_t **ppxIdleTaskStackBuffer,
-                                                             uint32_t *pulIdleTaskStackSize) 
-{
-    /* Idle task control block and stack */
-    static StaticTask_t Idle_TCB;
-    static StackType_t  Idle_Stack[configMINIMAL_STACK_SIZE];
+    __attribute__( ( __weak__ ) ) void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                                                      StackType_t ** ppxIdleTaskStackBuffer,
+                                                                      uint32_t * pulIdleTaskStackSize )
+    {
+        /* Idle task control block and stack */
+        static StaticTask_t Idle_TCB;
+        static StackType_t Idle_Stack[ configMINIMAL_STACK_SIZE ];
 
-    *ppxIdleTaskTCBBuffer   = &Idle_TCB;
-    *ppxIdleTaskStackBuffer = &Idle_Stack[0];
-    *pulIdleTaskStackSize   = (uint32_t)configMINIMAL_STACK_SIZE;
-}
+        *ppxIdleTaskTCBBuffer = &Idle_TCB;
+        *ppxIdleTaskStackBuffer = &Idle_Stack[ 0 ];
+        *pulIdleTaskStackSize = ( uint32_t ) configMINIMAL_STACK_SIZE;
+    }
 
 /*
-  vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
-  equals to 1 and is required for static memory allocation support.
-  This definition can be overwritten. 
-*/
-__attribute__((__weak__)) void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer,
-                                                               StackType_t **ppxTimerTaskStackBuffer,
-                                                               uint32_t *pulTimerTaskStackSize) 
-{
-    /* Timer task control block and stack */
-    static StaticTask_t Timer_TCB;
-    static StackType_t  Timer_Stack[configTIMER_TASK_STACK_DEPTH];
+ * vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+ * equals to 1 and is required for static memory allocation support.
+ * This definition can be overwritten.
+ */
+    __attribute__( ( __weak__ ) ) void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                                                       StackType_t ** ppxTimerTaskStackBuffer,
+                                                                       uint32_t * pulTimerTaskStackSize )
+    {
+        /* Timer task control block and stack */
+        static StaticTask_t Timer_TCB;
+        static StackType_t Timer_Stack[ configTIMER_TASK_STACK_DEPTH ];
 
-    *ppxTimerTaskTCBBuffer   = &Timer_TCB;
-    *ppxTimerTaskStackBuffer = &Timer_Stack[0];
-    *pulTimerTaskStackSize   = (uint32_t)configTIMER_TASK_STACK_DEPTH;
-}
-#endif
+        *ppxTimerTaskTCBBuffer = &Timer_TCB;
+        *ppxTimerTaskStackBuffer = &Timer_Stack[ 0 ];
+        *pulTimerTaskStackSize = ( uint32_t ) configTIMER_TASK_STACK_DEPTH;
+    }
+#endif /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */

--- a/tasks.c
+++ b/tasks.c
@@ -7668,8 +7668,8 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
                                         StackType_t ** ppxIdleTaskStackBuffer,
                                         uint32_t * pulIdleTaskStackSize )
     {
-        static StaticTask_t xIdleTaskTCB;
-        static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+        PRIVILEGED_DATA static StaticTask_t xIdleTaskTCB;
+        PRIVILEGED_DATA static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
         *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
         *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
@@ -7692,8 +7692,8 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
                                          StackType_t ** ppxTimerTaskStackBuffer,
                                          uint32_t * pulTimerTaskStackSize )
     {
-        static StaticTask_t xTimerTaskTCB;
-        static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+        PRIVILEGED_DATA static StaticTask_t xTimerTaskTCB;
+        PRIVILEGED_DATA static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
 
         *ppxTimerTaskTCBBuffer = &( xTimerTaskTCB );
         *ppxTimerTaskStackBuffer = &( uxTimerTaskStack[ 0 ] );

--- a/tasks.c
+++ b/tasks.c
@@ -7682,13 +7682,13 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
 
 #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) )
 
-    /*
-     * This is the kernel provided implementation of vApplicationGetIdleTaskMemory()
-     * to provide the memory that is used by the Idle task. It is used when
-     * configKERNEL_PROVIDED_STATIC_MEMORY is set to 1. The application can provide
-     * it's own implementation of vApplicationGetIdleTaskMemory by setting
-     * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
-     */
+/*
+ * This is the kernel provided implementation of vApplicationGetIdleTaskMemory()
+ * to provide the memory that is used by the Idle task. It is used when
+ * configKERNEL_PROVIDED_STATIC_MEMORY is set to 1. The application can provide
+ * it's own implementation of vApplicationGetIdleTaskMemory by setting
+ * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
+ */
     void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                         StackType_t ** ppxIdleTaskStackBuffer,
                                         uint32_t * pulIdleTaskStackSize )
@@ -7706,13 +7706,13 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
 
 #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) )
 
-    /*
-     * This is the kernel provided implementation of vApplicationGetTimerTaskMemory()
-     * to provide the memory that is used by the Timer service task. It is used when
-     * configKERNEL_PROVIDED_STATIC_MEMORY is set to 1. The application can provide
-     * it's own implementation of vApplicationGetTimerTaskMemory by setting
-     * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
-     */
+/*
+ * This is the kernel provided implementation of vApplicationGetTimerTaskMemory()
+ * to provide the memory that is used by the Timer service task. It is used when
+ * configKERNEL_PROVIDED_STATIC_MEMORY is set to 1. The application can provide
+ * it's own implementation of vApplicationGetTimerTaskMemory by setting
+ * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
+ */
     void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
                                          StackType_t ** ppxTimerTaskStackBuffer,
                                          uint32_t * pulTimerTaskStackSize )

--- a/tasks.c
+++ b/tasks.c
@@ -7689,9 +7689,9 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
      * it's own implementation of vApplicationGetIdleTaskMemory by setting
      * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
      */
-    void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
-                                        StackType_t **ppxIdleTaskStackBuffer,
-                                        uint32_t *pulIdleTaskStackSize )
+    void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                        StackType_t ** ppxIdleTaskStackBuffer,
+                                        uint32_t * pulIdleTaskStackSize )
     {
         static StaticTask_t xIdleTaskTCB;
         static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
@@ -7713,9 +7713,9 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
      * it's own implementation of vApplicationGetTimerTaskMemory by setting
      * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
      */
-    void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
-                                         StackType_t **ppxTimerTaskStackBuffer,
-                                         uint32_t *pulTimerTaskStackSize )
+    void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                         StackType_t ** ppxTimerTaskStackBuffer,
+                                         uint32_t * pulTimerTaskStackSize )
     {
         static StaticTask_t xTimerTaskTCB;
         static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];

--- a/tasks.c
+++ b/tasks.c
@@ -7678,3 +7678,44 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
     #endif
 
 #endif /* if ( configINCLUDE_FREERTOS_TASK_C_ADDITIONS_H == 1 ) */
+/*-----------------------------------------------------------*/
+
+/*
+  vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+  equals to 1 and is required for static memory allocation support.
+  This definition can be overwritten. 
+*/
+
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+
+__attribute__((__weak__)) void vApplicationGetIdleTaskMemory (StaticTask_t **ppxIdleTaskTCBBuffer,
+                                                             StackType_t **ppxIdleTaskStackBuffer,
+                                                             uint32_t *pulIdleTaskStackSize) 
+{
+    /* Idle task control block and stack */
+    static StaticTask_t Idle_TCB;
+    static StackType_t  Idle_Stack[configMINIMAL_STACK_SIZE];
+
+    *ppxIdleTaskTCBBuffer   = &Idle_TCB;
+    *ppxIdleTaskStackBuffer = &Idle_Stack[0];
+    *pulIdleTaskStackSize   = (uint32_t)configMINIMAL_STACK_SIZE;
+}
+
+/*
+  vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+  equals to 1 and is required for static memory allocation support.
+  This definition can be overwritten. 
+*/
+__attribute__((__weak__)) void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer,
+                                                               StackType_t **ppxTimerTaskStackBuffer,
+                                                               uint32_t *pulTimerTaskStackSize) 
+{
+    /* Timer task control block and stack */
+    static StaticTask_t Timer_TCB;
+    static StackType_t  Timer_Stack[configTIMER_TASK_STACK_DEPTH];
+
+    *ppxTimerTaskTCBBuffer   = &Timer_TCB;
+    *ppxTimerTaskStackBuffer = &Timer_Stack[0];
+    *pulTimerTaskStackSize   = (uint32_t)configTIMER_TASK_STACK_DEPTH;
+}
+#endif

--- a/tasks.c
+++ b/tasks.c
@@ -7680,42 +7680,50 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
 #endif /* if ( configINCLUDE_FREERTOS_TASK_C_ADDITIONS_H == 1 ) */
 /*-----------------------------------------------------------*/
 
-/*
- * vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
- * equals to 1 and is required for static memory allocation support.
- * This definition can be overwritten.
- */
+#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) )
 
-#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-
-    __attribute__( ( __weak__ ) ) void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
-                                                                      StackType_t ** ppxIdleTaskStackBuffer,
-                                                                      uint32_t * pulIdleTaskStackSize )
+    /*
+     * This is the kernel provided implementation of vApplicationGetIdleTaskMemory()
+     * to provide the memory that is used by the Idle task. It is used when
+     * configKERNEL_PROVIDED_STATIC_MEMORY is set to 1. The application can provide
+     * it's own implementation of vApplicationGetIdleTaskMemory by setting
+     * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
+     */
+    void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                        StackType_t **ppxIdleTaskStackBuffer,
+                                        uint32_t *pulIdleTaskStackSize )
     {
-        /* Idle task control block and stack */
-        static StaticTask_t Idle_TCB;
-        static StackType_t Idle_Stack[ configMINIMAL_STACK_SIZE ];
+        static StaticTask_t xIdleTaskTCB;
+        static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
-        *ppxIdleTaskTCBBuffer = &Idle_TCB;
-        *ppxIdleTaskStackBuffer = &Idle_Stack[ 0 ];
-        *pulIdleTaskStackSize = ( uint32_t ) configMINIMAL_STACK_SIZE;
+        *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
+        *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
+        *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
     }
 
-/*
- * vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
- * equals to 1 and is required for static memory allocation support.
- * This definition can be overwritten.
- */
-    __attribute__( ( __weak__ ) ) void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
-                                                                       StackType_t ** ppxTimerTaskStackBuffer,
-                                                                       uint32_t * pulTimerTaskStackSize )
-    {
-        /* Timer task control block and stack */
-        static StaticTask_t Timer_TCB;
-        static StackType_t Timer_Stack[ configTIMER_TASK_STACK_DEPTH ];
+#endif /* #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) ) */
+/*-----------------------------------------------------------*/
 
-        *ppxTimerTaskTCBBuffer = &Timer_TCB;
-        *ppxTimerTaskStackBuffer = &Timer_Stack[ 0 ];
-        *pulTimerTaskStackSize = ( uint32_t ) configTIMER_TASK_STACK_DEPTH;
+#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) )
+
+    /*
+     * This is the kernel provided implementation of vApplicationGetTimerTaskMemory()
+     * to provide the memory that is used by the Timer service task. It is used when
+     * configKERNEL_PROVIDED_STATIC_MEMORY is set to 1. The application can provide
+     * it's own implementation of vApplicationGetTimerTaskMemory by setting
+     * configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined.
+     */
+    void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                         StackType_t **ppxTimerTaskStackBuffer,
+                                         uint32_t *pulTimerTaskStackSize )
+    {
+        static StaticTask_t xTimerTaskTCB;
+        static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+
+        *ppxTimerTaskTCBBuffer = &( xTimerTaskTCB );
+        *ppxTimerTaskStackBuffer = &( uxTimerTaskStack[ 0 ] );
+        *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
     }
-#endif /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+
+#endif /* #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) ) */
+/*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------
This PR introduces `configKERNEL_PROVIDED_STATIC_MEMORY` option which the application can set to 1 to use the default implementations of `vApplicationGetIdleTaskMemory` and `vApplicationGetTimerTaskMemory` functions.

If the application enables static allocation (i.e. sets `configUSE_STATIC_ALLOCATION` to 1) and does not provide the above 2
functions, it will result in linker error. The application has two options:

1. Set `configKERNEL_PROVIDED_STATIC_MEMORY` to 1 to use the default implementations of these functions.
2. Provide implementations of these 2 functions.

Note that default definitions are only available for non-MPU ports. The reason is that the stack alignment requirements vary for different architectures. 

Test Steps
-----------
Build a FreeRTOS project and set `configUSE_STATIC_ALLOCATION` to 1. Observe linker error for missing symbols  `vApplicationGetIdleTaskMemory` and `vApplicationGetTimerTaskMemory`. 

1. Set `configKERNEL_PROVIDED_STATIC_MEMORY` to 1. The linker error goes away and the default implementations in the tasks.c are used.
2. Set `configKERNEL_PROVIDED_STATIC_MEMORY` to 0 and provide implementation of `vApplicationGetIdleTaskMemory` and `vApplicationGetTimerTaskMemory`.  The linker error goes away and the default implementations are used.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
