### PR TITLE
Fix prototype in mpu_prototypes.h

### DIFF
--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -122,8 +122,8 @@ BaseType_t MPU_xTaskCreateRestricted( const TaskParameters_t * const pxTaskDefin
                                       TaskHandle_t * pxCreatedTask ) PRIVILEGED_FUNCTION;
 BaseType_t MPU_xTaskCreateRestrictedStatic( const TaskParameters_t * const pxTaskDefinition,
                                             TaskHandle_t * pxCreatedTask ) PRIVILEGED_FUNCTION;
-void vTaskAllocateMPURegions( TaskHandle_t xTaskToModify,
-                              const MemoryRegion_t * const xRegions ) PRIVILEGED_FUNCTION;
+void MPU_vTaskAllocateMPURegions( TaskHandle_t xTaskToModify,
+                                  const MemoryRegion_t * const xRegions ) PRIVILEGED_FUNCTION;
 BaseType_t MPU_xTaskGetStaticBuffers( TaskHandle_t xTask,
                                       StackType_t ** ppuxStackBuffer,
                                       StaticTask_t ** ppxTaskBuffer ) PRIVILEGED_FUNCTION;


### PR DESCRIPTION
Description
-----------
MPU_vTaskAllocateMPURegions was declared incorrectly as vTaskAllocateMPURegions in mpu_prototypes.h.

Related Issue
-----------
https://forums.freertos.org/t/warning-redundant-redeclaration-of-vtaskallocatempuregions/18216/2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
