### PR TITLE
Redundant portRELEASE_TASK_LOCK

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3924,7 +3924,9 @@ BaseType_t xTaskResumeAll( void )
             configASSERT( uxSchedulerSuspended != 0U );
 
             --uxSchedulerSuspended;
+        #if ( configNUMBER_OF_CORES > 1 )
             portRELEASE_TASK_LOCK();
+        #endif
 
             if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
             {


### PR DESCRIPTION

<!--- Title -->

Description
In the single-core version, xTaskResumeAll does not require portRELEASE_TASK_LOCK
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
