### PR TITLE
Revert Portable/oWatcom formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check Formatting of FreeRTOS-Kernel Files
         uses: FreeRTOS/CI-CD-Github-Actions/formatting@main
+        with:
+          exclude-dirs: oWatcom
 
   spell-check:
       runs-on: ubuntu-latest

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -21,3 +21,6 @@ jobs:
     - name: Apply Formatting Fix
       uses: FreeRTOS/CI-CD-Github-Actions/formatting-bot@main
       id: check-formatting
+      with:
+        exclude-dirs: oWatcom
+

--- a/portable/oWatcom/16BitDOS/Flsh186/port.c
+++ b/portable/oWatcom/16BitDOS/Flsh186/port.c
@@ -27,27 +27,27 @@
  */
 
 /*
- * Changes from V1.00:
- *
- + Call to taskYIELD() from within tick ISR has been replaced by the more
- +    efficient portSWITCH_CONTEXT().
- + ISR function definitions renamed to include the prv prefix.
- +
- + Changes from V1.2.0:
- +
- + portRESET_PIC() is now called last thing before the end of the preemptive
- +    tick routine.
- +
- + Changes from V2.6.1
- +
- + Replaced the sUsingPreemption variable with the configUSE_PREEMPTION
- +    macro to be consistent with the later ports.
- */
+Changes from V1.00:
+
+    + Call to taskYIELD() from within tick ISR has been replaced by the more
+      efficient portSWITCH_CONTEXT().
+    + ISR function definitions renamed to include the prv prefix.
+
+Changes from V1.2.0:
+
+    + portRESET_PIC() is now called last thing before the end of the preemptive
+      tick routine.
+
+Changes from V2.6.1
+
+    + Replaced the sUsingPreemption variable with the configUSE_PREEMPTION
+      macro to be consistent with the later ports.
+*/
 
 /*-----------------------------------------------------------
-* Implementation of functions defined in portable.h for the Flashlite 186
-* port.
-*----------------------------------------------------------*/
+ * Implementation of functions defined in portable.h for the Flashlite 186
+ * port.
+ *----------------------------------------------------------*/
 
 #include <stdlib.h>
 #include <i86.h>
@@ -60,9 +60,9 @@
 
 /*lint -e950 Non ANSI reserved words okay in this file only. */
 
-#define portTIMER_EOI_TYPE              ( 8 )
-#define portRESET_PIC()    portOUTPUT_WORD( ( uint16_t ) 0xff22, portTIMER_EOI_TYPE )
-#define portTIMER_INT_NUMBER            0x12
+#define portTIMER_EOI_TYPE      ( 8 )
+#define portRESET_PIC()         portOUTPUT_WORD( ( uint16_t ) 0xff22, portTIMER_EOI_TYPE )
+#define portTIMER_INT_NUMBER    0x12
 
 #define portTIMER_1_CONTROL_REGISTER    ( ( uint16_t ) 0xff5e )
 #define portTIMER_0_CONTROL_REGISTER    ( ( uint16_t ) 0xff56 )
@@ -75,14 +75,12 @@ static void prvSetTickFrequency( uint32_t ulTickRateHz );
 static void prvExitFunction( void );
 
 #if configUSE_PREEMPTION == 1
-
-/* Tick service routine used by the scheduler when preemptive scheduling is
- * being used. */
+    /* Tick service routine used by the scheduler when preemptive scheduling is
+    being used. */
     static void __interrupt __far prvPreemptiveTick( void );
 #else
-
-/* Tick service routine used by the scheduler when cooperative scheduling is
- * being used. */
+    /* Tick service routine used by the scheduler when cooperative scheduling is
+    being used. */
     static void __interrupt __far prvNonPreemptiveTick( void );
 #endif
 
@@ -95,7 +93,7 @@ static void __interrupt __far prvYieldProcessor( void );
 static int16_t sSchedulerRunning = pdFALSE;
 
 /* Points to the original routine installed on the vector we use for manual context switches.  This is then used to restore the original routine during prvExitFunction(). */
-static void( __interrupt __far * pxOldSwitchISR )();
+static void ( __interrupt __far *pxOldSwitchISR )();
 
 /* Used to restore the original DOS context when the scheduler is ended. */
 static jmp_buf xJumpBuf;
@@ -108,11 +106,11 @@ BaseType_t xPortStartScheduler( void )
     /* This is called with interrupts already disabled. */
 
     /* Remember what was on the interrupts we are going to use
-     * so we can put them back later if required. */
+    so we can put them back later if required. */
     pxOldSwitchISR = _dos_getvect( portSWITCH_INT_NUMBER );
 
     /* Put our manual switch (yield) function on a known
-     * vector. */
+    vector. */
     _dos_setvect( portSWITCH_INT_NUMBER, prvYieldProcessor );
 
     #if configUSE_PREEMPTION == 1
@@ -148,7 +146,7 @@ BaseType_t xPortStartScheduler( void )
 /*-----------------------------------------------------------*/
 
 /* The tick ISR used depend on whether or not the preemptive or cooperative
- * kernel is being used. */
+kernel is being used. */
 #if configUSE_PREEMPTION == 1
     static void __interrupt __far prvPreemptiveTick( void )
     {
@@ -162,15 +160,15 @@ BaseType_t xPortStartScheduler( void )
         /* Reset the PIC ready for the next time. */
         portRESET_PIC();
     }
