### PR TITLE
Add nightly coverity scan

### DIFF
--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -33,9 +33,8 @@ jobs:
           COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
         run: |
           export PATH="$PATH:${{env.cov_scan_path}}"
-          mkdir build
+          cmake -S ./examples/cmake_example/ -B build
           cd build
-          cmake ../examples/cmake_example/
           cov-build --dir cov-int make -j
           tar czvf gcc_freertos_kerenl_sample_build.tgz cov-int
           COV_SCAN_UPLOAD_STATUS=$(curl --form token=${COVERITY_TOKEN} \

--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -42,6 +42,6 @@ jobs:
             --form email=tonyjosi@amazon.com \
             --form file=@gcc_freertos_kerenl_sample_build.tgz \
             --form version="Mainline" \
-            --form description="GCC Posix Demo" \
+            --form description="FreeRTOS Kernel Nightly Scan" \
             https://scan.coverity.com/builds?project=FreeRTOS-Kernel)
           echo "${COV_SCAN_UPLOAD_STATUS}" | grep -q -e 'Build successfully submitted' || echo >&2 "Error submitting build for analysis: ${COV_SCAN_UPLOAD_STATUS}"

--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -1,0 +1,47 @@
+name: FreeRTOS-Kernel Coverity Scan
+on:
+  schedule: ## Scheduled to run at 12 AM UTC.
+    - cron: '0 0 * * *'
+
+
+jobs:
+
+  Coverity-Scan:
+    name: Coverity Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+
+      - name: Install Build Essentials
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install build-essential
+
+      - name: Install Coverity Build
+        shell: bash
+        env:
+          COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        run: |
+          wget -nv -qO- https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_TOKEN}&project=FreeRTOS-Kernel" | tar -zx --one-top-level=cov_scan --strip-components 1
+          echo "cov_scan_path=$(pwd)/cov_scan/bin" >> $GITHUB_ENV
+
+      - name: Coverity Build & Upload for Scan
+        shell: bash
+        env:
+          COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        run: |
+          export PATH="$PATH:${{env.cov_scan_path}}"
+          mkdir build
+          cd build
+          cmake ../examples/cmake_example/
+          cov-build --dir cov-int make -j
+          tar czvf gcc_freertos_kerenl_sample_build.tgz cov-int
+          COV_SCAN_UPLOAD_STATUS=$(curl --form token=${COVERITY_TOKEN} \
+            --form email=tonyjosi@amazon.com \
+            --form file=@gcc_freertos_kerenl_sample_build.tgz \
+            --form version="Mainline" \
+            --form description="GCC Posix Demo" \
+            https://scan.coverity.com/builds?project=FreeRTOS-Kernel)
+          echo "${COV_SCAN_UPLOAD_STATUS}" | grep -q -e 'Build successfully submitted' || echo >&2 "Error submitting build for analysis: ${COV_SCAN_UPLOAD_STATUS}"

--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -1,7 +1,7 @@
 name: FreeRTOS-Kernel Coverity Scan
 on:
-  schedule: ## Scheduled to run at 12 AM UTC.
-    - cron: '0 0 * * *'
+  schedule: ## Scheduled to run at 1:15 AM UTC daily.
+    - cron: '15 1 * * *'
 
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CMock Unit Tests](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/workflows/unit-tests.yml/badge.svg?branch=main&event=push)](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/workflows/unit-tests.yml?query=branch%3Amain+event%3Apush+workflow%3A%22CMock+Unit+Tests%22++)
 [![codecov](https://codecov.io/gh/FreeRTOS/FreeRTOS-Kernel/badge.svg?branch=main)](https://codecov.io/gh/FreeRTOS/FreeRTOS-Kernel)
+[![Coverity Scan Status](https://scan.coverity.com/projects/freertos-kernel/badge.svg)](https://scan.coverity.com/projects/freertos-kernel)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![CMock Unit Tests](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/workflows/unit-tests.yml/badge.svg?branch=main&event=push)](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/workflows/unit-tests.yml?query=branch%3Amain+event%3Apush+workflow%3A%22CMock+Unit+Tests%22++)
 [![codecov](https://codecov.io/gh/FreeRTOS/FreeRTOS-Kernel/badge.svg?branch=main)](https://codecov.io/gh/FreeRTOS/FreeRTOS-Kernel)
-[![Coverity Scan Status](https://scan.coverity.com/projects/freertos-kernel/badge.svg)](https://scan.coverity.com/projects/freertos-kernel)
 
 ## Getting started
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds nightly coverity scan job to the FreeRTOS-Kernel which is scheduled to be run at 1:15 AM UTC daily.
Builds the minimal [cmake_example](https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/main/examples/cmake_example) project using cov_build and uploads to [coverity scan](https://scan.coverity.com/projects/freertos-kernel) for analysis.

Test Steps
-----------
Tested on fork:

- [Example run](https://github.com/tony-josi-aws/FreeRTOS-Kernel/actions/runs/6637851834/job/18032992133)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~ NA

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
