### PR TITLE
removed the copyright and license header for select files

### DIFF
--- a/.github/scripts/kernel_checker.py
+++ b/.github/scripts/kernel_checker.py
@@ -38,7 +38,6 @@ KERNEL_IGNORED_FILES = [
     'Makefile',
     '.DS_Store',
     'cspell.config.yaml'
-    'FreeRTOSConfig.h'
 ]
 
 KERNEL_IGNORED_EXTENSIONS = [
@@ -94,7 +93,8 @@ KERNEL_IGNORED_PATTERNS = [
     r'.*IAR/ARM_C*',
     r'.*IAR/78K0R/*',
     r'.*CCS/MSP430X/*',
-    r'.*portable/template/*'
+    r'.*portable/template/*',
+    r'.*sample_configuration/*'
 ]
 
 KERNEL_THIRD_PARTY_PATTERNS = [

--- a/portable/template/port.c
+++ b/portable/template/port.c
@@ -6,23 +6,23 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-BaseType_t xPortStartScheduler(void)
+BaseType_t xPortStartScheduler( void )
 {
     return pdTRUE;
 }
 
-void vPortEndScheduler(void)
+void vPortEndScheduler( void )
 {
 }
 
-StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack,
-                                   TaskFunction_t pxCode,
-                                   void *pvParameters)
+StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters )
 {
     return NULL;
 }
 
-void vPortYield(void)
+void vPortYield( void )
 {
     /* Save the current Context */
     /* Switch to the highest priority task that is ready to run. */
@@ -30,13 +30,13 @@ void vPortYield(void)
     /* Start executing the task we have just switched to. */
 }
 
-static void prvTickISR(void)
+static void prvTickISR( void )
 {
     /* Interrupts must have been enabled for the ISR to fire, so we have to
      * save the context with interrupts enabled. */
 
     /* Maintain the tick count. */
-    if (xTaskIncrementTick() != pdFALSE)
+    if( xTaskIncrementTick() != pdFALSE )
     {
         /* Switch to the highest priority task that is ready to run. */
         vTaskSwitchContext();

--- a/portable/template/port.c
+++ b/portable/template/port.c
@@ -1,51 +1,28 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
- * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
- *
- * SPDX-License-Identifier: MIT
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
- * https://www.FreeRTOS.org
- * https://github.com/FreeRTOS
- *
+ * license and copyright intentionally withheld to promote copying into user code.
  */
 
 #include "FreeRTOS.h"
 #include "task.h"
 
-BaseType_t xPortStartScheduler( void )
+BaseType_t xPortStartScheduler(void)
 {
     return pdTRUE;
 }
 
-void vPortEndScheduler( void )
+void vPortEndScheduler(void)
 {
 }
 
-StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                     TaskFunction_t pxCode,
-                                     void * pvParameters )
+StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack,
+                                   TaskFunction_t pxCode,
+                                   void *pvParameters)
 {
     return NULL;
 }
 
-void vPortYield( void )
+void vPortYield(void)
 {
     /* Save the current Context */
     /* Switch to the highest priority task that is ready to run. */
@@ -53,13 +30,13 @@ void vPortYield( void )
     /* Start executing the task we have just switched to. */
 }
 
-static void prvTickISR( void )
+static void prvTickISR(void)
 {
     /* Interrupts must have been enabled for the ISR to fire, so we have to
      * save the context with interrupts enabled. */
 
     /* Maintain the tick count. */
-    if( xTaskIncrementTick() != pdFALSE )
+    if (xTaskIncrementTick() != pdFALSE)
     {
         /* Switch to the highest priority task that is ready to run. */
         vTaskSwitchContext();

--- a/portable/template/portmacro.h
+++ b/portable/template/portmacro.h
@@ -1,30 +1,8 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
- * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
- *
- * SPDX-License-Identifier: MIT
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
- * https://www.FreeRTOS.org
- * https://github.com/FreeRTOS
- *
+ * license and copyright intentionally withheld to promote copying into user code.
  */
+
 #ifndef PORTMACRO_H
 #define PORTMACRO_H
 
@@ -39,54 +17,54 @@
  */
 
 /* Type definitions. */
-#define portCHAR                 char
-#define portFLOAT                float
-#define portDOUBLE               double
-#define portLONG                 long
-#define portSHORT                int
-#define portSTACK_TYPE           uint8_t
-#define portBASE_TYPE            char
+#define portCHAR char
+#define portFLOAT float
+#define portDOUBLE double
+#define portLONG long
+#define portSHORT int
+#define portSTACK_TYPE uint8_t
+#define portBASE_TYPE char
 
-#define portSTACK_GROWTH         ( -1 )
-#define portBYTE_ALIGNMENT       4
-#define portPOINTER_SIZE_TYPE    size_t
-typedef portSTACK_TYPE   StackType_t;
-typedef signed char      BaseType_t;
-typedef unsigned char    UBaseType_t;
+#define portSTACK_GROWTH (-1)
+#define portBYTE_ALIGNMENT 4
+#define portPOINTER_SIZE_TYPE size_t
+typedef portSTACK_TYPE StackType_t;
+typedef signed char BaseType_t;
+typedef unsigned char UBaseType_t;
 
-#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
-    typedef uint16_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) 0xffff
-#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
-    typedef uint32_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) 0xffffffffUL
+#if (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS)
+typedef uint16_t TickType_t;
+#define portMAX_DELAY (TickType_t)0xffff
+#elif (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS)
+typedef uint32_t TickType_t;
+#define portMAX_DELAY (TickType_t)0xffffffffUL
 #else
-    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+#error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif
 
 /* Architecture specific optimisations. */
 #ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
-    #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
 #endif
 
 #if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
 
 /* Check the configuration. */
-    #if ( configMAX_PRIORITIES > 32 )
-        #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
-    #endif
+#if (configMAX_PRIORITIES > 32)
+#error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
+#endif
 
 /* Store/clear the ready priorities in a bit map. */
-    #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
-    #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
+#define portRECORD_READY_PRIORITY(uxPriority, uxReadyPriorities) (uxReadyPriorities) |= (1UL << (uxPriority))
+#define portRESET_READY_PRIORITY(uxPriority, uxReadyPriorities) (uxReadyPriorities) &= ~(1UL << (uxPriority))
 
 /*-----------------------------------------------------------*/
 
-    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities ) \
-    {                                                                    \
-        uxTopPriority = 0;                                               \
-    }                                                                    \
-    while( 0 )
+#define portGET_HIGHEST_PRIORITY(uxTopPriority, uxReadyPriorities) \
+    {                                                              \
+        uxTopPriority = 0;                                         \
+    }                                                              \
+    while (0)
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
@@ -104,11 +82,11 @@ typedef unsigned char    UBaseType_t;
     { /* restore previously preserved interrupt state */ \
     }
 