-#else /* if configUSE_PREEMPTION == 1 */
+#else
     static void __interrupt __far prvNonPreemptiveTick( void )
     {
         /* Same as preemptive tick, but the cooperative scheduler is being used
-         * so we don't have to switch in the context of the next task. */
+        so we don't have to switch in the context of the next task. */
         xTaskIncrementTick();
         portRESET_PIC();
     }
-#endif /* if configUSE_PREEMPTION == 1 */
+#endif
 /*-----------------------------------------------------------*/
 
 static void __interrupt __far prvYieldProcessor( void )
@@ -183,31 +181,30 @@ static void __interrupt __far prvYieldProcessor( void )
 void vPortEndScheduler( void )
 {
     /* Jump back to the processor state prior to starting the
-     * scheduler.  This means we are not going to be using a
-     * task stack frame so the task can be deleted. */
+    scheduler.  This means we are not going to be using a
+    task stack frame so the task can be deleted. */
     longjmp( xJumpBuf, 1 );
 }
 /*-----------------------------------------------------------*/
 
 static void prvExitFunction( void )
 {
-    const uint16_t usTimerDisable = 0x0000;
-    uint16_t usTimer0Control;
+const uint16_t usTimerDisable = 0x0000;
+uint16_t usTimer0Control;
 
     /* Interrupts should be disabled here anyway - but no
-     * harm in making sure. */
+    harm in making sure. */
     portDISABLE_INTERRUPTS();
-
     if( sSchedulerRunning == pdTRUE )
     {
         /* Put back the switch interrupt routines that was in place
-         * before the scheduler started. */
+        before the scheduler started. */
         _dos_setvect( portSWITCH_INT_NUMBER, pxOldSwitchISR );
     }
 
     /* Disable the timer used for the tick to ensure the scheduler is
-     * not called before restoring interrupts.  There was previously nothing
-     * on this timer so there is no old ISR to restore. */
+    not called before restoring interrupts.  There was previously nothing
+    on this timer so there is no old ISR to restore. */
     portOUTPUT_WORD( portTIMER_1_CONTROL_REGISTER, usTimerDisable );
 
     /* Restart the DOS tick. */
@@ -222,18 +219,18 @@ static void prvExitFunction( void )
 
 static void prvSetTickFrequency( uint32_t ulTickRateHz )
 {
-    const uint16_t usMaxCountRegister = 0xff5a;
-    const uint16_t usTimerPriorityRegister = 0xff32;
-    const uint16_t usTimerEnable = 0xC000;
-    const uint16_t usRetrigger = 0x0001;
-    const uint16_t usTimerHighPriority = 0x0000;
-    uint16_t usTimer0Control;
+const uint16_t usMaxCountRegister = 0xff5a;
+const uint16_t usTimerPriorityRegister = 0xff32;
+const uint16_t usTimerEnable = 0xC000;
+const uint16_t usRetrigger = 0x0001;
+const uint16_t usTimerHighPriority = 0x0000;
+uint16_t usTimer0Control;
 
 /* ( CPU frequency / 4 ) / clock 2 max count [inpw( 0xff62 ) = 7] */
 
-    const uint32_t ulClockFrequency = 0x7f31a0;
+const uint32_t ulClockFrequency = 0x7f31a0;
 
-    uint32_t ulTimerCount = ulClockFrequency / ulTickRateHz;
+uint32_t ulTimerCount = ulClockFrequency / ulTickRateHz;
 
     portOUTPUT_WORD( portTIMER_1_CONTROL_REGISTER, usTimerEnable | portTIMER_INTERRUPT_ENABLE | usRetrigger );
     portOUTPUT_WORD( usMaxCountRegister, ( uint16_t ) ulTimerCount );

--- a/portable/oWatcom/16BitDOS/Flsh186/portmacro.h
+++ b/portable/oWatcom/16BitDOS/Flsh186/portmacro.h
@@ -29,11 +29,9 @@
 #ifndef PORTMACRO_H
 #define PORTMACRO_H
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
-/* *INDENT-ON* */
 
 /*-----------------------------------------------------------
  * Port specific definitions.
@@ -47,34 +45,32 @@
 
 
 /* Type definitions. */
-#define portCHAR          char
-#define portFLOAT         float
-#define portDOUBLE        long
-#define portLONG          long
-#define portSHORT         int
-#define portSTACK_TYPE    uint16_t
-#define portBASE_TYPE     short
+#define portCHAR        char
+#define portFLOAT       float
+#define portDOUBLE      long
+#define portLONG        long
+#define portSHORT       int
+#define portSTACK_TYPE  uint16_t
+#define portBASE_TYPE   short
 
-typedef portSTACK_TYPE   StackType_t;
-typedef short            BaseType_t;
-typedef unsigned short   UBaseType_t;
+typedef portSTACK_TYPE StackType_t;
+typedef short BaseType_t;
+typedef unsigned short UBaseType_t;
 
 
-#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
-    typedef uint16_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) 0xffff
-#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
-    typedef uint32_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) 0xffffffffUL
+#if( configUSE_16_BIT_TICKS == 1 )
+        typedef uint16_t TickType_t;
+        #define portMAX_DELAY ( TickType_t ) 0xffff
 #else
-    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+        typedef uint32_t TickType_t;
+        #define portMAX_DELAY ( TickType_t ) 0xffffffffUL
 #endif
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */
 void portENTER_CRITICAL( void );
 #pragma aux portENTER_CRITICAL = "pushf" \
