### PR TITLE
Suppress MISRA C rule 21.6 in MISRA.md

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -69,7 +69,7 @@ Copy below content to `misra.conf` to run Coverity on FreeRTOS-Kernel.
         }
         {
             deviation: "Rule 21.6",
-            reason: "snprintf is used in APIs vTaskListTasks and vTaskGetRunTimeStatistics to print the buffer."
+            reason: "Allow use of standard library input/output functions . The function snprintf is used to insert information in a logging string. This is only used in utility functions which aid in debugging and is not part of the 'core' code."
         }
     ]
 }

--- a/MISRA.md
+++ b/MISRA.md
@@ -67,6 +67,10 @@ Copy below content to `misra.conf` to run Coverity on FreeRTOS-Kernel.
             deviation: "Rule 11.5",
             reason: "Allow casts from `void *`. List owner, pvOwner, is stored as `void *` and are cast to various types for use in functions."
         }
+        {
+            deviation: "Rule 21.6",
+            reason: "snprintf is used in APIs vTaskListTasks and vTaskGetRunTimeStatistics to print the buffer."
+        }
     ]
 }
 ```


### PR DESCRIPTION
This PR suppresses MISRA C rule 21.6 in MISRA.md.

Description
-----------
MISRA C:2012 Rule 21.6

> The Standard Library input/output functions shall not be used.

### MISRA violation

FreeRTOS Kernel uses snprintf to print out the buffer in vTaskListTasks and vTaskGetRunTimeStatistics API.
```
iSnprintfReturnValue = snprintf( pcWriteBuffer,
                                 uxBufferLength - uxConsumedBufferLength, 
                                 "\t%c\t%u\t%u\t%u\r\n",
                                 cStatus,
                                 ( unsigned int ) pxTaskStatusArray[ x ].uxCurrentPriority,
                                 ( unsigned int ) pxTaskStatusArray[ x ].usStackHighWaterMark,
                                 ( unsigned int ) pxTaskStatusArray[ x ].xTaskNumber );
```

### Fix in this PR

-  We are suppressing this rule to allow use of snprintf library.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- <s> I have tested my changes. No regression in existing tests.</s>
- <s> I have modified and/or added unit-tests to cover the code changes in this Pull Request.</s>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
