### PR TITLE
Revert Portable/CCS formatting

### DIFF
--- a/portable/CCS/ARM_CM3/port.c
+++ b/portable/CCS/ARM_CM3/port.c
@@ -265,22 +265,22 @@ BaseType_t xPortStartScheduler( void )
         if( ulImplementedPrioBits == 8 )
         {
             /* When the hardware implements 8 priority bits, there is no way for
-             * the software to configure PRIGROUP to not have sub-priorities. As
-             * a result, the least significant bit is always used for sub-priority
-             * and there are 128 preemption priorities and 2 sub-priorities.
-             *
-             * This may cause some confusion in some cases - for example, if
-             * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-             * priority interrupts will be masked in Critical Sections as those
-             * are at the same preemption priority. This may appear confusing as
-             * 4 is higher (numerically lower) priority than
-             * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-             * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-             * to 4, this confusion does not happen and the behaviour remains the same.
-             *
-             * The following assert ensures that the sub-priority bit in the
-             * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-             * confusion. */
+            * the software to configure PRIGROUP to not have sub-priorities. As
+            * a result, the least significant bit is always used for sub-priority
+            * and there are 128 preemption priorities and 2 sub-priorities.
+            *
+            * This may cause some confusion in some cases - for example, if
+            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+            * priority interrupts will be masked in Critical Sections as those
+            * are at the same preemption priority. This may appear confusing as
+            * 4 is higher (numerically lower) priority than
+            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+            * to 4, this confusion does not happen and the behaviour remains the same.
+            *
+            * The following assert ensures that the sub-priority bit in the
+            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
+            * confusion. */
             configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
             ulMaxPRIGROUPValue = 0;
         }

--- a/portable/CCS/ARM_CM3/portmacro.h
+++ b/portable/CCS/ARM_CM3/portmacro.h
@@ -28,7 +28,7 @@
 
 
 #ifndef PORTMACRO_H
-#define PORTMACRO_H
+    #define PORTMACRO_H
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -47,52 +47,52 @@
  */
 
 /* Type definitions. */
-#define portCHAR          char
-#define portFLOAT         float
-#define portDOUBLE        double
-#define portLONG          long
-#define portSHORT         short
-#define portSTACK_TYPE    uint32_t
-#define portBASE_TYPE     long
+    #define portCHAR          char
+    #define portFLOAT         float
+    #define portDOUBLE        double
+    #define portLONG          long
+    #define portSHORT         short
+    #define portSTACK_TYPE    uint32_t
+    #define portBASE_TYPE     long
 
-typedef portSTACK_TYPE   StackType_t;
-typedef long             BaseType_t;
-typedef unsigned long    UBaseType_t;
+    typedef portSTACK_TYPE   StackType_t;
+    typedef long             BaseType_t;
+    typedef unsigned long    UBaseType_t;
 
-#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
-    typedef uint16_t     TickType_t;
-    #define portMAX_DELAY              ( TickType_t ) 0xffff
-#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
-    typedef uint32_t     TickType_t;
-    #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+    #if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
+        typedef uint16_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffff
+    #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
+        typedef uint32_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
 
 /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
  * not need to be guarded with a critical section. */
-    #define portTICK_TYPE_IS_ATOMIC    1
-#else
-    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
-#endif
+        #define portTICK_TYPE_IS_ATOMIC    1
+    #else
+        #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+    #endif
 /*-----------------------------------------------------------*/
 
 /* Architecture specifics. */
-#define portSTACK_GROWTH      ( -1 )
-#define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portBYTE_ALIGNMENT    8
+    #define portSTACK_GROWTH      ( -1 )
+    #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+    #define portBYTE_ALIGNMENT    8
 
 /*-----------------------------------------------------------*/
 
 /* Compiler directives. */
-#define portWEAK_SYMBOL    __attribute__( ( weak ) )
+    #define portWEAK_SYMBOL    __attribute__( ( weak ) )
 
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */
-#define portYIELD()                                     \
+    #define portYIELD()                                 \
     {                                                   \
         /* Set a PendSV to request a context switch. */ \
         portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
-        __asm( "    dsb" );                             \
-        __asm( "    isb" );                             \
+        __asm( "    dsb");                                \
+        __asm( "    isb");                                \
     }
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
@@ -115,68 +115,68 @@ typedef unsigned long    UBaseType_t;
 /*-----------------------------------------------------------*/
 
 /* Architecture specific optimisations. */
-#ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
-    #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
-#endif
-
-#if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
-
-/* Check the configuration. */
-    #if ( configMAX_PRIORITIES > 32 )
-        #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
+    #ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
+        #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
     #endif
 
+    #if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
+
+/* Check the configuration. */
+        #if ( configMAX_PRIORITIES > 32 )
+            #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
+        #endif
+
 /* Store/clear the ready priorities in a bit map. */
-    #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
-    #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
+        #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
+        #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
 
 /*-----------------------------------------------------------*/
 
-    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )    uxTopPriority = ( 31 - __clz( ( uxReadyPriorities ) ) )
+        #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )    uxTopPriority = ( 31 - __clz( ( uxReadyPriorities ) ) )
 
-#endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
+    #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */
-extern void vPortEnterCritical( void );
-extern void vPortExitCritical( void );
+    extern void vPortEnterCritical( void );
+    extern void vPortExitCritical( void );
 
-#define portDISABLE_INTERRUPTS()                                         \
+    #define portDISABLE_INTERRUPTS()                                     \
     {                                                                    \
         _set_interrupt_priority( configMAX_SYSCALL_INTERRUPT_PRIORITY ); \
-        __asm( "    dsb" );                                              \
-        __asm( "    isb" );                                              \
+        __asm( "    dsb");                                               \
+        __asm( "    isb");                                               \
     }
 
