### PR TITLE
Replace sprintf with snprintf

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2686,6 +2686,10 @@
     #endif
 #endif
 
+#ifndef configSTATS_BUFFER_MAX_LENGTH
+    #define configSTATS_BUFFER_MAX_LENGTH   0xFFFF
+#endif
+
 #ifndef configSTACK_DEPTH_TYPE
 
 /* Defaults to uint16_t for backward compatibility, but can be overridden

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2687,7 +2687,7 @@
 #endif
 
 #ifndef configSTATS_BUFFER_MAX_LENGTH
-    #define configSTATS_BUFFER_MAX_LENGTH   0xFFFF
+    #define configSTATS_BUFFER_MAX_LENGTH    0xFFFF
 #endif
 
 #ifndef configSTACK_DEPTH_TYPE

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2154,20 +2154,20 @@
     #define traceRETURN_vTaskExitCriticalFromISR()
 #endif
 
-#ifndef traceENTER_vTaskList
-    #define traceENTER_vTaskList( pcWriteBuffer )
+#ifndef traceENTER_vTaskListTasks
+    #define traceENTER_vTaskListTasks( pcWriteBuffer, uxBufferLength )
 #endif
 
-#ifndef traceRETURN_vTaskList
-    #define traceRETURN_vTaskList()
+#ifndef traceRETURN_vTaskListTasks
+    #define traceRETURN_vTaskListTasks()
 #endif
 
-#ifndef traceENTER_vTaskGetRunTimeStats
-    #define traceENTER_vTaskGetRunTimeStats( pcWriteBuffer )
+#ifndef traceENTER_vTaskGetRunTimeStatistics
+    #define traceENTER_vTaskGetRunTimeStatistics( pcWriteBuffer, uxBufferLength )
 #endif
 
-#ifndef traceRETURN_vTaskGetRunTimeStats
-    #define traceRETURN_vTaskGetRunTimeStats()
+#ifndef traceRETURN_vTaskGetRunTimeStatistics
+    #define traceRETURN_vTaskGetRunTimeStatistics()
 #endif
 
 #ifndef traceENTER_uxTaskResetEventItemValue

--- a/include/task.h
+++ b/include/task.h
@@ -2233,7 +2233,7 @@ void vTaskList2( char * pcWriteBuffer,
  * \defgroup vTaskGetRunTimeStats vTaskGetRunTimeStats
  * \ingroup TaskUtils
  */
