### PR TITLE
Make taskYIELD available to unprivileged tasks

### DIFF
--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -1118,6 +1118,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
+    #if ( configENABLE_MPU == 1 )
+        case portSVC_YIELD:
+            vPortYield();
+            break;
+    #endif
+
         default:
             /* Incorrect SVC call. */
             configASSERT( pdFALSE );

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -1122,7 +1122,7 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 case portSVC_YIELD:
                     vPortYield();
                     break;
-            #endif
+            #endif /* configENABLE_MPU == 1 */
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -1118,11 +1118,11 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                     break;
             #endif /* ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 1 ) */
 
-    #if ( configENABLE_MPU == 1 )
-        case portSVC_YIELD:
-            vPortYield();
-            break;
-    #endif
+            #if ( configENABLE_MPU == 1 )
+                case portSVC_YIELD:
+                    vPortYield();
+                    break;
+            #endif
 
         default:
             /* Incorrect SVC call. */

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -329,12 +329,20 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
 #define portSVC_SYSTEM_CALL_ENTER          4   /* System calls with upto 4 parameters. */
 #define portSVC_SYSTEM_CALL_ENTER_1        5   /* System calls with 5 parameters. */
 #define portSVC_SYSTEM_CALL_EXIT           6
+#define portSVC_YIELD                      7
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Scheduler utilities.
  */
-#define portYIELD()    vPortYield()
+#if ( configENABLE_MPU == 1 )
+    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()  vPortYield()
+#else
+    #define portYIELD()             vPortYield()
+    #define portYIELD_WITHIN_API()  vPortYield()
+#endif
+
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
 #define portNVIC_PENDSVSET_BIT    ( 1UL << 28UL )
 #define portEND_SWITCHING_ISR( xSwitchRequired )            \

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -336,11 +336,11 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()             __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD_WITHIN_API()    vPortYield()
 #else
-    #define portYIELD()             vPortYield()
-    #define portYIELD_WITHIN_API()  vPortYield()
+    #define portYIELD()               vPortYield()
+    #define portYIELD_WITHIN_API()    vPortYield()
 #endif
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -336,7 +336,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Scheduler utilities.
  */
 #if ( configENABLE_MPU == 1 )
-    #define portYIELD()               __asm volatile ( "svc %0" ::"i" ( portSVC_YIELD ) : "memory" )
+    #define portYIELD()               __asm volatile ( "svc %0" :: "i" ( portSVC_YIELD ) : "memory" )
     #define portYIELD_WITHIN_API()    vPortYield()
 #else
     #define portYIELD()               vPortYield()


### PR DESCRIPTION
Description
-----------
This PR makes taskYIELD available to unprivileged tasks on ARMv8-M ports.

Test Steps
-----------
Tested on Cortex-M23 and Cortex-M33 platforms. Calling taskYIELD from an unprivileged task results in fault without these changes and, works normally after these changes. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/788


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