-#define portENABLE_INTERRUPTS()                   _set_interrupt_priority( 0 )
-#define portENTER_CRITICAL()                      vPortEnterCritical()
-#define portEXIT_CRITICAL()                       vPortExitCritical()
-#define portSET_INTERRUPT_MASK_FROM_ISR()         _set_interrupt_priority( configMAX_SYSCALL_INTERRUPT_PRIORITY ); __asm( " dsb" ); __asm( "    isb" )
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    _set_interrupt_priority( x )
+    #define portENABLE_INTERRUPTS()                   _set_interrupt_priority( 0 )
+    #define portENTER_CRITICAL()                      vPortEnterCritical()
+    #define portEXIT_CRITICAL()                       vPortExitCritical()
+    #define portSET_INTERRUPT_MASK_FROM_ISR()         _set_interrupt_priority( configMAX_SYSCALL_INTERRUPT_PRIORITY ); __asm( " dsb" ); __asm( "    isb")
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    _set_interrupt_priority( x )
 /*-----------------------------------------------------------*/
 
 /* Tickless idle/low power functionality. */
-#ifndef portSUPPRESS_TICKS_AND_SLEEP
-    extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
-    #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
-#endif
+    #ifndef portSUPPRESS_TICKS_AND_SLEEP
+        extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+        #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
+    #endif
 
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site.  These are
  * not necessary for to use this port.  They are defined so the common demo files
  * (which build with all the ports) will build. */
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
-    void vPortValidateInterruptPriority( void );
-    #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
-#endif
+    #ifdef configASSERT
+        void vPortValidateInterruptPriority( void );
+        #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
+    #endif
 
 /* portNOP() is not required by this port. */
-#define portNOP()
+    #define portNOP()
 
 /*-----------------------------------------------------------*/
 

--- a/portable/CCS/ARM_CM4F/port.c
+++ b/portable/CCS/ARM_CM4F/port.c
@@ -284,22 +284,22 @@ BaseType_t xPortStartScheduler( void )
         if( ulImplementedPrioBits == 8 )
         {
             /* When the hardware implements 8 priority bits, there is no way for
-             * the software to configure PRIGROUP to not have sub-priorities. As
-             * a result, the least significant bit is always used for sub-priority
-             * and there are 128 preemption priorities and 2 sub-priorities.
-             *
-             * This may cause some confusion in some cases - for example, if
-             * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-             * priority interrupts will be masked in Critical Sections as those
-             * are at the same preemption priority. This may appear confusing as
-             * 4 is higher (numerically lower) priority than
-             * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-             * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-             * to 4, this confusion does not happen and the behaviour remains the same.
-             *
-             * The following assert ensures that the sub-priority bit in the
-             * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-             * confusion. */
+            * the software to configure PRIGROUP to not have sub-priorities. As
+            * a result, the least significant bit is always used for sub-priority
+            * and there are 128 preemption priorities and 2 sub-priorities.
+            *
+            * This may cause some confusion in some cases - for example, if
+            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+            * priority interrupts will be masked in Critical Sections as those
+            * are at the same preemption priority. This may appear confusing as
+            * 4 is higher (numerically lower) priority than
+            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+            * to 4, this confusion does not happen and the behaviour remains the same.
+            *
+            * The following assert ensures that the sub-priority bit in the
+            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
+            * confusion. */
             configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
             ulMaxPRIGROUPValue = 0;
         }

--- a/portable/CCS/ARM_CM4F/portmacro.h
+++ b/portable/CCS/ARM_CM4F/portmacro.h
@@ -28,7 +28,7 @@
 
 
 #ifndef PORTMACRO_H
-#define PORTMACRO_H
+    #define PORTMACRO_H
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -47,46 +47,46 @@
  */
 
 /* Type definitions. */
-#define portCHAR          char
-#define portFLOAT         float
-#define portDOUBLE        double
-#define portLONG          long
-#define portSHORT         short
-#define portSTACK_TYPE    uint32_t
-#define portBASE_TYPE     long
+    #define portCHAR          char
+    #define portFLOAT         float
+    #define portDOUBLE        double
+    #define portLONG          long
+    #define portSHORT         short
+    #define portSTACK_TYPE    uint32_t
+    #define portBASE_TYPE     long
 
-typedef portSTACK_TYPE   StackType_t;
-typedef long             BaseType_t;
-typedef unsigned long    UBaseType_t;
+    typedef portSTACK_TYPE   StackType_t;
+    typedef long             BaseType_t;
+    typedef unsigned long    UBaseType_t;
 
-#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
-    typedef uint16_t     TickType_t;
-    #define portMAX_DELAY              ( TickType_t ) 0xffff
-#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
-    typedef uint32_t     TickType_t;
-    #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+    #if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
+        typedef uint16_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffff
+    #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
+        typedef uint32_t     TickType_t;
+        #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
 
 /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
  * not need to be guarded with a critical section. */
-    #define portTICK_TYPE_IS_ATOMIC    1
-#else
-    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
-#endif
+        #define portTICK_TYPE_IS_ATOMIC    1
+    #else
+        #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+    #endif
 /*-----------------------------------------------------------*/
 
 /* Architecture specifics. */
-#define portSTACK_GROWTH      ( -1 )
-#define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portBYTE_ALIGNMENT    8
+    #define portSTACK_GROWTH      ( -1 )
+    #define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+    #define portBYTE_ALIGNMENT    8
 /*-----------------------------------------------------------*/
 
 /* Scheduler utilities. */
-#define portYIELD()                                     \
+    #define portYIELD()                                 \
     {                                                   \
         /* Set a PendSV to request a context switch. */ \
         portNVIC_INT_CTRL_REG = portNVIC_PENDSVSET_BIT; \
-        __asm( "    dsb" );                             \
-        __asm( "    isb" );                             \
+        __asm( "    dsb");                                \
+        __asm( "    isb");                                \
     }
 
 #define portNVIC_INT_CTRL_REG     ( *( ( volatile uint32_t * ) 0xe000ed04 ) )
@@ -109,68 +109,68 @@ typedef unsigned long    UBaseType_t;
 /*-----------------------------------------------------------*/
 
 /* Architecture specific optimisations. */