-    "cli";
+                                 "cli";
 
 void portEXIT_CRITICAL( void );
 #pragma aux portEXIT_CRITICAL   = "popf";
@@ -87,30 +83,28 @@ void portENABLE_INTERRUPTS( void );
 /*-----------------------------------------------------------*/
 
 /* Architecture specifics. */
-#define portSTACK_GROWTH         ( -1 )
-#define portSWITCH_INT_NUMBER    0x80
-#define portYIELD()    __asm { int portSWITCH_INT_NUMBER }
-#define portTICK_PERIOD_MS       ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portBYTE_ALIGNMENT       2
-#define portINITIAL_SW           ( ( portSTACK_TYPE ) 0x0202 )  /* Start the tasks with interrupts enabled. */
-#define portNOP()    __asm { nop }
+#define portSTACK_GROWTH        ( -1 )
+#define portSWITCH_INT_NUMBER   0x80
+#define portYIELD()             __asm{ int portSWITCH_INT_NUMBER }
+#define portTICK_PERIOD_MS        ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portBYTE_ALIGNMENT      2
+#define portINITIAL_SW          ( ( portSTACK_TYPE ) 0x0202 )   /* Start the tasks with interrupts enabled. */
+#define portNOP()               __asm{ nop }
 /*-----------------------------------------------------------*/
 
 /* Compiler specifics. */
-#define portINPUT_BYTE( xAddr )              inp( xAddr )
-#define portOUTPUT_BYTE( xAddr, ucValue )    outp( xAddr, ucValue )
-#define portINPUT_WORD( xAddr )              inpw( xAddr )
-#define portOUTPUT_WORD( xAddr, usValue )    outpw( xAddr, usValue )
+#define portINPUT_BYTE( xAddr )                 inp( xAddr )
+#define portOUTPUT_BYTE( xAddr, ucValue )       outp( xAddr, ucValue )
+#define portINPUT_WORD( xAddr )                 inpw( xAddr )
+#define portOUTPUT_WORD( xAddr, usValue )       outpw( xAddr, usValue )
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
-    }
+}
 #endif
-/* *INDENT-ON* */
 
 #endif /* PORTMACRO_H */

--- a/portable/oWatcom/16BitDOS/PC/port.c
+++ b/portable/oWatcom/16BitDOS/PC/port.c
@@ -27,27 +27,27 @@
  */
 
 /*
- * Changes from V1.00:
- *
- + Call to taskYIELD() from within tick ISR has been replaced by the more
- +    efficient portSWITCH_CONTEXT().
- + ISR function definitions renamed to include the prv prefix.
- +
- + Changes from V1.2.0:
- +
- + prvPortResetPIC() is now called last thing before the end of the
- +    preemptive tick routine.
- +
- + Changes from V2.6.1
- +
- + Replaced the sUsingPreemption variable with the configUSE_PREEMPTION
- +    macro to be consistent with the later ports.
- +
- + Changes from V4.0.1
- +
- + Add function prvSetTickFrequencyDefault() to set the DOS tick back to
- +    its proper value when the scheduler exits.
- */
+Changes from V1.00:
+
+    + Call to taskYIELD() from within tick ISR has been replaced by the more
+      efficient portSWITCH_CONTEXT().
+    + ISR function definitions renamed to include the prv prefix.
+
+Changes from V1.2.0:
+
+    + prvPortResetPIC() is now called last thing before the end of the
+      preemptive tick routine.
+
+Changes from V2.6.1
+
+    + Replaced the sUsingPreemption variable with the configUSE_PREEMPTION
+      macro to be consistent with the later ports.
+
+Changes from V4.0.1
+
+    + Add function prvSetTickFrequencyDefault() to set the DOS tick back to
+      its proper value when the scheduler exits.
+*/
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -60,9 +60,9 @@
 #include "portasm.h"
 
 /*-----------------------------------------------------------
-* Implementation of functions defined in portable.h for the industrial
-* PC port.
-*----------------------------------------------------------*/
+ * Implementation of functions defined in portable.h for the industrial
+ * PC port.
+ *----------------------------------------------------------*/
 
 /*lint -e950 Non ANSI reserved words okay in this file only. */
 
@@ -75,28 +75,26 @@ static void prvSetTickFrequency( uint32_t ulTickRateHz );
 static void prvExitFunction( void );
 
 /* Either chain to the DOS tick (which itself clears the PIC) or clear the PIC
- * directly.  We chain to the DOS tick as close as possible to the standard DOS
- * tick rate. */
+directly.  We chain to the DOS tick as close as possible to the standard DOS
+tick rate. */
 static void prvPortResetPIC( void );
 
 /* The tick ISR used depends on whether the preemptive or cooperative scheduler
- * is being used. */
+is being used. */
 #if configUSE_PREEMPTION == 1
-
-/* Tick service routine used by the scheduler when preemptive scheduling is
- * being used. */
+    /* Tick service routine used by the scheduler when preemptive scheduling is
+    being used. */
     static void __interrupt __far prvPreemptiveTick( void );
 #else
