### PR TITLE
Fix MISRA_C_2012 rule 7.2 violation

### DIFF
--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -89,7 +89,7 @@
     #define taskCHECK_FOR_STACK_OVERFLOW()                                                            \
     do {                                                                                              \
         const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                       \
-        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5;                                        \
+        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5u;                                        \
                                                                                                       \
         if( ( pulStack[ 0 ] != ulCheckValue ) ||                                                      \
             ( pulStack[ 1 ] != ulCheckValue ) ||                                                      \

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -89,7 +89,7 @@
     #define taskCHECK_FOR_STACK_OVERFLOW()                                                            \
     do {                                                                                              \
         const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                       \
-        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5u;                                        \
+        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5u;                                       \
                                                                                                       \
         if( ( pulStack[ 0 ] != ulCheckValue ) ||                                                      \
             ( pulStack[ 1 ] != ulCheckValue ) ||                                                      \


### PR DESCRIPTION
Description
-----------
This PR adds fix for the Misra rule 7.2 violation
Misra Rule 7.2 states that
_A "u" or "U" suffix shall be applied to all integer constants that are represented in an unsigned type._

Test Steps
-----------
Run the Coverity tool to verify these errors are no longer reported.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
