### PR TITLE
Fix vTaskSwitchContext for smp.

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -5142,7 +5142,7 @@ BaseType_t xTaskIncrementTick( void )
                      * are provided by the application, not the kernel. */
                     if( ulTotalRunTime[ xCoreID ] > ulTaskSwitchedInTime[ xCoreID ] )
                     {
-                        pxCurrentTCB->ulRunTimeCounter += ( ulTotalRunTime[ xCoreID ] - ulTaskSwitchedInTime[ xCoreID ] );
+                        pxCurrentTCBs[ xCoreID ]->ulRunTimeCounter += ( ulTotalRunTime[ xCoreID ] - ulTaskSwitchedInTime[ xCoreID ] );
                     }
                     else
                     {
@@ -5159,7 +5159,7 @@ BaseType_t xTaskIncrementTick( void )
                 /* Before the currently running task is switched out, save its errno. */
                 #if ( configUSE_POSIX_ERRNO == 1 )
                 {
-                    pxCurrentTCB->iTaskErrno = FreeRTOS_errno;
+                    pxCurrentTCBs[ xCoreID ]->iTaskErrno = FreeRTOS_errno;
                 }
                 #endif
 
@@ -5170,7 +5170,7 @@ BaseType_t xTaskIncrementTick( void )
                 /* After the new task is switched in, update the global errno. */
                 #if ( configUSE_POSIX_ERRNO == 1 )
                 {
-                    FreeRTOS_errno = pxCurrentTCB->iTaskErrno;
+                    FreeRTOS_errno = pxCurrentTCBs[ xCoreID ]->iTaskErrno;
                 }
                 #endif
 
@@ -5178,7 +5178,7 @@ BaseType_t xTaskIncrementTick( void )
                 {
                     /* Switch C-Runtime's TLS Block to point to the TLS
                      * Block specific to this task. */
-                    configSET_TLS_BLOCK( pxCurrentTCB->xTLSBlock );
+                    configSET_TLS_BLOCK( pxCurrentTCBs[ xCoreID ]->xTLSBlock );
                 }
                 #endif
             }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The function vTaskSwitchContext in smp has an parameter of core id, which means this function is not only used for the core who call it. 
Thus we should use the task running on the specific core id, instead of use the task running on the core who call this function.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