-
-/* Tick service routine used by the scheduler when cooperative scheduling is
- * being used. */
+    /* Tick service routine used by the scheduler when cooperative scheduling is
+    being used. */
     static void __interrupt __far prvNonPreemptiveTick( void );
 #endif
 /* Trap routine used by taskYIELD() to manually cause a context switch. */
 static void __interrupt __far prvYieldProcessor( void );
 
 /* Set the tick frequency back so the floppy drive works correctly when the
- * scheduler exits. */
+scheduler exits. */
 static void prvSetTickFrequencyDefault( void );
 
 /*lint -e956 File scopes necessary here. */
@@ -108,10 +106,10 @@ static int16_t sDOSTickCounter;
 static int16_t sSchedulerRunning = pdFALSE;
 
 /* Points to the original routine installed on the vector we use for manual context switches.  This is then used to restore the original routine during prvExitFunction(). */
-static void( __interrupt __far * pxOldSwitchISR )();
+static void ( __interrupt __far *pxOldSwitchISR )();
 
 /* Points to the original routine installed on the vector we use to chain to the DOS tick.  This is then used to restore the original routine during prvExitFunction(). */
-static void( __interrupt __far * pxOldSwitchISRPlus1 )();
+static void ( __interrupt __far *pxOldSwitchISRPlus1 )();
 
 /* Used to restore the original DOS context when the scheduler is ended. */
 static jmp_buf xJumpBuf;