-#ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
-    #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
-#endif
-
-#if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
-
-/* Check the configuration. */
-    #if ( configMAX_PRIORITIES > 32 )
-        #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
+    #ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
+        #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
     #endif
 
+    #if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
+
+/* Check the configuration. */
+        #if ( configMAX_PRIORITIES > 32 )
+            #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
+        #endif
+
 /* Store/clear the ready priorities in a bit map. */
-    #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
-    #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
+        #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
+        #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
 
 /*-----------------------------------------------------------*/
 
-    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )    uxTopPriority = ( 31 - __clz( ( uxReadyPriorities ) ) )
+        #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )    uxTopPriority = ( 31 - __clz( ( uxReadyPriorities ) ) )
 
-#endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
+    #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 /*-----------------------------------------------------------*/
 
 /* Critical section management. */
-extern void vPortEnterCritical( void );
-extern void vPortExitCritical( void );
+    extern void vPortEnterCritical( void );
+    extern void vPortExitCritical( void );
 
-#define portDISABLE_INTERRUPTS()                                         \
+    #define portDISABLE_INTERRUPTS()                                     \
     {                                                                    \
         _set_interrupt_priority( configMAX_SYSCALL_INTERRUPT_PRIORITY ); \
-        __asm( "    dsb" );                                              \
-        __asm( "    isb" );                                              \
+        __asm( "    dsb");                                                 \
+        __asm( "    isb");                                                 \
     }
 
-#define portENABLE_INTERRUPTS()                   _set_interrupt_priority( 0 )
-#define portENTER_CRITICAL()                      vPortEnterCritical()
-#define portEXIT_CRITICAL()                       vPortExitCritical()
-#define portSET_INTERRUPT_MASK_FROM_ISR()         _set_interrupt_priority( configMAX_SYSCALL_INTERRUPT_PRIORITY ); __asm( " dsb" ); __asm( "    isb" )
-#define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    _set_interrupt_priority( x )
+    #define portENABLE_INTERRUPTS()                   _set_interrupt_priority( 0 )
+    #define portENTER_CRITICAL()                      vPortEnterCritical()
+    #define portEXIT_CRITICAL()                       vPortExitCritical()
+    #define portSET_INTERRUPT_MASK_FROM_ISR()         _set_interrupt_priority( configMAX_SYSCALL_INTERRUPT_PRIORITY ); __asm( " dsb" ); __asm( "    isb")
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )    _set_interrupt_priority( x )
 /*-----------------------------------------------------------*/
 
 /* Tickless idle/low power functionality. */
-#ifndef portSUPPRESS_TICKS_AND_SLEEP
-    extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
-    #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
-#endif
+    #ifndef portSUPPRESS_TICKS_AND_SLEEP
+        extern void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime );
+        #define portSUPPRESS_TICKS_AND_SLEEP( xExpectedIdleTime )    vPortSuppressTicksAndSleep( xExpectedIdleTime )
+    #endif
 
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site.  These are
  * not necessary for to use this port.  They are defined so the common demo files
  * (which build with all the ports) will build. */
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+    #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
-    void vPortValidateInterruptPriority( void );
-    #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
-#endif
+    #ifdef configASSERT
+        void vPortValidateInterruptPriority( void );
+        #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
+    #endif
 
 /* portNOP() is not required by this port. */
-#define portNOP()
+    #define portNOP()
 
 /*-----------------------------------------------------------*/
 

--- a/portable/CCS/ARM_Cortex-R4/port.c
+++ b/portable/CCS/ARM_Cortex-R4/port.c
@@ -38,27 +38,27 @@ uint32_t ulCriticalNesting = 9999;
 /*-----------------------------------------------------------*/
 
 /* Registers required to configure the RTI. */
-#define portRTI_GCTRL_REG          ( *( ( volatile uint32_t * ) 0xFFFFFC00 ) )
-#define portRTI_TBCTRL_REG         ( *( ( volatile uint32_t * ) 0xFFFFFC04 ) )
-#define portRTI_COMPCTRL_REG       ( *( ( volatile uint32_t * ) 0xFFFFFC0C ) )
-#define portRTI_CNT0_FRC0_REG      ( *( ( volatile uint32_t * ) 0xFFFFFC10 ) )
-#define portRTI_CNT0_UC0_REG       ( *( ( volatile uint32_t * ) 0xFFFFFC14 ) )
-#define portRTI_CNT0_CPUC0_REG     ( *( ( volatile uint32_t * ) 0xFFFFFC18 ) )
-#define portRTI_CNT0_COMP0_REG     ( *( ( volatile uint32_t * ) 0xFFFFFC50 ) )
-#define portRTI_CNT0_UDCP0_REG     ( *( ( volatile uint32_t * ) 0xFFFFFC54 ) )
-#define portRTI_SETINTENA_REG      ( *( ( volatile uint32_t * ) 0xFFFFFC80 ) )
-#define portRTI_CLEARINTENA_REG    ( *( ( volatile uint32_t * ) 0xFFFFFC84 ) )
-#define portRTI_INTFLAG_REG        ( *( ( volatile uint32_t * ) 0xFFFFFC88 ) )
+#define portRTI_GCTRL_REG       ( * ( ( volatile uint32_t * ) 0xFFFFFC00 ) )
+#define portRTI_TBCTRL_REG      ( * ( ( volatile uint32_t * ) 0xFFFFFC04 ) )
+#define portRTI_COMPCTRL_REG    ( * ( ( volatile uint32_t * ) 0xFFFFFC0C ) )
+#define portRTI_CNT0_FRC0_REG   ( * ( ( volatile uint32_t * ) 0xFFFFFC10 ) )
+#define portRTI_CNT0_UC0_REG    ( * ( ( volatile uint32_t * ) 0xFFFFFC14 ) )
+#define portRTI_CNT0_CPUC0_REG  ( * ( ( volatile uint32_t * ) 0xFFFFFC18 ) )
+#define portRTI_CNT0_COMP0_REG  ( * ( ( volatile uint32_t * ) 0xFFFFFC50 ) )
+#define portRTI_CNT0_UDCP0_REG  ( * ( ( volatile uint32_t * ) 0xFFFFFC54 ) )
+#define portRTI_SETINTENA_REG   ( * ( ( volatile uint32_t * ) 0xFFFFFC80 ) )
+#define portRTI_CLEARINTENA_REG ( * ( ( volatile uint32_t * ) 0xFFFFFC84 ) )
+#define portRTI_INTFLAG_REG     ( * ( ( volatile uint32_t * ) 0xFFFFFC88 ) )
 
 
 /* Constants required to set up the initial stack of each task. */
