### PR TITLE
Update pxMutexHolder is NULL comment

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -6186,9 +6186,8 @@ static void prvResetNextTaskUnblockTime( void )
 
         traceENTER_xTaskPriorityInherit( pxMutexHolder );
 
-        /* If the mutex was given back by an interrupt while the queue was
-         * locked then the mutex holder might now be NULL.  _RB_ Is this still
-         * needed as interrupts can no longer use mutexes? */
+        /* If the mutex is taken by an interrupt, the mutex holder is NULL. Priority
+         * inheritance is not applied in this scenario. */
         if( pxMutexHolder != NULL )
         {
             /* If the holder of the mutex has a priority below the priority of


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Update the pxMutexHolder is NULL comment in tasks.c. If the mutex is taken by an interrupt, the mutex holder is NULL. Priority inheritance is not applied when a task wants to take the mutex tasken by an interrrupt.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have tested my changes. No regression in existing tests.~~
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
