### PR TITLE
bugfix: correct computation of stack size on Mac Posix port

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -148,10 +148,14 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
      */
     thread = ( Thread_t * ) ( pxTopOfStack + 1 ) - 1;
     pxTopOfStack = ( StackType_t * ) thread - 1;
+
+    #ifdef __APPLE__
+        pxEndOfStack = ( StackType_t * ) mach_vm_round_page( pxEndOfStack );
+    #endif
+
     ulStackSize = ( size_t ) ( pxTopOfStack + 1 - pxEndOfStack ) * sizeof( *pxTopOfStack );
 
     #ifdef __APPLE__
-        pxEndOfStack = mach_vm_round_page( pxEndOfStack );
         ulStackSize = mach_vm_trunc_page( ulStackSize );
     #endif
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Aligns the stack end to a page boundary before computing its size, since the size depends on both the start and end.

The original change which introduced stack alignment (#674) only worked for cases where the round + trunc operation would wind up within the same area, but would lead to segfaults in other cases.

Tested on ARM64 and Intel MacOS, as well as ARM64 and Intel Linux.  The test cases included a single-task case, as well as a case with two tasks passing queue messages.

Test Steps
-----------
Using the Posix port on an M1 Mac, create a task with the default `PTHREAD_STACK_MIN` 
or some other "lucky" size.  The task can do nothing more than delay in a loop, and you should
get a segfault.  If not, a different stack size will cause one.  Example backtrace:

```
(lldb) bt
* thread #2, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x0000000000000000
    frame #1: 0x000000010000750c single`prvWaitForStart(pvParams=0x000000010002bff0) at port.c:478:5 [opt]
    frame #2: 0x00000001a2d1ffa8 libsystem_pthread.dylib`_pthread_start + 148
(lldb) f 1
warning: single was compiled with optimization - stepping may behave oddly; variables may not be available.
frame #1: 0x000000010000750c single`prvWaitForStart(pvParams=0x000000010002bff0) at port.c:478:5 [opt]
   475 	   vPortEnableInterrupts();
   476 	
   477 	   /* Call the task's entry point. */
-> 478 	   pxThread->pxCode( pxThread->pvParams );
   479 	
   480 	   /* A function that implements a task must not exit or attempt to return to
   481 	    * its caller as there is nothing to return to. If a task wants to exit it
```

Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.  **so far only tested with my own tests**
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
