### PR TITLE
Fix misra C rule 10.4 an rule 11.9 deviations in configASSERT

### DIFF
--- a/event_groups.c
+++ b/event_groups.c
@@ -85,7 +85,7 @@ static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
         traceENTER_xEventGroupCreateStatic( pxEventGroupBuffer );
 
         /* A StaticEventGroup_t object must be provided. */
-        configASSERT( pxEventGroupBuffer );
+        configASSERT( pxEventGroupBuffer != NULL );
 
         #if ( configASSERT_DEFINED == 1 )
         {
@@ -326,7 +326,7 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
 
     /* Check the user is not attempting to wait on the bits used by the kernel
      * itself, and that at least one bit is being requested. */
-    configASSERT( xEventGroup );
+    configASSERT( xEventGroup != NULL );
     configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0U );
     configASSERT( uxBitsToWaitFor != 0U );
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
@@ -481,7 +481,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
 
     /* Check the user is not attempting to clear the bits used by the kernel
      * itself. */
-    configASSERT( xEventGroup );
+    configASSERT( xEventGroup != NULL );
     configASSERT( ( uxBitsToClear & eventEVENT_BITS_CONTROL_BYTES ) == 0U );
 
     taskENTER_CRITICAL();
@@ -558,7 +558,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
 
     /* Check the user is not attempting to set the bits used by the kernel
      * itself. */
-    configASSERT( xEventGroup );
+    configASSERT( xEventGroup != NULL );
     configASSERT( ( uxBitsToSet & eventEVENT_BITS_CONTROL_BYTES ) == 0U );
 
     pxList = &( pxEventBits->xTasksWaitingForBits );
@@ -650,7 +650,7 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 
     traceENTER_vEventGroupDelete( xEventGroup );
 
-    configASSERT( pxEventBits );
+    configASSERT( pxEventBits != NULL );
 
     pxTasksWaitingForBits = &( pxEventBits->xTasksWaitingForBits );
 
@@ -702,8 +702,8 @@ void vEventGroupDelete( EventGroupHandle_t xEventGroup )
 
         traceENTER_xEventGroupGetStaticBuffer( xEventGroup, ppxEventGroupBuffer );
 
-        configASSERT( pxEventBits );
-        configASSERT( ppxEventGroupBuffer );
+        configASSERT( pxEventBits != NULL );
+        configASSERT( ppxEventGroupBuffer != NULL );
 
         #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
         {

--- a/event_groups.c
+++ b/event_groups.c
@@ -196,11 +196,11 @@ EventBits_t xEventGroupSync( EventGroupHandle_t xEventGroup,
 
     traceENTER_xEventGroupSync( xEventGroup, uxBitsToSet, uxBitsToWaitFor, xTicksToWait );
 
-    configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
-    configASSERT( uxBitsToWaitFor != 0 );
+    configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0U );
+    configASSERT( uxBitsToWaitFor != 0U );
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
     {
-        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0 ) ) );
+        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0U ) ) );
     }
     #endif
 
@@ -327,11 +327,11 @@ EventBits_t xEventGroupWaitBits( EventGroupHandle_t xEventGroup,
     /* Check the user is not attempting to wait on the bits used by the kernel
      * itself, and that at least one bit is being requested. */
     configASSERT( xEventGroup );
-    configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
-    configASSERT( uxBitsToWaitFor != 0 );
+    configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0U );
+    configASSERT( uxBitsToWaitFor != 0U );
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
     {
-        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0 ) ) );
+        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0U ) ) );
     }
     #endif
 
@@ -482,7 +482,7 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
     /* Check the user is not attempting to clear the bits used by the kernel
      * itself. */
     configASSERT( xEventGroup );
