### PR TITLE
Fix xTaskNotifyWait & ulTaskNotifyTake determinism.

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -5127,7 +5127,7 @@ void vTaskPlaceOnEventList( List_t * const pxEventList,
 
     configASSERT( pxEventList );
 
-    /* THIS FUNCTION MUST BE CALLED WITH EITHER INTERRUPTS DISABLED OR THE
+    /* THIS FUNCTION MUST BE CALLED WITH THE
      * SCHEDULER SUSPENDED AND THE QUEUE BEING ACCESSED LOCKED. */
 
     /* Place the event list item of the TCB in the appropriate event list.
@@ -7415,7 +7415,6 @@ TickType_t uxTaskResetEventItemValue( void )
         configASSERT( uxIndexToWaitOn < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
         taskENTER_CRITICAL();
-        {
             /* Only block if the notification count is not already non-zero. */
             if( pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] == 0UL )
             {
@@ -7427,11 +7426,27 @@ TickType_t uxTaskResetEventItemValue( void )
                     prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
                     traceTASK_NOTIFY_TAKE_BLOCK( uxIndexToWaitOn );
 
-                    /* All ports are written to allow a yield in a critical
-                     * section (some will yield immediately, others wait until the
-                     * critical section exits) - but it is not something that
-                     * application code should ever do. */
-                    taskYIELD_WITHIN_API();
+                /* Suspend the scheduler before enabling interrupts. */
+                vTaskSuspendAll();
+                taskEXIT_CRITICAL();
+
+                prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
+
+                /* All ports are written to allow a yield in a critical
+                 * section (some will yield immediately, others wait until the
+                 * critical section exits) - but it is not something that
+                 * application code should ever do. */
+                if( xTaskResumeAll() == pdFALSE )
+                {
+                    #if ( configNUMBER_OF_CORES == 1 )
+                    {
+                        portYIELD_WITHIN_API();
+                    }
+                    #else
+                    {
+                        vTaskYieldWithinAPI();
+                    }
+                    #endif
                 }
                 else
                 {
@@ -7440,10 +7455,13 @@ TickType_t uxTaskResetEventItemValue( void )
             }
             else
             {
-                mtCOVERAGE_TEST_MARKER();
+                taskEXIT_CRITICAL();
             }
         }
-        taskEXIT_CRITICAL();
+        else
+        {
+            taskEXIT_CRITICAL();
+        }
 
         taskENTER_CRITICAL();
         {
@@ -7493,28 +7511,43 @@ TickType_t uxTaskResetEventItemValue( void )
         configASSERT( uxIndexToWaitOn < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
         taskENTER_CRITICAL();
+
+        /* Only block if a notification is not already pending. */
+        if( pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] != taskNOTIFICATION_RECEIVED )
         {
-            /* Only block if a notification is not already pending. */
-            if( pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] != taskNOTIFICATION_RECEIVED )
+            /* Clear bits in the task's notification value as bits may get
+             * set  by the notifying task or interrupt.  This can be used to
+             * clear the value to zero. */
+            pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] &= ~ulBitsToClearOnEntry;
+
+            /* Mark this task as waiting for a notification. */
+            pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskWAITING_NOTIFICATION;
+
+            if( xTicksToWait > ( TickType_t ) 0 )
             {
-                /* Clear bits in the task's notification value as bits may get
-                 * set  by the notifying task or interrupt.  This can be used to
-                 * clear the value to zero. */
-                pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] &= ~ulBitsToClearOnEntry;
+                traceTASK_NOTIFY_WAIT_BLOCK( uxIndexToWaitOn );
 
-                /* Mark this task as waiting for a notification. */
-                pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskWAITING_NOTIFICATION;
+                /* Suspend the scheduler before enabling interrupts. */
+                vTaskSuspendAll();
+                taskEXIT_CRITICAL();
 
