### PR TITLE
Add trace hook macro for most ports

### DIFF
--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -341,7 +341,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
     do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
          else { traceISR_EXIT(); }                                                                               \
-    while( 0 )
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/CCS/ARM_CM3/port.c
+++ b/portable/CCS/ARM_CM3/port.c
@@ -363,13 +363,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     ( void ) portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( 0 );

--- a/portable/CCS/ARM_CM3/port.c
+++ b/portable/CCS/ARM_CM3/port.c
@@ -369,6 +369,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/CCS/ARM_CM3/portmacro.h
+++ b/portable/CCS/ARM_CM3/portmacro.h
@@ -97,7 +97,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/

--- a/portable/CCS/ARM_CM3/portmacro.h
+++ b/portable/CCS/ARM_CM3/portmacro.h
@@ -97,9 +97,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/CCS/ARM_CM3/portmacro.h
+++ b/portable/CCS/ARM_CM3/portmacro.h
@@ -97,18 +97,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/CCS/ARM_CM3/portmacro.h
+++ b/portable/CCS/ARM_CM3/portmacro.h
@@ -97,11 +97,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/CCS/ARM_CM4F/port.c
+++ b/portable/CCS/ARM_CM4F/port.c
@@ -394,6 +394,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/CCS/ARM_CM4F/port.c
+++ b/portable/CCS/ARM_CM4F/port.c
@@ -388,13 +388,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     ( void ) portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( 0 );

--- a/portable/CCS/ARM_CM4F/portmacro.h
+++ b/portable/CCS/ARM_CM4F/portmacro.h
@@ -91,18 +91,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/CCS/ARM_CM4F/portmacro.h
+++ b/portable/CCS/ARM_CM4F/portmacro.h
@@ -91,9 +91,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/CCS/ARM_CM4F/portmacro.h
+++ b/portable/CCS/ARM_CM4F/portmacro.h
@@ -91,11 +91,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/CCS/ARM_CM4F/portmacro.h
+++ b/portable/CCS/ARM_CM4F/portmacro.h
@@ -91,7 +91,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/

--- a/portable/CodeWarrior/ColdFire_V1/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V1/portmacro.h
@@ -106,10 +106,10 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
+         while( 0 )
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/portable/CodeWarrior/ColdFire_V1/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V1/portmacro.h
@@ -106,18 +106,18 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 
 /* *INDENT-OFF* */

--- a/portable/CodeWarrior/ColdFire_V1/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V1/portmacro.h
@@ -106,8 +106,10 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )              do { if( xSwitchRequired != pdFALSE ) { portYIELD(); } } while( 0 )
-
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    while( 0 )
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/portable/CodeWarrior/ColdFire_V1/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V1/portmacro.h
@@ -106,10 +106,19 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/portable/CodeWarrior/ColdFire_V2/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V2/portmacro.h
@@ -105,10 +105,10 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
+         while( 0 )
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/portable/CodeWarrior/ColdFire_V2/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V2/portmacro.h
@@ -105,18 +105,18 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 
 /* *INDENT-OFF* */

--- a/portable/CodeWarrior/ColdFire_V2/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V2/portmacro.h
@@ -105,8 +105,10 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )              do { if( xSwitchRequired != pdFALSE ) { portYIELD(); } } while( 0 )
-
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    while( 0 )
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/portable/CodeWarrior/ColdFire_V2/portmacro.h
+++ b/portable/CodeWarrior/ColdFire_V2/portmacro.h
@@ -105,10 +105,19 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/portable/GCC/ARM_CM0/port.c
+++ b/portable/GCC/ARM_CM0/port.c
@@ -375,12 +375,18 @@ void xPortSysTickHandler( void )
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -87,8 +87,9 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -87,18 +87,18 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -87,10 +87,19 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM0/portmacro.h
+++ b/portable/GCC/ARM_CM0/portmacro.h
@@ -87,10 +87,10 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -340,8 +340,8 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
     do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                              \
-    while( 0 )
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                              \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM3/port.c
+++ b/portable/GCC/ARM_CM3/port.c
@@ -452,13 +452,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     portDISABLE_INTERRUPTS();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portENABLE_INTERRUPTS();

--- a/portable/GCC/ARM_CM3/port.c
+++ b/portable/GCC/ARM_CM3/port.c
@@ -458,6 +458,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -95,9 +95,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -95,7 +95,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -95,18 +95,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -95,11 +95,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -986,7 +986,7 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
         }
-        else 
+        else
         {
             traceISR_EXIT();
         }

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else 
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -986,7 +986,7 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
         }
-        else 
+        else
         {
             traceISR_EXIT();
         }

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else 
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -340,8 +340,8 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
     do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                              \