-    configASSERT( ( uxBitsToClear & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
+    configASSERT( ( uxBitsToClear & eventEVENT_BITS_CONTROL_BYTES ) == 0U );
 
     taskENTER_CRITICAL();
     {
@@ -559,7 +559,7 @@ EventBits_t xEventGroupSetBits( EventGroupHandle_t xEventGroup,
     /* Check the user is not attempting to set the bits used by the kernel
      * itself. */
     configASSERT( xEventGroup );
-    configASSERT( ( uxBitsToSet & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
+    configASSERT( ( uxBitsToSet & eventEVENT_BITS_CONTROL_BYTES ) == 0U );
 
     pxList = &( pxEventBits->xTasksWaitingForBits );
     pxListEnd = listGET_END_MARKER( pxList ); /*lint !e826 !e740 !e9087 The mini list structure is used as the list end to save RAM.  This is checked and valid. */

--- a/queue.c
+++ b/queue.c
@@ -305,7 +305,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
     traceENTER_xQueueGenericReset( xQueue, xNewQueue );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
 
     if( ( pxQueue != NULL ) &&
         ( pxQueue->uxLength >= 1U ) &&
@@ -382,7 +382,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
         /* The StaticQueue_t structure and the queue storage area must be
          * supplied. */
-        configASSERT( pxStaticQueue );
+        configASSERT( pxStaticQueue != NULL );
 
         if( ( uxQueueLength > ( UBaseType_t ) 0 ) &&
             ( pxStaticQueue != NULL ) &&
@@ -423,7 +423,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         }
         else
         {
-            configASSERT( pxNewQueue );
+            configASSERT( pxNewQueue != NULL );
             mtCOVERAGE_TEST_MARKER();
         }
 
@@ -446,8 +446,8 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
         traceENTER_xQueueGenericGetStaticBuffers( xQueue, ppucQueueStorage, ppxStaticQueue );
 
-        configASSERT( pxQueue );
-        configASSERT( ppxStaticQueue );
+        configASSERT( pxQueue != NULL );
+        configASSERT( ppxStaticQueue != NULL );
 
         #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
         {
@@ -548,7 +548,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         }
         else
         {
-            configASSERT( pxNewQueue );
+            configASSERT( pxNewQueue != NULL );
             mtCOVERAGE_TEST_MARKER();
         }
 
@@ -690,7 +690,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
 
         traceENTER_xQueueGetMutexHolder( xSemaphore );
 
-        configASSERT( xSemaphore );
+        configASSERT( xSemaphore != NULL );
 
         /* This function is called by xSemaphoreGetMutexHolder(), and should not
          * be called directly.  Note:  This is a good way of determining if the
@@ -726,7 +726,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
 
         traceENTER_xQueueGetMutexHolderFromISR( xSemaphore );
 
-        configASSERT( xSemaphore );
+        configASSERT( xSemaphore != NULL );
 
         /* Mutexes cannot be used in interrupt service routines, so the mutex
          * holder should not change in an ISR, and therefore a critical section is
@@ -757,7 +757,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
 
         traceENTER_xQueueGiveMutexRecursive( xMutex );
 
-        configASSERT( pxMutex );
+        configASSERT( pxMutex != NULL );
 
         /* If this is the task that holds the mutex then xMutexHolder will not
          * change outside of this task.  If this task does not hold the mutex then
@@ -817,7 +817,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
 
         traceENTER_xQueueTakeMutexRecursive( xMutex, xTicksToWait );
 
-        configASSERT( pxMutex );
+        configASSERT( pxMutex != NULL );
 
         /* Comments regarding mutual exclusion as per those within
          * xQueueGiveMutexRecursive(). */
@@ -882,7 +882,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
         else
         {
-            configASSERT( xHandle );
+            configASSERT( xHandle != NULL );
             mtCOVERAGE_TEST_MARKER();
         }
 
@@ -921,7 +921,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         }
         else
         {
-            configASSERT( xHandle );
+            configASSERT( xHandle != NULL );
             mtCOVERAGE_TEST_MARKER();
         }
 
@@ -944,7 +944,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
 
     traceENTER_xQueueGenericSend( xQueue, pvItemToQueue, xTicksToWait, xCopyPosition );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
     configASSERT( !( ( xCopyPosition == queueOVERWRITE ) && ( pxQueue->uxLength != 1U ) ) );
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
@@ -1165,7 +1165,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
 
     traceENTER_xQueueGenericSendFromISR( xQueue, pvItemToQueue, pxHigherPriorityTaskWoken, xCopyPosition );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
     configASSERT( !( ( xCopyPosition == queueOVERWRITE ) && ( pxQueue->uxLength != 1U ) ) );
 
@@ -1338,7 +1338,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
      * not (i.e. has a task with a higher priority than us been woken by this
      * post). */
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
 
     /* xQueueGenericSendFromISR() should be used instead of xQueueGiveFromISR()
      * if the item size is not 0. */
@@ -1504,7 +1504,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
     traceENTER_xQueueReceive( xQueue, pvBuffer, xTicksToWait );
 
     /* Check the pointer is not NULL. */
-    configASSERT( ( pxQueue ) );
+    configASSERT( pxQueue != NULL );
 
     /* The buffer into which data is received can only be NULL if the data size
      * is zero (so no data is copied into the buffer). */
@@ -1660,7 +1660,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
     traceENTER_xQueueSemaphoreTake( xQueue, xTicksToWait );
 
     /* Check the queue pointer is not NULL. */
-    configASSERT( ( pxQueue ) );
+    configASSERT( pxQueue != NULL );
 
     /* Check this really is a semaphore, in which case the item size will be
      * 0. */
@@ -1878,7 +1878,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
     traceENTER_xQueuePeek( xQueue, pvBuffer, xTicksToWait );
 
     /* Check the pointer is not NULL. */
-    configASSERT( ( pxQueue ) );
+    configASSERT( pxQueue != NULL );
 
     /* The buffer into which data is received can only be NULL if the data size
      * is zero (so no data is copied into the buffer. */
@@ -2037,7 +2037,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
 
     traceENTER_xQueueReceiveFromISR( xQueue, pvBuffer, pxHigherPriorityTaskWoken );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
     configASSERT( !( ( pvBuffer == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
 
     /* RTOS ports that support interrupt nesting have the concept of a maximum
@@ -2134,7 +2134,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
 
     traceENTER_xQueuePeekFromISR( xQueue, pvBuffer );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
     configASSERT( !( ( pvBuffer == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
     configASSERT( pxQueue->uxItemSize != 0U ); /* Can't peek a semaphore. */
 
@@ -2189,7 +2189,7 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
 
     traceENTER_uxQueueMessagesWaiting( xQueue );
 
-    configASSERT( xQueue );
+    configASSERT( xQueue != NULL );
 
     taskENTER_CRITICAL();
     {
@@ -2210,7 +2210,7 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
 
     traceENTER_uxQueueSpacesAvailable( xQueue );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
 
     taskENTER_CRITICAL();
     {
@@ -2231,7 +2231,7 @@ UBaseType_t uxQueueMessagesWaitingFromISR( const QueueHandle_t xQueue )
 
     traceENTER_uxQueueMessagesWaitingFromISR( xQueue );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
     uxReturn = pxQueue->uxMessagesWaiting;
 
     traceRETURN_uxQueueMessagesWaitingFromISR( uxReturn );
@@ -2246,7 +2246,7 @@ void vQueueDelete( QueueHandle_t xQueue )
 
     traceENTER_vQueueDelete( xQueue );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
     traceQUEUE_DELETE( pxQueue );
 
     #if ( configQUEUE_REGISTRY_SIZE > 0 )
@@ -2628,7 +2628,7 @@ BaseType_t xQueueIsQueueEmptyFromISR( const QueueHandle_t xQueue )
 
     traceENTER_xQueueIsQueueEmptyFromISR( xQueue );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
 
     if( pxQueue->uxMessagesWaiting == ( UBaseType_t ) 0 )
     {
@@ -2673,7 +2673,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
     traceENTER_xQueueIsQueueFullFromISR( xQueue );
 
-    configASSERT( pxQueue );
+    configASSERT( pxQueue != NULL );
 
     if( pxQueue->uxMessagesWaiting == pxQueue->uxLength )
     {
@@ -3003,7 +3003,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
         traceENTER_vQueueAddToRegistry( xQueue, pcQueueName );
 
-        configASSERT( xQueue );
+        configASSERT( xQueue != NULL );
 
         if( pcQueueName != NULL )
         {
@@ -3053,7 +3053,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
         traceENTER_pcQueueGetName( xQueue );
 
-        configASSERT( xQueue );
+        configASSERT( xQueue != NULL );
 
         /* Note there is nothing here to protect against another task adding or
          * removing entries from the registry while it is being searched. */
@@ -3087,7 +3087,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
         traceENTER_vQueueUnregisterQueue( xQueue );
 
-        configASSERT( xQueue );
+        configASSERT( xQueue != NULL );
 
         /* See if the handle of the queue being unregistered in actually in the
          * registry. */
@@ -3306,7 +3306,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         /* The following line is not reachable in unit tests because every call
          * to prvNotifyQueueSetContainer is preceded by a check that
          * pxQueueSetContainer != NULL */
-        configASSERT( pxQueueSetContainer ); /* LCOV_EXCL_BR_LINE */
+        configASSERT( pxQueueSetContainer != NULL ); /* LCOV_EXCL_BR_LINE */
         configASSERT( pxQueueSetContainer->uxMessagesWaiting < pxQueueSetContainer->uxLength );
 
         if( pxQueueSetContainer->uxMessagesWaiting < pxQueueSetContainer->uxLength )

--- a/queue.c
+++ b/queue.c
@@ -946,10 +946,10 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
-    configASSERT( !( ( xCopyPosition == queueOVERWRITE ) && ( pxQueue->uxLength != 1 ) ) );
+    configASSERT( !( ( xCopyPosition == queueOVERWRITE ) && ( pxQueue->uxLength != 1U ) ) );
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
     {
-        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0 ) ) );
+        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0U ) ) );
     }
     #endif
 
@@ -1167,7 +1167,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvItemToQueue == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
-    configASSERT( !( ( xCopyPosition == queueOVERWRITE ) && ( pxQueue->uxLength != 1 ) ) );
+    configASSERT( !( ( xCopyPosition == queueOVERWRITE ) && ( pxQueue->uxLength != 1U ) ) );
 
     /* RTOS ports that support interrupt nesting have the concept of a maximum
      * system call (or maximum API call) interrupt priority.  Interrupts that are
@@ -1342,7 +1342,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
 
     /* xQueueGenericSendFromISR() should be used instead of xQueueGiveFromISR()
      * if the item size is not 0. */
-    configASSERT( pxQueue->uxItemSize == 0 );
+    configASSERT( pxQueue->uxItemSize == 0U );
 
     /* Normally a mutex would not be given from an interrupt, especially if
      * there is a mutex holder, as priority inheritance makes no sense for an
@@ -1513,7 +1513,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
     /* Cannot block if the scheduler is suspended. */
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
     {
-        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0 ) ) );
+        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0U ) ) );
     }
     #endif
 
@@ -1664,12 +1664,12 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
 
     /* Check this really is a semaphore, in which case the item size will be
      * 0. */
-    configASSERT( pxQueue->uxItemSize == 0 );
+    configASSERT( pxQueue->uxItemSize == 0U );
 
     /* Cannot block if the scheduler is suspended. */
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
     {
-        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0 ) ) );
+        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0U ) ) );
     }
     #endif
 