@@ -121,12 +119,12 @@ static jmp_buf xJumpBuf;
 /*-----------------------------------------------------------*/
 BaseType_t xPortStartScheduler( void )
 {
-    pxISR pxOriginalTickISR;
+pxISR pxOriginalTickISR;
 
     /* This is called with interrupts already disabled. */
 
     /* Remember what was on the interrupts we are going to use
-     * so we can put them back later if required. */
+    so we can put them back later if required. */
     pxOldSwitchISR = _dos_getvect( portSWITCH_INT_NUMBER );
     pxOriginalTickISR = _dos_getvect( portTIMER_INT_NUMBER );
     pxOldSwitchISRPlus1 = _dos_getvect( portSWITCH_INT_NUMBER + 1 );
@@ -134,11 +132,11 @@ BaseType_t xPortStartScheduler( void )
     prvSetTickFrequency( configTICK_RATE_HZ );
 
     /* Put our manual switch (yield) function on a known
-     * vector. */
+    vector. */
     _dos_setvect( portSWITCH_INT_NUMBER, prvYieldProcessor );
 
     /* Put the old tick on a different interrupt number so we can
-     * call it when we want. */
+    call it when we want. */
     _dos_setvect( portSWITCH_INT_NUMBER + 1, pxOriginalTickISR );
 
     #if configUSE_PREEMPTION == 1
@@ -154,8 +152,8 @@ BaseType_t xPortStartScheduler( void )
     #endif
 
     /* Setup a counter that is used to call the DOS interrupt as close
-     * to it's original frequency as can be achieved given our chosen tick
-     * frequency. */
+    to it's original frequency as can be achieved given our chosen tick
+    frequency. */
     sDOSTickCounter = portTICKS_PER_DOS_TICK;
 
     /* Clean up function if we want to return to DOS. */
@@ -177,11 +175,10 @@ BaseType_t xPortStartScheduler( void )
 /*-----------------------------------------------------------*/
 
 /* The tick ISR used depends on whether the preemptive or cooperative scheduler
- * is being used. */
+is being used. */
 #if configUSE_PREEMPTION == 1
-
-/* Tick service routine used by the scheduler when preemptive scheduling is
- * being used. */
+    /* Tick service routine used by the scheduler when preemptive scheduling is
+    being used. */
     static void __interrupt __far prvPreemptiveTick( void )
     {
         /* Get the scheduler to update the task states following the tick. */
@@ -194,15 +191,15 @@ BaseType_t xPortStartScheduler( void )
         /* Reset the PIC ready for the next time. */
         prvPortResetPIC();
     }
-#else /* if configUSE_PREEMPTION == 1 */
+#else
     static void __interrupt __far prvNonPreemptiveTick( void )
     {
         /* Same as preemptive tick, but the cooperative scheduler is being used
-         * so we don't have to switch in the context of the next task. */
+        so we don't have to switch in the context of the next task. */
         xTaskIncrementTick();
         prvPortResetPIC();
     }
-#endif /* if configUSE_PREEMPTION == 1 */
+#endif
 /*-----------------------------------------------------------*/
 
 
@@ -216,22 +213,19 @@ static void __interrupt __far prvYieldProcessor( void )
 static void prvPortResetPIC( void )
 {
     /* We are going to call the DOS tick interrupt at as close a
-     * frequency to the normal DOS tick as possible. */
+    frequency to the normal DOS tick as possible. */
 
     /* WE SHOULD NOT DO THIS IF YIELD WAS CALLED. */
     --sDOSTickCounter;
-
     if( sDOSTickCounter <= 0 )
     {
         sDOSTickCounter = ( int16_t ) portTICKS_PER_DOS_TICK;
-        __asm {
-            int portSWITCH_INT_NUMBER + 1
-        };
+        __asm{ int  portSWITCH_INT_NUMBER + 1 };
     }
     else
     {
         /* Reset the PIC as the DOS tick is not being called to
-         * do it. */
+        do it. */
         __asm
         {
             mov al, 20H
@@ -244,20 +238,19 @@ static void prvPortResetPIC( void )
 void vPortEndScheduler( void )
 {
     /* Jump back to the processor state prior to starting the
-     * scheduler.  This means we are not going to be using a
-     * task stack frame so the task can be deleted. */
+    scheduler.  This means we are not going to be using a
+    task stack frame so the task can be deleted. */
     longjmp( xJumpBuf, 1 );
 }
 /*-----------------------------------------------------------*/
 
 static void prvExitFunction( void )
 {
-    void( __interrupt __far * pxOriginalTickISR )();
+void ( __interrupt __far *pxOriginalTickISR )();
 
     /* Interrupts should be disabled here anyway - but no
-     * harm in making sure. */
+    harm in making sure. */
     portDISABLE_INTERRUPTS();
-
     if( sSchedulerRunning == pdTRUE )
     {
         /* Set the DOS tick back onto the timer ticker. */
@@ -266,30 +259,29 @@ static void prvExitFunction( void )
         prvSetTickFrequencyDefault();
 
         /* Put back the switch interrupt routines that was in place
-         * before the scheduler started. */
+        before the scheduler started. */
         _dos_setvect( portSWITCH_INT_NUMBER, pxOldSwitchISR );
         _dos_setvect( portSWITCH_INT_NUMBER + 1, pxOldSwitchISRPlus1 );
     }
-
     /* The tick timer is back how DOS wants it.  We can re-enable
-     * interrupts without the scheduler being called. */
+    interrupts without the scheduler being called. */
     portENABLE_INTERRUPTS();
 }
 /*-----------------------------------------------------------*/
 
 static void prvSetTickFrequency( uint32_t ulTickRateHz )
 {
-    const uint16_t usPIT_MODE = ( uint16_t ) 0x43;
-    const uint16_t usPIT0 = ( uint16_t ) 0x40;
-    const uint32_t ulPIT_CONST = ( uint32_t ) 1193180;
-    const uint16_t us8254_CTR0_MODE3 = ( uint16_t ) 0x36;
-    uint32_t ulOutput;
+const uint16_t usPIT_MODE = ( uint16_t ) 0x43;
+const uint16_t usPIT0 = ( uint16_t ) 0x40;
+const uint32_t ulPIT_CONST = ( uint32_t ) 1193180;
+const uint16_t us8254_CTR0_MODE3 = ( uint16_t ) 0x36;
+uint32_t ulOutput;
 
     /* Setup the 8245 to tick at the wanted frequency. */
     portOUTPUT_BYTE( usPIT_MODE, us8254_CTR0_MODE3 );
     ulOutput = ulPIT_CONST / ulTickRateHz;
 
-    portOUTPUT_BYTE( usPIT0, ( uint16_t ) ( ulOutput & ( uint32_t ) 0xff ) );
+    portOUTPUT_BYTE( usPIT0, ( uint16_t )( ulOutput & ( uint32_t ) 0xff ) );
     ulOutput >>= 8;
     portOUTPUT_BYTE( usPIT0, ( uint16_t ) ( ulOutput & ( uint32_t ) 0xff ) );
 }
@@ -297,13 +289,13 @@ static void prvSetTickFrequency( uint32_t ulTickRateHz )
 
 static void prvSetTickFrequencyDefault( void )
 {
-    const uint16_t usPIT_MODE = ( uint16_t ) 0x43;
-    const uint16_t usPIT0 = ( uint16_t ) 0x40;
-    const uint16_t us8254_CTR0_MODE3 = ( uint16_t ) 0x36;
+const uint16_t usPIT_MODE = ( uint16_t ) 0x43;
+const uint16_t usPIT0 = ( uint16_t ) 0x40;
+const uint16_t us8254_CTR0_MODE3 = ( uint16_t ) 0x36;
 
     portOUTPUT_BYTE( usPIT_MODE, us8254_CTR0_MODE3 );
-    portOUTPUT_BYTE( usPIT0, 0 );
-    portOUTPUT_BYTE( usPIT0, 0 );
+    portOUTPUT_BYTE( usPIT0,0 );
+    portOUTPUT_BYTE( usPIT0,0 );
 }
 
 

--- a/portable/oWatcom/16BitDOS/PC/portmacro.h
+++ b/portable/oWatcom/16BitDOS/PC/portmacro.h
@@ -29,11 +29,9 @@
 #ifndef PORTMACRO_H
 #define PORTMACRO_H
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
-/* *INDENT-ON* */
 
 /*-----------------------------------------------------------
  * Port specific definitions.
@@ -46,36 +44,34 @@
  */
 
 /* Type definitions. */
-#define portCHAR          char
-#define portFLOAT         float
-#define portDOUBLE        double
-#define portLONG          long
-#define portSHORT         int
-#define portSTACK_TYPE    uint16_t
-#define portBASE_TYPE     short
+#define portCHAR        char
+#define portFLOAT       float
+#define portDOUBLE      double
+#define portLONG        long
+#define portSHORT       int
+#define portSTACK_TYPE  uint16_t
+#define portBASE_TYPE   short
 
-typedef portSTACK_TYPE   StackType_t;
-typedef short            BaseType_t;
-typedef unsigned short   UBaseType_t;
+typedef portSTACK_TYPE StackType_t;
+typedef short BaseType_t;
+typedef unsigned short UBaseType_t;
 
 
-#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
-    typedef uint16_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) 0xffff
-#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
-    typedef uint32_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) 0xffffffffUL
+#if( configUSE_16_BIT_TICKS == 1 )
+    typedef uint16_t TickType_t;
+    #define portMAX_DELAY ( TickType_t ) 0xffff
 #else
-    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+    typedef uint32_t TickType_t;
+    #define portMAX_DELAY ( TickType_t ) 0xffffffffUL
 #endif
 /*-----------------------------------------------------------*/
 
 /* Critical section definitions.  portENTER_CRITICAL() must be defined as a
- * macro for portable.h to work properly. */
+macro for portable.h to work properly. */
 void portLOCAL_ENTER_CRITICAL( void );
 #pragma aux portLOCAL_ENTER_CRITICAL =  "pushf" \
-    "cli";
-#define portENTER_CRITICAL()    portLOCAL_ENTER_CRITICAL()
+                                        "cli";
+#define portENTER_CRITICAL() portLOCAL_ENTER_CRITICAL()
 
 void portEXIT_CRITICAL( void );
 #pragma aux portEXIT_CRITICAL   =       "popf";
@@ -88,31 +84,29 @@ void portENABLE_INTERRUPTS( void );
 /*-----------------------------------------------------------*/
 
 /* Architecture specifics. */
-#define portSTACK_GROWTH          ( -1 )
-#define portSWITCH_INT_NUMBER     0x80
-#define portYIELD()    __asm { int portSWITCH_INT_NUMBER }
-#define portDOS_TICK_RATE         ( 18.20648 )
+#define portSTACK_GROWTH        ( -1 )
+#define portSWITCH_INT_NUMBER   0x80
+#define portYIELD()             __asm{ int portSWITCH_INT_NUMBER }
+#define portDOS_TICK_RATE       ( 18.20648 )
 #define portTICK_PERIOD_MS        ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portTICKS_PER_DOS_TICK    ( ( uint16_t ) ( ( ( portDOUBLE ) configTICK_RATE_HZ / portDOS_TICK_RATE ) + 0.5 ) )
-#define portINITIAL_SW            ( ( portSTACK_TYPE ) 0x0202 ) /* Start the tasks with interrupts enabled. */
-#define portBYTE_ALIGNMENT        ( 2 )
+#define portTICKS_PER_DOS_TICK  ( ( uint16_t ) ( ( ( portDOUBLE ) configTICK_RATE_HZ / portDOS_TICK_RATE ) + 0.5 ) )
+#define portINITIAL_SW          ( ( portSTACK_TYPE ) 0x0202 )   /* Start the tasks with interrupts enabled. */
+#define portBYTE_ALIGNMENT      ( 2 )
 /*-----------------------------------------------------------*/
 
 /* Compiler specifics. */
-#define portINPUT_BYTE( xAddr )              inp( xAddr )
-#define portOUTPUT_BYTE( xAddr, ucValue )    outp( xAddr, ucValue )
-#define portNOP()                            __asm { nop }
+#define portINPUT_BYTE( xAddr )             inp( xAddr )
+#define portOUTPUT_BYTE( xAddr, ucValue )   outp( xAddr, ucValue )
+#define portNOP() __asm{ nop }
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION_PROTO( vTaskFunction, pvParameters )    void vTaskFunction( void * pvParameters )
-#define portTASK_FUNCTION( vTaskFunction, pvParameters )          void vTaskFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vTaskFunction, pvParameters ) void vTaskFunction( void *pvParameters )
+#define portTASK_FUNCTION( vTaskFunction, pvParameters ) void vTaskFunction( void *pvParameters )
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
-    }
+}
 #endif
