### PR TITLE
Removes redundant API calls in MPU wrappers

### DIFF
--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -2106,8 +2106,7 @@
         BaseType_t xReturn = pdFAIL;
         BaseType_t xIsItemToQueueReadable = pdFALSE;
         BaseType_t xCallingTaskIsAuthorizedToAccessQueue = pdFALSE;
-        UBaseType_t uxQueueItemSize;
-        UBaseType_t uxQueueLength;
+        UBaseType_t uxQueueItemSize, uxQueueLength;
 
         lIndex = ( int32_t ) xQueue;
 

--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -2106,7 +2106,8 @@
         BaseType_t xReturn = pdFAIL;
         BaseType_t xIsItemToQueueReadable = pdFALSE;
         BaseType_t xCallingTaskIsAuthorizedToAccessQueue = pdFALSE;
-        UBaseType_t uxQueueItemSize, uxQueueLength;
+        UBaseType_t uxQueueItemSize;
+        UBaseType_t uxQueueLength;
 
         lIndex = ( int32_t ) xQueue;
 
@@ -2133,7 +2134,7 @@
                         if( pvItemToQueue != NULL )
                         {
                             xIsItemToQueueReadable = xPortIsAuthorizedToAccessBuffer( pvItemToQueue,
-                                                                                      uxQueueGetQueueItemSize( xInternalQueueHandle ),
+                                                                                      uxQueueItemSize,
                                                                                       tskMPU_READ_PERMISSION );
                         }
 
@@ -2246,7 +2247,7 @@
                         )
                     {
                         xIsReceiveBufferWritable = xPortIsAuthorizedToAccessBuffer( pvBuffer,
-                                                                                    uxQueueGetQueueItemSize( xInternalQueueHandle ),
+                                                                                    uxQueueItemSize,
                                                                                     tskMPU_WRITE_PERMISSION );
 
                         if( xIsReceiveBufferWritable == pdTRUE )
@@ -2298,7 +2299,7 @@
                         )
                     {
                         xIsReceiveBufferWritable = xPortIsAuthorizedToAccessBuffer( pvBuffer,
-                                                                                    uxQueueGetQueueItemSize( xInternalQueueHandle ),
+                                                                                    uxQueueItemSize,
                                                                                     tskMPU_WRITE_PERMISSION );
 
                         if( xIsReceiveBufferWritable == pdTRUE )


### PR DESCRIPTION
Description
-----------
This PR removes redundant API calls in MPU wrappers for the following Queue APIs

1. MPU_xQueueGenericSend
2. MPU_xQueueGenericReceive
3. MPU_xQueuePeek

Test Steps
-----------
Tested using STM32H743ZI demo project.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