@@ -1887,7 +1887,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
     /* Cannot block if the scheduler is suspended. */
     #if ( ( INCLUDE_xTaskGetSchedulerState == 1 ) || ( configUSE_TIMERS == 1 ) )
     {
-        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0 ) ) );
+        configASSERT( !( ( xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED ) && ( xTicksToWait != 0U ) ) );
     }
     #endif
 
@@ -2136,7 +2136,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
 
     configASSERT( pxQueue );
     configASSERT( !( ( pvBuffer == NULL ) && ( pxQueue->uxItemSize != ( UBaseType_t ) 0U ) ) );
-    configASSERT( pxQueue->uxItemSize != 0 ); /* Can't peek a semaphore. */
+    configASSERT( pxQueue->uxItemSize != 0U ); /* Can't peek a semaphore. */
 
     /* RTOS ports that support interrupt nesting have the concept of a maximum
      * system call (or maximum API call) interrupt priority.  Interrupts that are

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -412,8 +412,8 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
         traceENTER_xStreamBufferGenericCreateStatic( xBufferSizeBytes, xTriggerLevelBytes, xIsMessageBuffer, pucStreamBufferStorageArea, pxStaticStreamBuffer, pxSendCompletedCallback, pxReceiveCompletedCallback );
 
-        configASSERT( pucStreamBufferStorageArea );
-        configASSERT( pxStaticStreamBuffer );
+        configASSERT( pucStreamBufferStorageArea != NULL );
+        configASSERT( pxStaticStreamBuffer != NULL );
         configASSERT( xTriggerLevelBytes <= xBufferSizeBytes );
 
         /* A trigger level of 0 would cause a waiting task to unblock even when
@@ -491,9 +491,9 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
         traceENTER_xStreamBufferGetStaticBuffers( xStreamBuffer, ppucStreamBufferStorageArea, ppxStaticStreamBuffer );
 
-        configASSERT( pxStreamBuffer );
-        configASSERT( ppucStreamBufferStorageArea );
-        configASSERT( ppxStaticStreamBuffer );
+        configASSERT( pxStreamBuffer != NULL );
+        configASSERT( ppucStreamBufferStorageArea != NULL );
+        configASSERT( ppxStaticStreamBuffer != NULL );
 
         if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_STATICALLY_ALLOCATED ) != ( uint8_t ) 0 )
         {
@@ -519,7 +519,7 @@ void vStreamBufferDelete( StreamBufferHandle_t xStreamBuffer )
 
     traceENTER_vStreamBufferDelete( xStreamBuffer );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     traceSTREAM_BUFFER_DELETE( xStreamBuffer );
 
@@ -562,7 +562,7 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
 
     traceENTER_xStreamBufferReset( xStreamBuffer );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     #if ( configUSE_TRACE_FACILITY == 1 )
     {
@@ -619,7 +619,7 @@ BaseType_t xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
 
     traceENTER_xStreamBufferSetTriggerLevel( xStreamBuffer, xTriggerLevel );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* It is not valid for the trigger level to be 0. */
     if( xTriggerLevel == ( size_t ) 0 )
