### PR TITLE
Fix ASSERT_SIDE_EFFECT for static type size check

### DIFF
--- a/event_groups.c
+++ b/event_groups.c
@@ -92,8 +92,13 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
             /* Sanity check that the size of the structure used to declare a
              * variable of type StaticEventGroup_t equals the size of the real
              * event group structure. */
-            volatile size_t xSize = sizeof( StaticEventGroup_t );
+            size_t xSize = sizeof( StaticEventGroup_t );
             configASSERT( xSize == sizeof( EventGroup_t ) );
+
+            /* The followwing line is added for unused parameter in configASSERT.
+             * There will be compiler warning when configASSERT is defined but the
+             * parameter is not used. For example, `#define configASSERT( x )`. */
+            ( void ) xSize;
         } /*lint !e529 xSize is referenced if configASSERT() is defined. */
         #endif /* configASSERT_DEFINED */
 

--- a/event_groups.c
+++ b/event_groups.c
@@ -96,8 +96,8 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
             configASSERT( xSize == sizeof( EventGroup_t ) );
 
             /* The followwing line is added for unused parameter in configASSERT.
-             * There will be compiler warning when configASSERT is defined but the
-             * parameter is not used. For example, `#define configASSERT( x )`. */
+            * There will be compiler warning when configASSERT is defined but the
+            * parameter is not used. For example, `#define configASSERT( x )`. */
             ( void ) xSize;
         } /*lint !e529 xSize is referenced if configASSERT() is defined. */
         #endif /* configASSERT_DEFINED */

--- a/queue.c
+++ b/queue.c
@@ -397,11 +397,15 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
                 /* Sanity check that the size of the structure used to declare a
                  * variable of type StaticQueue_t or StaticSemaphore_t equals the size of
                  * the real queue and semaphore structures. */
-                volatile size_t xSize = sizeof( StaticQueue_t );
+                size_t xSize = sizeof( StaticQueue_t );
 
                 /* This assertion cannot be branch covered in unit tests */
                 configASSERT( xSize == sizeof( Queue_t ) ); /* LCOV_EXCL_BR_LINE */
-                ( void ) xSize;                             /* Keeps lint quiet when configASSERT() is not defined. */
+
+                /* The followwing line is added for unused parameter in configASSERT.
+                * There will be compiler warning when configASSERT is defined but the
+                * parameter is not used. For example, `#define configASSERT( x )`. */
+                ( void ) xSize;
             }
             #endif /* configASSERT_DEFINED */
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -445,8 +445,13 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             /* Sanity check that the size of the structure used to declare a
              * variable of type StaticStreamBuffer_t equals the size of the real
              * message buffer structure. */
-            volatile size_t xSize = sizeof( StaticStreamBuffer_t );
+            size_t xSize = sizeof( StaticStreamBuffer_t );
             configASSERT( xSize == sizeof( StreamBuffer_t ) );
+
+            /* The followwing line is added for unused parameter in configASSERT.
+             * There will be compiler warning when configASSERT is defined but the
+             * parameter is not used. For example, `#define configASSERT( x )`. */
+            ( void ) xSize;
         } /*lint !e529 xSize is referenced is configASSERT() is defined. */
         #endif /* configASSERT_DEFINED */
 

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -449,8 +449,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             configASSERT( xSize == sizeof( StreamBuffer_t ) );
 
             /* The followwing line is added for unused parameter in configASSERT.
-             * There will be compiler warning when configASSERT is defined but the
-             * parameter is not used. For example, `#define configASSERT( x )`. */
+            * There will be compiler warning when configASSERT is defined but the
+            * parameter is not used. For example, `#define configASSERT( x )`. */
             ( void ) xSize;
         } /*lint !e529 xSize is referenced is configASSERT() is defined. */
         #endif /* configASSERT_DEFINED */

--- a/tasks.c
+++ b/tasks.c
@@ -1261,9 +1261,13 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             /* Sanity check that the size of the structure used to declare a
              * variable of type StaticTask_t equals the size of the real task
              * structure. */
-            volatile size_t xSize = sizeof( StaticTask_t );
+            size_t xSize = sizeof( StaticTask_t );
             configASSERT( xSize == sizeof( TCB_t ) );
-            ( void ) xSize; /* Prevent lint warning when configASSERT() is not used. */
+
+            /* The followwing line is added for unused parameter in configASSERT.
+             * There will be compiler warning when configASSERT is defined but the
+             * parameter is not used. For example, `#define configASSERT( x )`. */
+            ( void ) xSize;
         }
         #endif /* configASSERT_DEFINED */
 

--- a/tasks.c
+++ b/tasks.c
@@ -1265,8 +1265,8 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             configASSERT( xSize == sizeof( TCB_t ) );
 
             /* The followwing line is added for unused parameter in configASSERT.
-             * There will be compiler warning when configASSERT is defined but the
-             * parameter is not used. For example, `#define configASSERT( x )`. */
+            * There will be compiler warning when configASSERT is defined but the
+            * parameter is not used. For example, `#define configASSERT( x )`. */
             ( void ) xSize;
         }
         #endif /* configASSERT_DEFINED */

--- a/timers.c
+++ b/timers.c
@@ -386,9 +386,13 @@
                 /* Sanity check that the size of the structure used to declare a
                  * variable of type StaticTimer_t equals the size of the real timer
                  * structure. */
-                volatile size_t xSize = sizeof( StaticTimer_t );
+                size_t xSize = sizeof( StaticTimer_t );
                 configASSERT( xSize == sizeof( Timer_t ) );
-                ( void ) xSize; /* Keeps lint quiet when configASSERT() is not defined. */
+
+                /* The followwing line is added for unused parameter in configASSERT.
+                * There will be compiler warning when configASSERT is defined but the
+                * parameter is not used. For example, `#define configASSERT( x )`. */
+                ( void ) xSize;
             }
             #endif /* configASSERT_DEFINED */
 


### PR DESCRIPTION
Fix ASSERT side effect for volatile variable

Description
-----------
Using volatile variable in assertion could result in different behavior in non-debug mode. Unused variable warning should also be considered when using assertion to check the size of static type.

In this PR:
* Remove the volatile prefix to prevent assert side effect.
* Add `( void ) xSize;` statement for unused parameter in configASSERT.

Test Steps
-----------
* Using GCC compiler with `-wunused-variable`. Define configASSERT with the following should have no error.
```
#define configASSERT( x )
```

* Assertion when static type has different size.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