-    while( 0 )
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                              \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -1057,12 +1057,18 @@ void xPortSysTickHandler( void )
     uint32_t ulDummy;
 
     ulDummy = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulDummy );

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -183,10 +183,10 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -183,10 +183,19 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -183,18 +183,18 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -176,8 +176,9 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -527,6 +527,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -521,13 +521,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     portDISABLE_INTERRUPTS();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portENABLE_INTERRUPTS();

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -98,18 +98,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -98,7 +98,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -98,11 +98,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -98,9 +98,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -1203,12 +1203,18 @@ void xPortSysTickHandler( void )
     uint32_t ulDummy;
 
     ulDummy = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulDummy );

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -277,18 +277,18 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -277,10 +277,10 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -270,8 +270,9 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -277,10 +277,19 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -95,9 +95,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -95,18 +95,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -95,9 +95,9 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -95,9 +95,9 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ColdFire_V2/portmacro.h
+++ b/portable/GCC/ColdFire_V2/portmacro.h
@@ -105,10 +105,10 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
+         while( 0 )
 
 
 /* *INDENT-OFF* */

--- a/portable/GCC/ColdFire_V2/portmacro.h
+++ b/portable/GCC/ColdFire_V2/portmacro.h
@@ -105,18 +105,18 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 
 

--- a/portable/GCC/ColdFire_V2/portmacro.h
+++ b/portable/GCC/ColdFire_V2/portmacro.h
@@ -105,7 +105,10 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )              do { if( xSwitchRequired != pdFALSE ) { portYIELD(); } } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    while( 0 )
 
 
 /* *INDENT-OFF* */

--- a/portable/GCC/ColdFire_V2/portmacro.h
+++ b/portable/GCC/ColdFire_V2/portmacro.h
@@ -105,10 +105,19 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 
 
 /* *INDENT-OFF* */

--- a/portable/GCC/NiosII/portmacro.h
+++ b/portable/GCC/NiosII/portmacro.h
@@ -85,11 +85,19 @@ typedef unsigned long    UBaseType_t;
 
 extern void vTaskSwitchContext( void );
 #define portYIELD()    asm volatile ( "trap" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                  \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vTaskSwitchContext(); } \
-         else { traceISR_EXIT(); }                                                                \
-         while( 0 )
-
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            vTaskSwitchContext();                   \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 
 /* Include the port_asm.S file where the Context saving/restoring is defined. */
 __asm__ ( "\n\t.globl    save_context" );

--- a/portable/GCC/NiosII/portmacro.h
+++ b/portable/GCC/NiosII/portmacro.h
@@ -85,18 +85,18 @@ typedef unsigned long    UBaseType_t;
 
 extern void vTaskSwitchContext( void );
 #define portYIELD()    asm volatile ( "trap" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            vTaskSwitchContext();                   \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            vTaskSwitchContext();                \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 
 /* Include the port_asm.S file where the Context saving/restoring is defined. */

--- a/portable/GCC/NiosII/portmacro.h
+++ b/portable/GCC/NiosII/portmacro.h
@@ -85,7 +85,10 @@ typedef unsigned long    UBaseType_t;
 
 extern void vTaskSwitchContext( void );
 #define portYIELD()                                 asm volatile ( "trap" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired ) vTaskSwitchContext( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vTaskSwitchContext( ); } \
+         else { traceISR_EXIT( ); }                                                                 \
+    while( 0 )
 
 
 /* Include the port_asm.S file where the Context saving/restoring is defined. */

--- a/portable/GCC/NiosII/portmacro.h
+++ b/portable/GCC/NiosII/portmacro.h
@@ -84,11 +84,11 @@ typedef unsigned long    UBaseType_t;
 /*-----------------------------------------------------------*/
 
 extern void vTaskSwitchContext( void );
-#define portYIELD()                                 asm volatile ( "trap" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vTaskSwitchContext( ); } \
-         else { traceISR_EXIT( ); }                                                                 \
-    while( 0 )
+#define portYIELD()    asm volatile ( "trap" );
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                  \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vTaskSwitchContext(); } \
+         else { traceISR_EXIT(); }                                                                \
+         while( 0 )
 
 
 /* Include the port_asm.S file where the Context saving/restoring is defined. */

--- a/portable/GCC/RISC-V/portmacro.h
+++ b/portable/GCC/RISC-V/portmacro.h
@@ -92,7 +92,10 @@ typedef portUBASE_TYPE   TickType_t;
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
 #define portYIELD()                                 __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired ) vTaskSwitchContext( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vTaskSwitchContext( ); } \
+         else { traceISR_EXIT( ); }                                                                 \
+    while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/RISC-V/portmacro.h
+++ b/portable/GCC/RISC-V/portmacro.h
@@ -92,18 +92,18 @@ typedef portUBASE_TYPE   TickType_t;
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
 #define portYIELD()                __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            vTaskSwitchContext();                   \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            vTaskSwitchContext();                \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/GCC/RISC-V/portmacro.h
+++ b/portable/GCC/RISC-V/portmacro.h
@@ -92,10 +92,19 @@ typedef portUBASE_TYPE   TickType_t;
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
 #define portYIELD()                __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                  \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vTaskSwitchContext(); } \