@@ -653,7 +653,7 @@ size_t xStreamBufferSpacesAvailable( StreamBufferHandle_t xStreamBuffer )
 
     traceENTER_xStreamBufferSpacesAvailable( xStreamBuffer );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* The code below reads xTail and then xHead.  This is safe if the stream
      * buffer is updated once between the two reads - but not if the stream buffer
@@ -689,7 +689,7 @@ size_t xStreamBufferBytesAvailable( StreamBufferHandle_t xStreamBuffer )
 
     traceENTER_xStreamBufferBytesAvailable( xStreamBuffer );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     xReturn = prvBytesInBuffer( pxStreamBuffer );
 
@@ -712,8 +712,8 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
 
     traceENTER_xStreamBufferSend( xStreamBuffer, pvTxData, xDataLengthBytes, xTicksToWait );
 
-    configASSERT( pvTxData );
-    configASSERT( pxStreamBuffer );
+    configASSERT( pvTxData != NULL );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* The maximum amount of space a stream buffer will ever report is its length
      * minus 1. */
@@ -845,8 +845,8 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
 
     traceENTER_xStreamBufferSendFromISR( xStreamBuffer, pvTxData, xDataLengthBytes, pxHigherPriorityTaskWoken );
 
-    configASSERT( pvTxData );
-    configASSERT( pxStreamBuffer );
+    configASSERT( pvTxData != NULL );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* This send function is used to write to both message buffers and stream
      * buffers.  If this is a message buffer then the space needed must be
