### PR TITLE
Rename "CPU" to "Core"

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2120,12 +2120,12 @@
     #define traceRETURN_xTaskGetCurrentTaskHandle( xReturn )
 #endif
 
-#ifndef traceENTER_xTaskGetCurrentTaskHandleCPU
-    #define traceENTER_xTaskGetCurrentTaskHandleCPU( xCoreID )
+#ifndef traceENTER_xTaskGetCurrentTaskHandleForCore
+    #define traceENTER_xTaskGetCurrentTaskHandleForCore( xCoreID )
 #endif
 
-#ifndef traceRETURN_xTaskGetCurrentTaskHandleCPU
-    #define traceRETURN_xTaskGetCurrentTaskHandleCPU( xReturn )
+#ifndef traceRETURN_xTaskGetCurrentTaskHandleForCore
+    #define traceRETURN_xTaskGetCurrentTaskHandleForCore( xReturn )
 #endif
 
 #ifndef traceENTER_xTaskGetSchedulerState

--- a/include/task.h
+++ b/include/task.h
@@ -3539,7 +3539,7 @@ TaskHandle_t xTaskGetCurrentTaskHandle( void ) PRIVILEGED_FUNCTION;
 /*
  * Return the handle of the task running on specified core.
  */
-TaskHandle_t xTaskGetCurrentTaskHandleCPU( BaseType_t xCoreID ) PRIVILEGED_FUNCTION;
+TaskHandle_t xTaskGetCurrentTaskHandleForCore( BaseType_t xCoreID ) PRIVILEGED_FUNCTION;
 
 /*
  * Shortcut used by the queue implementation to prevent unnecessary call to

--- a/tasks.c
+++ b/tasks.c
@@ -6425,18 +6425,18 @@ static void prvResetNextTaskUnblockTime( void )
             return xReturn;
         }
 
-        TaskHandle_t xTaskGetCurrentTaskHandleCPU( BaseType_t xCoreID )
+        TaskHandle_t xTaskGetCurrentTaskHandleForCore( BaseType_t xCoreID )
         {
             TaskHandle_t xReturn = NULL;
 
-            traceENTER_xTaskGetCurrentTaskHandleCPU( xCoreID );
+            traceENTER_xTaskGetCurrentTaskHandleForCore( xCoreID );
 
             if( taskVALID_CORE_ID( xCoreID ) != pdFALSE )
             {
                 xReturn = pxCurrentTCBs[ xCoreID ];
             }
 
-            traceRETURN_xTaskGetCurrentTaskHandleCPU( xReturn );
+            traceRETURN_xTaskGetCurrentTaskHandleForCore( xReturn );
 
             return xReturn;
         }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

SMP is enabled/disabled via the `configNUMBER_OF_CORES` option. This PR simply renames all occurrences of `CPU` to `Core` in any public facing API for naming consistency. The following APIs have been renamed:

- `traceENTER_xTaskGetCurrentTaskHandleCPU` -> `traceENTER_xTaskGetCurrentTaskHandleForCore`
- `xTaskGetCurrentTaskHandleCPU` -> `xTaskGetCurrentTaskHandleForCore`


This commit renames "CPU" to "Core" for any public facing API for consistency with other SMP related APIs (e.g., "configNUMBER_OF_CORES").

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