-         else { traceISR_EXIT(); }                                                                \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            vTaskSwitchContext();                   \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/RISC-V/portmacro.h
+++ b/portable/GCC/RISC-V/portmacro.h
@@ -91,12 +91,12 @@ typedef portUBASE_TYPE   TickType_t;
 
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
-#define portYIELD()                                 __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vTaskSwitchContext( ); } \
-         else { traceISR_EXIT( ); }                                                                 \
-    while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD()                __asm volatile ( "ecall" );
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                  \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vTaskSwitchContext(); } \
+         else { traceISR_EXIT(); }                                                                \
+         while( 0 )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/GCC/STR75x/portmacro.h
+++ b/portable/GCC/STR75x/portmacro.h
@@ -129,7 +129,11 @@ extern void vPortExitCritical( void );
                                                  \
         if( xSwitchRequired )                    \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/STR75x/portmacro.h
+++ b/portable/GCC/STR75x/portmacro.h
@@ -132,7 +132,8 @@ extern void vPortExitCritical( void );
             traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     }

--- a/portable/IAR/ARM_CM0/port.c
+++ b/portable/IAR/ARM_CM0/port.c
@@ -233,12 +233,18 @@ void xPortSysTickHandler( void )
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM0/portmacro.h
+++ b/portable/IAR/ARM_CM0/portmacro.h
@@ -87,10 +87,19 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL     ( ( volatile uint32_t * ) 0xe000ed04 )
 #define portNVIC_PENDSVSET    0x10000000
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                        \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
-         else { traceISR_EXIT(); }                                                                                      \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )        \
+    do                                                  \
+    {                                                   \
+        if( xSwitchRequired != pdFALSE )                \
+        {                                               \
+            traceISR_EXIT_TO_SCHEDULER();               \
+            *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET \
+        }                                               \
+        else                                            \
+        {                                               \
+            traceISR_EXIT();                            \
+        }                                               \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM0/portmacro.h
+++ b/portable/IAR/ARM_CM0/portmacro.h
@@ -87,7 +87,10 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL     ( ( volatile uint32_t * ) 0xe000ed04 )
 #define portNVIC_PENDSVSET    0x10000000
 #define portYIELD()                                 vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )    if( xSwitchRequired ) *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
+         else { traceISR_EXIT( ); }                                                                                      \
+    while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM0/portmacro.h
+++ b/portable/IAR/ARM_CM0/portmacro.h
@@ -86,12 +86,12 @@ typedef unsigned long    UBaseType_t;
 extern void vPortYield( void );
 #define portNVIC_INT_CTRL     ( ( volatile uint32_t * ) 0xe000ed04 )
 #define portNVIC_PENDSVSET    0x10000000
-#define portYIELD()                                 vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
-         else { traceISR_EXIT( ); }                                                                                      \
-    while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD()                vPortYield()
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                        \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
+         else { traceISR_EXIT(); }                                                                                      \
+         while( 0 )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM3/port.c
+++ b/portable/IAR/ARM_CM3/port.c
@@ -361,6 +361,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/IAR/ARM_CM3/port.c
+++ b/portable/IAR/ARM_CM3/port.c
@@ -355,13 +355,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     portDISABLE_INTERRUPTS();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portENABLE_INTERRUPTS();

--- a/portable/IAR/ARM_CM3/portmacro.h
+++ b/portable/IAR/ARM_CM3/portmacro.h
@@ -100,9 +100,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/IAR/ARM_CM3/portmacro.h
+++ b/portable/IAR/ARM_CM3/portmacro.h
@@ -100,11 +100,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM3/portmacro.h
+++ b/portable/IAR/ARM_CM3/portmacro.h
@@ -100,18 +100,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/IAR/ARM_CM3/portmacro.h
+++ b/portable/IAR/ARM_CM3/portmacro.h
@@ -100,7 +100,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM4F/port.c
+++ b/portable/IAR/ARM_CM4F/port.c
@@ -405,6 +405,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/IAR/ARM_CM4F/port.c
+++ b/portable/IAR/ARM_CM4F/port.c
@@ -399,13 +399,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     portDISABLE_INTERRUPTS();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portENABLE_INTERRUPTS();

--- a/portable/IAR/ARM_CM4F/portmacro.h
+++ b/portable/IAR/ARM_CM4F/portmacro.h
@@ -99,7 +99,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM4F/portmacro.h
+++ b/portable/IAR/ARM_CM4F/portmacro.h
@@ -99,9 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/IAR/ARM_CM4F/portmacro.h
+++ b/portable/IAR/ARM_CM4F/portmacro.h
@@ -99,18 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/IAR/ARM_CM4F/portmacro.h
+++ b/portable/IAR/ARM_CM4F/portmacro.h
@@ -99,11 +99,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -993,6 +993,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -987,13 +987,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     portDISABLE_INTERRUPTS();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portENABLE_INTERRUPTS();

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -275,11 +275,11 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                      \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD_WITHIN_API( ); } \
-         else { traceISR_EXIT( ); }                                                                   \
-    while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD_WITHIN_API(); } \
+         else { traceISR_EXIT(); }                                                                  \
+         while( 0 )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Architecture specific optimisations. */

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -275,10 +275,19 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD_WITHIN_API(); } \
-         else { traceISR_EXIT(); }                                                                  \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD_WITHIN_API();                 \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -268,7 +268,10 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD_WITHIN_API( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                      \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD_WITHIN_API( ); } \
+         else { traceISR_EXIT( ); }                                                                   \
+    while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -275,19 +275,19 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD_WITHIN_API();                 \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
-     } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD_WITHIN_API();              \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM7/r0p1/port.c
+++ b/portable/IAR/ARM_CM7/r0p1/port.c
@@ -387,13 +387,19 @@ void xPortSysTickHandler( void )
      * save and then restore the interrupt mask value as its value is already
      * known. */
     portDISABLE_INTERRUPTS();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portENABLE_INTERRUPTS();