-extern void vPortYield( void );
-#define portYIELD()                                           vPortYield()
+extern void vPortYield(void);
+#define portYIELD() vPortYield()
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO(vFunction, pvParameters) void vFunction(void *pvParameters)
+#define portTASK_FUNCTION(vFunction, pvParameters) void vFunction(void *pvParameters)
 
 #endif /* PORTMACRO_H */

--- a/portable/template/portmacro.h
+++ b/portable/template/portmacro.h
@@ -17,54 +17,54 @@
  */
 
 /* Type definitions. */
-#define portCHAR char
-#define portFLOAT float
-#define portDOUBLE double
-#define portLONG long
-#define portSHORT int
-#define portSTACK_TYPE uint8_t
-#define portBASE_TYPE char
+#define portCHAR                 char
+#define portFLOAT                float
+#define portDOUBLE               double
+#define portLONG                 long
+#define portSHORT                int
+#define portSTACK_TYPE           uint8_t
+#define portBASE_TYPE            char
 
-#define portSTACK_GROWTH (-1)
-#define portBYTE_ALIGNMENT 4
-#define portPOINTER_SIZE_TYPE size_t
-typedef portSTACK_TYPE StackType_t;
-typedef signed char BaseType_t;
-typedef unsigned char UBaseType_t;
+#define portSTACK_GROWTH         ( -1 )
+#define portBYTE_ALIGNMENT       4
+#define portPOINTER_SIZE_TYPE    size_t
+typedef portSTACK_TYPE   StackType_t;
+typedef signed char      BaseType_t;
+typedef unsigned char    UBaseType_t;
 
-#if (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS)
-typedef uint16_t TickType_t;
-#define portMAX_DELAY (TickType_t)0xffff
-#elif (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS)
-typedef uint32_t TickType_t;
-#define portMAX_DELAY (TickType_t)0xffffffffUL
+#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
+    typedef uint16_t     TickType_t;
+    #define portMAX_DELAY    ( TickType_t ) 0xffff
+#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
+    typedef uint32_t     TickType_t;
+    #define portMAX_DELAY    ( TickType_t ) 0xffffffffUL
 #else
-#error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif
 
 /* Architecture specific optimisations. */
 #ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
+    #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
 #endif
 
 #if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
 
 /* Check the configuration. */
-#if (configMAX_PRIORITIES > 32)
-#error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
-#endif
+    #if ( configMAX_PRIORITIES > 32 )
+        #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
+    #endif
 
 /* Store/clear the ready priorities in a bit map. */
-#define portRECORD_READY_PRIORITY(uxPriority, uxReadyPriorities) (uxReadyPriorities) |= (1UL << (uxPriority))
-#define portRESET_READY_PRIORITY(uxPriority, uxReadyPriorities) (uxReadyPriorities) &= ~(1UL << (uxPriority))
+    #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
+    #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
 
 /*-----------------------------------------------------------*/
 
-#define portGET_HIGHEST_PRIORITY(uxTopPriority, uxReadyPriorities) \
-    {                                                              \
-        uxTopPriority = 0;                                         \
-    }                                                              \
-    while (0)
+    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities ) \
+    {                                                                    \
+        uxTopPriority = 0;                                               \
+    }                                                                    \
+    while( 0 )
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
@@ -82,11 +82,11 @@ typedef uint32_t TickType_t;
     { /* restore previously preserved interrupt state */ \
     }
 
-extern void vPortYield(void);
-#define portYIELD() vPortYield()
+extern void vPortYield( void );
+#define portYIELD()                                           vPortYield()
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION_PROTO(vFunction, pvParameters) void vFunction(void *pvParameters)
-#define portTASK_FUNCTION(vFunction, pvParameters) void vFunction(void *pvParameters)
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
 #endif /* PORTMACRO_H */

--- a/sample_configuration/FreeRTOSConfig.h
+++ b/sample_configuration/FreeRTOSConfig.h
@@ -51,7 +51,7 @@
  * The default value is set to 20MHz and matches the QEMU demo settings.  Your
  * application will certainly need a different value so set this correctly.
  * This is very often, but not always, equal to the main system clock frequency. */
-#define configCPU_CLOCK_HZ ((unsigned long)20000000)
+#define configCPU_CLOCK_HZ    ( ( unsigned long ) 20000000 )
 
 /* configSYSTICK_CLOCK_HZ is an optional parameter for ARM Cortex-M ports only.
  *
@@ -75,19 +75,19 @@
 
 /* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz, normally
  * calculated from the configCPU_CLOCK_HZ value. */
-#define configTICK_RATE_HZ 100
+#define configTICK_RATE_HZ                         100
 
 /* Set configUSE_PREEMPTION to 1 to use pre-emptive scheduling.  Set
  * configUSE_PREEMPTION to 0 to use co-operative scheduling.
  * See https://www.freertos.org/single-core-amp-smp-rtos-scheduling.html */
-#define configUSE_PREEMPTION 1
+#define configUSE_PREEMPTION                       1
 
 /* Set configUSE_TIME_SLICING to 1 to have the scheduler switch between Ready
  * state tasks of equal priority on every tick interrupt.  Set
  * configUSE_TIME_SLICING to 0 to prevent the scheduler switching between Ready
  * state tasks just because there was a tick interrupt.  See
  * https://freertos.org/single-core-amp-smp-rtos-scheduling.html */
-#define configUSE_TIME_SLICING 0
+#define configUSE_TIME_SLICING                     0
 
 /* Set configUSE_PORT_OPTIMISED_TASK_SELECTION to 1 to select the next task to
  * run using an algorithm optimised to the instruction set of the target hardware -
@@ -95,28 +95,28 @@
  * the next task to run using a generic C algorithm that works for all FreeRTOS
  * ports.  Not all FreeRTOS ports have this option.  Defaults to 0 if left
  * undefined. */
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
 
 /* Set configUSE_TICKLESS_IDLE to 1 to use the low power tickless mode.  Set to
  * 0 to keep the tick interrupt running at all times.  Not all FreeRTOS ports
  * support tickless mode. See https://www.freertos.org/low-power-tickless-rtos.html
  * Defaults to 0 if left undefined. */
-#define configUSE_TICKLESS_IDLE 0
+#define configUSE_TICKLESS_IDLE                    0
 
 /* configMAX_PRIORITIES Sets the number of available task priorities.  Tasks can
  * be assigned priorities of 0 to (configMAX_PRIORITIES - 1).  Zero is the lowest
  * priority. */
