### PR TITLE
Add HalIncTick() call inside SysTickHandler definiton otherwise HAL t…

### DIFF
--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -510,6 +510,7 @@ void xPortSysTickHandler( void )
      * executes all interrupts must be unmasked.  There is therefore no need to
      * save and then restore the interrupt mask value as its value is already
      * known. */
+    HAL_IncTick();
     portDISABLE_INTERRUPTS();
     traceISR_ENTER();
     {


### PR DESCRIPTION
When porting FreeRTOS to STM32F7x I noticed that FreeRTOS redefines some functions auto generated by the STM32 IDE, so I commented them out and everything started compiling correctly. 
The problem was that time-based HAL functions stopped working. This happens because FreeRTOS redefines SysTickHandler, but does not call HAL_IncTick() - this is required for time-based HAL functions to work and by default it is called in the STM32 IDE version of SysTickHandler that is now commented out.
To fix this, I added a call to HAL_IncTick() to the xPortSysTickHandler function in portable/GCC/ARM_CM7/r0p1/ port.c
I believe that adding this would make the porting process more seamless.
If any further alterations are required I'm happy to contribute

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