-/* *INDENT-ON* */
 
 
 #endif /* PORTMACRO_H */

--- a/portable/oWatcom/16BitDOS/common/portasm.h
+++ b/portable/oWatcom/16BitDOS/common/portasm.h
@@ -45,65 +45,65 @@ void portSWITCH_CONTEXT( void );
 void portFIRST_CONTEXT( void );
 
 /* There are slightly different versions depending on whether you are building
- * to include debugger information.  If debugger information is used then there
- * are a couple of extra bytes left of the ISR stack (presumably for use by the
- * debugger).  The true stack pointer is then stored in the bp register.  We add
- * 2 to the stack pointer to remove the extra bytes before we restore our context. */
+to include debugger information.  If debugger information is used then there
+are a couple of extra bytes left of the ISR stack (presumably for use by the
+debugger).  The true stack pointer is then stored in the bp register.  We add
+2 to the stack pointer to remove the extra bytes before we restore our context. */
 
 #ifdef DEBUG_BUILD
 
-    #pragma aux portSWITCH_CONTEXT =    "mov    ax, seg pxCurrentTCB"                                                        \
-    "mov    ds, ax"                                                                                                          \
-    "les    bx, pxCurrentTCB" /* Save the stack pointer into the TCB. */                                                     \
-    "mov    es:0x2[ bx ], ss"                                                                                                \
-    "mov    es:[ bx ], sp"                                                                                                   \
-    "call   vTaskSwitchContext"   /* Perform the switch. */                                                                  \
-    "mov    ax, seg pxCurrentTCB" /* Restore the stack pointer from the TCB. */                                              \
-    "mov    ds, ax"                                                                                                          \
-    "les    bx, dword ptr pxCurrentTCB"                                                                                      \
-    "mov    ss, es:[ bx + 2 ]"                                                                                               \
-    "mov    sp, es:[ bx ]"                                                                                                   \
-    "mov    bp, sp" /* Prepair the bp register for the restoration of the SP in the compiler generated portion of the ISR */ \
-    "add    bp, 0x0002"
+    #pragma aux portSWITCH_CONTEXT =    "mov    ax, seg pxCurrentTCB"                                                       \
+                                        "mov    ds, ax"                                                                     \
+                                        "les    bx, pxCurrentTCB"           /* Save the stack pointer into the TCB. */      \
+                                        "mov    es:0x2[ bx ], ss"                                                           \
+                                        "mov    es:[ bx ], sp"                                                              \
+                                        "call   vTaskSwitchContext"         /* Perform the switch. */                       \
+                                        "mov    ax, seg pxCurrentTCB"       /* Restore the stack pointer from the TCB. */   \
+                                        "mov    ds, ax"                                                                     \
+                                        "les    bx, dword ptr pxCurrentTCB"                                                 \
+                                        "mov    ss, es:[ bx + 2 ]"                                                          \
+                                        "mov    sp, es:[ bx ]"                                                              \
+                                        "mov    bp, sp"                     /* Prepair the bp register for the restoration of the SP in the compiler generated portion of the ISR */    \
+                                        "add    bp, 0x0002"
 
 
 