-#define configMAX_PRIORITIES 5
+#define configMAX_PRIORITIES                       5
 
 /* configMINIMAL_STACK_SIZE defines the size of the stack used by the Idle task
  * (in words, not in bytes!).  The kernel does not use this constant for any other
  * purpose.  Demo applications use the constant to make the demos somewhat portable
  * across hardware architectures. */
-#define configMINIMAL_STACK_SIZE 128
+#define configMINIMAL_STACK_SIZE                   128
 
 /* configMAX_TASK_NAME_LEN sets the maximum length (in characters) of a task's
  * human readable name.  Includes the NULL terminator. */
-#define configMAX_TASK_NAME_LEN 16
+#define configMAX_TASK_NAME_LEN                    16
 
 /* The tick count is held in a variable of type TickType_t.  Set
  * configUSE_16_BIT_TICKS to 1 to make TickType_t a 16-bit type.  Set
@@ -124,47 +124,47 @@
  * depending on the architecture.  Using a 16-bit type can greatly improve
  * efficiency on 8-bit and 16-bit microcontrollers, but at the cost of limiting the
  * maximum specifiable block time to 0xffff. */
-#define configUSE_16_BIT_TICKS 0
+#define configUSE_16_BIT_TICKS                     0
 
 /* Set configIDLE_SHOULD_YIELD to 1 to have the Idle task yield to an
  * application task if there is an Idle priority (priority 0) application task that
  * can run.  Set to 0 to have the Idle task use all of its timeslice.  Default to 1
  * if left undefined. */
-#define configIDLE_SHOULD_YIELD 1
+#define configIDLE_SHOULD_YIELD                    1
 
 /* Each task has an array of task notifications.
  * configTASK_NOTIFICATION_ARRAY_ENTRIES sets the number of indexes in the array.
  * See https://www.freertos.org/RTOS-task-notifications.html  Defaults to 1 if
  * left undefined. */
-#define configTASK_NOTIFICATION_ARRAY_ENTRIES 1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES      1
 
 /* configQUEUE_REGISTRY_SIZE sets the maximum number of queues and semaphores
  * that can be referenced from the queue registry.  Only required when using a
  * kernel aware debugger.  Defaults to 0 if left undefined. */
-#define configQUEUE_REGISTRY_SIZE 0
+#define configQUEUE_REGISTRY_SIZE                  0
 
 /* Set configENABLE_BACKWARD_COMPATIBILITY to 1 to map function names and
  * datatypes from old version of FreeRTOS to their latest equivalent.  Defaults to
  * 1 if left undefined. */
-#define configENABLE_BACKWARD_COMPATIBILITY 0
+#define configENABLE_BACKWARD_COMPATIBILITY        0
 
 /* Each task has its own array of pointers that can be used as thread local
  * storage.  configNUM_THREAD_LOCAL_STORAGE_POINTERS set the number of indexes in
  * the array.  See https://www.freertos.org/thread-local-storage-pointers.html
  * Defaults to 0 if left undefined. */
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    0
 
 /* Sets the type used by the parameter to xTaskCreate() that specifies the stack
  * size of the task being created.  The same type is used to return information
  * about stack usage in various other API calls.  Defaults to size_t if left
  * undefined. */
-#define configSTACK_DEPTH_TYPE size_t
+#define configSTACK_DEPTH_TYPE                     size_t
 
 /* configMESSAGE_BUFFER_LENGTH_TYPE sets the type used to store the length of
  *  each message written to a FreeRTOS message buffer (the length is also written to
  *  the message buffer.  Defaults to size_t if left undefined - but that may waste
  *  space if messages never go above a length that could be held in a uint8_t. */
-#define configMESSAGE_BUFFER_LENGTH_TYPE size_t
+#define configMESSAGE_BUFFER_LENGTH_TYPE           size_t
 
 /* Set configUSE_NEWLIB_REENTRANT to 1 to have a newlib reent structure
  * allocated for each task.  Set to 0 to not support newlib reent structures.
@@ -176,7 +176,7 @@
  * system-wide implementations of the necessary stubs. Note that (at the time of
  * writing) the current newlib design implements a system-wide malloc() that must
  * be provided with locks. */
-#define configUSE_NEWLIB_REENTRANT 0
+#define configUSE_NEWLIB_REENTRANT                 0
 
 /******************************************************************************/
 /* Software timer related definitions. ****************************************/
@@ -187,26 +187,26 @@
  * FreeRTOS/source/timers.c source file must be included in the build if
  * configUSE_TIMERS is set to 1.  Default to 0 if left undefined.  See
  * https://www.freertos.org/RTOS-software-timer.html */
-#define configUSE_TIMERS 1
+#define configUSE_TIMERS                1
 
 /* configTIMER_TASK_PRIORITY sets the priority used by the timer task.  Only
  * used if configUSE_TIMERS is set to 1.  The timer task is a standard FreeRTOS
  * task, so its priority is set like any other task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
  * if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_PRIORITY (configMAX_PRIORITIES - 1)
+#define configTIMER_TASK_PRIORITY       ( configMAX_PRIORITIES - 1 )
 
 /* configTIMER_TASK_STACK_DEPTH sets the size of the stack allocated to the
  * timer task (in words, not in bytes!).  The timer task is a standard FreeRTOS
  * task.  See https://www.freertos.org/RTOS-software-timer-service-daemon-task.html
  * Only used if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_STACK_DEPTH configMINIMAL_STACK_SIZE
+#define configTIMER_TASK_STACK_DEPTH    configMINIMAL_STACK_SIZE
 
 /* configTIMER_QUEUE_LENGTH sets the length of the queue (the number of discrete
  * items the queue can hold) used to send commands to the timer task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
  * if configUSE_TIMERS is set to 1. */
-#define configTIMER_QUEUE_LENGTH 10
+#define configTIMER_QUEUE_LENGTH        10
 
 /******************************************************************************/
 /* Memory allocation related definitions. *************************************/
@@ -217,25 +217,25 @@
  * memory in the build.  Set to 0 to exclude the ability to create statically
  * allocated objects from the build.  Defaults to 0 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html */
-#define configSUPPORT_STATIC_ALLOCATION 1
+#define configSUPPORT_STATIC_ALLOCATION              1
 
 /* Set configSUPPORT_DYNAMIC_ALLOCATION to 1 to include FreeRTOS API functions
  * that create FreeRTOS objects (tasks, queues, etc.) using dynamically allocated
  * memory in the build.  Set to 0 to exclude the ability to create dynamically
  * allocated objects from the build.  Defaults to 1 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html */
