### PR TITLE
Remove default behaviour of FREERTOS_HEAP.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,12 @@ cmake_minimum_required(VERSION 3.15)
 #
 # DEPRECATED: FREERTOS_CONFIG_FILE_DIRECTORY - but still supported if no freertos_config defined for now.
 #             May be removed at some point in the future.
+#
 # User can choose which heap implementation to use (either the implementations
-# included with FreeRTOS [1..5] or a custom implementation ) by providing the
-# option FREERTOS_HEAP. If the option is not set, the cmake will default to
-# using heap_4.c.
+# included with FreeRTOS [1..5] or a custom implementation) by providing the
+# option FREERTOS_HEAP. When dynamic allocation is used, the user must specify a
+# heap implementation. If the option is not set, the cmake will use no heap
+# implementation (e.g. when only static allocation is used).
 
 # `freertos_config` target defines the path to FreeRTOSConfig.h and optionally other freertos based config files
 if(NOT TARGET freertos_config )
@@ -36,9 +38,6 @@ if(NOT TARGET freertos_config )
             "    projCOVERAGE_TEST=0)\n")
     endif()
 endif()
-
-# Heap number or absolute path to custom heap implementation provided by user
-set(FREERTOS_HEAP "4" CACHE STRING "FreeRTOS heap model number. 1 .. 5. Or absolute path to custom heap source file")
 
 # FreeRTOS port option
 if(NOT FREERTOS_PORT)
@@ -284,10 +283,15 @@ target_sources(freertos_kernel PRIVATE
     stream_buffer.c
     tasks.c
     timers.c
-
-    # If FREERTOS_HEAP is digit between 1 .. 5 - it is heap number, otherwise - it is path to custom heap source file
-    $<IF:$<BOOL:$<FILTER:${FREERTOS_HEAP},EXCLUDE,^[1-5]$>>,${FREERTOS_HEAP},portable/MemMang/heap_${FREERTOS_HEAP}.c>
 )
+
+if (DEFINED FREERTOS_HEAP )
+    # User specified a heap implementation add heap implementation to freertos_kernel.
+    target_sources(freertos_kernel PRIVATE
+        # If FREERTOS_HEAP is digit between 1 .. 5 - it is heap number, otherwise - it is path to custom heap source file
+        $<IF:$<BOOL:$<FILTER:${FREERTOS_HEAP},EXCLUDE,^[1-5]$>>,${FREERTOS_HEAP},portable/MemMang/heap_${FREERTOS_HEAP}.c>
+    )
+endif()
 
 
 target_link_libraries(freertos_kernel


### PR DESCRIPTION
To build a complete static application (configSUPPORT_DYNAMIC_ALLOCATION set to 0) an ugly workaround is necessary. When FREERTOS_HEAP (CMake variable) is not set, heap 4 is automatically selected in the current CMake. Without this change I got the following error:

`/home/boris/workspace/base/external/freertos/portable/MemMang/heap_4.c:51:6: error: #error This file must not be used if configSUPPORT_DYNAMIC_ALLOCATION is 0
   51 |     #error This file must not be used if configSUPPORT_DYNAMIC_ALLOCATION is 0`

For additional context, please read: https://forums.freertos.org/t/i-cannot-build-a-complete-static-application-bug-or-feature/9553

-----------
I opted to modify the default behavior of the FREERTOS_HEAP CMake variable because I believe it's essential for the user to be conscious of the chosen heap implementation. While another option was to introduce a magic variable to prevent automatic heap implementation selection, I find this approach to be the most straightforward and logical one.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
