### PR TITLE
Fix xStreamBufferCreateStatic() API for buffer size <= 4

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -417,22 +417,22 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             xTriggerLevelBytes = ( size_t ) 1;
         }
 
+        /* In case the stream buffer is going to be used as a message buffer
+         * (that is, it will hold discrete messages with a little meta data that
+         * says how big the next message is) check the buffer will be large enough
+         * to hold at least one message. */
+
         if( xIsMessageBuffer != pdFALSE )
         {
             /* Statically allocated message buffer. */
             ucFlags = sbFLAGS_IS_MESSAGE_BUFFER | sbFLAGS_IS_STATICALLY_ALLOCATED;
+            configASSERT( xBufferSizeBytes > sbBYTES_TO_STORE_MESSAGE_LENGTH );
         }
         else
         {
             /* Statically allocated stream buffer. */
             ucFlags = sbFLAGS_IS_STATICALLY_ALLOCATED;
         }
-
-        /* In case the stream buffer is going to be used as a message buffer
-         * (that is, it will hold discrete messages with a little meta data that
-         * says how big the next message is) check the buffer will be large enough
-         * to hold at least one message. */
-        configASSERT( xBufferSizeBytes > sbBYTES_TO_STORE_MESSAGE_LENGTH );
 
         #if ( configASSERT_DEFINED == 1 )
         {


### PR DESCRIPTION
Description
-----------
This PR addresses the bug in xStreamBufferCreateStatic() API when xBufferSizeBytes is less than sbBYTES_TO_STORE_MESSAGE_LENGTH .
Static creation of StreamBuffer of BufferSize <= sbBYTES_TO_STORE_MESSAGE_LENGTH can be allowed , in case it is not a MessageBuffer.

Test Steps
-----------
Executing this code 
```
void pvTask1( void *pvParameters )
{
   ( void ) pvParameters;
   
    StreamBufferHandle_t xStreamBuffer;
    uint8_t ucBufferStrorage;
    StaticStreamBuffer_t xStaticStreamBuffer;
    xStreamBuffer = xStreamBufferCreateStatic( 1, 1, &ucBufferStrorage, &xStaticStreamBuffer );
    
    configASSERT( xStreamBuffer != NULL );
 }
```
**Before applying the patch :** 
StreamBuffer creation fails and assert occurs at
```
configASSERT( xBufferSizeBytes > sbBYTES_TO_STORE_MESSAGE_LENGTH );
```
**After applying the patch :** 
StreamBuffer creation is successful .

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#792 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
