### PR TITLE
Coverity Report Directory Fix

### DIFF
--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -61,7 +61,8 @@ jobs:
           cmake -S ./examples/cmake_example/ -B build
           cd build
           cov-build --dir cov-int make -j
-          tar czvf gcc_freertos_kernel_sample_build.tgz cov-int
+          # Move the report out of the build directory
+          tar czvf ../gcc_freertos_kernel_sample_build.tgz cov-int
 
           echo "::endgroup::"
           echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }} "


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The curl command to send the report expects the tar file to be in its current directory. The step either needed to have the working-directory: set to the build directory, or the tar file needs to be created in the parent directory.


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
