### PR TITLE
Fix IAR/CM0/portmacro.h missing semicolon

### DIFF
--- a/portable/IAR/ARM_CM0/portmacro.h
+++ b/portable/IAR/ARM_CM0/portmacro.h
@@ -87,18 +87,18 @@ extern void vPortYield( void );
 #define portNVIC_INT_CTRL     ( ( volatile uint32_t * ) 0xe000ed04 )
 #define portNVIC_PENDSVSET    0x10000000
 #define portYIELD()                vPortYield()
-#define portEND_SWITCHING_ISR( xSwitchRequired )        \
-    do                                                  \
-    {                                                   \
-        if( xSwitchRequired != pdFALSE )                \
-        {                                               \
-            traceISR_EXIT_TO_SCHEDULER();               \
-            *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET \
-        }                                               \
-        else                                            \
-        {                                               \
-            traceISR_EXIT();                            \
-        }                                               \
+#define portEND_SWITCHING_ISR( xSwitchRequired )         \
+    do                                                   \
+    {                                                    \
+        if( xSwitchRequired != pdFALSE )                 \
+        {                                                \
+            traceISR_EXIT_TO_SCHEDULER();                \
+            *( portNVIC_INT_CTRL ) = portNVIC_PENDSVSET; \
+        }                                                \
+        else                                             \
+        {                                                \
+            traceISR_EXIT();                             \
+        }                                                \
     } while( 0 )
 #define portYIELD_FROM_ISR( x )    portEND_SWITCHING_ISR( x )
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------

Fix missing semicolon in portEND_SWITCHING_ISR() in IAR/CM0/portmacro.h

Test Steps
-----------

Found when running ci on my repo https://github.com/hathach/tinyusb/actions/runs/6892688960/job/18750555563?pr=2320#step:5:7399

```
Error[Pe065]: 
          expected a ";"

      portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
````

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
- n/a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
