### PR TITLE
Fix for MISRA C 2012 Rule 11.1

### DIFF
--- a/event_groups.c
+++ b/event_groups.c
@@ -736,7 +736,7 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 /* For internal use only - execute a 'set bits' command that was pended from
  * an interrupt. */
 void vEventGroupSetBitsCallback( void * pvEventGroup,
-                                 const uint32_t ulBitsToSet )
+                                 uint32_t ulBitsToSet )
 {
     traceENTER_vEventGroupSetBitsCallback( pvEventGroup, ulBitsToSet );
 
@@ -749,7 +749,7 @@ void vEventGroupSetBitsCallback( void * pvEventGroup,
 /* For internal use only - execute a 'clear bits' command that was pended from
  * an interrupt. */
 void vEventGroupClearBitsCallback( void * pvEventGroup,
-                                   const uint32_t ulBitsToClear )
+                                   uint32_t ulBitsToClear )
 {
     traceENTER_vEventGroupClearBitsCallback( pvEventGroup, ulBitsToClear );
 

--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -807,9 +807,9 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup ) PRIVILEGED_FUNCTION;
 
 /* For internal use only. */
 void vEventGroupSetBitsCallback( void * pvEventGroup,
-                                 const uint32_t ulBitsToSet ) PRIVILEGED_FUNCTION;
+                                 uint32_t ulBitsToSet ) PRIVILEGED_FUNCTION;
 void vEventGroupClearBitsCallback( void * pvEventGroup,
-                                   const uint32_t ulBitsToClear ) PRIVILEGED_FUNCTION;
+                                   uint32_t ulBitsToClear ) PRIVILEGED_FUNCTION;
 
 
 #if ( configUSE_TRACE_FACILITY == 1 )


### PR DESCRIPTION


Fix for MISRA C 2012 Rule 11.1

Description
-----------
* Update vEventGroupSetBitsCallback and vEventGroupClearBitsCallback to compatible callback function pointer type

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have tested my changes. No regression in existing tests.~~
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