-    #pragma aux portFIRST_CONTEXT =     "mov    ax, seg pxCurrentTCB"                                         \
-    "mov    ds, ax"                                                                                           \
-    "les    bx, dword ptr pxCurrentTCB"                                                                       \
-    "mov    ss, es:[ bx + 2 ]"                                                                                \
-    "mov    sp, es:[ bx ]"                                                                                    \
-    "add    sp, 0x0002" /* Remove the extra bytes that exist in debug builds before restoring the context. */ \
-    "pop    ax"                                                                                               \
-    "pop    ax"                                                                                               \
-    "pop    es"                                                                                               \
-    "pop    ds"                                                                                               \
-    "popa"                                                                                                    \
-    "iret"
-#else /* ifdef DEBUG_BUILD */
+    #pragma aux portFIRST_CONTEXT =     "mov    ax, seg pxCurrentTCB"           \
+                                        "mov    ds, ax"                         \
+                                        "les    bx, dword ptr pxCurrentTCB"     \
+                                        "mov    ss, es:[ bx + 2 ]"              \
+                                        "mov    sp, es:[ bx ]"                  \
+                                        "add    sp, 0x0002"                     /* Remove the extra bytes that exist in debug builds before restoring the context. */ \
+                                        "pop    ax"                             \
+                                        "pop    ax"                             \
+                                        "pop    es"                             \
+                                        "pop    ds"                             \
+                                        "popa"                                  \
+                                        "iret"
+#else
 
-    #pragma aux portSWITCH_CONTEXT =    "mov    ax, seg pxCurrentTCB"           \
-    "mov    ds, ax"                                                             \
-    "les    bx, pxCurrentTCB" /* Save the stack pointer into the TCB. */        \
-    "mov    es:0x2[ bx ], ss"                                                   \
-    "mov    es:[ bx ], sp"                                                      \
-    "call   vTaskSwitchContext"   /* Perform the switch. */                     \
-    "mov    ax, seg pxCurrentTCB" /* Restore the stack pointer from the TCB. */ \
-    "mov    ds, ax"                                                             \
-    "les    bx, dword ptr pxCurrentTCB"                                         \
-    "mov    ss, es:[ bx + 2 ]"                                                  \
-    "mov    sp, es:[ bx ]"
+    #pragma aux portSWITCH_CONTEXT =    "mov    ax, seg pxCurrentTCB"                                                       \
+                                        "mov    ds, ax"                                                                     \
+                                        "les    bx, pxCurrentTCB"           /* Save the stack pointer into the TCB. */      \
+                                        "mov    es:0x2[ bx ], ss"                                                           \
+                                        "mov    es:[ bx ], sp"                                                              \
+                                        "call   vTaskSwitchContext"         /* Perform the switch. */                       \
+                                        "mov    ax, seg pxCurrentTCB"       /* Restore the stack pointer from the TCB. */   \
+                                        "mov    ds, ax"                                                                     \
+                                        "les    bx, dword ptr pxCurrentTCB"                                                 \
+                                        "mov    ss, es:[ bx + 2 ]"                                                          \
+                                        "mov    sp, es:[ bx ]"
 
 
-    #pragma aux portFIRST_CONTEXT =     "mov    ax, seg pxCurrentTCB" \
-    "mov    ds, ax"                                                   \
-    "les    bx, dword ptr pxCurrentTCB"                               \
-    "mov    ss, es:[ bx + 2 ]"                                        \
-    "mov    sp, es:[ bx ]"                                            \
-    "pop    ax"                                                       \
-    "pop    ax"                                                       \
-    "pop    es"                                                       \
-    "pop    ds"                                                       \
-    "popa"                                                            \
-    "iret"
-#endif /* ifdef DEBUG_BUILD */
+    #pragma aux portFIRST_CONTEXT =     "mov    ax, seg pxCurrentTCB"           \
+                                        "mov    ds, ax"                         \
+                                        "les    bx, dword ptr pxCurrentTCB"     \
+                                        "mov    ss, es:[ bx + 2 ]"              \
+                                        "mov    sp, es:[ bx ]"                  \
+                                        "pop    ax"                             \
+                                        "pop    ax"                             \
+                                        "pop    es"                             \
+                                        "pop    ds"                             \
+                                        "popa"                                  \
+                                        "iret"
+#endif