--- a/portable/IAR/ARM_CM7/r0p1/port.c
+++ b/portable/IAR/ARM_CM7/r0p1/port.c
@@ -393,6 +393,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/IAR/ARM_CM7/r0p1/portmacro.h
+++ b/portable/IAR/ARM_CM7/r0p1/portmacro.h
@@ -99,7 +99,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM7/r0p1/portmacro.h
+++ b/portable/IAR/ARM_CM7/r0p1/portmacro.h
@@ -99,9 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/IAR/ARM_CM7/r0p1/portmacro.h
+++ b/portable/IAR/ARM_CM7/r0p1/portmacro.h
@@ -99,18 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/IAR/ARM_CM7/r0p1/portmacro.h
+++ b/portable/IAR/ARM_CM7/r0p1/portmacro.h
@@ -99,11 +99,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -977,12 +977,18 @@ void SysTick_Handler( void ) /* PRIVILEGED_FUNCTION */
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -331,8 +331,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,10 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -338,18 +338,18 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -338,10 +338,19 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portYIELD()    vPortYield()
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/AtmelSAM7S64/portmacro.h
+++ b/portable/IAR/AtmelSAM7S64/portmacro.h
@@ -97,7 +97,11 @@ __arm __interwork void vPortExitCritical( void );
                                                  \
         if( xSwitchRequired )                    \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/AtmelSAM7S64/portmacro.h
+++ b/portable/IAR/AtmelSAM7S64/portmacro.h
@@ -100,7 +100,8 @@ __arm __interwork void vPortExitCritical( void );
             traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     }

--- a/portable/IAR/AtmelSAM9XE/portmacro.h
+++ b/portable/IAR/AtmelSAM9XE/portmacro.h
@@ -100,7 +100,11 @@ __arm __interwork void vPortExitCritical( void );
                                                  \
         if( xSwitchRequired )                    \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/AtmelSAM9XE/portmacro.h
+++ b/portable/IAR/AtmelSAM9XE/portmacro.h
@@ -103,7 +103,8 @@ __arm __interwork void vPortExitCritical( void );
             traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     }

--- a/portable/IAR/LPC2000/portmacro.h
+++ b/portable/IAR/LPC2000/portmacro.h
@@ -100,7 +100,11 @@ __arm __interwork void vPortExitCritical( void );
                                                  \
         if( xSwitchRequired )                    \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/LPC2000/portmacro.h
+++ b/portable/IAR/LPC2000/portmacro.h
@@ -103,7 +103,8 @@ __arm __interwork void vPortExitCritical( void );
             traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     }

--- a/portable/IAR/RISC-V/portmacro.h
+++ b/portable/IAR/RISC-V/portmacro.h
@@ -94,10 +94,19 @@ typedef portUBASE_TYPE   TickType_t;
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
 #define portYIELD()                __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                  \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vTaskSwitchContext(); } \
-         else { traceISR_EXIT(); }                                                                \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            vTaskSwitchContext();                   \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/RISC-V/portmacro.h
+++ b/portable/IAR/RISC-V/portmacro.h
@@ -94,7 +94,10 @@ typedef portUBASE_TYPE   TickType_t;
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
 #define portYIELD()                                 __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired ) vTaskSwitchContext( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vTaskSwitchContext( ); } \
+         else { traceISR_EXIT( ); }                                                                 \
+    while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/RISC-V/portmacro.h
+++ b/portable/IAR/RISC-V/portmacro.h
@@ -93,12 +93,12 @@ typedef portUBASE_TYPE   TickType_t;
 
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
-#define portYIELD()                                 __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                    \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vTaskSwitchContext( ); } \
-         else { traceISR_EXIT( ); }                                                                 \
-    while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD()                __asm volatile ( "ecall" );
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                  \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vTaskSwitchContext(); } \
+         else { traceISR_EXIT(); }                                                                \
+         while( 0 )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/IAR/RISC-V/portmacro.h
+++ b/portable/IAR/RISC-V/portmacro.h
@@ -94,18 +94,18 @@ typedef portUBASE_TYPE   TickType_t;
 /* Scheduler utilities. */
 extern void vTaskSwitchContext( void );
 #define portYIELD()                __asm volatile ( "ecall" );
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            vTaskSwitchContext();                   \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            vTaskSwitchContext();                \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/IAR/STR71x/portmacro.h
+++ b/portable/IAR/STR71x/portmacro.h
@@ -101,7 +101,11 @@ __arm __interwork void vPortExitCritical( void );
                                                  \
         if( xSwitchRequired )                    \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/STR71x/portmacro.h
