### PR TITLE
Move trace macro after declaration 

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2462,11 +2462,11 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         UBaseType_t uxCurrentBasePriority, uxPriorityUsedOnEntry;
         BaseType_t xYieldRequired = pdFALSE;
 
-        traceENTER_vTaskPrioritySet( xTask, uxNewPriority );
-
         #if ( configNUMBER_OF_CORES > 1 )
             BaseType_t xYieldForTask = pdFALSE;
         #endif
+
+        traceENTER_vTaskPrioritySet( xTask, uxNewPriority );
 
         configASSERT( uxNewPriority < configMAX_PRIORITIES );
 
@@ -4376,11 +4376,11 @@ BaseType_t xTaskIncrementTick( void )
     TickType_t xItemValue;
     BaseType_t xSwitchRequired = pdFALSE;
 
-    traceENTER_xTaskIncrementTick();
-
     #if ( configUSE_PREEMPTION == 1 ) && ( configNUMBER_OF_CORES > 1 )
     BaseType_t xYieldRequiredForCore[ configNUMBER_OF_CORES ] = { pdFALSE };
     #endif /* #if ( configUSE_PREEMPTION == 1 ) && ( configNUMBER_OF_CORES > 1 ) */
+
+    traceENTER_xTaskIncrementTick();
 
     /* Called by the portable layer each time a tick interrupt occurs.
      * Increments the tick then checks to see if the new tick value will cause any
@@ -5566,9 +5566,9 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
             const UBaseType_t uxNonApplicationTasks = 1;
         #endif /* INCLUDE_vTaskSuspend */
 
-        traceENTER_eTaskConfirmSleepModeStatus();
-
         eSleepModeStatus eReturn = eStandardSleep;
+
+        traceENTER_eTaskConfirmSleepModeStatus();
 
         /* This function must be called from a critical section. */
 


### PR DESCRIPTION

<!--- Title -->

Description
-----------
* Move trace macro after declaration to comply with ISO C90

Test Steps
-----------
Before this PR
```
/mnt/c/msys64/home/chinglee/kernel/init_review/test/FreeRTOS/FreeRTOS/Source/tasks.c: In function ‘vTaskPrioritySet’:
/mnt/c/msys64/home/chinglee/kernel/init_review/test/FreeRTOS/FreeRTOS/Source/tasks.c:2468:13: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
 2468 |             BaseType_t xYieldForTask = pdFALSE;
      |             ^~~~~~~~~~
/mnt/c/msys64/home/chinglee/kernel/init_review/test/FreeRTOS/FreeRTOS/Source/tasks.c: In function ‘xTaskIncrementTick’:
/mnt/c/msys64/home/chinglee/kernel/init_review/test/FreeRTOS/FreeRTOS/Source/tasks.c:4382:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
 4382 |     BaseType_t xYieldRequiredForCore[ configNUMBER_OF_CORES ] = { pdFALSE };
      |     ^~~~~~~~~~
/mnt/c/msys64/home/chinglee/kernel/init_review/test/FreeRTOS/FreeRTOS/Source/tasks.c: In function ‘eTaskConfirmSleepModeStatus’:
/mnt/c/msys64/home/chinglee/kernel/init_review/test/FreeRTOS/FreeRTOS/Source/tasks.c:5571:9: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
 5571 |         eSleepModeStatus eReturn = eStandardSleep;
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
#786


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