--- a/portable/oWatcom/16BitDOS/common/portcomn.c
+++ b/portable/oWatcom/16BitDOS/common/portcomn.c
@@ -27,21 +27,21 @@
  */
 
 /*
- * Changes from V1.00:
- *
- + pxPortInitialiseStack() now initialises the stack of new tasks to the
- +    same format used by the compiler.  This allows the compiler generated
- +    interrupt mechanism to be used for context switches.
- +
- + Changes from V2.4.2:
- +
- + pvPortMalloc and vPortFree have been removed.  The projects now use
- +    the definitions from the source/portable/MemMang directory.
- +
- + Changes from V2.6.1:
- +
- + usPortCheckFreeStackSpace() has been moved to tasks.c.
- */
+Changes from V1.00:
+
+    + pxPortInitialiseStack() now initialises the stack of new tasks to the
+      same format used by the compiler.  This allows the compiler generated
+      interrupt mechanism to be used for context switches.
+
+Changes from V2.4.2:
+
+    + pvPortMalloc and vPortFree have been removed.  The projects now use
+      the definitions from the source/portable/MemMang directory.
+
+Changes from V2.6.1:
+
+    + usPortCheckFreeStackSpace() has been moved to tasks.c.
+*/
 
 
 
@@ -51,15 +51,13 @@
 /*-----------------------------------------------------------*/
 
 /* See header file for description. */
-StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                     TaskFunction_t pxCode,
-                                     void * pvParameters )
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
 {
-    StackType_t DS_Reg = 0;
-    StackType_t * pxOriginalSP;
+StackType_t DS_Reg = 0;
+StackType_t * pxOriginalSP;
 
     /* Place a few bytes of known values on the bottom of the stack.
-     * This is just useful for debugging. */
+    This is just useful for debugging. */
 
     *pxTopOfStack = 0x1111;
     pxTopOfStack--;
@@ -76,9 +74,9 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     /*lint -e950 -e611 -e923 Lint doesn't like this much - but nothing I can do about it. */
 
     /* We are going to start the scheduler using a return from interrupt
-     * instruction to load the program counter, so first there would be the
-     * status register and interrupt return address.  We make this the start
-     * of the task. */
+    instruction to load the program counter, so first there would be the
+    status register and interrupt return address.  We make this the start
+    of the task. */
     *pxTopOfStack = portINITIAL_SW;
     pxTopOfStack--;
     *pxTopOfStack = FP_SEG( pxCode );
@@ -87,24 +85,24 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     pxTopOfStack--;
 
     /* We are going to setup the stack for the new task to look like
-     * the stack frame was setup by a compiler generated ISR.  We need to know
-     * the address of the existing stack top to place in the SP register within
-     * the stack frame.  pxOriginalSP holds SP before (simulated) pusha was
-     * called. */
+    the stack frame was setup by a compiler generated ISR.  We need to know
+    the address of the existing stack top to place in the SP register within
+    the stack frame.  pxOriginalSP holds SP before (simulated) pusha was
+    called. */
     pxOriginalSP = pxTopOfStack;
 
     /* The remaining registers would be pushed on the stack by our context
-     * switch function.  These are loaded with values simply to make debugging
-     * easier. */
-    *pxTopOfStack = FP_OFF( pvParameters ); /* AX */
+    switch function.  These are loaded with values simply to make debugging
+    easier. */
+    *pxTopOfStack = FP_OFF( pvParameters );     /* AX */
     pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) 0xCCCC; /* CX */
     pxTopOfStack--;
-    *pxTopOfStack = FP_SEG( pvParameters ); /* DX */
+    *pxTopOfStack = FP_SEG( pvParameters );     /* DX */
     pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) 0xBBBB; /* BX */
     pxTopOfStack--;
-    *pxTopOfStack = FP_OFF( pxOriginalSP ); /* SP */
+    *pxTopOfStack = FP_OFF( pxOriginalSP );     /* SP */
     pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) 0xBBBB; /* BP */
     pxTopOfStack--;
@@ -113,9 +111,7 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     *pxTopOfStack = ( StackType_t ) 0xDDDD; /* DI */
 
     /* We need the true data segment. */
-    __asm {
-        MOV DS_Reg, DS
-    };
+    __asm{  MOV DS_Reg, DS };
 
     pxTopOfStack--;
     *pxTopOfStack = DS_Reg; /* DS */
@@ -125,17 +121,16 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
 
     /* The AX register is pushed again twice - don't know why. */
     pxTopOfStack--;
-    *pxTopOfStack = FP_OFF( pvParameters ); /* AX */
+    *pxTopOfStack = FP_OFF( pvParameters );     /* AX */
     pxTopOfStack--;
-    *pxTopOfStack = FP_OFF( pvParameters ); /* AX */
+    *pxTopOfStack = FP_OFF( pvParameters );     /* AX */
 
 
     #ifdef DEBUG_BUILD
-
         /* The compiler adds space to each ISR stack if building to
-         * include debug information.  Presumably this is used by the
-         * debugger - we don't need to initialise it to anything just
-         * make sure it is there. */
+        include debug information.  Presumably this is used by the
+        debugger - we don't need to initialise it to anything just
+        make sure it is there. */
         pxTopOfStack--;
     #endif
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Revert the formatting on oWatcom ports

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