+++ b/portable/IAR/STR71x/portmacro.h
@@ -104,7 +104,8 @@ __arm __interwork void vPortExitCritical( void );
             traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     }

--- a/portable/IAR/STR75x/portmacro.h
+++ b/portable/IAR/STR75x/portmacro.h
@@ -101,7 +101,8 @@ __arm __interwork void vPortExitCritical( void );
             traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     }

--- a/portable/IAR/STR75x/portmacro.h
+++ b/portable/IAR/STR75x/portmacro.h
@@ -98,7 +98,11 @@ __arm __interwork void vPortExitCritical( void );
                                                  \
         if( xSwitchRequired )                    \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/STR91x/portmacro.h
+++ b/portable/IAR/STR91x/portmacro.h
@@ -100,7 +100,11 @@ __arm __interwork void vPortExitCritical( void );
                                                  \
         if( xSwitchRequired )                    \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/STR91x/portmacro.h
+++ b/portable/IAR/STR91x/portmacro.h
@@ -103,7 +103,8 @@ __arm __interwork void vPortExitCritical( void );
             traceISR_EXIT_TO_SCHEDULER();        \
             vTaskSwitchContext();                \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     }

--- a/portable/MPLAB/PIC32MEC14xx/portmacro.h
+++ b/portable/MPLAB/PIC32MEC14xx/portmacro.h
@@ -240,7 +240,10 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )              do { if( xSwitchRequired ) { portYIELD(); } } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MEC14xx/portmacro.h
+++ b/portable/MPLAB/PIC32MEC14xx/portmacro.h
@@ -240,10 +240,19 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MEC14xx/portmacro.h
+++ b/portable/MPLAB/PIC32MEC14xx/portmacro.h
@@ -240,18 +240,18 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 
 /* Required by the kernel aware debugger. */

--- a/portable/MPLAB/PIC32MEC14xx/portmacro.h
+++ b/portable/MPLAB/PIC32MEC14xx/portmacro.h
@@ -240,10 +240,10 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
+         while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MX/portmacro.h
+++ b/portable/MPLAB/PIC32MX/portmacro.h
@@ -191,7 +191,10 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )              do { if( xSwitchRequired ) { portYIELD(); } } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MX/portmacro.h
+++ b/portable/MPLAB/PIC32MX/portmacro.h
@@ -191,10 +191,19 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MX/portmacro.h
+++ b/portable/MPLAB/PIC32MX/portmacro.h
@@ -191,18 +191,18 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 
 /* Required by the kernel aware debugger. */

--- a/portable/MPLAB/PIC32MX/portmacro.h
+++ b/portable/MPLAB/PIC32MX/portmacro.h
@@ -191,10 +191,10 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
+         while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/portable/MPLAB/PIC32MZ/portmacro.h
@@ -203,18 +203,18 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 
 /* Required by the kernel aware debugger. */

--- a/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/portable/MPLAB/PIC32MZ/portmacro.h
@@ -203,10 +203,10 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
+         while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/portable/MPLAB/PIC32MZ/portmacro.h
@@ -203,10 +203,19 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/portable/MPLAB/PIC32MZ/portmacro.h
@@ -203,7 +203,10 @@ extern volatile UBaseType_t uxInterruptNesting;
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )              do { if( xSwitchRequired ) { portYIELD(); } } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    while( 0 )
 
 /* Required by the kernel aware debugger. */
 #ifdef __DEBUG

--- a/portable/MikroC/ARM_CM4F/port.c
+++ b/portable/MikroC/ARM_CM4F/port.c
@@ -515,6 +515,7 @@ void xPortSysTickHandler( void ) iv IVT_INT_SysTick ics ICS_AUTO
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/MikroC/ARM_CM4F/port.c
+++ b/portable/MikroC/ARM_CM4F/port.c
@@ -509,13 +509,19 @@ void xPortSysTickHandler( void ) iv IVT_INT_SysTick ics ICS_AUTO
      * known - therefore the slightly faster portDISABLE_INTERRUPTS() function is
      * used in place of portSET_INTERRUPT_MASK_FROM_ISR(). */
     portDISABLE_INTERRUPTS();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portENABLE_INTERRUPTS();

--- a/portable/MikroC/ARM_CM4F/portmacro.h
+++ b/portable/MikroC/ARM_CM4F/portmacro.h
@@ -99,7 +99,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT(); }                                                         \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/MikroC/ARM_CM4F/portmacro.h
+++ b/portable/MikroC/ARM_CM4F/portmacro.h
@@ -99,18 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/MikroC/ARM_CM4F/portmacro.h
+++ b/portable/MikroC/ARM_CM4F/portmacro.h
@@ -99,11 +99,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT(); }                                                         \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/MikroC/ARM_CM4F/portmacro.h
+++ b/portable/MikroC/ARM_CM4F/portmacro.h
@@ -99,9 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM0/port.c
+++ b/portable/RVDS/ARM_CM0/port.c
@@ -352,12 +352,18 @@ void xPortSysTickHandler( void )
     uint32_t ulPreviousMask;
 
     ulPreviousMask = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulPreviousMask );

