### PR TITLE
Fix MISRA C 2012 rule 8.3 error

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -8500,13 +8500,13 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
         void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                             StackType_t ** ppxIdleTaskStackBuffer,
                                             uint32_t * pulIdleTaskStackSize,
-                                            BaseType_t xCoreId )
+                                            BaseType_t xCoreID )
         {
             static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
             static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
 
-            *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
-            *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
+            *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreID ] );
+            *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreID ][ 0 ] );
             *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
         }
 


### PR DESCRIPTION

Fix MISRA C 2012 rule 8.3 error
<!--- Title -->

Description
-----------
MISRA C 2012 rule 8.3 requires all declaration of an object or function shall use the same names and type qualifiers.

In this PR.
* Use same parameter name for declaration and definition in vApplicationGetIdleTaskMemory for SMP

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