@@ -948,8 +948,8 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
 
     traceENTER_xStreamBufferReceive( xStreamBuffer, pvRxData, xBufferLengthBytes, xTicksToWait );
 
-    configASSERT( pvRxData );
-    configASSERT( pxStreamBuffer );
+    configASSERT( pvRxData != NULL );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* This receive function is used by both message buffers, which store
      * discrete messages, and stream buffers, which store a continuous stream of
@@ -1054,7 +1054,7 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
 
     traceENTER_xStreamBufferNextMessageLengthBytes( xStreamBuffer );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* Ensure the stream buffer is being used as a message buffer. */
     if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_MESSAGE_BUFFER ) != ( uint8_t ) 0 )
@@ -1100,8 +1100,8 @@ size_t xStreamBufferReceiveFromISR( StreamBufferHandle_t xStreamBuffer,
 
     traceENTER_xStreamBufferReceiveFromISR( xStreamBuffer, pvRxData, xBufferLengthBytes, pxHigherPriorityTaskWoken );
 
-    configASSERT( pvRxData );
-    configASSERT( pxStreamBuffer );
+    configASSERT( pvRxData != NULL );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* This receive function is used by both message buffers, which store
      * discrete messages, and stream buffers, which store a continuous stream of
@@ -1210,7 +1210,7 @@ BaseType_t xStreamBufferIsEmpty( StreamBufferHandle_t xStreamBuffer )
 
     traceENTER_xStreamBufferIsEmpty( xStreamBuffer );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* True if no bytes are available. */
     xTail = pxStreamBuffer->xTail;
@@ -1238,7 +1238,7 @@ BaseType_t xStreamBufferIsFull( StreamBufferHandle_t xStreamBuffer )
 
     traceENTER_xStreamBufferIsFull( xStreamBuffer );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     /* This generic version of the receive function is used by both message
      * buffers, which store discrete messages, and stream buffers, which store a
@@ -1278,7 +1278,7 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
 
     traceENTER_xStreamBufferSendCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
     {
@@ -1313,7 +1313,7 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
 
     traceENTER_xStreamBufferReceiveCompletedFromISR( xStreamBuffer, pxHigherPriorityTaskWoken );
 
-    configASSERT( pxStreamBuffer );
+    configASSERT( pxStreamBuffer != NULL );
 
     uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
     {

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -342,7 +342,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         {
             /* Not a message buffer and not statically allocated. */
             ucFlags = 0;
-            configASSERT( xBufferSizeBytes > 0 );
+            configASSERT( xBufferSizeBytes > 0U );
         }
 
         configASSERT( xTriggerLevelBytes <= xBufferSizeBytes );
@@ -1075,7 +1075,7 @@ size_t xStreamBufferNextMessageLengthBytes( StreamBufferHandle_t xStreamBuffer )
              * ( sbBYTES_TO_STORE_MESSAGE_LENGTH + 1 ), so if xBytesAvailable is
              * less than sbBYTES_TO_STORE_MESSAGE_LENGTH the only other valid
              * value is 0. */
-            configASSERT( xBytesAvailable == 0 );
+            configASSERT( xBytesAvailable == 0U );
             xReturn = 0;
         }
     }

--- a/tasks.c
+++ b/tasks.c
@@ -176,7 +176,7 @@
         /* Find the highest priority queue that contains ready tasks. */      \
         while( listLIST_IS_EMPTY( &( pxReadyTasksLists[ uxTopPriority ] ) ) ) \
         {                                                                     \
-            configASSERT( uxTopPriority );                                    \
+            configASSERT( uxTopPriority > 0U );                               \
             --uxTopPriority;                                                  \
         }                                                                     \
                                                                               \
@@ -2334,7 +2334,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_xTaskDelayUntil( pxPreviousWakeTime, xTimeIncrement );
 
-        configASSERT( pxPreviousWakeTime );
+        configASSERT( pxPreviousWakeTime != NULL );
         configASSERT( ( xTimeIncrement > 0U ) );
 
         vTaskSuspendAll();
@@ -2479,7 +2479,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_eTaskGetState( xTask );
 
-        configASSERT( pxTCB );
+        configASSERT( pxTCB != NULL );
 
         #if ( configNUMBER_OF_CORES == 1 )
             if( pxTCB == pxCurrentTCB )