--- a/portable/RVDS/ARM_CM0/portmacro.h
+++ b/portable/RVDS/ARM_CM0/portmacro.h
@@ -86,10 +86,10 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM0/portmacro.h
+++ b/portable/RVDS/ARM_CM0/portmacro.h
@@ -86,10 +86,19 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM0/portmacro.h
+++ b/portable/RVDS/ARM_CM0/portmacro.h
@@ -86,8 +86,9 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM0/portmacro.h
+++ b/portable/RVDS/ARM_CM0/portmacro.h
@@ -86,18 +86,18 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM3/port.c
+++ b/portable/RVDS/ARM_CM3/port.c
@@ -455,6 +455,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/RVDS/ARM_CM3/port.c
+++ b/portable/RVDS/ARM_CM3/port.c
@@ -449,13 +449,19 @@ void xPortSysTickHandler( void )
      * known - therefore the slightly faster vPortRaiseBASEPRI() function is used
      * in place of portSET_INTERRUPT_MASK_FROM_ISR(). */
     vPortRaiseBASEPRI();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
 

--- a/portable/RVDS/ARM_CM3/portmacro.h
+++ b/portable/RVDS/ARM_CM3/portmacro.h
@@ -99,11 +99,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/RVDS/ARM_CM3/portmacro.h
+++ b/portable/RVDS/ARM_CM3/portmacro.h
@@ -99,18 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM3/portmacro.h
+++ b/portable/RVDS/ARM_CM3/portmacro.h
@@ -99,7 +99,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM3/portmacro.h
+++ b/portable/RVDS/ARM_CM3/portmacro.h
@@ -99,9 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM4F/port.c
+++ b/portable/RVDS/ARM_CM4F/port.c
@@ -551,6 +551,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/RVDS/ARM_CM4F/port.c
+++ b/portable/RVDS/ARM_CM4F/port.c
@@ -545,13 +545,19 @@ void xPortSysTickHandler( void )
      * known - therefore the slightly faster vPortRaiseBASEPRI() function is used
      * in place of portSET_INTERRUPT_MASK_FROM_ISR(). */
     vPortRaiseBASEPRI();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
 

--- a/portable/RVDS/ARM_CM4F/portmacro.h
+++ b/portable/RVDS/ARM_CM4F/portmacro.h
@@ -99,11 +99,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/RVDS/ARM_CM4F/portmacro.h
+++ b/portable/RVDS/ARM_CM4F/portmacro.h
@@ -99,18 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM4F/portmacro.h
+++ b/portable/RVDS/ARM_CM4F/portmacro.h
@@ -99,7 +99,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM4F/portmacro.h
+++ b/portable/RVDS/ARM_CM4F/portmacro.h
@@ -99,9 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -1185,12 +1185,18 @@ void xPortSysTickHandler( void )
     uint32_t ulDummy;
 
     ulDummy = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulDummy );

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -281,10 +281,10 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                               \
-    while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                               \
+         while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -281,10 +281,19 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                 \
-    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                               \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -281,18 +281,18 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -274,8 +274,9 @@ typedef struct MPU_SETTINGS
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                 \
-    do { if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                  \
+    do { if( xSwitchRequired ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                               \
     while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM7/r0p1/port.c
+++ b/portable/RVDS/ARM_CM7/r0p1/port.c
@@ -537,6 +537,7 @@ void xPortSysTickHandler( void )
         if( xTaskIncrementTick() != pdFALSE )
         {
             traceISR_EXIT_TO_SCHEDULER();
+
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;

--- a/portable/RVDS/ARM_CM7/r0p1/port.c
+++ b/portable/RVDS/ARM_CM7/r0p1/port.c
@@ -531,13 +531,19 @@ void xPortSysTickHandler( void )
      * known - therefore the slightly faster vPortRaiseBASEPRI() function is used
      * in place of portSET_INTERRUPT_MASK_FROM_ISR(). */
     vPortRaiseBASEPRI();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* A context switch is required.  Context switching is performed in
              * the PendSV interrupt.  Pend the PendSV interrupt. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
 

--- a/portable/RVDS/ARM_CM7/r0p1/portmacro.h
+++ b/portable/RVDS/ARM_CM7/r0p1/portmacro.h
@@ -99,11 +99,11 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
-         else { traceISR_EXIT( ); }                                                        \
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
+         else { traceISR_EXIT(); }                                                       \
     } while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/RVDS/ARM_CM7/r0p1/portmacro.h
+++ b/portable/RVDS/ARM_CM7/r0p1/portmacro.h
@@ -99,18 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            portYIELD();                            \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            portYIELD();                         \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/RVDS/ARM_CM7/r0p1/portmacro.h
+++ b/portable/RVDS/ARM_CM7/r0p1/portmacro.h
@@ -99,7 +99,10 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )    do { if( xSwitchRequired != pdFALSE ) portYIELD( ); } while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portYIELD( ); } \
+         else { traceISR_EXIT( ); }                                                        \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/RVDS/ARM_CM7/r0p1/portmacro.h
+++ b/portable/RVDS/ARM_CM7/r0p1/portmacro.h
@@ -99,9 +99,18 @@ typedef unsigned long    UBaseType_t;
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portYIELD(); } \
-         else { traceISR_EXIT(); }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            portYIELD();                            \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/Tasking/ARM_CM4F/port.c
+++ b/portable/Tasking/ARM_CM4F/port.c
@@ -246,11 +246,17 @@ void SysTick_Handler( void )
     uint32_t ulDummy;
 
     ulDummy = portSET_INTERRUPT_MASK_FROM_ISR();
