### PR TITLE
Fix MISRA_C_2012 rule 20.7 violation

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -153,16 +153,16 @@
  * invoke the callback else use the send complete macro which is provided by default for all instances.
  */
 #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
-    #define prvSEND_COMPLETED( pxStreamBuffer )                                           \
-    do {                                                                                  \
-        if( ( pxStreamBuffer )->pxSendCompletedCallback != NULL )                         \
-        {                                                                                 \
-            pxStreamBuffer->pxSendCompletedCallback( ( pxStreamBuffer ), pdFALSE, NULL ); \
-        }                                                                                 \
-        else                                                                              \
-        {                                                                                 \
-            sbSEND_COMPLETED( ( pxStreamBuffer ) );                                       \
-        }                                                                                 \
+    #define prvSEND_COMPLETED( pxStreamBuffer )                                               \
+    do {                                                                                      \
+        if( ( pxStreamBuffer )->pxSendCompletedCallback != NULL )                             \
+        {                                                                                     \
+            ( pxStreamBuffer )->pxSendCompletedCallback( ( pxStreamBuffer ), pdFALSE, NULL ); \
+        }                                                                                     \
+        else                                                                                  \
+        {                                                                                     \
+            sbSEND_COMPLETED( ( pxStreamBuffer ) );                                           \
+        }                                                                                     \
     } while( 0 )
 #else /* if ( configUSE_SB_COMPLETED_CALLBACK == 1 ) */
     #define prvSEND_COMPLETED( pxStreamBuffer )    sbSEND_COMPLETED( ( pxStreamBuffer ) )


### PR DESCRIPTION
Description
-----------
This PR adds fix for the Misra rule 20.7 violation
Misra Rule 20.7 states that
_Expressions resulting from the expansion of macro parameters shall be enclosed in parentheses._

Test Steps
-----------
Run the Coverity tool to verify these errors are no longer reported.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