-#define portINITIAL_SPSR                        ( ( StackType_t ) 0x1F )
-#define portINITIAL_FPSCR                       ( ( StackType_t ) 0x00 )
-#define portINSTRUCTION_SIZE                    ( ( StackType_t ) 0x04 )
-#define portTHUMB_MODE_BIT                      ( ( StackType_t ) 0x20 )
+#define portINITIAL_SPSR        ( ( StackType_t ) 0x1F )
+#define portINITIAL_FPSCR       ( ( StackType_t ) 0x00 )
+#define portINSTRUCTION_SIZE    ( ( StackType_t ) 0x04 )
+#define portTHUMB_MODE_BIT      ( ( StackType_t ) 0x20 )
 
 /* The number of words on the stack frame between the saved Top Of Stack and
- * R0 (in which the parameters are passed. */
+R0 (in which the parameters are passed. */
 #define portSPACE_BETWEEN_TOS_AND_PARAMETERS    ( 12 )
 
 /*-----------------------------------------------------------*/
@@ -69,7 +69,7 @@ extern void vPortStartFirstTask( void );
 /*-----------------------------------------------------------*/
 
 /* Saved as part of the task context.  Set to pdFALSE if the task does not
- * require an FPU context. */
+require an FPU context. */
 uint32_t ulTaskHasFPUContext = 0;
 
 /*-----------------------------------------------------------*/
@@ -78,11 +78,9 @@ uint32_t ulTaskHasFPUContext = 0;
 /*
  * See header file for description.
  */
-StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                     TaskFunction_t pxCode,
-                                     void * pvParameters )
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
 {
-    StackType_t * pxOriginalTOS;
+StackType_t *pxOriginalTOS;
 
     pxOriginalTOS = pxTopOfStack;
 
@@ -94,15 +92,15 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     #endif
 
     /* Setup the initial stack of the task.  The stack is set exactly as
-     * expected by the portRESTORE_CONTEXT() macro. */
+    expected by the portRESTORE_CONTEXT() macro. */
 
     /* First on the stack is the return address - which is the start of the as
-     * the task has not executed yet.  The offset is added to make the return
-     * address appear as it would within an IRQ ISR. */
+    the task has not executed yet.  The offset is added to make the return
+    address appear as it would within an IRQ ISR. */
     *pxTopOfStack = ( StackType_t ) pxCode + portINSTRUCTION_SIZE;
     pxTopOfStack--;
 
-    *pxTopOfStack = ( StackType_t ) 0x00000000;    /* R14 */
+    *pxTopOfStack = ( StackType_t ) 0x00000000; /* R14 */
     pxTopOfStack--;
     *pxTopOfStack = ( StackType_t ) pxOriginalTOS; /* Stack used when task starts goes in R13. */
     pxTopOfStack--;
@@ -134,11 +132,11 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         *pxTopOfStack = ( StackType_t ) 0x01010101; /* R1 */
         pxTopOfStack--;
     }
-    #else /* ifdef portPRELOAD_TASK_REGISTERS */
+    #else
     {
         pxTopOfStack -= portSPACE_BETWEEN_TOS_AND_PARAMETERS;
     }
-    #endif /* ifdef portPRELOAD_TASK_REGISTERS */
+    #endif
 
     /* Function parameters are passed in R0. */
     *pxTopOfStack = ( StackType_t ) pvParameters; /* R0 */
@@ -158,8 +156,8 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         pxTopOfStack--;
 
         /* The last thing on the stack is the tasks ulUsingFPU value, which by
-         * default is set to indicate that the stack frame does not include FPU
-         * registers. */
+        default is set to indicate that the stack frame does not include FPU
+        registers. */
         *pxTopOfStack = pdFALSE;
     }
     #endif
@@ -168,7 +166,7 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
 }
 /*-----------------------------------------------------------*/
 