@@ -3275,7 +3275,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
          * section. */
 
         /* It does not make sense to check if the calling task is suspended. */
-        configASSERT( xTask );
+        configASSERT( xTask != NULL );
 
         /* Is the task being resumed actually in the suspended list? */
         if( listIS_CONTAINED_WITHIN( &xSuspendedTaskList, &( pxTCB->xStateListItem ) ) != pdFALSE )
@@ -3319,7 +3319,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         traceENTER_vTaskResume( xTaskToResume );
 
         /* It does not make sense to resume the calling task. */
-        configASSERT( xTaskToResume );
+        configASSERT( xTaskToResume != NULL );
 
         #if ( configNUMBER_OF_CORES == 1 )
 
@@ -3381,7 +3381,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_xTaskResumeFromISR( xTaskToResume );
 
-        configASSERT( xTaskToResume );
+        configASSERT( xTaskToResume != NULL );
 
         /* RTOS ports that support interrupt nesting have the concept of a
          * maximum  system call (or maximum API call) interrupt priority.
@@ -4085,7 +4085,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) /*lint !e971 Unqualified char 
     /* If null is passed in here then the name of the calling task is being
      * queried. */
     pxTCB = prvGetTCBFromHandle( xTaskToQuery );
-    configASSERT( pxTCB );
+    configASSERT( pxTCB != NULL );
 
     traceRETURN_pcTaskGetName( &( pxTCB->pcTaskName[ 0 ] ) );
 
@@ -4550,7 +4550,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
 
         traceENTER_xTaskAbortDelay( xTask );
 