+    traceISR_ENTER();
     {
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     portCLEAR_INTERRUPT_MASK_FROM_ISR( ulDummy );

--- a/portable/Tasking/ARM_CM4F/portmacro.h
+++ b/portable/Tasking/ARM_CM4F/portmacro.h
@@ -86,13 +86,13 @@ typedef unsigned long    UBaseType_t;
 extern void vPortYield( void );
 #define portNVIC_INT_CTRL     ( ( volatile uint32_t * ) 0xe000ed04 )
 #define portNVIC_PENDSVSET    0x10000000
-#define portYIELD()                                 vPortYield()
+#define portYIELD()                vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                         \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
-         else { traceISR_EXIT( ); }                                                                                      \
-    while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                        \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
+         else { traceISR_EXIT(); }                                                                                      \
+         while( 0 )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 

--- a/portable/Tasking/ARM_CM4F/portmacro.h
+++ b/portable/Tasking/ARM_CM4F/portmacro.h
@@ -88,18 +88,18 @@ extern void vPortYield( void );
 #define portNVIC_PENDSVSET    0x10000000
 #define portYIELD()                vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )            \
-    do                                                      \
-    {                                                       \
-        if( xSwitchRequired != pdFALSE )                    \
-        {                                                   \
-            traceISR_EXIT_TO_SCHEDULER();                   \
-            *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;    \
-        }                                                   \
-        else                                                \
-        {                                                   \
-            traceISR_EXIT();                                \
-        }                                                   \
+#define portEND_SWITCHING_ISR( xSwitchRequired )         \
+    do                                                   \
+    {                                                    \
+        if( xSwitchRequired != pdFALSE )                 \
+        {                                                \
+            traceISR_EXIT_TO_SCHEDULER();                \
+            *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET; \
+        }                                                \
+        else                                             \
+        {                                                \
+            traceISR_EXIT();                             \
+        }                                                \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/Tasking/ARM_CM4F/portmacro.h
+++ b/portable/Tasking/ARM_CM4F/portmacro.h
@@ -88,10 +88,19 @@ extern void vPortYield( void );
 #define portNVIC_PENDSVSET    0x10000000
 #define portYIELD()                vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                        \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
-         else { traceISR_EXIT(); }                                                                                      \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired != pdFALSE )                    \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET;    \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/Tasking/ARM_CM4F/portmacro.h
+++ b/portable/Tasking/ARM_CM4F/portmacro.h
@@ -88,7 +88,10 @@ extern void vPortYield( void );
 #define portNVIC_PENDSVSET    0x10000000
 #define portYIELD()                                 vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    if( xSwitchRequired ) *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                         \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET } \
+         else { traceISR_EXIT( ); }                                                                                      \
+    while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/CDK/T-HEAD_CK802/port.c
+++ b/portable/ThirdParty/CDK/T-HEAD_CK802/port.c
@@ -125,10 +125,16 @@ void vPortExitCritical( void )
         portLONG ulDummy;
 
         ulDummy = portSET_INTERRUPT_MASK_FROM_ISR();
+        traceISR_ENTER();
         {
             if( xTaskIncrementTick() != pdFALSE )
             {
+                traceISR_EXIT_TO_SCHEDULER();
                 portYIELD_FROM_ISR( pdTRUE );
+            }
+            else
+            {
+                traceISR_EXIT();
             }
         }
         portCLEAR_INTERRUPT_MASK_FROM_ISR( ulDummy );

--- a/portable/ThirdParty/CDK/T-HEAD_CK802/portmacro.h
+++ b/portable/ThirdParty/CDK/T-HEAD_CK802/portmacro.h
@@ -155,7 +155,8 @@ extern portLONG pendsvflag;
             traceISR_EXIT_TO_SCHEDULER();        \
             portYIELD();                         \
         }                                        \
-        else {                                   \
+        else                                     \
+        {                                        \
             traceISR_EXIT();                     \
         }                                        \
     } while( 0 )

--- a/portable/ThirdParty/CDK/T-HEAD_CK802/portmacro.h
+++ b/portable/ThirdParty/CDK/T-HEAD_CK802/portmacro.h
@@ -152,7 +152,11 @@ extern portLONG pendsvflag;
     do {                                         \
         if( xSwitchRequired != pdFALSE )         \
         {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
             portYIELD();                         \
+        }                                        \
+        else {                                   \
+            traceISR_EXIT();                     \
         }                                        \
     } while( 0 )
 

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -83,10 +83,19 @@ extern void vPortYield( void );
 
 #define portYIELD()                vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                          \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vPortYield(); } \
-         else { traceISR_EXIT(); }                                                        \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )    \
+    do                                              \
+    {                                               \
+        if( xSwitchRequired != pdFALSE )            \
+        {                                           \
+            traceISR_EXIT_TO_SCHEDULER();           \
+            vPortYield();                           \
+        }                                           \
+        else                                        \
+        {                                           \
+            traceISR_EXIT();                        \
+        }                                           \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -83,18 +83,18 @@ extern void vPortYield( void );
 
 #define portYIELD()                vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    \
-    do                                              \
-    {                                               \
-        if( xSwitchRequired != pdFALSE )            \
-        {                                           \
-            traceISR_EXIT_TO_SCHEDULER();           \
-            vPortYield();                           \
-        }                                           \
-        else                                        \
-        {                                           \
-            traceISR_EXIT();                        \
-        }                                           \
+#define portEND_SWITCHING_ISR( xSwitchRequired ) \
+    do                                           \
+    {                                            \
+        if( xSwitchRequired != pdFALSE )         \
+        {                                        \
+            traceISR_EXIT_TO_SCHEDULER();        \
+            vPortYield();                        \
+        }                                        \
+        else                                     \
+        {                                        \
+            traceISR_EXIT();                     \
+        }                                        \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -83,7 +83,10 @@ extern void vPortYield( void );
 
 #define portYIELD()                                 vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )    if( xSwitchRequired != pdFALSE ) vPortYield( )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vPortYield(); } \
+         else { traceISR_EXIT( ); }                                                        \
+    while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -81,13 +81,13 @@ typedef unsigned long    TickType_t;
 /* Scheduler utilities. */
 extern void vPortYield( void );
 
-#define portYIELD()                                 vPortYield()
+#define portYIELD()                vPortYield()
 
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                           \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); vPortYield(); } \
-         else { traceISR_EXIT( ); }                                                        \
-    while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                          \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); vPortYield(); } \
+         else { traceISR_EXIT(); }                                                        \
+         while( 0 )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -97,12 +97,12 @@ typedef uint32_t         UBaseType_t;
 extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
