### PR TITLE
Remove Queue No Return Compilation Warnings

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -1151,6 +1151,9 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
             return errQUEUE_FULL;
         }
     } /*lint -restore */
+
+    /* This case should never be hit */
+    return pdFAIL;
 }
 /*-----------------------------------------------------------*/
 
@@ -1160,6 +1163,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
                                      const BaseType_t xCopyPosition )
 {
     BaseType_t xReturn;
+
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
 
@@ -1643,6 +1647,9 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
             }
         }
     } /*lint -restore */
+
+    /* This case should never be hit */
+    return pdFAIL;
 }
 /*-----------------------------------------------------------*/
 
@@ -1650,6 +1657,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                                 TickType_t xTicksToWait )
 {
     BaseType_t xEntryTimeSet = pdFALSE;
+
     TimeOut_t xTimeOut;
     Queue_t * const pxQueue = xQueue;
 
@@ -1863,6 +1871,9 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
             }
         }
     } /*lint -restore */
+
+    /* This case should never be hit */
+    return pdFAIL;
 }
 /*-----------------------------------------------------------*/
 
@@ -1871,6 +1882,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                        TickType_t xTicksToWait )
 {
     BaseType_t xEntryTimeSet = pdFALSE;
+
     TimeOut_t xTimeOut;
     int8_t * pcOriginalReadPosition;
     Queue_t * const pxQueue = xQueue;
@@ -2024,6 +2036,9 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
             }
         }
     } /*lint -restore */
+
+    /* This case should never be hit */
+    return pdFAIL;
 }
 /*-----------------------------------------------------------*/
 
@@ -2032,6 +2047,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
                                  BaseType_t * const pxHigherPriorityTaskWoken )
 {
     BaseType_t xReturn;
+
     UBaseType_t uxSavedInterruptStatus;
     Queue_t * const pxQueue = xQueue;
 

--- a/queue.c
+++ b/queue.c
@@ -1152,7 +1152,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
         }
     } /*lint -restore */
 
-    /* This case should never be hit */
+    /* This case should never be hit. */
     return pdFAIL;
 }
 /*-----------------------------------------------------------*/
@@ -1648,7 +1648,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
         }
     } /*lint -restore */
 
-    /* This case should never be hit */
+    /* This case should never be hit. */
     return pdFAIL;
 }
 /*-----------------------------------------------------------*/
@@ -1872,7 +1872,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
         }
     } /*lint -restore */
 
-    /* This case should never be hit */
+    /* This case should never be hit. */
     return pdFAIL;
 }
 /*-----------------------------------------------------------*/
@@ -2037,7 +2037,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
         }
     } /*lint -restore */
 
-    /* This case should never be hit */
+    /* This case should never be hit. */
     return pdFAIL;
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add a return of pdFALSE to bottom of functions to remove compilation warning about no return types

Test Steps
-----------
Performed a build without the return and received this compilation warning:
`No return, in function returning non-void`

Added the returns and now see no warnings
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