-        configASSERT( pxTCB );
+        configASSERT( pxTCB != NULL );
 
         vTaskSuspendAll();
         {
@@ -5196,7 +5196,7 @@ void vTaskPlaceOnEventList( List_t * const pxEventList,
 {
     traceENTER_vTaskPlaceOnEventList( pxEventList, xTicksToWait );
 
-    configASSERT( pxEventList );
+    configASSERT( pxEventList != NULL );
 
     /* THIS FUNCTION MUST BE CALLED WITH THE
      * SCHEDULER SUSPENDED AND THE QUEUE BEING ACCESSED LOCKED. */
@@ -5226,7 +5226,7 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 {
     traceENTER_vTaskPlaceOnUnorderedEventList( pxEventList, xItemValue, xTicksToWait );
 
-    configASSERT( pxEventList );
+    configASSERT( pxEventList != NULL );
 
     /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
      * the event groups implementation. */
@@ -5258,7 +5258,7 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
     {
         traceENTER_vTaskPlaceOnEventListRestricted( pxEventList, xTicksToWait, xWaitIndefinitely );
 
-        configASSERT( pxEventList );
+        configASSERT( pxEventList != NULL );
 
         /* This function should not be called by application code hence the
          * 'Restricted' in its name.  It is not part of the public API.  It is
@@ -5310,7 +5310,7 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
      * This function assumes that a check has already been made to ensure that
      * pxEventList is not empty. */
     pxUnblockedTCB = listGET_OWNER_OF_HEAD_ENTRY( pxEventList ); /*lint !e9079 void * is used as this macro is used with timers and co-routines too.  Alignment is known to be fine as the type of the pointer stored and retrieved is the same. */
-    configASSERT( pxUnblockedTCB );
+    configASSERT( pxUnblockedTCB != NULL );
     listREMOVE_ITEM( &( pxUnblockedTCB->xEventListItem ) );
 
     if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
@@ -5396,7 +5396,7 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
     /* Remove the event list form the event flag.  Interrupts do not access
      * event flags. */
     pxUnblockedTCB = listGET_LIST_ITEM_OWNER( pxEventListItem ); /*lint !e9079 void * is used as this macro is used with timers and co-routines too.  Alignment is known to be fine as the type of the pointer stored and retrieved is the same. */
-    configASSERT( pxUnblockedTCB );
+    configASSERT( pxUnblockedTCB != NULL );
     listREMOVE_ITEM( pxEventListItem );
 
     #if ( configUSE_TICKLESS_IDLE != 0 )
@@ -5452,7 +5452,7 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
 {
     traceENTER_vTaskSetTimeOutState( pxTimeOut );
 
-    configASSERT( pxTimeOut );
+    configASSERT( pxTimeOut != NULL );
     taskENTER_CRITICAL();
     {
         pxTimeOut->xOverflowCount = xNumOfOverflows;
@@ -5483,8 +5483,8 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
 
     traceENTER_xTaskCheckForTimeOut( pxTimeOut, pxTicksToWait );
 
-    configASSERT( pxTimeOut );
-    configASSERT( pxTicksToWait );
+    configASSERT( pxTimeOut != NULL );
+    configASSERT( pxTicksToWait != NULL );
 
     taskENTER_CRITICAL();
     {
@@ -7750,7 +7750,7 @@ TickType_t uxTaskResetEventItemValue( void )
         traceENTER_xTaskGenericNotify( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue );
 
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
-        configASSERT( xTaskToNotify );
+        configASSERT( xTaskToNotify != NULL );
         pxTCB = xTaskToNotify;
 
         taskENTER_CRITICAL();
@@ -7871,7 +7871,7 @@ TickType_t uxTaskResetEventItemValue( void )
 
         traceENTER_xTaskGenericNotifyFromISR( xTaskToNotify, uxIndexToNotify, ulValue, eAction, pulPreviousNotificationValue, pxHigherPriorityTaskWoken );
 
-        configASSERT( xTaskToNotify );
+        configASSERT( xTaskToNotify != NULL );
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
         /* RTOS ports that support interrupt nesting have the concept of a
@@ -8030,7 +8030,7 @@ TickType_t uxTaskResetEventItemValue( void )
 
         traceENTER_vTaskGenericNotifyGiveFromISR( xTaskToNotify, uxIndexToNotify, pxHigherPriorityTaskWoken );
 
-        configASSERT( xTaskToNotify );
+        configASSERT( xTaskToNotify != NULL );
         configASSERT( uxIndexToNotify < configTASK_NOTIFICATION_ARRAY_ENTRIES );
 
         /* RTOS ports that support interrupt nesting have the concept of a

--- a/tasks.c
+++ b/tasks.c
@@ -876,7 +876,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         configASSERT( portGET_CRITICAL_NESTING_COUNT() > 0U );
 
         #if ( configRUN_MULTIPLE_PRIORITIES == 0 )
-
             /* No task should yield for this one if it is a lower priority
              * than priority level of currently ready tasks. */
             if( pxTCB->uxPriority >= uxTopReadyPriority )
@@ -3322,12 +3321,10 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         configASSERT( xTaskToResume != NULL );
 
         #if ( configNUMBER_OF_CORES == 1 )
-
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. */
             if( ( pxTCB != pxCurrentTCB ) && ( pxTCB != NULL ) )
         #else
-
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. It is also impossible to resume a task
              * that is actively running on another core but it is not safe

--- a/timers.c
+++ b/timers.c
@@ -422,7 +422,7 @@
                                        Timer_t * pxNewTimer )
     {
         /* 0 is not a valid value for xTimerPeriodInTicks. */
-        configASSERT( ( xTimerPeriodInTicks > 0 ) );
+        configASSERT( ( xTimerPeriodInTicks > 0U ) );
 
         /* Ensure the infrastructure used by the timer service task has been
          * created/initialised. */
@@ -1031,7 +1031,7 @@
                     case tmrCOMMAND_CHANGE_PERIOD_FROM_ISR:
                         pxTimer->ucStatus |= ( uint8_t ) tmrSTATUS_IS_ACTIVE;
                         pxTimer->xTimerPeriodInTicks = xMessage.u.xTimerParameters.xMessageValue;
-                        configASSERT( ( pxTimer->xTimerPeriodInTicks > 0 ) );
+                        configASSERT( ( pxTimer->xTimerPeriodInTicks > 0U ) );
 
                         /* The new period does not really have a reference, and can
                          * be longer or shorter than the old one.  The command time is

--- a/timers.c
+++ b/timers.c
@@ -329,7 +329,7 @@
             mtCOVERAGE_TEST_MARKER();
         }
 
-        configASSERT( xReturn );
+        configASSERT( xReturn == pdTRUE );
 
         traceRETURN_xTimerCreateTimerTask( xReturn );
 
@@ -393,7 +393,7 @@
             #endif /* configASSERT_DEFINED */
 
             /* A pointer to a StaticTimer_t structure MUST be provided, use it. */
-            configASSERT( pxTimerBuffer );
+            configASSERT( pxTimerBuffer != NULL );
             pxNewTimer = ( Timer_t * ) pxTimerBuffer; /*lint !e740 !e9087 StaticTimer_t is a pointer to a Timer_t, so guaranteed to be aligned and sized correctly (checked by an assert()), so this is safe. */
 
             if( pxNewTimer != NULL )
@@ -458,7 +458,7 @@
 
         traceENTER_xTimerGenericCommandFromTask( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
 
         /* Send a message to the timer service task to perform a particular action
          * on a particular timer definition. */
@@ -509,7 +509,7 @@
 
         traceENTER_xTimerGenericCommandFromISR( xTimer, xCommandID, xOptionalValue, pxHigherPriorityTaskWoken, xTicksToWait );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
 
         /* Send a message to the timer service task to perform a particular action
          * on a particular timer definition. */
@@ -560,7 +560,7 @@
 
         traceENTER_xTimerGetPeriod( xTimer );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
 
         traceRETURN_xTimerGetPeriod( pxTimer->xTimerPeriodInTicks );
 
@@ -575,7 +575,7 @@
 
         traceENTER_vTimerSetReloadMode( xTimer, xAutoReload );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
         taskENTER_CRITICAL();
         {
             if( xAutoReload != pdFALSE )
@@ -600,7 +600,7 @@
 
         traceENTER_xTimerGetReloadMode( xTimer );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
         taskENTER_CRITICAL();
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_AUTORELOAD ) == 0 )
@@ -642,7 +642,7 @@
 
         traceENTER_xTimerGetExpiryTime( xTimer );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
         xReturn = listGET_LIST_ITEM_VALUE( &( pxTimer->xTimerListItem ) );
 
         traceRETURN_xTimerGetExpiryTime( xReturn );
@@ -685,7 +685,7 @@
 
         traceENTER_pcTimerGetName( xTimer );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
 
         traceRETURN_pcTimerGetName( pxTimer->pcTimerName );
 
@@ -948,7 +948,7 @@
 
                     /* The timer uses the xCallbackParameters member to request a
                      * callback be executed.  Check the callback is not NULL. */
-                    configASSERT( pxCallback );
+                    configASSERT( pxCallback != NULL );
 
                     /* Call the function. */
                     pxCallback->pxCallbackFunction( pxCallback->pvParameter1, pxCallback->ulParameter2 );
@@ -1160,7 +1160,7 @@
 
         traceENTER_xTimerIsTimerActive( xTimer );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
 
         /* Is the timer in the list of active timers? */
         taskENTER_CRITICAL();
@@ -1189,7 +1189,7 @@
 
         traceENTER_pvTimerGetTimerID( xTimer );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
 
         taskENTER_CRITICAL();
         {
@@ -1210,7 +1210,7 @@
 
         traceENTER_vTimerSetTimerID( xTimer, pvNewID );
 
-        configASSERT( xTimer );
+        configASSERT( xTimer != NULL );
 
         taskENTER_CRITICAL();
         {
@@ -1267,7 +1267,7 @@
             /* This function can only be called after a timer has been created or
              * after the scheduler has been started because, until then, the timer
              * queue does not exist. */
-            configASSERT( xTimerQueue );
+            configASSERT( xTimerQueue != NULL );
 
             /* Complete the message with the function parameters and post it to the
              * daemon task. */

--- a/timers.c
+++ b/timers.c
@@ -1044,19 +1044,19 @@
 
                     case tmrCOMMAND_DELETE:
                         #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
-                        {
-                            /* The timer has already been removed from the active list,
-                             * just free up the memory if the memory was dynamically
-                             * allocated. */
-                            if( ( pxTimer->ucStatus & tmrSTATUS_IS_STATICALLY_ALLOCATED ) == ( uint8_t ) 0 )
-                            {
-                                vPortFree( pxTimer );
-                            }
-                            else
-                            {
-                                pxTimer->ucStatus &= ( ( uint8_t ) ~tmrSTATUS_IS_ACTIVE );
-                            }
-                        }
+                       {
+                           /* The timer has already been removed from the active list,
+                            * just free up the memory if the memory was dynamically
+                            * allocated. */
+                           if( ( pxTimer->ucStatus & tmrSTATUS_IS_STATICALLY_ALLOCATED ) == ( uint8_t ) 0 )
+                           {
+                               vPortFree( pxTimer );
+                           }
+                           else
+                           {
+                               pxTimer->ucStatus &= ( ( uint8_t ) ~tmrSTATUS_IS_ACTIVE );
+                           }
+                       }
                         #else /* if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) */
                         {
                             /* If dynamic allocation is not enabled, the memory


### PR DESCRIPTION
Fix misra C rule 10.4 an rule 10.9 deviations in configASSERT

Description
-----------
## MISRA C:2012 Rule 10.4 ##
>Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category

### MISRA deviations ###
The operands of arithmetic operation should have the same essential type to prevent implicit type conversion which may result in unintended result. The following is an example of violation. Constant 0 is of type int and uxBitsToWaitFor is of type UBaseType_t. There will be implicit type conversion.
```
configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
```

### Fix in the PR ###
* Append type suffix to the constant to specify type.
In the example above,
```
/* Append "U" to constant 1 to specify the type of the constant. */
configASSERT( ( uxBitsToWaitFor & eventEVENT_BITS_CONTROL_BYTES ) == 0U ); 
```

## MISRA C:2012 Rule 11.9 ##
>The macro NULL shall be the only permitted form of integer null pointer constant

### MISRA deviations ###
This rule requires to use NULL rather than 0 makes it clear that a null pointer constant was intended. The following is an example of deviation.
```
configASSERT( xTaskToNotify );
```

### Fix in the PR ###
* Use NULL as null pointer constant.
In the example above,
```
/* Compare xTaskToNotify with NULL. */
configASSERT( xTaskToNotify != NULL );
```

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