-#define portYIELD()                                 vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                             \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT( ); }                                                                                          \
-    while( 0 )
-#define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
+#define portYIELD()                vPortYield()
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                            \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT(); }                                                                                          \
+         while( 0 )
+#define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/
 

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -98,18 +98,18 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                \
-    do                                                          \
-    {                                                           \
-        if( xSwitchRequired )                                   \
-        {                                                       \
-            traceISR_EXIT_TO_SCHEDULER();                       \
-            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            traceISR_EXIT();                                    \
-        }                                                       \
+#define portEND_SWITCHING_ISR( xSwitchRequired )            \
+    do                                                      \
+    {                                                       \
+        if( xSwitchRequired )                               \
+        {                                                   \
+            traceISR_EXIT_TO_SCHEDULER();                   \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
+        }                                                   \
+        else                                                \
+        {                                                   \
+            traceISR_EXIT();                                \
+        }                                                   \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -98,10 +98,19 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                            \
-    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER(); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
-         else { traceISR_EXIT(); }                                                                                          \
-         while( 0 )
+#define portEND_SWITCHING_ISR( xSwitchRequired )                \
+    do                                                          \
+    {                                                           \
+        if( xSwitchRequired )                                   \
+        {                                                       \
+            traceISR_EXIT_TO_SCHEDULER();                       \
+            portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;     \
+        }                                                       \
+        else                                                    \
+        {                                                       \
+            traceISR_EXIT();                                    \
+        }                                                       \
+    } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -98,7 +98,10 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portYIELD()                                 vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )    if( xSwitchRequired ) portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT
+#define portEND_SWITCHING_ISR( xSwitchRequired )                                                                             \
+    do { if( xSwitchRequired != pdFALSE ) { traceISR_EXIT_TO_SCHEDULER( ); portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; } \
+         else { traceISR_EXIT( ); }                                                                                          \
+    while( 0 )
 #define portYIELD_FROM_ISR( x )                     portEND_SWITCHING_ISR( x )
 
 /*-----------------------------------------------------------*/

--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -741,12 +741,18 @@ void xPortSysTickHandler( void )
     uint32_t ulPreviousMask;
 
     ulPreviousMask = taskENTER_CRITICAL_FROM_ISR();
+    traceISR_ENTER();
     {
         /* Increment the RTOS tick. */
         if( xTaskIncrementTick() != pdFALSE )
         {
+            traceISR_EXIT_TO_SCHEDULER();
             /* Pend a context switch. */
             portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT;
+        }
+        else
+        {
+            traceISR_EXIT();
         }
     }
     taskEXIT_CRITICAL_FROM_ISR( ulPreviousMask );

--- a/portable/ThirdParty/GCC/Xtensa_ESP32/port_systick.c
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/port_systick.c
@@ -185,6 +185,7 @@ BaseType_t xPortSysTickHandler( void )
 
     if( ret != pdFALSE )
     {
+        traceISR_EXIT_TO_SCHEDULER();
         portYIELD_FROM_ISR();
     }
     else


### PR DESCRIPTION
Add trace hook macro for most ports

In pull request #659 (https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/659) we introduced better support for tracing tools like systemview. This patchset adds support for more ports as requested in the original pull request.

----------
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
