### PR TITLE
Remove CORTEX_M3_MPS2_QEMU_GCC Demo from yaml file

### DIFF
--- a/.github/workflows/kernel-demos.yml
+++ b/.github/workflows/kernel-demos.yml
@@ -166,20 +166,6 @@ jobs:
         working-directory: FreeRTOS/Demo/CORTEX_LM3S102_GCC
         run: make -j
 
-      - name: Build CORTEX_M3_MPS2_QEMU_GCC Demo
-        shell: bash
-        working-directory: FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC
-        run: |
-          make clean
-          make -j
-
-      - name: Build CORTEX_M3_MPS2_QEMU_GCC Demo
-        shell: bash
-        working-directory: FreeRTOS/Demo/CORTEX_M3_MPS2_QEMU_GCC
-        run: |
-          make clean
-          make FULL_DEMO=1 -j
-
       - name: Build CORTEX_LM3S811_GCC Demo
         shell: bash
         working-directory: FreeRTOS/Demo/CORTEX_LM3S811_GCC


### PR DESCRIPTION
Description
-----------
This PR removes the dependency to build the CORTEX_M3_MPS2_QEMU_GCC demo in the CI checks for FreeRTOS+Kernel repository , since this demo is removed from the FreeRTOS repository.

Test Steps
-----------

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[#1089](https://github.com/FreeRTOS/FreeRTOS/pull/1089)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