-#define configSUPPORT_DYNAMIC_ALLOCATION 1
+#define configSUPPORT_DYNAMIC_ALLOCATION             1
 
 /* Sets the total size of the FreeRTOS heap, in bytes, when heap_1.c, heap_2.c
  * or heap_4.c are included in the build.  This value is defaulted to 4096 bytes but
  * it must be tailored to each application.  Note the heap will appear in the .bss
  * section.  See https://www.freertos.org/a00111.html */
-#define configTOTAL_HEAP_SIZE 4096
+#define configTOTAL_HEAP_SIZE                        4096
 
 /* Set configAPPLICATION_ALLOCATED_HEAP to 1 to have the application allocate
  * the array used as the FreeRTOS heap.  Set to 0 to have the linker allocate the
  * array used as the FreeRTOS heap.  Defaults to 0 if left undefined. */
-#define configAPPLICATION_ALLOCATED_HEAP 0
+#define configAPPLICATION_ALLOCATED_HEAP             0
 
 /* Set configSTACK_ALLOCATION_FROM_SEPARATE_HEAP to 1 to have task stacks
  * allocated from somewhere other than the FreeRTOS heap.  This is useful if you
@@ -243,7 +243,7 @@
  * come from the standard FreeRTOS heap.  The application writer must provide
  * implementations for pvPortMallocStack() and vPortFreeStack() if set to 1.
  * Defaults to 0 if left undefined. */
-#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP 0
+#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP    0
 
 /******************************************************************************/
 /* Interrupt nesting behaviour configuration. *********************************/
@@ -254,7 +254,7 @@
  * priority (0).  Not supported by all FreeRTOS ports.  See
  * https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to ARM
  * Cortex-M devices. */
-#define configKERNEL_INTERRUPT_PRIORITY 0
+#define configKERNEL_INTERRUPT_PRIORITY          0
 
 /* configMAX_SYSCALL_INTERRUPT_PRIORITY sets the interrupt priority above which
  * FreeRTOS API calls must not be made.  Interrupts above this priority are never
@@ -262,11 +262,11 @@
  * highest interrupt priority (0).  Not supported by all FreeRTOS ports.
  * See https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
  * ARM Cortex-M devices. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY 0
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY     0
 
 /* Another name for configMAX_SYSCALL_INTERRUPT_PRIORITY - the name used depends
  * on the FreeRTOS port. */
-#define configMAX_API_CALL_INTERRUPT_PRIORITY 0
+#define configMAX_API_CALL_INTERRUPT_PRIORITY    0
 
 /******************************************************************************/
 /* Hook and callback function related definitions. ****************************/
@@ -276,10 +276,10 @@
  * functionality in the build.  Set to 0 to exclude the hook functionality from the
  * build.  The application writer is responsible for providing the hook function
  * for any set to 1.  See https://www.freertos.org/a00016.html */
-#define configUSE_IDLE_HOOK 0
-#define configUSE_TICK_HOOK 0
-#define configUSE_MALLOC_FAILED_HOOK 0
-#define configUSE_DAEMON_TASK_STARTUP_HOOK 0
+#define configUSE_IDLE_HOOK                   0
+#define configUSE_TICK_HOOK                   0
+#define configUSE_MALLOC_FAILED_HOOK          0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK    0
 
 /* Set configCHECK_FOR_STACK_OVERFLOW to 1 or 2 for FreeRTOS to check for a
  * stack overflow at the time of a context switch.  Set to 0 to not look for a
@@ -292,30 +292,30 @@
  * the stack overflow callback when configCHECK_FOR_STACK_OVERFLOW is set to 1.
  * See https://www.freertos.org/Stacks-and-stack-overflow-checking.html  Defaults
  * to 0 if left undefined. */
-#define configCHECK_FOR_STACK_OVERFLOW 2
+#define configCHECK_FOR_STACK_OVERFLOW        2
 
 /******************************************************************************/
 /* Run time and task stats gathering related definitions. *********************/
 /******************************************************************************/
 
 /* Set configGENERATE_RUN_TIME_STATS to 1 to have FreeRTOS collect data on the
- * processing time used by each task.  Set to 0 to not collect the data.  The
- * application writer needs to provide a clock source if set to 1.  Defaults to 0
- * if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html */
-#define configGENERATE_RUN_TIME_STATS 0
+* processing time used by each task.  Set to 0 to not collect the data.  The
+* application writer needs to provide a clock source if set to 1.  Defaults to 0
+* if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html */
+#define configGENERATE_RUN_TIME_STATS           0
 
 /* Set configUSE_TRACE_FACILITY to include additional task structure members
  * are used by trace and visualisation functions and tools.  Set to 0 to exclude
  * the additional information from the structures.  Defaults to 0 if left
  * undefined. */
-#define configUSE_TRACE_FACILITY 0
+#define configUSE_TRACE_FACILITY                0
 
 /* Set to 1 to include the vTaskList() and vTaskGetRunTimeStats() functions in
  * the build.  Set to 0 to exclude these functions from the build.  These two
  * functions introduce a dependency on string formatting functions that would
  * otherwise not exist - hence they are kept separate.  Defaults to 0 if left
  * undefined. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS 0
+#define configUSE_STATS_FORMATTING_FUNCTIONS    0
 
 /******************************************************************************/
 /* Debugging assistance. ******************************************************/