-                if( xTicksToWait > ( TickType_t ) 0 )
+                prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
+
+                /* All ports are written to allow a yield in a critical
+                 * section (some will yield immediately, others wait until the
+                 * critical section exits) - but it is not something that
+                 * application code should ever do. */
+                if( xTaskResumeAll() == pdFALSE )
                 {
-                    prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
-                    traceTASK_NOTIFY_WAIT_BLOCK( uxIndexToWaitOn );
-
-                    /* All ports are written to allow a yield in a critical
-                     * section (some will yield immediately, others wait until the
-                     * critical section exits) - but it is not something that
-                     * application code should ever do. */
-                    taskYIELD_WITHIN_API();
+                    #if ( configNUMBER_OF_CORES == 1 )
+                    {
+                        portYIELD_WITHIN_API();
+                    }
+                    #else
+                    {
+                        vTaskYieldWithinAPI();
+                    }
+                    #endif
                 }
                 else
                 {
@@ -7523,10 +7556,13 @@ TickType_t uxTaskResetEventItemValue( void )
             }
             else
             {
-                mtCOVERAGE_TEST_MARKER();
+                taskEXIT_CRITICAL();
             }
         }
-        taskEXIT_CRITICAL();
+        else
+        {
+            taskEXIT_CRITICAL();
+        }
 
         taskENTER_CRITICAL();
         {

--- a/tasks.c
+++ b/tasks.c
@@ -7424,7 +7424,6 @@ TickType_t uxTaskResetEventItemValue( void )
 
             if( xTicksToWait > ( TickType_t ) 0 )
             {
-                prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
                 traceTASK_NOTIFY_TAKE_BLOCK( uxIndexToWaitOn );
 
                 /* Suspend the scheduler before enabling interrupts. */

--- a/tasks.c
+++ b/tasks.c
@@ -7415,16 +7415,17 @@ TickType_t uxTaskResetEventItemValue( void )
         configASSERT( uxIndexToWaitOn < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
         taskENTER_CRITICAL();
-            /* Only block if the notification count is not already non-zero. */
-            if( pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] == 0UL )
-            {
-                /* Mark this task as waiting for a notification. */
-                pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskWAITING_NOTIFICATION;
 
-                if( xTicksToWait > ( TickType_t ) 0 )
-                {
-                    prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
-                    traceTASK_NOTIFY_TAKE_BLOCK( uxIndexToWaitOn );
+        /* Only block if the notification count is not already non-zero. */
+        if( pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] == 0UL )
+        {
+            /* Mark this task as waiting for a notification. */
+            pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskWAITING_NOTIFICATION;
+
+            if( xTicksToWait > ( TickType_t ) 0 )
+            {
+                prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
+                traceTASK_NOTIFY_TAKE_BLOCK( uxIndexToWaitOn );
 
                 /* Suspend the scheduler before enabling interrupts. */
                 vTaskSuspendAll();


### PR DESCRIPTION
Description
-----------
Fixes the bug described in this issue: https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/612. This was originally contributed in this PR: https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/625.

The implementation suspends the scheduler before exiting the critical section (i.e. before enabling interrupts).  If we do not do so, a notification sent from an ISR, which happens after exiting the critical section and before suspending the scheduler, will get lost. The sequence of events will be:
1. Exit critical section.
2. Interrupt - ISR calls `xTaskNotifyFromISR` which adds the task to the Ready list.
3. Suspend scheduler.
4. `prvAddCurrentTaskToDelayedList` moves the task to the delayed or suspended list.
5. Resume scheduler does not touch the task (because it is not on the pendingReady list), effectively losing the notification from the ISR.

The same does not happen when we suspend the scheduler before exiting the critical section. The sequence of events in this
case will be:
1. Suspend scheduler.
2. Exit critical section.
3. Interrupt - ISR calls `xTaskNotifyFromISR` which adds the task to the pendingReady list as the scheduler is suspended.
4. `prvAddCurrentTaskToDelayedList` adds the task to delayed or suspended list. Note that this operation does not nullify
   the add to pendingReady list done in the above step because a different list item, namely xEventListItem, is used for
   adding the task to the pendingReady list. In other words, the task still remains on the pendingReady list.
5. Resume scheduler moves the task from pendingReady list to the Ready list.

Test Steps
-----------
Tested by adding a dummy loop in the implementation to cause a button press interrupt at the desired point and ensured that the notification is not lost. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/612

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
