### PR TITLE
Add vApplicationGetPassiveIdleTaskMemory for SMP

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -1960,9 +1960,6 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
 #endif
 
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-
-    #if ( configNUMBER_OF_CORES == 1 )
-
 /**
  * task.h
  * @code{c}
@@ -1976,15 +1973,14 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
  * @param ppxIdleTaskStackBuffer A handle to a statically allocated Stack buffer for the idle task
  * @param pulIdleTaskStackSize A pointer to the number of elements that will fit in the allocated stack buffer
  */
-        void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
-                                            StackType_t ** ppxIdleTaskStackBuffer,
-                                            uint32_t * pulIdleTaskStackSize ); /*lint !e526 Symbol not defined as it is an application callback. */
-    #else /* #if ( configNUMBER_OF_CORES == 1 ) */
+    void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                        StackType_t ** ppxIdleTaskStackBuffer,
+                                        uint32_t * pulIdleTaskStackSize ); /*lint !e526 Symbol not defined as it is an application callback. */
 
 /**
  * task.h
  * @code{c}
- * void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer, StackType_t ** ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize, BaseType_t xCoreID )
+ * void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer, StackType_t ** ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize, BaseType_t xCoreID )
  * @endcode
  *
  * This function is used to provide a statically allocated block of memory to FreeRTOS to hold the Idle Tasks TCB.  This function is required when
@@ -1996,20 +1992,21 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
  * These idle tasks are created to ensure that each core has an idle task to run when
  * no other task is available to run.
  *
- * The function vApplicationGetIdleTaskMemory is called with xCoreID 0 to get the
- * memory for Active idle task. It is called with xCoreID 1, 2 ... ( configNUMBER_OF_CORES - 1 )
- * to get memory for passive idle tasks.
+ * The function vApplicationGetPassiveIdleTaskMemory is called with passive idle
+ * task index 0, 1 ... ( configNUMBER_OF_CORES - 2 ) to get memory for passive idle
+ * tasks.
  *
  * @param ppxIdleTaskTCBBuffer A handle to a statically allocated TCB buffer
  * @param ppxIdleTaskStackBuffer A handle to a statically allocated Stack buffer for the idle task
  * @param pulIdleTaskStackSize A pointer to the number of elements that will fit in the allocated stack buffer
- * @param xCoreId The core index of the idle task buffer
+ * @param xPassiveIdleTaskIndex The passive idle task index of the idle task buffer
  */
-        void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
-                                            StackType_t ** ppxIdleTaskStackBuffer,
-                                            uint32_t * pulIdleTaskStackSize, /*lint !e526 Symbol not defined as it is an application callback. */
-                                            BaseType_t xCoreID );
-    #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+    #if ( configNUMBER_OF_CORES > 1 )
+        void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                                   StackType_t ** ppxIdleTaskStackBuffer,
+                                                   uint32_t * pulIdleTaskStackSize,
+                                                   BaseType_t xPassiveIdleTaskIndex );
+    #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 #endif /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
 
 /**

--- a/include/task.h
+++ b/include/task.h
@@ -1960,6 +1960,7 @@ configSTACK_DEPTH_TYPE uxTaskGetStackHighWaterMark2( TaskHandle_t xTask ) PRIVIL
 #endif
 
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+
 /**
  * task.h
  * @code{c}


### PR DESCRIPTION
Description
-----------
Compatibility update for get idle task memory. The prototype for `vApplicationGetIdleTaskMemory` is different for single core and SMP due to the passive idle task memory.

The original implementation.
```c
#if configNUMBER_OF_CORES == 1
    void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                        StackType_t ** ppxIdleTaskStackBuffer,
                                        uint32_t * pulIdleTaskStackSize );
#else
    void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                        StackType_t ** ppxIdleTaskStackBuffer,
                                        uint32_t * pulIdleTaskStackSize,
                                        BaseType_t xCoreID );
#endif
```
This brings compatibility problem for single core and SMP. Compile option `#if configNUMBER_OF_CORES == 1` has to be used in application to built with single core and SMP. This PR tries to reduce the compile option usage for `vApplicationGetIdleTaskMemory` such that a SMP application can be built with `configNUMBER_OF_CORES == 1` without any modification.

#### In this PR
Update API prototype with the following:
```c
void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                    StackType_t ** ppxIdleTaskStackBuffer,
                                    uint32_t * pulIdleTaskStackSize );

#if ( configNUMBER_OF_CORES > 1 )
    void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                               StackType_t ** ppxIdleTaskStackBuffer,
                                               uint32_t * pulIdleTaskStackSize,
                                               BaseType_t xPassiveIdleTaskIndex );
#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
```

* Update `vApplicationGetIdleTaskMemory` prototype for SMP. Now SMP and single core use the same prototype for compatibility.
* Add `vApplicationGetPassiveIdleTaskMemory` for SMP to get passive idle task memory.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
Unit test is covered in this PR : https://github.com/FreeRTOS/FreeRTOS/pull/1114

Related Issue
-----------
#834


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