@@ -329,12 +329,12 @@
  * number of the failing assert (for example, "vAssertCalled( __FILE__, __LINE__ )"
  * or it can simple disable interrupts and sit in a loop to halt all execution
  * on the failing line for viewing in a debugger. */
-#define configASSERT(x)           \
-    if ((x) == 0)                 \
+#define configASSERT( x )         \
+    if( ( x ) == 0 )              \
     {                             \
         taskDISABLE_INTERRUPTS(); \
-        for (;;)                  \
-            ;                     \
+        for( ; ; )                \
+        ;                         \
     }
 
 /******************************************************************************/
@@ -346,41 +346,41 @@
  * See: https://www.freertos.org/a00110.html#configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
  * Defaults to 0 if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports,
  * not the standard ARMv7-M Cortex-M port. */
-#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS 0
+#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS    0
 
 /* Set configTOTAL_MPU_REGIONS to the number of MPU regions implemented on your
  * target hardware.  Normally 8 or 16.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port.  Defaults to 8 if left
  * undefined. */
-#define configTOTAL_MPU_REGIONS 8
+#define configTOTAL_MPU_REGIONS                                   8
 
 /* configTEX_S_C_B_FLASH allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
  * the MPU region covering Flash.  Defaults to 0x07UL (which means TEX=000, S=1,
  * C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
  * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_FLASH 0x07UL
+#define configTEX_S_C_B_FLASH                                     0x07UL
 
 /* configTEX_S_C_B_SRAM allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
  * the MPU region covering RAM. Defaults to 0x07UL (which means TEX=000, S=1, C=1,
  * B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
  * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_SRAM 0x07UL
+#define configTEX_S_C_B_SRAM                                      0x07UL
 
 /* Set configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY to 0 to prevent any privilege
  * escalations originating from outside of the kernel code itself.  Set to 1 to
  * allow application tasks to raise privilege.  Defaults to 1 if left undefined.
  * Only used by the FreeRTOS Cortex-M MPU ports, not the standard ARMv7-M Cortex-M
  * port.*/
-#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY 1
+#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY               1
 
 /* Set configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS to 1 to allow unprivileged
  * tasks enter critical sections (effectively mask interrupts).  Set to 0 to
  * prevent unprivileged tasks entering critical sections.  Defaults to 1 if left
  * undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not the standard
  * ARMv7-M Cortex-M port.*/
-#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS 0
+#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS                0
 
 /******************************************************************************/
 /* ARMv8-M secure side port related definitions. ******************************/
@@ -388,7 +388,7 @@
 
 /* secureconfigMAX_SECURE_CONTEXTS define the maximum number of tasks that can
  *  call into the secure side of an ARMv8-M chip.  Not used by any other ports. */
-#define secureconfigMAX_SECURE_CONTEXTS 5
+#define secureconfigMAX_SECURE_CONTEXTS    5
 
 /******************************************************************************/
 /* Definitions that include or exclude functionality. *************************/
@@ -396,32 +396,32 @@
 
 /* Set the following configUSE_* constants to 1 to include the named feature in
  * the build, or 0 to exclude the named feature from the build. */
-#define configUSE_TASK_NOTIFICATIONS 1
-#define configUSE_MUTEXES 1
-#define configUSE_RECURSIVE_MUTEXES 1
-#define configUSE_COUNTING_SEMAPHORES 1
-#define configUSE_QUEUE_SETS 0
-#define configUSE_APPLICATION_TASK_TAG 0
+#define configUSE_TASK_NOTIFICATIONS           1
+#define configUSE_MUTEXES                      1
+#define configUSE_RECURSIVE_MUTEXES            1
+#define configUSE_COUNTING_SEMAPHORES          1
+#define configUSE_QUEUE_SETS                   0
+#define configUSE_APPLICATION_TASK_TAG         0
 
 /* Set the following INCLUDE_* constants to 1 to incldue the named API function,
  * or 0 to exclude the named API function.  Most linkers will remove unused
  * functions even when the constant is 1. */
-#define INCLUDE_vTaskPrioritySet 1
-#define INCLUDE_uxTaskPriorityGet 1
-#define INCLUDE_vTaskDelete 1
-#define INCLUDE_vTaskSuspend 1
-#define INCLUDE_xResumeFromISR 1
-#define INCLUDE_vTaskDelayUntil 1
-#define INCLUDE_vTaskDelay 1
-#define INCLUDE_xTaskGetSchedulerState 1
-#define INCLUDE_xTaskGetCurrentTaskHandle 1
-#define INCLUDE_uxTaskGetStackHighWaterMark 0
-#define INCLUDE_xTaskGetIdleTaskHandle 0
-#define INCLUDE_eTaskGetState 0
-#define INCLUDE_xEventGroupSetBitFromISR 1
-#define INCLUDE_xTimerPendFunctionCall 0
-#define INCLUDE_xTaskAbortDelay 0
-#define INCLUDE_xTaskGetHandle 0
-#define INCLUDE_xTaskResumeFromISR 1
+#define INCLUDE_vTaskPrioritySet               1
+#define INCLUDE_uxTaskPriorityGet              1
+#define INCLUDE_vTaskDelete                    1
+#define INCLUDE_vTaskSuspend                   1
+#define INCLUDE_xResumeFromISR                 1
+#define INCLUDE_vTaskDelayUntil                1
+#define INCLUDE_vTaskDelay                     1
+#define INCLUDE_xTaskGetSchedulerState         1
+#define INCLUDE_xTaskGetCurrentTaskHandle      1
+#define INCLUDE_uxTaskGetStackHighWaterMark    0
+#define INCLUDE_xTaskGetIdleTaskHandle         0
+#define INCLUDE_eTaskGetState                  0
+#define INCLUDE_xEventGroupSetBitFromISR       1
+#define INCLUDE_xTimerPendFunctionCall         0
+#define INCLUDE_xTaskAbortDelay                0
+#define INCLUDE_xTaskGetHandle                 0
+#define INCLUDE_xTaskResumeFromISR             1
 
 #endif /* __FREERTOS_CONFIG_H__ */

--- a/sample_configuration/FreeRTOSConfig.h
+++ b/sample_configuration/FreeRTOSConfig.h
@@ -1,6 +1,29 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
- * license and copyright intentionally withheld to promote copying into user code.
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
  */
 
 /*******************************************************************************

--- a/sample_configuration/FreeRTOSConfig.h
+++ b/sample_configuration/FreeRTOSConfig.h
@@ -1,29 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
- * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
- *
- * SPDX-License-Identifier: MIT
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
- * https://www.FreeRTOS.org
- * https://github.com/FreeRTOS
- *
+ * license and copyright intentionally withheld to promote copying into user code.
  */
 
 /*******************************************************************************
@@ -51,7 +28,7 @@
  * The default value is set to 20MHz and matches the QEMU demo settings.  Your
  * application will certainly need a different value so set this correctly.
  * This is very often, but not always, equal to the main system clock frequency. */
-#define configCPU_CLOCK_HZ    ( ( unsigned long ) 20000000 )
+#define configCPU_CLOCK_HZ ((unsigned long)20000000)
 
 /* configSYSTICK_CLOCK_HZ is an optional parameter for ARM Cortex-M ports only.
  *
@@ -75,19 +52,19 @@
 
 /* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz, normally
  * calculated from the configCPU_CLOCK_HZ value. */
-#define configTICK_RATE_HZ                         100
+#define configTICK_RATE_HZ 100
 
 /* Set configUSE_PREEMPTION to 1 to use pre-emptive scheduling.  Set
  * configUSE_PREEMPTION to 0 to use co-operative scheduling.
  * See https://www.freertos.org/single-core-amp-smp-rtos-scheduling.html */
-#define configUSE_PREEMPTION                       1
+#define configUSE_PREEMPTION 1
 
 /* Set configUSE_TIME_SLICING to 1 to have the scheduler switch between Ready
  * state tasks of equal priority on every tick interrupt.  Set
  * configUSE_TIME_SLICING to 0 to prevent the scheduler switching between Ready
  * state tasks just because there was a tick interrupt.  See
  * https://freertos.org/single-core-amp-smp-rtos-scheduling.html */
-#define configUSE_TIME_SLICING                     0
+#define configUSE_TIME_SLICING 0
 
 /* Set configUSE_PORT_OPTIMISED_TASK_SELECTION to 1 to select the next task to
  * run using an algorithm optimised to the instruction set of the target hardware -
@@ -95,28 +72,28 @@
  * the next task to run using a generic C algorithm that works for all FreeRTOS
  * ports.  Not all FreeRTOS ports have this option.  Defaults to 0 if left
  * undefined. */
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
 
 /* Set configUSE_TICKLESS_IDLE to 1 to use the low power tickless mode.  Set to
  * 0 to keep the tick interrupt running at all times.  Not all FreeRTOS ports
  * support tickless mode. See https://www.freertos.org/low-power-tickless-rtos.html
  * Defaults to 0 if left undefined. */
-#define configUSE_TICKLESS_IDLE                    0
+#define configUSE_TICKLESS_IDLE 0
 
 /* configMAX_PRIORITIES Sets the number of available task priorities.  Tasks can
  * be assigned priorities of 0 to (configMAX_PRIORITIES - 1).  Zero is the lowest
  * priority. */
-#define configMAX_PRIORITIES                       5
+#define configMAX_PRIORITIES 5
 
 /* configMINIMAL_STACK_SIZE defines the size of the stack used by the Idle task
  * (in words, not in bytes!).  The kernel does not use this constant for any other
  * purpose.  Demo applications use the constant to make the demos somewhat portable
  * across hardware architectures. */
-#define configMINIMAL_STACK_SIZE                   128
+#define configMINIMAL_STACK_SIZE 128
 
 /* configMAX_TASK_NAME_LEN sets the maximum length (in characters) of a task's
  * human readable name.  Includes the NULL terminator. */
-#define configMAX_TASK_NAME_LEN                    16
+#define configMAX_TASK_NAME_LEN 16
 
 /* The tick count is held in a variable of type TickType_t.  Set
  * configUSE_16_BIT_TICKS to 1 to make TickType_t a 16-bit type.  Set
@@ -124,47 +101,47 @@
  * depending on the architecture.  Using a 16-bit type can greatly improve
  * efficiency on 8-bit and 16-bit microcontrollers, but at the cost of limiting the
  * maximum specifiable block time to 0xffff. */
-#define configUSE_16_BIT_TICKS                     0
+#define configUSE_16_BIT_TICKS 0
 
 /* Set configIDLE_SHOULD_YIELD to 1 to have the Idle task yield to an
  * application task if there is an Idle priority (priority 0) application task that
  * can run.  Set to 0 to have the Idle task use all of its timeslice.  Default to 1
  * if left undefined. */
-#define configIDLE_SHOULD_YIELD                    1
+#define configIDLE_SHOULD_YIELD 1
 
 /* Each task has an array of task notifications.
  * configTASK_NOTIFICATION_ARRAY_ENTRIES sets the number of indexes in the array.
  * See https://www.freertos.org/RTOS-task-notifications.html  Defaults to 1 if
  * left undefined. */
-#define configTASK_NOTIFICATION_ARRAY_ENTRIES      1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES 1
 
 /* configQUEUE_REGISTRY_SIZE sets the maximum number of queues and semaphores
  * that can be referenced from the queue registry.  Only required when using a
  * kernel aware debugger.  Defaults to 0 if left undefined. */
-#define configQUEUE_REGISTRY_SIZE                  0
+#define configQUEUE_REGISTRY_SIZE 0
 
 /* Set configENABLE_BACKWARD_COMPATIBILITY to 1 to map function names and
  * datatypes from old version of FreeRTOS to their latest equivalent.  Defaults to
  * 1 if left undefined. */
-#define configENABLE_BACKWARD_COMPATIBILITY        0
+#define configENABLE_BACKWARD_COMPATIBILITY 0
 
 /* Each task has its own array of pointers that can be used as thread local
  * storage.  configNUM_THREAD_LOCAL_STORAGE_POINTERS set the number of indexes in
  * the array.  See https://www.freertos.org/thread-local-storage-pointers.html
  * Defaults to 0 if left undefined. */
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 0
 
 /* Sets the type used by the parameter to xTaskCreate() that specifies the stack
  * size of the task being created.  The same type is used to return information
  * about stack usage in various other API calls.  Defaults to size_t if left
  * undefined. */
-#define configSTACK_DEPTH_TYPE                     size_t
+#define configSTACK_DEPTH_TYPE size_t
 
 /* configMESSAGE_BUFFER_LENGTH_TYPE sets the type used to store the length of
  *  each message written to a FreeRTOS message buffer (the length is also written to
  *  the message buffer.  Defaults to size_t if left undefined - but that may waste
  *  space if messages never go above a length that could be held in a uint8_t. */
-#define configMESSAGE_BUFFER_LENGTH_TYPE           size_t
+#define configMESSAGE_BUFFER_LENGTH_TYPE size_t
 
 /* Set configUSE_NEWLIB_REENTRANT to 1 to have a newlib reent structure
  * allocated for each task.  Set to 0 to not support newlib reent structures.
@@ -176,7 +153,7 @@
  * system-wide implementations of the necessary stubs. Note that (at the time of
  * writing) the current newlib design implements a system-wide malloc() that must
  * be provided with locks. */
-#define configUSE_NEWLIB_REENTRANT                 0
+#define configUSE_NEWLIB_REENTRANT 0
 
 /******************************************************************************/
 /* Software timer related definitions. ****************************************/
@@ -187,26 +164,26 @@
  * FreeRTOS/source/timers.c source file must be included in the build if
  * configUSE_TIMERS is set to 1.  Default to 0 if left undefined.  See
  * https://www.freertos.org/RTOS-software-timer.html */
-#define configUSE_TIMERS                1
+#define configUSE_TIMERS 1
 
 /* configTIMER_TASK_PRIORITY sets the priority used by the timer task.  Only
  * used if configUSE_TIMERS is set to 1.  The timer task is a standard FreeRTOS
  * task, so its priority is set like any other task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
  * if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_PRIORITY       ( configMAX_PRIORITIES - 1 )
+#define configTIMER_TASK_PRIORITY (configMAX_PRIORITIES - 1)
 
 /* configTIMER_TASK_STACK_DEPTH sets the size of the stack allocated to the
  * timer task (in words, not in bytes!).  The timer task is a standard FreeRTOS
  * task.  See https://www.freertos.org/RTOS-software-timer-service-daemon-task.html
  * Only used if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_STACK_DEPTH    configMINIMAL_STACK_SIZE
+#define configTIMER_TASK_STACK_DEPTH configMINIMAL_STACK_SIZE
 
 /* configTIMER_QUEUE_LENGTH sets the length of the queue (the number of discrete
  * items the queue can hold) used to send commands to the timer task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
  * if configUSE_TIMERS is set to 1. */
-#define configTIMER_QUEUE_LENGTH        10
+#define configTIMER_QUEUE_LENGTH 10
 
 /******************************************************************************/
 /* Memory allocation related definitions. *************************************/
@@ -217,25 +194,25 @@
  * memory in the build.  Set to 0 to exclude the ability to create statically
  * allocated objects from the build.  Defaults to 0 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html */
-#define configSUPPORT_STATIC_ALLOCATION              1
+#define configSUPPORT_STATIC_ALLOCATION 1
 
 /* Set configSUPPORT_DYNAMIC_ALLOCATION to 1 to include FreeRTOS API functions
  * that create FreeRTOS objects (tasks, queues, etc.) using dynamically allocated
  * memory in the build.  Set to 0 to exclude the ability to create dynamically
  * allocated objects from the build.  Defaults to 1 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html */
-#define configSUPPORT_DYNAMIC_ALLOCATION             1
+#define configSUPPORT_DYNAMIC_ALLOCATION 1
 
 /* Sets the total size of the FreeRTOS heap, in bytes, when heap_1.c, heap_2.c
  * or heap_4.c are included in the build.  This value is defaulted to 4096 bytes but
  * it must be tailored to each application.  Note the heap will appear in the .bss
  * section.  See https://www.freertos.org/a00111.html */
-#define configTOTAL_HEAP_SIZE                        4096
+#define configTOTAL_HEAP_SIZE 4096
 
 /* Set configAPPLICATION_ALLOCATED_HEAP to 1 to have the application allocate
  * the array used as the FreeRTOS heap.  Set to 0 to have the linker allocate the
  * array used as the FreeRTOS heap.  Defaults to 0 if left undefined. */
-#define configAPPLICATION_ALLOCATED_HEAP             0
+#define configAPPLICATION_ALLOCATED_HEAP 0
 
 /* Set configSTACK_ALLOCATION_FROM_SEPARATE_HEAP to 1 to have task stacks
  * allocated from somewhere other than the FreeRTOS heap.  This is useful if you
@@ -243,7 +220,7 @@
  * come from the standard FreeRTOS heap.  The application writer must provide
  * implementations for pvPortMallocStack() and vPortFreeStack() if set to 1.
  * Defaults to 0 if left undefined. */
-#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP    0
+#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP 0
 
 /******************************************************************************/
 /* Interrupt nesting behaviour configuration. *********************************/
@@ -254,7 +231,7 @@
  * priority (0).  Not supported by all FreeRTOS ports.  See
  * https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to ARM
  * Cortex-M devices. */
-#define configKERNEL_INTERRUPT_PRIORITY          0
+#define configKERNEL_INTERRUPT_PRIORITY 0
 
 /* configMAX_SYSCALL_INTERRUPT_PRIORITY sets the interrupt priority above which
  * FreeRTOS API calls must not be made.  Interrupts above this priority are never
@@ -262,11 +239,11 @@
  * highest interrupt priority (0).  Not supported by all FreeRTOS ports.
  * See https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
  * ARM Cortex-M devices. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY     0
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY 0
 
 /* Another name for configMAX_SYSCALL_INTERRUPT_PRIORITY - the name used depends
  * on the FreeRTOS port. */
-#define configMAX_API_CALL_INTERRUPT_PRIORITY    0
+#define configMAX_API_CALL_INTERRUPT_PRIORITY 0
 
 /******************************************************************************/
 /* Hook and callback function related definitions. ****************************/
@@ -276,10 +253,10 @@
  * functionality in the build.  Set to 0 to exclude the hook functionality from the
  * build.  The application writer is responsible for providing the hook function
  * for any set to 1.  See https://www.freertos.org/a00016.html */
-#define configUSE_IDLE_HOOK                   0
-#define configUSE_TICK_HOOK                   0
-#define configUSE_MALLOC_FAILED_HOOK          0
-#define configUSE_DAEMON_TASK_STARTUP_HOOK    0
+#define configUSE_IDLE_HOOK 0
+#define configUSE_TICK_HOOK 0
+#define configUSE_MALLOC_FAILED_HOOK 0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK 0
 
 /* Set configCHECK_FOR_STACK_OVERFLOW to 1 or 2 for FreeRTOS to check for a
  * stack overflow at the time of a context switch.  Set to 0 to not look for a
@@ -292,30 +269,30 @@
  * the stack overflow callback when configCHECK_FOR_STACK_OVERFLOW is set to 1.
  * See https://www.freertos.org/Stacks-and-stack-overflow-checking.html  Defaults
  * to 0 if left undefined. */
-#define configCHECK_FOR_STACK_OVERFLOW        2
+#define configCHECK_FOR_STACK_OVERFLOW 2
 
 /******************************************************************************/
 /* Run time and task stats gathering related definitions. *********************/
 /******************************************************************************/
 
 /* Set configGENERATE_RUN_TIME_STATS to 1 to have FreeRTOS collect data on the
-* processing time used by each task.  Set to 0 to not collect the data.  The
-* application writer needs to provide a clock source if set to 1.  Defaults to 0
-* if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html */
-#define configGENERATE_RUN_TIME_STATS           0
+ * processing time used by each task.  Set to 0 to not collect the data.  The
+ * application writer needs to provide a clock source if set to 1.  Defaults to 0
+ * if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html */
+#define configGENERATE_RUN_TIME_STATS 0
 
 /* Set configUSE_TRACE_FACILITY to include additional task structure members
  * are used by trace and visualisation functions and tools.  Set to 0 to exclude
  * the additional information from the structures.  Defaults to 0 if left
  * undefined. */
-#define configUSE_TRACE_FACILITY                0
+#define configUSE_TRACE_FACILITY 0
 
 /* Set to 1 to include the vTaskList() and vTaskGetRunTimeStats() functions in
  * the build.  Set to 0 to exclude these functions from the build.  These two
  * functions introduce a dependency on string formatting functions that would
  * otherwise not exist - hence they are kept separate.  Defaults to 0 if left
  * undefined. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS    0
+#define configUSE_STATS_FORMATTING_FUNCTIONS 0
 
 /******************************************************************************/
 /* Debugging assistance. ******************************************************/
@@ -329,12 +306,12 @@
  * number of the failing assert (for example, "vAssertCalled( __FILE__, __LINE__ )"
  * or it can simple disable interrupts and sit in a loop to halt all execution
  * on the failing line for viewing in a debugger. */
-#define configASSERT( x )         \
-    if( ( x ) == 0 )              \
+#define configASSERT(x)           \
+    if ((x) == 0)                 \
     {                             \
         taskDISABLE_INTERRUPTS(); \
-        for( ; ; )                \
-        ;                         \
+        for (;;)                  \
+            ;                     \
     }
 
 /******************************************************************************/
@@ -346,41 +323,41 @@
  * See: https://www.freertos.org/a00110.html#configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
  * Defaults to 0 if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports,
  * not the standard ARMv7-M Cortex-M port. */
-#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS    0
+#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS 0
 
 /* Set configTOTAL_MPU_REGIONS to the number of MPU regions implemented on your
  * target hardware.  Normally 8 or 16.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port.  Defaults to 8 if left
  * undefined. */
-#define configTOTAL_MPU_REGIONS                                   8
+#define configTOTAL_MPU_REGIONS 8
 
 /* configTEX_S_C_B_FLASH allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
  * the MPU region covering Flash.  Defaults to 0x07UL (which means TEX=000, S=1,
  * C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
  * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_FLASH                                     0x07UL
+#define configTEX_S_C_B_FLASH 0x07UL
 
 /* configTEX_S_C_B_SRAM allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
  * the MPU region covering RAM. Defaults to 0x07UL (which means TEX=000, S=1, C=1,
  * B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
  * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_SRAM                                      0x07UL
+#define configTEX_S_C_B_SRAM 0x07UL
 
 /* Set configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY to 0 to prevent any privilege
  * escalations originating from outside of the kernel code itself.  Set to 1 to
  * allow application tasks to raise privilege.  Defaults to 1 if left undefined.
  * Only used by the FreeRTOS Cortex-M MPU ports, not the standard ARMv7-M Cortex-M
  * port.*/
-#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY               1
+#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY 1
 
 /* Set configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS to 1 to allow unprivileged
  * tasks enter critical sections (effectively mask interrupts).  Set to 0 to
  * prevent unprivileged tasks entering critical sections.  Defaults to 1 if left
  * undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not the standard
  * ARMv7-M Cortex-M port.*/
-#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS                0
+#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS 0
 
 /******************************************************************************/
 /* ARMv8-M secure side port related definitions. ******************************/
@@ -388,7 +365,7 @@
 
 /* secureconfigMAX_SECURE_CONTEXTS define the maximum number of tasks that can
  *  call into the secure side of an ARMv8-M chip.  Not used by any other ports. */
-#define secureconfigMAX_SECURE_CONTEXTS    5
+#define secureconfigMAX_SECURE_CONTEXTS 5
 
 /******************************************************************************/
 /* Definitions that include or exclude functionality. *************************/
@@ -396,32 +373,32 @@
 
 /* Set the following configUSE_* constants to 1 to include the named feature in
  * the build, or 0 to exclude the named feature from the build. */
-#define configUSE_TASK_NOTIFICATIONS           1
-#define configUSE_MUTEXES                      1
-#define configUSE_RECURSIVE_MUTEXES            1
-#define configUSE_COUNTING_SEMAPHORES          1
-#define configUSE_QUEUE_SETS                   0
-#define configUSE_APPLICATION_TASK_TAG         0
+#define configUSE_TASK_NOTIFICATIONS 1
+#define configUSE_MUTEXES 1
+#define configUSE_RECURSIVE_MUTEXES 1
+#define configUSE_COUNTING_SEMAPHORES 1
+#define configUSE_QUEUE_SETS 0
+#define configUSE_APPLICATION_TASK_TAG 0
 
 /* Set the following INCLUDE_* constants to 1 to incldue the named API function,
  * or 0 to exclude the named API function.  Most linkers will remove unused
  * functions even when the constant is 1. */
-#define INCLUDE_vTaskPrioritySet               1
-#define INCLUDE_uxTaskPriorityGet              1
-#define INCLUDE_vTaskDelete                    1
-#define INCLUDE_vTaskSuspend                   1
-#define INCLUDE_xResumeFromISR                 1
-#define INCLUDE_vTaskDelayUntil                1
-#define INCLUDE_vTaskDelay                     1
-#define INCLUDE_xTaskGetSchedulerState         1
-#define INCLUDE_xTaskGetCurrentTaskHandle      1
-#define INCLUDE_uxTaskGetStackHighWaterMark    0
-#define INCLUDE_xTaskGetIdleTaskHandle         0
-#define INCLUDE_eTaskGetState                  0
-#define INCLUDE_xEventGroupSetBitFromISR       1
-#define INCLUDE_xTimerPendFunctionCall         0
-#define INCLUDE_xTaskAbortDelay                0
-#define INCLUDE_xTaskGetHandle                 0
-#define INCLUDE_xTaskResumeFromISR             1
+#define INCLUDE_vTaskPrioritySet 1
+#define INCLUDE_uxTaskPriorityGet 1
+#define INCLUDE_vTaskDelete 1
+#define INCLUDE_vTaskSuspend 1
+#define INCLUDE_xResumeFromISR 1
+#define INCLUDE_vTaskDelayUntil 1
+#define INCLUDE_vTaskDelay 1
+#define INCLUDE_xTaskGetSchedulerState 1
+#define INCLUDE_xTaskGetCurrentTaskHandle 1
+#define INCLUDE_uxTaskGetStackHighWaterMark 0
+#define INCLUDE_xTaskGetIdleTaskHandle 0
+#define INCLUDE_eTaskGetState 0
+#define INCLUDE_xEventGroupSetBitFromISR 1
+#define INCLUDE_xTimerPendFunctionCall 0
+#define INCLUDE_xTaskAbortDelay 0
+#define INCLUDE_xTaskGetHandle 0
+#define INCLUDE_xTaskResumeFromISR 1
 
 #endif /* __FREERTOS_CONFIG_H__ */


### PR DESCRIPTION
the template port, example project and sample configuration are expected to be incorporated into user code and therefore should not have a copyright or license.  All users are free to use these files in their projects and modify them as they see fit without restrictions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