-void vTaskGetRunTimeStats( char * pcWriteBuffer ) PRIVILEGED_FUNCTION;  /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+void vTaskGetRunTimeStats( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -2182,7 +2182,7 @@ void vTaskListTasks( char * pcWriteBuffer,
  * \defgroup vTaskList vTaskList
  * \ingroup TaskUtils
  */
-#define vTaskList( pcWriteBuffer )  vTaskListTasks( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH )
+#define vTaskList( pcWriteBuffer )    vTaskListTasks( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH )
 
 /**
  * task. h
@@ -2303,7 +2303,7 @@ void vTaskGetRunTimeStatistics( char * pcWriteBuffer,
  * \defgroup vTaskGetRunTimeStats vTaskGetRunTimeStats
  * \ingroup TaskUtils
  */
-#define vTaskGetRunTimeStats( pcWriteBuffer )   vTaskGetRunTimeStatistics( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH )
+#define vTaskGetRunTimeStats( pcWriteBuffer )    vTaskGetRunTimeStatistics( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH )
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -2084,6 +2084,11 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * both be defined as 1 for this function to be available.  See the
  * configuration section of the FreeRTOS.org website for more information.
  *
+ * WARN: This function assumes that the pcWriteBuffer is of length
+ * configSTATS_BUFFER_MAX_LENGTH. This function is there only for
+ * backward compatibility. New applications are recommended to
+ * use vTaskList2 and supply the buffer length explicitly.
+ *
  * NOTE 1: This function will disable interrupts for its duration.  It is
  * not intended for normal application runtime use but as a debug aid.
  *
@@ -2192,6 +2197,11 @@ void vTaskList2( char * pcWriteBuffer,
  * to configure a peripheral timer/counter and return the timers current count
  * value respectively.  The counter should be at least 10 times the frequency of
  * the tick count.
+ *
+ * WARN: This function assumes that the pcWriteBuffer is of length
+ * configSTATS_BUFFER_MAX_LENGTH. This function is there only for
+ * backward compatiblity. New applications are recommended to use
+ * vTaskGetRunTimeStats2 and supply the buffer length explicitly.
  *
  * NOTE 1: This function will disable interrupts for its duration.  It is
  * not intended for normal application runtime use but as a debug aid.

--- a/include/task.h
+++ b/include/task.h
@@ -2077,6 +2077,60 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
 /**
  * task. h
  * @code{c}
+ * void vTaskListTasks( char *pcWriteBuffer, size_t uxBufferLength );
+ * @endcode
+ *
+ * configUSE_TRACE_FACILITY and configUSE_STATS_FORMATTING_FUNCTIONS must
+ * both be defined as 1 for this function to be available.  See the
+ * configuration section of the FreeRTOS.org website for more information.
+ *
+ * NOTE 1: This function will disable interrupts for its duration.  It is
+ * not intended for normal application runtime use but as a debug aid.
+ *
+ * Lists all the current tasks, along with their current state and stack
+ * usage high water mark.
+ *
+ * Tasks are reported as blocked ('B'), ready ('R'), deleted ('D') or
+ * suspended ('S').
+ *
+ * PLEASE NOTE:
+ *
+ * This function is provided for convenience only, and is used by many of the
+ * demo applications.  Do not consider it to be part of the scheduler.
+ *
+ * vTaskListTasks() calls uxTaskGetSystemState(), then formats part of the
+ * uxTaskGetSystemState() output into a human readable table that displays task:
+ * names, states, priority, stack usage and task number.
+ * Stack usage specified as the number of unused StackType_t words stack can hold
+ * on top of stack - not the number of bytes.
+ *
+ * vTaskListTasks() has a dependency on the snprintf() C library function that might
+ * bloat the code size, use a lot of stack, and provide different results on
+ * different platforms.  An alternative, tiny, third party, and limited
+ * functionality implementation of snprintf() is provided in many of the
+ * FreeRTOS/Demo sub-directories in a file called printf-stdarg.c (note
+ * printf-stdarg.c does not provide a full snprintf() implementation!).
+ *
+ * It is recommended that production systems call uxTaskGetSystemState()
+ * directly to get access to raw stats data, rather than indirectly through a
+ * call to vTaskListTasks().
+ *
+ * @param pcWriteBuffer A buffer into which the above mentioned details
+ * will be written, in ASCII form.  This buffer is assumed to be large
+ * enough to contain the generated report.  Approximately 40 bytes per
+ * task should be sufficient.
+ *
+ * @param uxBufferLength Length of the pcWriteBuffer.
+ *
+ * \defgroup vTaskListTasks vTaskListTasks
+ * \ingroup TaskUtils
+ */
+void vTaskListTasks( char * pcWriteBuffer,
+                     size_t uxBufferLength ) PRIVILEGED_FUNCTION;
+
+/**
+ * task. h
+ * @code{c}
  * void vTaskList( char *pcWriteBuffer );
  * @endcode
  *
@@ -2087,7 +2141,7 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * WARN: This function assumes that the pcWriteBuffer is of length
  * configSTATS_BUFFER_MAX_LENGTH. This function is there only for
  * backward compatibility. New applications are recommended to
- * use vTaskList2 and supply the length of the pcWriteBuffer explicitly.
+ * use vTaskListTasks and supply the length of the pcWriteBuffer explicitly.
  *
  * NOTE 1: This function will disable interrupts for its duration.  It is
  * not intended for normal application runtime use but as a debug aid.
@@ -2109,10 +2163,10 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * Stack usage specified as the number of unused StackType_t words stack can hold
  * on top of stack - not the number of bytes.
  *
- * vTaskList() has a dependency on the sprintf() C library function that might
+ * vTaskList() has a dependency on the snprintf() C library function that might
  * bloat the code size, use a lot of stack, and provide different results on
  * different platforms.  An alternative, tiny, third party, and limited
- * functionality implementation of sprintf() is provided in many of the
+ * functionality implementation of snprintf() is provided in many of the
  * FreeRTOS/Demo sub-directories in a file called printf-stdarg.c (note
  * printf-stdarg.c does not provide a full snprintf() implementation!).
  *
@@ -2128,61 +2182,66 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * \defgroup vTaskList vTaskList
  * \ingroup TaskUtils
  */
-void vTaskList( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+#define vTaskList( pcWriteBuffer )  vTaskListTasks( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH )
 
 /**
  * task. h
  * @code{c}
- * void vTaskList2( char *pcWriteBuffer, size_t uxBufferLength );
+ * void vTaskGetRunTimeStatistics( char *pcWriteBuffer, size_t uxBufferLength );
  * @endcode
  *
- * configUSE_TRACE_FACILITY and configUSE_STATS_FORMATTING_FUNCTIONS must
- * both be defined as 1 for this function to be available.  See the
- * configuration section of the FreeRTOS.org website for more information.
+ * configGENERATE_RUN_TIME_STATS and configUSE_STATS_FORMATTING_FUNCTIONS
+ * must both be defined as 1 for this function to be available.  The application
+ * must also then provide definitions for
+ * portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() and portGET_RUN_TIME_COUNTER_VALUE()
+ * to configure a peripheral timer/counter and return the timers current count
+ * value respectively.  The counter should be at least 10 times the frequency of
+ * the tick count.
  *
  * NOTE 1: This function will disable interrupts for its duration.  It is
  * not intended for normal application runtime use but as a debug aid.
  *
- * Lists all the current tasks, along with their current state and stack
- * usage high water mark.
+ * Setting configGENERATE_RUN_TIME_STATS to 1 will result in a total
+ * accumulated execution time being stored for each task.  The resolution
+ * of the accumulated time value depends on the frequency of the timer
+ * configured by the portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() macro.
+ * Calling vTaskGetRunTimeStatistics() writes the total execution time of each
+ * task into a buffer, both as an absolute count value and as a percentage
+ * of the total system execution time.
  *
- * Tasks are reported as blocked ('B'), ready ('R'), deleted ('D') or
- * suspended ('S').
- *
- * PLEASE NOTE:
+ * NOTE 2:
  *
  * This function is provided for convenience only, and is used by many of the
  * demo applications.  Do not consider it to be part of the scheduler.
  *
- * vTaskList2() calls uxTaskGetSystemState(), then formats part of the
- * uxTaskGetSystemState() output into a human readable table that displays task:
- * names, states, priority, stack usage and task number.
- * Stack usage specified as the number of unused StackType_t words stack can hold
- * on top of stack - not the number of bytes.
+ * vTaskGetRunTimeStatistics() calls uxTaskGetSystemState(), then formats part of the
+ * uxTaskGetSystemState() output into a human readable table that displays the
+ * amount of time each task has spent in the Running state in both absolute and
+ * percentage terms.
  *
- * vTaskList2() has a dependency on the sprintf() C library function that might
- * bloat the code size, use a lot of stack, and provide different results on
- * different platforms.  An alternative, tiny, third party, and limited
- * functionality implementation of sprintf() is provided in many of the
+ * vTaskGetRunTimeStatistics() has a dependency on the snprintf() C library function
+ * that might bloat the code size, use a lot of stack, and provide different
+ * results on different platforms.  An alternative, tiny, third party, and
+ * limited functionality implementation of snprintf() is provided in many of the
  * FreeRTOS/Demo sub-directories in a file called printf-stdarg.c (note
  * printf-stdarg.c does not provide a full snprintf() implementation!).
  *
- * It is recommended that production systems call uxTaskGetSystemState()
- * directly to get access to raw stats data, rather than indirectly through a
- * call to vTaskList2().
+ * It is recommended that production systems call uxTaskGetSystemState() directly
+ * to get access to raw stats data, rather than indirectly through a call to
+ * vTaskGetRunTimeStatistics().
  *
- * @param pcWriteBuffer A buffer into which the above mentioned details
- * will be written, in ASCII form.  This buffer is assumed to be large
- * enough to contain the generated report.  Approximately 40 bytes per
- * task should be sufficient.
+ * @param pcWriteBuffer A buffer into which the execution times will be
+ * written, in ASCII form.  This buffer is assumed to be large enough to
+ * contain the generated report.  Approximately 40 bytes per task should
+ * be sufficient.
  *
  * @param uxBufferLength Length of the pcWriteBuffer.
  *
- * \defgroup vTaskList2 vTaskList2
+ * \defgroup vTaskGetRunTimeStatistics vTaskGetRunTimeStatistics
  * \ingroup TaskUtils
  */
-void vTaskList2( char * pcWriteBuffer,
-                 size_t uxBufferLength ) PRIVILEGED_FUNCTION;
+void vTaskGetRunTimeStatistics( char * pcWriteBuffer,
+                                size_t uxBufferLength ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
 
 /**
  * task. h
@@ -2201,7 +2260,7 @@ void vTaskList2( char * pcWriteBuffer,
  * WARN: This function assumes that the pcWriteBuffer is of length
  * configSTATS_BUFFER_MAX_LENGTH. This function is there only for
  * backward compatiblity. New applications are recommended to use
- * vTaskGetRunTimeStats2 and supply the length of the pcWriteBuffer
+ * vTaskGetRunTimeStatistics and supply the length of the pcWriteBuffer
  * explicitly.
  *
  * NOTE 1: This function will disable interrupts for its duration.  It is
@@ -2225,10 +2284,10 @@ void vTaskList2( char * pcWriteBuffer,
  * amount of time each task has spent in the Running state in both absolute and
  * percentage terms.
  *
- * vTaskGetRunTimeStats() has a dependency on the sprintf() C library function
+ * vTaskGetRunTimeStats() has a dependency on the snprintf() C library function
  * that might bloat the code size, use a lot of stack, and provide different
  * results on different platforms.  An alternative, tiny, third party, and
- * limited functionality implementation of sprintf() is provided in many of the
+ * limited functionality implementation of snprintf() is provided in many of the
  * FreeRTOS/Demo sub-directories in a file called printf-stdarg.c (note
  * printf-stdarg.c does not provide a full snprintf() implementation!).
  *
@@ -2244,66 +2303,7 @@ void vTaskList2( char * pcWriteBuffer,
  * \defgroup vTaskGetRunTimeStats vTaskGetRunTimeStats
  * \ingroup TaskUtils
  */
-void vTaskGetRunTimeStats( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
-
-/**
- * task. h
- * @code{c}
- * void vTaskGetRunTimeStats2( char *pcWriteBuffer, size_t uxBufferLength );
- * @endcode
- *
- * configGENERATE_RUN_TIME_STATS and configUSE_STATS_FORMATTING_FUNCTIONS
- * must both be defined as 1 for this function to be available.  The application
- * must also then provide definitions for
- * portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() and portGET_RUN_TIME_COUNTER_VALUE()
- * to configure a peripheral timer/counter and return the timers current count
- * value respectively.  The counter should be at least 10 times the frequency of
- * the tick count.
- *
- * NOTE 1: This function will disable interrupts for its duration.  It is
- * not intended for normal application runtime use but as a debug aid.
- *
- * Setting configGENERATE_RUN_TIME_STATS to 1 will result in a total
- * accumulated execution time being stored for each task.  The resolution
- * of the accumulated time value depends on the frequency of the timer
- * configured by the portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() macro.
- * Calling vTaskGetRunTimeStats2() writes the total execution time of each
- * task into a buffer, both as an absolute count value and as a percentage
- * of the total system execution time.
- *
- * NOTE 2:
- *
- * This function is provided for convenience only, and is used by many of the
- * demo applications.  Do not consider it to be part of the scheduler.
- *
- * vTaskGetRunTimeStats2() calls uxTaskGetSystemState(), then formats part of the
- * uxTaskGetSystemState() output into a human readable table that displays the
- * amount of time each task has spent in the Running state in both absolute and
- * percentage terms.
- *
- * vTaskGetRunTimeStats2() has a dependency on the sprintf() C library function
- * that might bloat the code size, use a lot of stack, and provide different
- * results on different platforms.  An alternative, tiny, third party, and
- * limited functionality implementation of sprintf() is provided in many of the
- * FreeRTOS/Demo sub-directories in a file called printf-stdarg.c (note
- * printf-stdarg.c does not provide a full snprintf() implementation!).
- *
- * It is recommended that production systems call uxTaskGetSystemState() directly
- * to get access to raw stats data, rather than indirectly through a call to
- * vTaskGetRunTimeStats2().
- *
- * @param pcWriteBuffer A buffer into which the execution times will be
- * written, in ASCII form.  This buffer is assumed to be large enough to
- * contain the generated report.  Approximately 40 bytes per task should
- * be sufficient.
- *
- * @param uxBufferLength Length of the pcWriteBuffer.
- *
- * \defgroup vTaskGetRunTimeStats2 vTaskGetRunTimeStats2
- * \ingroup TaskUtils
- */
-void vTaskGetRunTimeStats2( char * pcWriteBuffer,
-                            size_t uxBufferLength ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+#define vTaskGetRunTimeStats( pcWriteBuffer )   vTaskGetRunTimeStatistics( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH )
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -2214,8 +2214,8 @@ void vTaskListTasks( char * pcWriteBuffer,
  * This function is provided for convenience only, and is used by many of the
  * demo applications.  Do not consider it to be part of the scheduler.
  *
- * vTaskGetRunTimeStatistics() calls uxTaskGetSystemState(), then formats part of the
- * uxTaskGetSystemState() output into a human readable table that displays the
+ * vTaskGetRunTimeStatistics() calls uxTaskGetSystemState(), then formats part of
+ * the uxTaskGetSystemState() output into a human readable table that displays the
  * amount of time each task has spent in the Running state in both absolute and
  * percentage terms.
  *

--- a/include/task.h
+++ b/include/task.h
@@ -2124,6 +2124,7 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * \ingroup TaskUtils
  */
 void vTaskList( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+void vTaskList2( char * pcWriteBuffer, size_t xBufferLength ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
@@ -2180,6 +2181,7 @@ void vTaskList( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unquali
  * \ingroup TaskUtils
  */
 void vTaskGetRunTimeStats( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+void vTaskGetRunTimeStats2( char * pcWriteBuffer , size_t xBufferLength ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -2087,7 +2087,7 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * WARN: This function assumes that the pcWriteBuffer is of length
  * configSTATS_BUFFER_MAX_LENGTH. This function is there only for
  * backward compatibility. New applications are recommended to
- * use vTaskList2 and supply the buffer length explicitly.
+ * use vTaskList2 and supply the length of the pcWriteBuffer explicitly.
  *
  * NOTE 1: This function will disable interrupts for its duration.  It is
  * not intended for normal application runtime use but as a debug aid.
@@ -2201,7 +2201,8 @@ void vTaskList2( char * pcWriteBuffer,
  * WARN: This function assumes that the pcWriteBuffer is of length
  * configSTATS_BUFFER_MAX_LENGTH. This function is there only for
  * backward compatiblity. New applications are recommended to use
- * vTaskGetRunTimeStats2 and supply the buffer length explicitly.
+ * vTaskGetRunTimeStats2 and supply the length of the pcWriteBuffer
+ * explicitly.
  *
  * NOTE 1: This function will disable interrupts for its duration.  It is
  * not intended for normal application runtime use but as a debug aid.

--- a/include/task.h
+++ b/include/task.h
@@ -2124,8 +2124,60 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * \ingroup TaskUtils
  */
 void vTaskList( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+
+/**
+ * task. h
+ * @code{c}
+ * void vTaskList2( char *pcWriteBuffer, size_t uxBufferLength );
+ * @endcode
+ *
+ * configUSE_TRACE_FACILITY and configUSE_STATS_FORMATTING_FUNCTIONS must
+ * both be defined as 1 for this function to be available.  See the
+ * configuration section of the FreeRTOS.org website for more information.
+ *
+ * NOTE 1: This function will disable interrupts for its duration.  It is
+ * not intended for normal application runtime use but as a debug aid.
+ *
+ * Lists all the current tasks, along with their current state and stack
+ * usage high water mark.
+ *
+ * Tasks are reported as blocked ('B'), ready ('R'), deleted ('D') or
+ * suspended ('S').
+ *
+ * PLEASE NOTE:
+ *
+ * This function is provided for convenience only, and is used by many of the
+ * demo applications.  Do not consider it to be part of the scheduler.
+ *
+ * vTaskList2() calls uxTaskGetSystemState(), then formats part of the
+ * uxTaskGetSystemState() output into a human readable table that displays task:
+ * names, states, priority, stack usage and task number.
+ * Stack usage specified as the number of unused StackType_t words stack can hold
+ * on top of stack - not the number of bytes.
+ *
+ * vTaskList2() has a dependency on the sprintf() C library function that might
+ * bloat the code size, use a lot of stack, and provide different results on
+ * different platforms.  An alternative, tiny, third party, and limited
+ * functionality implementation of sprintf() is provided in many of the
+ * FreeRTOS/Demo sub-directories in a file called printf-stdarg.c (note
+ * printf-stdarg.c does not provide a full snprintf() implementation!).
+ *
+ * It is recommended that production systems call uxTaskGetSystemState()
+ * directly to get access to raw stats data, rather than indirectly through a
+ * call to vTaskList2().
+ *
+ * @param pcWriteBuffer A buffer into which the above mentioned details
+ * will be written, in ASCII form.  This buffer is assumed to be large
+ * enough to contain the generated report.  Approximately 40 bytes per
+ * task should be sufficient.
+ *
+ * @param uxBufferLength Length of the pcWriteBuffer.
+ *
+ * \defgroup vTaskList2 vTaskList2
+ * \ingroup TaskUtils
+ */
 void vTaskList2( char * pcWriteBuffer,
-                 size_t xBufferLength ) PRIVILEGED_FUNCTION;
+                 size_t uxBufferLength ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
@@ -2182,8 +2234,65 @@ void vTaskList2( char * pcWriteBuffer,
  * \ingroup TaskUtils
  */
 void vTaskGetRunTimeStats( char * pcWriteBuffer ) PRIVILEGED_FUNCTION;  /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+
+/**
+ * task. h
+ * @code{c}
+ * void vTaskGetRunTimeStats2( char *pcWriteBuffer, size_t uxBufferLength );
+ * @endcode
+ *
+ * configGENERATE_RUN_TIME_STATS and configUSE_STATS_FORMATTING_FUNCTIONS
+ * must both be defined as 1 for this function to be available.  The application
+ * must also then provide definitions for
+ * portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() and portGET_RUN_TIME_COUNTER_VALUE()
+ * to configure a peripheral timer/counter and return the timers current count
+ * value respectively.  The counter should be at least 10 times the frequency of
+ * the tick count.
+ *
+ * NOTE 1: This function will disable interrupts for its duration.  It is
+ * not intended for normal application runtime use but as a debug aid.
+ *
+ * Setting configGENERATE_RUN_TIME_STATS to 1 will result in a total
+ * accumulated execution time being stored for each task.  The resolution
+ * of the accumulated time value depends on the frequency of the timer
+ * configured by the portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() macro.
+ * Calling vTaskGetRunTimeStats2() writes the total execution time of each
+ * task into a buffer, both as an absolute count value and as a percentage
+ * of the total system execution time.
+ *
+ * NOTE 2:
+ *
+ * This function is provided for convenience only, and is used by many of the
+ * demo applications.  Do not consider it to be part of the scheduler.
+ *
+ * vTaskGetRunTimeStats2() calls uxTaskGetSystemState(), then formats part of the
+ * uxTaskGetSystemState() output into a human readable table that displays the
+ * amount of time each task has spent in the Running state in both absolute and
+ * percentage terms.
+ *
+ * vTaskGetRunTimeStats2() has a dependency on the sprintf() C library function
+ * that might bloat the code size, use a lot of stack, and provide different
+ * results on different platforms.  An alternative, tiny, third party, and
+ * limited functionality implementation of sprintf() is provided in many of the
+ * FreeRTOS/Demo sub-directories in a file called printf-stdarg.c (note
+ * printf-stdarg.c does not provide a full snprintf() implementation!).
+ *
+ * It is recommended that production systems call uxTaskGetSystemState() directly
+ * to get access to raw stats data, rather than indirectly through a call to
+ * vTaskGetRunTimeStats2().
+ *
+ * @param pcWriteBuffer A buffer into which the execution times will be
+ * written, in ASCII form.  This buffer is assumed to be large enough to
+ * contain the generated report.  Approximately 40 bytes per task should
+ * be sufficient.
+ *
+ * @param uxBufferLength Length of the pcWriteBuffer.
+ *
+ * \defgroup vTaskGetRunTimeStats2 vTaskGetRunTimeStats2
+ * \ingroup TaskUtils
+ */
 void vTaskGetRunTimeStats2( char * pcWriteBuffer,
-                            size_t xBufferLength ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+                            size_t uxBufferLength ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -2124,7 +2124,8 @@ UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
  * \ingroup TaskUtils
  */
 void vTaskList( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
-void vTaskList2( char * pcWriteBuffer, size_t xBufferLength ) PRIVILEGED_FUNCTION;
+void vTaskList2( char * pcWriteBuffer,
+                 size_t xBufferLength ) PRIVILEGED_FUNCTION;
 
 /**
  * task. h
@@ -2180,8 +2181,9 @@ void vTaskList2( char * pcWriteBuffer, size_t xBufferLength ) PRIVILEGED_FUNCTIO
  * \defgroup vTaskGetRunTimeStats vTaskGetRunTimeStats
  * \ingroup TaskUtils
  */
-void vTaskGetRunTimeStats( char * pcWriteBuffer ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
-void vTaskGetRunTimeStats2( char * pcWriteBuffer , size_t xBufferLength ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+void vTaskGetRunTimeStats( char * pcWriteBuffer ) PRIVILEGED_FUNCTION;  /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+void vTaskGetRunTimeStats2( char * pcWriteBuffer,
+                            size_t xBufferLength ) PRIVILEGED_FUNCTION; /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
 
 /**
  * task. h

--- a/tasks.c
+++ b/tasks.c
@@ -721,26 +721,26 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
 
-    /*
-     * Convert the snprintf return value to the number of characters
-     * written. The following are the possible cases:
-     *
-     * 1. The buffer supplied to snprintf is large enough to hold the
-     *    generated string. The return value in this case is the number
-     *    of characters actually written, not counting the terminating
-     *    null character.
-     * 2. The buffer supplied to snprintf is NOT large enough to hold
-     *    the generated string. The return value in this case is the
-     *    number of characters that would have been written if n had
-     *    been sufficiently large, not counting the terminating null
-     *    character.
-     * 3. Encoding error. The return value in this case is a negative
-     *    number.
-     *
-     * From 1 and 2 above ==> Only when the return value is non-negative
-     * and less than the supplied buffer length, the string has been
-     * completely written.
-     */
+/*
+ * Convert the snprintf return value to the number of characters
+ * written. The following are the possible cases:
+ *
+ * 1. The buffer supplied to snprintf is large enough to hold the
+ *    generated string. The return value in this case is the number
+ *    of characters actually written, not counting the terminating
+ *    null character.
+ * 2. The buffer supplied to snprintf is NOT large enough to hold
+ *    the generated string. The return value in this case is the
+ *    number of characters that would have been written if n had
+ *    been sufficiently large, not counting the terminating null
+ *    character.
+ * 3. Encoding error. The return value in this case is a negative
+ *    number.
+ *
+ * From 1 and 2 above ==> Only when the return value is non-negative
+ * and less than the supplied buffer length, the string has been
+ * completely written.
+ */
     static size_t prvSnprintfReturnValueToCharsWritten( int lSnprintfReturnValue,
                                                         size_t n );
 
@@ -7153,7 +7153,7 @@ static void prvResetNextTaskUnblockTime( void )
                                                                  ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter,
                                                                  ( unsigned int ) ulStatsAsPercentage ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
                             }
-                            #endif
+                            #endif /* ifdef portLU_PRINTF_SPECIFIER_REQUIRED */
                         }
                         else
                         {
@@ -7175,7 +7175,7 @@ static void prvResetNextTaskUnblockTime( void )
                                                                  "\t%u\t\t<1%%\r\n",
                                                                  ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
                             }
-                            #endif
+                            #endif /* ifdef portLU_PRINTF_SPECIFIER_REQUIRED */
                         }
 
                         uxCharsWrittenBySnprintf = prvSnprintfReturnValueToCharsWritten( lSnprintfReturnValue, uxBufferLength - uxConsumedBufferLength );

--- a/tasks.c
+++ b/tasks.c
@@ -6871,22 +6871,8 @@ static void prvResetNextTaskUnblockTime( void )
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
 
-    void vTaskList( char * pcWriteBuffer )
-    {
-        /* Only here for backward compatiblity. Please use vTaskList2
-         * and supply the actual buffer length to avoid memory corruption.
-         * Using this function will result in memory corruption if the
-         * buffer is not large enough. */
-        vTaskList2( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH );
-    }
-
-#endif /* ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) */
-/*-----------------------------------------------------------*/
-
-#if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
-
-    void vTaskList2( char * pcWriteBuffer,
-                     size_t uxBufferLength )
+    void vTaskListTasks( char * pcWriteBuffer,
+                         size_t uxBufferLength )
     {
         TaskStatus_t * pxTaskStatusArray;
         size_t uxConsumedBufferLength = 0;
@@ -6896,7 +6882,7 @@ static void prvResetNextTaskUnblockTime( void )
         UBaseType_t uxArraySize, x;
         char cStatus;
 
-        traceENTER_vTaskList( pcWriteBuffer );
+        traceENTER_vTaskListTasks( pcWriteBuffer, uxBufferLength );
 
         /*
          * PLEASE NOTE:
@@ -6905,23 +6891,23 @@ static void prvResetNextTaskUnblockTime( void )
          * of the demo applications.  Do not consider it to be part of the
          * scheduler.
          *
-         * vTaskList() calls uxTaskGetSystemState(), then formats part of the
+         * vTaskListTasks() calls uxTaskGetSystemState(), then formats part of the
          * uxTaskGetSystemState() output into a human readable table that
          * displays task: names, states, priority, stack usage and task number.
          * Stack usage specified as the number of unused StackType_t words stack can hold
          * on top of stack - not the number of bytes.
          *
-         * vTaskList() has a dependency on the sprintf() C library function that
+         * vTaskListTasks() has a dependency on the snprintf() C library function that
          * might bloat the code size, use a lot of stack, and provide different
          * results on different platforms.  An alternative, tiny, third party,
-         * and limited functionality implementation of sprintf() is provided in
+         * and limited functionality implementation of snprintf() is provided in
          * many of the FreeRTOS/Demo sub-directories in a file called
          * printf-stdarg.c (note printf-stdarg.c does not provide a full
          * snprintf() implementation!).
          *
          * It is recommended that production systems call uxTaskGetSystemState()
          * directly to get access to raw stats data, rather than indirectly
-         * through a call to vTaskList().
+         * through a call to vTaskListTasks().
          */
 
 
@@ -7022,7 +7008,7 @@ static void prvResetNextTaskUnblockTime( void )
             mtCOVERAGE_TEST_MARKER();
         }
 
-        traceRETURN_vTaskList();
+        traceRETURN_vTaskListTasks();
     }
 
 #endif /* ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
@@ -7030,22 +7016,8 @@ static void prvResetNextTaskUnblockTime( void )
 
 #if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configUSE_TRACE_FACILITY == 1 ) )
 
-    void vTaskGetRunTimeStats( char * pcWriteBuffer )
-    {
-        /* Only here for backward compatiblity. Please use vTaskGetRunTimeStats2
-         * and supply the actual buffer length to avoid memory corruption.
-         * Using this function will result in memory corruption if the
-         * buffer is not large enough. */
-        vTaskGetRunTimeStats2( pcWriteBuffer, configSTATS_BUFFER_MAX_LENGTH );
-    }
-
-#endif /* ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
-/*----------------------------------------------------------*/
-
-#if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configUSE_TRACE_FACILITY == 1 ) )
-
-    void vTaskGetRunTimeStats2( char * pcWriteBuffer,
-                                size_t uxBufferLength )
+    void vTaskGetRunTimeStatistics( char * pcWriteBuffer,
+                                    size_t uxBufferLength )
     {
         TaskStatus_t * pxTaskStatusArray;
         size_t uxConsumedBufferLength = 0;
@@ -7055,7 +7027,7 @@ static void prvResetNextTaskUnblockTime( void )
         UBaseType_t uxArraySize, x;
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulStatsAsPercentage;
 
-        traceENTER_vTaskGetRunTimeStats( pcWriteBuffer );
+        traceENTER_vTaskGetRunTimeStatistics( pcWriteBuffer, uxBufferLength );
 
         /*
          * PLEASE NOTE:
@@ -7064,22 +7036,22 @@ static void prvResetNextTaskUnblockTime( void )
          * of the demo applications.  Do not consider it to be part of the
          * scheduler.
          *
-         * vTaskGetRunTimeStats() calls uxTaskGetSystemState(), then formats part
+         * vTaskGetRunTimeStatistics() calls uxTaskGetSystemState(), then formats part
          * of the uxTaskGetSystemState() output into a human readable table that
          * displays the amount of time each task has spent in the Running state
          * in both absolute and percentage terms.
          *
-         * vTaskGetRunTimeStats() has a dependency on the sprintf() C library
+         * vTaskGetRunTimeStatistics() has a dependency on the snprintf() C library
          * function that might bloat the code size, use a lot of stack, and
          * provide different results on different platforms.  An alternative,
          * tiny, third party, and limited functionality implementation of
-         * sprintf() is provided in many of the FreeRTOS/Demo sub-directories in
+         * snprintf() is provided in many of the FreeRTOS/Demo sub-directories in
          * a file called printf-stdarg.c (note printf-stdarg.c does not provide
          * a full snprintf() implementation!).
          *
          * It is recommended that production systems call uxTaskGetSystemState()
          * directly to get access to raw stats data, rather than indirectly
-         * through a call to vTaskGetRunTimeStats().
+         * through a call to vTaskGetRunTimeStatistics().
          */
 
         /* Make sure the write buffer does not contain a string. */
@@ -7203,7 +7175,7 @@ static void prvResetNextTaskUnblockTime( void )
             mtCOVERAGE_TEST_MARKER();
         }
 
-        traceRETURN_vTaskGetRunTimeStats();
+        traceRETURN_vTaskGetRunTimeStatistics();
     }
 
 #endif /* ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */

--- a/tasks.c
+++ b/tasks.c
@@ -6992,12 +6992,12 @@ static void prvResetNextTaskUnblockTime( void )
                     {
                         /* Write the rest of the string. */
                         iSnprintfReturnValue = snprintf( pcWriteBuffer,
-                                                        uxBufferLength - uxConsumedBufferLength,
-                                                        "\t%c\t%u\t%u\t%u\r\n",
-                                                        cStatus,
-                                                        ( unsigned int ) pxTaskStatusArray[ x ].uxCurrentPriority,
-                                                        ( unsigned int ) pxTaskStatusArray[ x ].usStackHighWaterMark,
-                                                        ( unsigned int ) pxTaskStatusArray[ x ].xTaskNumber ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
+                                                         uxBufferLength - uxConsumedBufferLength,
+                                                         "\t%c\t%u\t%u\t%u\r\n",
+                                                         cStatus,
+                                                         ( unsigned int ) pxTaskStatusArray[ x ].uxCurrentPriority,
+                                                         ( unsigned int ) pxTaskStatusArray[ x ].usStackHighWaterMark,
+                                                         ( unsigned int ) pxTaskStatusArray[ x ].xTaskNumber ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
                         uxCharsWrittenBySnprintf = prvSnprintfReturnValueToCharsWritten( iSnprintfReturnValue, uxBufferLength - uxConsumedBufferLength );
 
                         uxConsumedBufferLength += uxCharsWrittenBySnprintf;
@@ -7107,7 +7107,7 @@ static void prvResetNextTaskUnblockTime( void )
             if( ulTotalTime > 0UL )
             {
                 /* Create a human readable table from the binary data. */
-                for( x = 0; ( x < uxArraySize ) && ( xOutputBufferFull == pdFALSE ) ; x++ )
+                for( x = 0; ( x < uxArraySize ) && ( xOutputBufferFull == pdFALSE ); x++ )
                 {
                     /* What percentage of the total run time has the task used?
                      * This will always be rounded down to the nearest integer.
@@ -7135,20 +7135,20 @@ static void prvResetNextTaskUnblockTime( void )
                                 #ifdef portLU_PRINTF_SPECIFIER_REQUIRED
                                 {
                                     iSnprintfReturnValue = snprintf( pcWriteBuffer,
-                                                                    uxBufferLength - uxConsumedBufferLength,
-                                                                    "\t%lu\t\t%lu%%\r\n",
-                                                                    pxTaskStatusArray[ x ].ulRunTimeCounter,
-                                                                    ulStatsAsPercentage );
+                                                                     uxBufferLength - uxConsumedBufferLength,
+                                                                     "\t%lu\t\t%lu%%\r\n",
+                                                                     pxTaskStatusArray[ x ].ulRunTimeCounter,
+                                                                     ulStatsAsPercentage );
                                 }
                                 #else
                                 {
                                     /* sizeof( int ) == sizeof( long ) so a smaller
                                      * printf() library can be used. */
                                     iSnprintfReturnValue = snprintf( pcWriteBuffer,
-                                                                    uxBufferLength - uxConsumedBufferLength,
-                                                                    "\t%u\t\t%u%%\r\n",
-                                                                    ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter,
-                                                                    ( unsigned int ) ulStatsAsPercentage ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
+                                                                     uxBufferLength - uxConsumedBufferLength,
+                                                                     "\t%u\t\t%u%%\r\n",
+                                                                     ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter,
+                                                                     ( unsigned int ) ulStatsAsPercentage ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
                                 }
                                 #endif /* ifdef portLU_PRINTF_SPECIFIER_REQUIRED */
                             }
@@ -7159,18 +7159,18 @@ static void prvResetNextTaskUnblockTime( void )
                                 #ifdef portLU_PRINTF_SPECIFIER_REQUIRED
                                 {
                                     iSnprintfReturnValue = snprintf( pcWriteBuffer,
-                                                                    uxBufferLength - uxConsumedBufferLength,
-                                                                    "\t%lu\t\t<1%%\r\n",
-                                                                    pxTaskStatusArray[ x ].ulRunTimeCounter );
+                                                                     uxBufferLength - uxConsumedBufferLength,
+                                                                     "\t%lu\t\t<1%%\r\n",
+                                                                     pxTaskStatusArray[ x ].ulRunTimeCounter );
                                 }
                                 #else
                                 {
                                     /* sizeof( int ) == sizeof( long ) so a smaller
                                      * printf() library can be used. */
                                     iSnprintfReturnValue = snprintf( pcWriteBuffer,
-                                                                    uxBufferLength - uxConsumedBufferLength,
-                                                                    "\t%u\t\t<1%%\r\n",
-                                                                    ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
+                                                                     uxBufferLength - uxConsumedBufferLength,
+                                                                     "\t%u\t\t<1%%\r\n",
+                                                                     ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
                                 }
                                 #endif /* ifdef portLU_PRINTF_SPECIFIER_REQUIRED */
                             }

--- a/tasks.c
+++ b/tasks.c
@@ -140,26 +140,26 @@
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
 
     static int vsnprintf_safe( char * s,
-                            size_t n,
-                            const char * format,
-                            va_list arg )
+                               size_t n,
+                               const char * format,
+                               va_list arg )
     {
         int ret;
 
         ret = vsnprintf( s, n, format, arg );
 
         /* Check if the string was truncated and if so, update the return value
-        * to reflect the number of characters actually written. */
-        if( ret >= ( int )n )
+         * to reflect the number of characters actually written. */
+        if( ret >= ( int ) n )
         {
             /* Do not include the terminating NULL character to keep the behaviour
-            * same as the standard. */
+             * same as the standard. */
             ret = n - 1;
         }
         else if( ret < 0 )
         {
             /* Encoding error - Return 0 to indicate that nothing was written to the
-            * buffer. */
+             * buffer. */
             ret = 0;
         }
         else
@@ -170,12 +170,12 @@
         return ret;
     }
 
-    /*-----------------------------------------------------------*/
+/*-----------------------------------------------------------*/
 
     static int snprintf_safe( char * s,
-                            size_t n,
-                            const char * format,
-                            ... )
+                              size_t n,
+                              const char * format,
+                              ... )
     {
         int ret;
         va_list args;
@@ -6870,9 +6870,9 @@ static void prvResetNextTaskUnblockTime( void )
     void vTaskList( char * pcWriteBuffer )
     {
         /* Only here for backward compatiblity. Please use vTaskList2
-        * and supply the actual buffer length to avoid memory corruption.
-        * Using this function will result in memory corruption if the
-        * buffer is not large enough. */
+         * and supply the actual buffer length to avoid memory corruption.
+         * Using this function will result in memory corruption if the
+         * buffer is not large enough. */
         vTaskList2( pcWriteBuffer, SIZE_MAX );
     }
 
@@ -6881,12 +6881,12 @@ static void prvResetNextTaskUnblockTime( void )
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
 
-    void vTaskList2( char * pcWriteBuffer , size_t xBufferLength )
+    void vTaskList2( char * pcWriteBuffer,
+                     size_t xBufferLength )
     {
         TaskStatus_t * pxTaskStatusArray;
         size_t xLength = 0;
         size_t xTotalLength = 0;
-        TaskStatus_t * pxTaskStatusArray;
         UBaseType_t uxArraySize, x;
         char cStatus;
 
@@ -6983,7 +6983,7 @@ static void prvResetNextTaskUnblockTime( void )
                 else
                 {
                     break;
-                }                                                                                                                                                                                                /*lint !e9016 Pointer arithmetic ok on char pointers especially as in this case where it best denotes the intent of the code. */
+                } /*lint !e9016 Pointer arithmetic ok on char pointers especially as in this case where it best denotes the intent of the code. */
             }
 
             /* Free the array again.  NOTE!  If configSUPPORT_DYNAMIC_ALLOCATION
@@ -7006,9 +7006,9 @@ static void prvResetNextTaskUnblockTime( void )
     void vTaskGetRunTimeStats( char * pcWriteBuffer )
     {
         /* Only here for backward compatiblity. Please use vTaskGetRunTimeStats2
-        * and supply the actual buffer length to avoid memory corruption.
-        * Using this function will result in memory corruption if the
-        * buffer is not large enough. */
+         * and supply the actual buffer length to avoid memory corruption.
+         * Using this function will result in memory corruption if the
+         * buffer is not large enough. */
         vTaskGetRunTimeStats2( pcWriteBuffer, SIZE_MAX );
     }
 
@@ -7017,12 +7017,12 @@ static void prvResetNextTaskUnblockTime( void )
 
 #if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) && ( configUSE_TRACE_FACILITY == 1 ) )
 
-    void vTaskGetRunTimeStats2( char * pcWriteBuffer , size_t xBufferLength )
+    void vTaskGetRunTimeStats2( char * pcWriteBuffer,
+                                size_t xBufferLength )
     {
         TaskStatus_t * pxTaskStatusArray;
         size_t xLength = 0;
-        size_t xTotlaLength = 0;
-        TaskStatus_t * pxTaskStatusArray;
+        size_t xTotalLength = 0;
         UBaseType_t uxArraySize, x;
         configRUN_TIME_COUNTER_TYPE ulTotalTime, ulStatsAsPercentage;
 
@@ -7090,35 +7090,35 @@ static void prvResetNextTaskUnblockTime( void )
                     pcWriteBuffer = prvWriteNameToBuffer( pcWriteBuffer, pxTaskStatusArray[ x ].pcTaskName );
                     xTotalLength += configMAX_TASK_NAME_LEN;
 
-                    if ( xTotalLength < xBufferLength )
+                    if( xTotalLength < xBufferLength )
                     {
                         if( ulStatsAsPercentage > 0UL )
                         {
                             #ifdef portLU_PRINTF_SPECIFIER_REQUIRED
                             {
-                                xLength = snprintf_safe( pcWriteBuffer , xBufferLength - xTotalLength,"\t%lu\t\t%lu%%\r\n", pxTaskStatusArray[ x ].ulRunTimeCounter, ulStatsAsPercentage );
+                                xLength = snprintf_safe( pcWriteBuffer, xBufferLength - xTotalLength, "\t%lu\t\t%lu%%\r\n", pxTaskStatusArray[ x ].ulRunTimeCounter, ulStatsAsPercentage );
                             }
                             #else
                             {
                                 /* sizeof( int ) == sizeof( long ) so a smaller
-                                * printf() library can be used. */
-                                xLength = snprintf_safe( pcWriteBuffer , xBufferLength - xTotalLength, "\t%u\t\t%u%%\r\n", ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter, ( unsigned int ) ulStatsAsPercentage ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
+                                 * printf() library can be used. */
+                                xLength = snprintf_safe( pcWriteBuffer, xBufferLength - xTotalLength, "\t%u\t\t%u%%\r\n", ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter, ( unsigned int ) ulStatsAsPercentage ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
                             }
                             #endif
                         }
                         else
                         {
                             /* If the percentage is zero here then the task has
-                            * consumed less than 1% of the total run time. */
+                             * consumed less than 1% of the total run time. */
                             #ifdef portLU_PRINTF_SPECIFIER_REQUIRED
                             {
-                                xLength = snprintf_safe( pcWriteBuffer , xBufferLength - xTotalLength, "\t%lu\t\t<1%%\r\n", pxTaskStatusArray[ x ].ulRunTimeCounter );
+                                xLength = snprintf_safe( pcWriteBuffer, xBufferLength - xTotalLength, "\t%lu\t\t<1%%\r\n", pxTaskStatusArray[ x ].ulRunTimeCounter );
                             }
                             #else
                             {
                                 /* sizeof( int ) == sizeof( long ) so a smaller
-                                * printf() library can be used. */
-                                xLength = snprintf_safe( pcWriteBuffer , xBufferLength - xTotalLength, ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
+                                 * printf() library can be used. */
+                                xLength = snprintf_safe( pcWriteBuffer, xBufferLength - xTotalLength, ( unsigned int ) pxTaskStatusArray[ x ].ulRunTimeCounter ); /*lint !e586 sprintf() allowed as this is compiled with many compilers and this is a utility function only - not part of the core kernel implementation. */
                             }
                             #endif
                         }

--- a/tasks.c
+++ b/tasks.c
@@ -1955,7 +1955,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
         else if( lSnprintfReturnValue >= ( int ) n )
         {
-            /* This is the case when the supplied buffer was not
+            /* This is the case when the supplied buffer is not
              * large to hold the generated string. Return the
              * number of characters actually written without
              * counting the terminating NULL character. */


### PR DESCRIPTION
Description
-----------
This change necessitates the introduction of 2 new APIs:

```c
void vTaskListTasks( char * pcWriteBuffer, size_t uxBufferLength );
void vTaskGetRunTimeStatistics( char * pcWriteBuffer, size_t uxBufferLength );
```

These 2 APIs behave exactly as `vTaskList` and `vTaskGetRunTimeStats` except the fact that they take the length of the `pcWriteBuffer` as the second argument to ensure that we do not write past the buffer.

`vTaskList` and `vTaskGetRunTimeStats` assume that the length of the buffer is `configSTATS_BUFFER_MAX_LENGTH` which defaults to `0xFFFF`. This is done to ensure that the existing applications do not break. New applications should use the new APIs to avoid memory corruption.

Test Steps
-----------
Tested behavior of these APIs for various buffer sizes on Cortex-M7.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
* https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/746


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