-static void prvSetupTimerInterrupt( void )
+static void prvSetupTimerInterrupt(void)
 {
     /* Disable timer 0. */
     portRTI_GCTRL_REG &= 0xFFFFFFFEUL;
@@ -180,8 +178,8 @@ static void prvSetupTimerInterrupt( void )
     portRTI_COMPCTRL_REG = 0x00000000U;
 
     /* Initialise the counter and the prescale counter registers. */
-    portRTI_CNT0_UC0_REG = 0x00000000U;
-    portRTI_CNT0_FRC0_REG = 0x00000000U;
+    portRTI_CNT0_UC0_REG =  0x00000000U;
+    portRTI_CNT0_FRC0_REG =  0x00000000U;
 
     /* Set Prescalar for RTI clock. */
     portRTI_CNT0_CPUC0_REG = 0x00000001U;
@@ -189,7 +187,7 @@ static void prvSetupTimerInterrupt( void )
     portRTI_CNT0_UDCP0_REG = ( configCPU_CLOCK_HZ / 2 ) / configTICK_RATE_HZ;
 
     /* Clear interrupts. */
-    portRTI_INTFLAG_REG = 0x0007000FU;
+    portRTI_INTFLAG_REG =  0x0007000FU;
     portRTI_CLEARINTENA_REG = 0x00070F0FU;
 
     /* Enable the compare 0 interrupt. */
@@ -201,7 +199,7 @@ static void prvSetupTimerInterrupt( void )
 /*
  * See header file for description.
  */
-BaseType_t xPortStartScheduler( void )
+BaseType_t xPortStartScheduler(void)
 {
     /* Start the timer that generates the tick ISR. */
     prvSetupTimerInterrupt();
@@ -210,7 +208,7 @@ BaseType_t xPortStartScheduler( void )
     ulCriticalNesting = 0;
 
     /* Start the first task.  This is done from portASM.asm as ARM mode must be
-     * used. */
+    used. */
     vPortStartFirstTask();
 
     /* Should not get here! */
@@ -221,40 +219,40 @@ BaseType_t xPortStartScheduler( void )
 /*
  * See header file for description.
  */
-void vPortEndScheduler( void )
+void vPortEndScheduler(void)
 {
     /* Not implemented in ports where there is nothing to return to.
-     * Artificially force an assert. */
+    Artificially force an assert. */
     configASSERT( ulCriticalNesting == 1000UL );
 }
 /*-----------------------------------------------------------*/
 
 #if configUSE_PREEMPTION == 0
 
-/* The cooperative scheduler requires a normal IRQ service routine to
- * simply increment the system tick. */
+    /* The cooperative scheduler requires a normal IRQ service routine to
+     * simply increment the system tick. */
     __interrupt void vPortNonPreemptiveTick( void )
     {
         /* clear clock interrupt flag */
         portRTI_INTFLAG_REG = 0x00000001;
 
         /* Increment the tick count - this may make a delaying task ready
-         * to run - but a context switch is not performed. */
+        to run - but a context switch is not performed. */
         xTaskIncrementTick();
     }
 
-#else /* if configUSE_PREEMPTION == 0 */
+ #else
 
-/*
- **************************************************************************
- * The preemptive scheduler ISR is written in assembler and can be found
- * in the portASM.asm file. This will only get used if portUSE_PREEMPTION
- * is set to 1 in portmacro.h
- **************************************************************************
- */
+    /*
+     **************************************************************************
+     * The preemptive scheduler ISR is written in assembler and can be found
+     * in the portASM.asm file. This will only get used if portUSE_PREEMPTION
+     * is set to 1 in portmacro.h
+     **************************************************************************
+     */
     void vPortPreemptiveTick( void );
 
-#endif /* if configUSE_PREEMPTION == 0 */
+#endif
 /*-----------------------------------------------------------*/
 
 
@@ -266,9 +264,9 @@ void vPortEnterCritical( void )
     /* Disable interrupts as per portDISABLE_INTERRUPTS(); */
     portDISABLE_INTERRUPTS();
 
-    /* Now that interrupts are disabled, ulCriticalNesting can be accessed
-     * directly.  Increment ulCriticalNesting to keep a count of how many times
-     * portENTER_CRITICAL() has been called. */
+    /* Now interrupts are disabled ulCriticalNesting can be accessed
+    directly.  Increment ulCriticalNesting to keep a count of how many times
+    portENTER_CRITICAL() has been called. */
     ulCriticalNesting++;
 }
 /*-----------------------------------------------------------*/
@@ -285,7 +283,7 @@ void vPortExitCritical( void )
         ulCriticalNesting--;
 
         /* If the nesting level has reached zero then interrupts should be
-         * re-enabled. */
+        re-enabled. */
         if( ulCriticalNesting == 0 )
         {
             /* Enable interrupts as per portENABLE_INTERRUPTS(). */
@@ -299,10 +297,10 @@ void vPortExitCritical( void )
 
     void vPortTaskUsesFPU( void )
     {
-        extern void vPortInitialiseFPSCR( void );
+    extern void vPortInitialiseFPSCR( void );
 
         /* A task is registering the fact that it needs an FPU context.  Set the
-         * FPU flag (saved as part of the task context. */
+        FPU flag (saved as part of the task context. */
         ulTaskHasFPUContext = pdTRUE;
 
         /* Initialise the floating point status register. */

--- a/portable/CCS/ARM_Cortex-R4/portmacro.h
+++ b/portable/CCS/ARM_Cortex-R4/portmacro.h
@@ -40,80 +40,80 @@
  */
 
 /* Type definitions. */
-#define portCHAR          char
-#define portFLOAT         float
-#define portDOUBLE        double
-#define portLONG          long
-#define portSHORT         short
-#define portSTACK_TYPE    uint32_t
-#define portBASE_TYPE     long
+#define portCHAR        char
+#define portFLOAT       float
+#define portDOUBLE      double
+#define portLONG        long
+#define portSHORT       short
+#define portSTACK_TYPE  uint32_t
+#define portBASE_TYPE   long
 
-typedef portSTACK_TYPE   StackType_t;
-typedef long             BaseType_t;
-typedef unsigned long    UBaseType_t;
+typedef portSTACK_TYPE StackType_t;
+typedef long BaseType_t;
+typedef unsigned long UBaseType_t;
 
-#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
-    typedef uint16_t     TickType_t;
-    #define portMAX_DELAY              ( TickType_t ) 0xFFFF
+#if (configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS)
+    typedef uint16_t TickType_t;
+    #define portMAX_DELAY (TickType_t) 0xFFFF
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
-    typedef uint32_t     TickType_t;
-    #define portMAX_DELAY              ( TickType_t ) 0xFFFFFFFFF
+    typedef uint32_t TickType_t;
+    #define portMAX_DELAY (TickType_t) 0xFFFFFFFFF
 
-/* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
- * not need to be guarded with a critical section. */
-    #define portTICK_TYPE_IS_ATOMIC    1
+    /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
+    not need to be guarded with a critical section. */
+    #define portTICK_TYPE_IS_ATOMIC 1
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif
 
 
 /* Architecture specifics. */
-#define portSTACK_GROWTH      ( -1 )
-#define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portBYTE_ALIGNMENT    8
+#define portSTACK_GROWTH    (-1)
+#define portTICK_PERIOD_MS    ((TickType_t) 1000 / configTICK_RATE_HZ)
+#define portBYTE_ALIGNMENT  8
 
 /* Critical section handling. */
-extern void vPortEnterCritical( void );
-extern void vPortExitCritical( void );
+extern void vPortEnterCritical(void);
+extern void vPortExitCritical(void);
 #define portENTER_CRITICAL()        vPortEnterCritical()
 #define portEXIT_CRITICAL()         vPortExitCritical()
-#define portDISABLE_INTERRUPTS()    asm ( " CPSID I" )
-#define portENABLE_INTERRUPTS()     asm ( " CPSIE I" )
+#define portDISABLE_INTERRUPTS()    asm( " CPSID I" )
+#define portENABLE_INTERRUPTS()     asm( " CPSIE I" )
 
 /* Scheduler utilities. */
 #pragma SWI_ALIAS( vPortYield, 0 )
 extern void vPortYield( void );
-#define portYIELD()                vPortYield()
-#define portSYS_SSIR1_REG      ( *( ( volatile uint32_t * ) 0xFFFFFFB0 ) )
-#define portSYS_SSIR1_SSKEY    ( 0x7500UL )
-#define portYIELD_WITHIN_API()     { portSYS_SSIR1_REG = portSYS_SSIR1_SSKEY;  asm ( " DSB " ); asm ( " ISB " ); }
-#define portYIELD_FROM_ISR( x )    do { if( x != pdFALSE ) { portSYS_SSIR1_REG = portSYS_SSIR1_SSKEY;  ( void ) portSYS_SSIR1_REG; } } while( 0 )
+#define portYIELD()                 vPortYield()
+#define portSYS_SSIR1_REG           ( * ( ( volatile uint32_t * ) 0xFFFFFFB0 ) )
+#define portSYS_SSIR1_SSKEY         ( 0x7500UL )
+#define portYIELD_WITHIN_API()      { portSYS_SSIR1_REG = portSYS_SSIR1_SSKEY;  asm( " DSB " ); asm( " ISB " ); }
+#define portYIELD_FROM_ISR( x )     do { if( x != pdFALSE ) { portSYS_SSIR1_REG = portSYS_SSIR1_SSKEY;  ( void ) portSYS_SSIR1_REG; } } while( 0 )
 
 #ifndef configUSE_PORT_OPTIMISED_TASK_SELECTION
-    #define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
+    #define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
 #endif
 
 /* Architecture specific optimisations. */
 #if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
 
-/* Check the configuration. */
-    #if ( configMAX_PRIORITIES > 32 )
+    /* Check the configuration. */
+    #if( configMAX_PRIORITIES > 32 )
         #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.  It is very rare that a system requires more than 10 to 15 difference priorities as tasks that share a priority will time slice.
     #endif
 
-/* Store/clear the ready priorities in a bit map. */
-    #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
-    #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
+    /* Store/clear the ready priorities in a bit map. */
+    #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities ) ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
+    #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities ) ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
 
-/*-----------------------------------------------------------*/
+    /*-----------------------------------------------------------*/
 
-    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )    uxTopPriority = ( 31 - __clz( ( uxReadyPriorities ) ) )
+    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities ) uxTopPriority = ( 31 - __clz( ( uxReadyPriorities ) ) )
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION(vFunction, pvParameters)       void vFunction(void *pvParameters)
+#define portTASK_FUNCTION_PROTO(vFunction, pvParameters) void vFunction(void *pvParameters)
 
 #endif /* __PORTMACRO_H__ */

--- a/portable/CCS/MSP430X/data_model.h
+++ b/portable/CCS/MSP430X/data_model.h
@@ -1,53 +1,49 @@
-; /*
-   * ; * FreeRTOS Kernel <DEVELOPMENT BRANCH>
-   * ; * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-   * ; *
-   * ; * SPDX-License-Identifier: MIT
-   * ; *
-   * ; * Permission is hereby granted, free of charge, to any person obtaining a copy of
-   * ; * this software and associated documentation files (the "Software"), to deal in
-   * ; * the Software without restriction, including without limitation the rights to
-   * ; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-   * ; * the Software, and to permit persons to whom the Software is furnished to do so,
-   * ; * subject to the following conditions:
-   * ; *
-   * ; * The above copyright notice and this permission notice shall be included in all
-   * ; * copies or substantial portions of the Software.
-   * ; *
-   * ; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   * ; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-   * ; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-   * ; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-   * ; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-   * ; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-   * ; *
-   * ; * https://www.FreeRTOS.org
-   * ; * https://github.com/FreeRTOS
-   * ; *
-   * ; */
+;/*
+; * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+; * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+; *
+; * SPDX-License-Identifier: MIT
+; *
+; * Permission is hereby granted, free of charge, to any person obtaining a copy of
+; * this software and associated documentation files (the "Software"), to deal in
+; * the Software without restriction, including without limitation the rights to
+; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+; * the Software, and to permit persons to whom the Software is furnished to do so,
+; * subject to the following conditions:
+; *
+; * The above copyright notice and this permission notice shall be included in all
+; * copies or substantial portions of the Software.
+; *
+; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+; *
+; * https://www.FreeRTOS.org
+; * https://github.com/FreeRTOS
+; *
+; */
 
-.
+    .if $DEFINED( __LARGE_DATA_MODEL__ )
+        .define "pushm.a", pushm_x
+        .define "popm.a", popm_x
+        .define "push.a", push_x
+        .define "pop.a", pop_x
+        .define "mov.a", mov_x
+    .else
+        .define "pushm.w", pushm_x
+        .define "popm.w", popm_x
+        .define "push.w", push_x
+        .define "pop.w", pop_x
+        .define "mov.w", mov_x
+    .endif
 
-   if $DEFINED( __LARGE_DATA_MODEL__ )
-   .define "pushm.a", pushm_x
-   .define "popm.a", popm_x
-   .define "push.a", push_x
-   .define "pop.a", pop_x
-   .define "mov.a", mov_x
-   .else
-    .define "pushm.w", pushm_x
-       .define "popm.w", popm_x
-       .define "push.w", push_x
-       .define "pop.w", pop_x
-       .define "mov.w", mov_x
-       .endif
-
-       .
-
-       if $DEFINED( __LARGE_CODE_MODEL__ )
-       .define "calla", call_x
-       .define "reta", ret_x
-       .else
+    .if $DEFINED( __LARGE_CODE_MODEL__ )
+        .define "calla", call_x
+        .define "reta", ret_x
+    .else
         .define "call", call_x
-           .define "ret", ret_x
-           .endif
+        .define "ret", ret_x
+    .endif

--- a/portable/CCS/MSP430X/port.c
+++ b/portable/CCS/MSP430X/port.c
@@ -31,28 +31,28 @@
 #include "task.h"
 
 /*-----------------------------------------------------------
-* Implementation of functions defined in portable.h for the MSP430X port.
-*----------------------------------------------------------*/
+ * Implementation of functions defined in portable.h for the MSP430X port.
+ *----------------------------------------------------------*/
 
 /* Constants required for hardware setup.  The tick ISR runs off the ACLK,
- * not the MCLK. */
+not the MCLK. */
 #define portACLK_FREQUENCY_HZ           ( ( TickType_t ) 32768 )
 #define portINITIAL_CRITICAL_NESTING    ( ( uint16_t ) 10 )
 #define portFLAGS_INT_ENABLED           ( ( StackType_t ) 0x08 )
 
 /* We require the address of the pxCurrentTCB variable, but don't want to know
- * any details of its type. */
+any details of its type. */
 typedef void TCB_t;
 extern volatile TCB_t * volatile pxCurrentTCB;
 
 /* Each task maintains a count of the critical section nesting depth.  Each
- * time a critical section is entered the count is incremented.  Each time a
- * critical section is exited the count is decremented - with interrupts only
- * being re-enabled if the count is zero.
- *
- * usCriticalNesting will get set to zero when the scheduler starts, but must
- * not be initialised to zero as this will cause problems during the startup
- * sequence. */
+time a critical section is entered the count is incremented.  Each time a
+critical section is exited the count is decremented - with interrupts only
+being re-enabled if the count is zero.
+
+usCriticalNesting will get set to zero when the scheduler starts, but must
+not be initialised to zero as this will cause problems during the startup
+sequence. */
 volatile uint16_t usCriticalNesting = portINITIAL_CRITICAL_NESTING;
 /*-----------------------------------------------------------*/
 
@@ -70,27 +70,25 @@ void vPortSetupTimerInterrupt( void );
  *
  * See the header file portable.h.
  */
-StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                     TaskFunction_t pxCode,
-                                     void * pvParameters )
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
 {
-    uint16_t * pusTopOfStack;
-    uint32_t * pulTopOfStack, ulTemp;
+uint16_t *pusTopOfStack;
+uint32_t *pulTopOfStack, ulTemp;
 
     /*
-     *  Place a few bytes of known values on the bottom of the stack.
-     *  This is just useful for debugging and can be included if required.
-     *
-     * pxTopOfStack = ( StackType_t ) 0x1111;
-     *  pxTopOfStack--;
-     * pxTopOfStack = ( StackType_t ) 0x2222;
-     *  pxTopOfStack--;
-     * pxTopOfStack = ( StackType_t ) 0x3333;
-     *  pxTopOfStack--;
-     */
+        Place a few bytes of known values on the bottom of the stack.
+        This is just useful for debugging and can be included if required.
+
+        *pxTopOfStack = ( StackType_t ) 0x1111;
+        pxTopOfStack--;
+        *pxTopOfStack = ( StackType_t ) 0x2222;
+        pxTopOfStack--;
+        *pxTopOfStack = ( StackType_t ) 0x3333;
+        pxTopOfStack--;
+    */
 
     /* Data types are need either 16 bits or 32 bits depending on the data
-     * and code model used. */
+    and code model used. */
     if( sizeof( pxCode ) == sizeof( uint16_t ) )
     {
         pusTopOfStack = ( uint16_t * ) pxTopOfStack;
@@ -139,19 +137,19 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         pxTopOfStack--;
         *pxTopOfStack = ( StackType_t ) 0x4444;
         pxTopOfStack--;
-    #else /* ifdef PRELOAD_REGISTER_VALUES */
+    #else
         pxTopOfStack -= 3;
         *pxTopOfStack = ( StackType_t ) pvParameters;
         pxTopOfStack -= 9;
-    #endif /* ifdef PRELOAD_REGISTER_VALUES */
+    #endif
 
     /* A variable is used to keep track of the critical section nesting.
-     * This variable has to be stored as part of the task context and is
-     * initially set to zero. */
+    This variable has to be stored as part of the task context and is
+    initially set to zero. */
     *pxTopOfStack = ( StackType_t ) portNO_CRITICAL_SECTION_NESTING;
 
     /* Return a pointer to the top of the stack we have generated so this can
-     * be stored in the task control block for the task. */
+    be stored in the task control block for the task. */
     return pxTopOfStack;
 }
 /*-----------------------------------------------------------*/
@@ -159,7 +157,7 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
 void vPortEndScheduler( void )
 {
     /* It is unlikely that the MSP430 port will get stopped.  If required simply
-     * disable the tick interrupt here. */
+    disable the tick interrupt here. */
 }
 /*-----------------------------------------------------------*/
 
@@ -175,7 +173,7 @@ void vPortSetupTimerInterrupt( void )
 #pragma vector=configTICK_VECTOR
 interrupt void vTickISREntry( void )
 {
-    extern void vPortTickISR( void );
+extern void vPortTickISR( void );
 
     __bic_SR_register_on_exit( SCG1 + SCG0 + OSCOFF + CPUOFF );
     #if configUSE_PREEMPTION == 1
@@ -186,3 +184,5 @@ interrupt void vTickISREntry( void )
         vPortCooperativeTickISR();
     #endif
 }
+
+

--- a/portable/CCS/MSP430X/portmacro.h
+++ b/portable/CCS/MSP430X/portmacro.h
@@ -43,31 +43,31 @@
 #include "msp430.h"
 
 /* Type definitions. */
-#define portCHAR         char
-#define portFLOAT        float
-#define portDOUBLE       double
-#define portLONG         long
-#define portSHORT        int
-#define portBASE_TYPE    portSHORT
+#define portCHAR        char
+#define portFLOAT       float
+#define portDOUBLE      double
+#define portLONG        long
+#define portSHORT       int
+#define portBASE_TYPE   portSHORT
 
 /* The stack type changes depending on the data model. */
 #ifdef __LARGE_DATA_MODEL__
-    #define portSTACK_TYPE           uint32_t
+    #define portSTACK_TYPE uint32_t
 #else
-    #define portSTACK_TYPE           uint16_t
-    #define portPOINTER_SIZE_TYPE    uint16_t
+    #define portSTACK_TYPE uint16_t
+    #define portPOINTER_SIZE_TYPE uint16_t
 #endif
 
-typedef portSTACK_TYPE   StackType_t;
-typedef short            BaseType_t;
-typedef unsigned short   UBaseType_t;
+typedef portSTACK_TYPE StackType_t;
+typedef short BaseType_t;
+typedef unsigned short UBaseType_t;
 
-#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
-    typedef uint16_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) 0xffff
+#if( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
+    typedef uint16_t TickType_t;
+    #define portMAX_DELAY ( TickType_t ) 0xffff
 #elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
-    typedef uint32_t     TickType_t;
-    #define portMAX_DELAY    ( TickType_t ) ( 0xFFFFFFFFUL )
+    typedef uint32_t TickType_t;
+    #define portMAX_DELAY ( TickType_t )    ( 0xFFFFFFFFUL )
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif
@@ -80,37 +80,37 @@ typedef unsigned short   UBaseType_t;
 /*-----------------------------------------------------------*/
 
 /* Critical section control macros. */
-#define portNO_CRITICAL_SECTION_NESTING    ( ( uint16_t ) 0 )
+#define portNO_CRITICAL_SECTION_NESTING     ( ( uint16_t ) 0 )
 
-#define portENTER_CRITICAL()                                                     \
-    {                                                                            \
-        extern volatile uint16_t usCriticalNesting;                              \
-                                                                                 \
-        portDISABLE_INTERRUPTS();                                                \
-                                                                                 \
-        /* Now interrupts are disabled usCriticalNesting can be accessed */      \
-        /* directly.  Increment ulCriticalNesting to keep a count of how many */ \
-        /* times portENTER_CRITICAL() has been called. */                        \
-        usCriticalNesting++;                                                     \
-    }
+#define portENTER_CRITICAL()                                                    \
+{                                                                               \
+extern volatile uint16_t usCriticalNesting;                                     \
+                                                                                \
+    portDISABLE_INTERRUPTS();                                                   \
+                                                                                \
+    /* Now interrupts are disabled usCriticalNesting can be accessed */         \
+    /* directly.  Increment ulCriticalNesting to keep a count of how many */    \
+    /* times portENTER_CRITICAL() has been called. */                           \
+    usCriticalNesting++;                                                        \
+}
 
-#define portEXIT_CRITICAL()                                                         \
-    {                                                                               \
-        extern volatile uint16_t usCriticalNesting;                                 \
-                                                                                    \
-        if( usCriticalNesting > portNO_CRITICAL_SECTION_NESTING )                   \
-        {                                                                           \
-            /* Decrement the nesting count as we are leaving a critical section. */ \
-            usCriticalNesting--;                                                    \
-                                                                                    \
-            /* If the nesting level has reached zero then interrupts should be */   \
-            /* re-enabled. */                                                       \
-            if( usCriticalNesting == portNO_CRITICAL_SECTION_NESTING )              \
-            {                                                                       \
-                portENABLE_INTERRUPTS();                                            \
-            }                                                                       \
-        }                                                                           \
-    }
+#define portEXIT_CRITICAL()                                                     \
+{                                                                               \
+extern volatile uint16_t usCriticalNesting;                                     \
+                                                                                \
+    if( usCriticalNesting > portNO_CRITICAL_SECTION_NESTING )                   \
+    {                                                                           \
+        /* Decrement the nesting count as we are leaving a critical section. */ \
+        usCriticalNesting--;                                                    \
+                                                                                \
+        /* If the nesting level has reached zero then interrupts should be */   \
+        /* re-enabled. */                                                       \
+        if( usCriticalNesting == portNO_CRITICAL_SECTION_NESTING )              \
+        {                                                                       \
+            portENABLE_INTERRUPTS();                                            \
+        }                                                                       \
+    }                                                                           \
+}
 /*-----------------------------------------------------------*/
 
 /* Task utilities. */
@@ -119,27 +119,27 @@ typedef unsigned short   UBaseType_t;
  * Manual context switch called by portYIELD or taskYIELD.
  */
 extern void vPortYield( void );
-#define portYIELD()    vPortYield()
+#define portYIELD() vPortYield()
 /*-----------------------------------------------------------*/
 
 /* Hardware specifics. */
-#define portBYTE_ALIGNMENT    2
-#define portSTACK_GROWTH      ( -1 )
-#define portTICK_PERIOD_MS    ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portNOP()    __no_operation()
+#define portBYTE_ALIGNMENT          2
+#define portSTACK_GROWTH            ( -1 )
+#define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portNOP()                   __no_operation()
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
-#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
 
 extern void vTaskSwitchContext( void );
-#define portYIELD_FROM_ISR( x )                               do { if( x ) vPortYield( ); } while( 0 )
+#define portYIELD_FROM_ISR( x ) do { if( x ) vPortYield(); } while( 0 )
 
 void vApplicationSetupTimerInterrupt( void );
 
 /* sizeof( int ) != sizeof( long ) so a full printf() library is required if
- * run time stats information is to be displayed. */
+run time stats information is to be displayed. */
 #define portLU_PRINTF_SPECIFIER_REQUIRED
 
 #endif /* PORTMACRO_H */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Revert the #768 PR on CCS ports

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
