### PR TITLE
Fix build error for MSP430 and Cortex A with IAR

### DIFF
--- a/portable/IAR/ARM_CA5_No_GIC/portASM.h
+++ b/portable/IAR/ARM_CA5_No_GIC/portASM.h
@@ -1,158 +1,109 @@
-; /*
-   * ; * FreeRTOS Kernel <DEVELOPMENT BRANCH>
-   * ; * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-   * ; *
-   * ; * SPDX-License-Identifier: MIT
-   * ; *
-   * ; * Permission is hereby granted, free of charge, to any person obtaining a copy of
-   * ; * this software and associated documentation files (the "Software"), to deal in
-   * ; * the Software without restriction, including without limitation the rights to
-   * ; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-   * ; * the Software, and to permit persons to whom the Software is furnished to do so,
-   * ; * subject to the following conditions:
-   * ; *
-   * ; * The above copyright notice and this permission notice shall be included in all
-   * ; * copies or substantial portions of the Software.
-   * ; *
-   * ; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   * ; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-   * ; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-   * ; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-   * ; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-   * ; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-   * ; *
-   * ; * https://www.FreeRTOS.org
-   * ; * https://github.com/FreeRTOS
-   * ; *
-   * ; */
+;/*
+; * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+; * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+; *
+; * SPDX-License-Identifier: MIT
+; *
+; * Permission is hereby granted, free of charge, to any person obtaining a copy of
+; * this software and associated documentation files (the "Software"), to deal in
+; * the Software without restriction, including without limitation the rights to
+; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+; * the Software, and to permit persons to whom the Software is furnished to do so,
+; * subject to the following conditions:
+; *
+; * The above copyright notice and this permission notice shall be included in all
+; * copies or substantial portions of the Software.
+; *
+; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+; *
+; * https://www.FreeRTOS.org
+; * https://github.com/FreeRTOS
+; *
+; */
 
-EXTERN vTaskSwitchContext
-EXTERN ulCriticalNesting
-EXTERN pxCurrentTCB
-EXTERN ulPortTaskHasFPUContext
-EXTERN ulAsmAPIPriorityMask
+    EXTERN  vTaskSwitchContext
+    EXTERN  ulCriticalNesting
+    EXTERN  pxCurrentTCB
+    EXTERN  ulPortTaskHasFPUContext
+    EXTERN  ulAsmAPIPriorityMask
 
 portSAVE_CONTEXT macro
 
-;
-Save the LR and SPSR onto the system mode stack before switching to
-;
-system mode to save the remaining system mode registers
-SRSDB sp !, # SYS_MODE
-      CPS     # SYS_MODE
-      PUSH    {
-    R0 - R12, R14
-}
+    ; Save the LR and SPSR onto the system mode stack before switching to
+    ; system mode to save the remaining system mode registers
+    SRSDB   sp!, #SYS_MODE
+    CPS     #SYS_MODE
+    PUSH    {R0-R12, R14}
 
-;
-Push the critical nesting count
-LDR R2, = ulCriticalNesting
-          LDR R1, [ R2 ]
-PUSH    {
-    R1
-}
+    ; Push the critical nesting count
+    LDR     R2, =ulCriticalNesting
+    LDR     R1, [R2]
+    PUSH    {R1}
 
-;
-Does the task have a floating point context that needs saving ? If
-;
-ulPortTaskHasFPUContext is 0 then no.
-   LDR R2, = ulPortTaskHasFPUContext
-             LDR R3, [ R2 ]
-CMP R3, # 0
+    ; Does the task have a floating point context that needs saving?  If
+    ; ulPortTaskHasFPUContext is 0 then no.
+    LDR     R2, =ulPortTaskHasFPUContext
+    LDR     R3, [R2]
+    CMP     R3, #0
 
-;
-Save the floating point context,
-
-if any
-FMRXNE R1, FPSCR
-                        VPUSHNE {
-    D0 - D15
-}
-
+    ; Save the floating point context, if any
+    FMRXNE  R1,  FPSCR
+    VPUSHNE {D0-D15}
 #if configFPU_D32 == 1
-VPUSHNE {
-    D16 - D31
-}
-#endif; configFPU_D32
-PUSHNE  {
-    R1
-}
+    VPUSHNE {D16-D31}
+#endif ; configFPU_D32
+    PUSHNE  {R1}
 
-;
-Save ulPortTaskHasFPUContext itself
-    PUSH    {
-    R3
-}
+    ; Save ulPortTaskHasFPUContext itself
+    PUSH    {R3}
 
-;
-Save the stack pointer in the TCB
-LDR R0, = pxCurrentTCB
-          LDR R1, [ R0 ]
-STR SP, [ R1 ]
+    ; Save the stack pointer in the TCB
+    LDR     R0, =pxCurrentTCB
+    LDR     R1, [R0]
+    STR     SP, [R1]
 
-endm
+    endm
 
 ; /**********************************************************************/
 
 portRESTORE_CONTEXT macro
 
-;
-Set the SP to point to the stack of the task being restored.
-   LDR R0, = pxCurrentTCB
-             LDR R1, [ R0 ]
-LDR SP, [ R1 ]
+    ; Set the SP to point to the stack of the task being restored.
+    LDR     R0, =pxCurrentTCB
+    LDR     R1, [R0]
+    LDR     SP, [R1]
 
-;
-Is there a floating point context to restore ? If the restored
-;
-ulPortTaskHasFPUContext is zero then no.
-   LDR R0, = ulPortTaskHasFPUContext
-             POP     {
-    R1
-}
-STR R1, [ R0 ]
-CMP R1, # 0
+    ; Is there a floating point context to restore?  If the restored
+    ; ulPortTaskHasFPUContext is zero then no.
+    LDR     R0, =ulPortTaskHasFPUContext
+    POP     {R1}
+    STR     R1, [R0]
+    CMP     R1, #0
 
-;
-Restore the floating point context,
-
-if any
-                           POPNE   {
-    R0
-}
-
+    ; Restore the floating point context, if any
+    POPNE   {R0}
 #if configFPU_D32 == 1
-VPOPNE  {
-    D16 - D31
-}
-#endif; configFPU_D32
-VPOPNE  {
-    D0 - D15
-}
-VMSRNE FPSCR, R0
+    VPOPNE  {D16-D31}
+#endif ; configFPU_D32
+    VPOPNE  {D0-D15}
+    VMSRNE  FPSCR, R0
 
-;
-Restore the critical section nesting depth
-LDR R0, = ulCriticalNesting
-          POP     {
-    R1
-}
-STR R1, [ R0 ]
+    ; Restore the critical section nesting depth
+    LDR     R0, =ulCriticalNesting
+    POP     {R1}
+    STR     R1, [R0]
 
-;
-Restore all system mode registers other than the SP( which is already
-                                                     ;
-                                                     being used )
-POP
-{
-    R0 - R12, R14
-}
+    ; Restore all system mode registers other than the SP (which is already
+    ; being used)
+    POP     {R0-R12, R14}
 
-Return to the task code, loading CPSR on the way.CPSR has the interrupt
-;
-enable bit set appropriately
+    ; Return to the task code, loading CPSR on the way.  CPSR has the interrupt
+    ; enable bit set appropriately for the task about to execute.
+    RFEIA   sp!
 
-for the task about to execute.
-   RFEIA sp !
-
-endm
+    endm

--- a/portable/IAR/ARM_CA9/portASM.h
+++ b/portable/IAR/ARM_CA9/portASM.h
@@ -1,160 +1,111 @@
-; /*
-   * ; * FreeRTOS Kernel <DEVELOPMENT BRANCH>
-   * ; * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-   * ; *
-   * ; * SPDX-License-Identifier: MIT
-   * ; *
-   * ; * Permission is hereby granted, free of charge, to any person obtaining a copy of
-   * ; * this software and associated documentation files (the "Software"), to deal in
-   * ; * the Software without restriction, including without limitation the rights to
-   * ; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-   * ; * the Software, and to permit persons to whom the Software is furnished to do so,
-   * ; * subject to the following conditions:
-   * ; *
-   * ; * The above copyright notice and this permission notice shall be included in all
-   * ; * copies or substantial portions of the Software.
-   * ; *
-   * ; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   * ; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-   * ; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-   * ; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-   * ; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-   * ; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-   * ; *
-   * ; * https://www.FreeRTOS.org
-   * ; * https://github.com/FreeRTOS
-   * ; *
-   * ; */
+;/*
+; * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+; * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+; *
+; * SPDX-License-Identifier: MIT
+; *
+; * Permission is hereby granted, free of charge, to any person obtaining a copy of
+; * this software and associated documentation files (the "Software"), to deal in
+; * the Software without restriction, including without limitation the rights to
+; * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+; * the Software, and to permit persons to whom the Software is furnished to do so,
+; * subject to the following conditions:
+; *
+; * The above copyright notice and this permission notice shall be included in all
+; * copies or substantial portions of the Software.
+; *
+; * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+; * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+; * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+; * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+; * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+; * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+; *
+; * https://www.FreeRTOS.org
+; * https://github.com/FreeRTOS
+; *
+; */
 
-EXTERN vTaskSwitchContext
-EXTERN ulCriticalNesting
-EXTERN pxCurrentTCB
-EXTERN ulPortTaskHasFPUContext
-EXTERN ulAsmAPIPriorityMask
+    EXTERN  vTaskSwitchContext
+    EXTERN  ulCriticalNesting
+    EXTERN  pxCurrentTCB
+    EXTERN  ulPortTaskHasFPUContext
+    EXTERN  ulAsmAPIPriorityMask
 
 portSAVE_CONTEXT macro
 
-;
-Save the LR and SPSR onto the system mode stack before switching to
-;
-system mode to save the remaining system mode registers
-SRSDB sp !, # SYS_MODE
-      CPS     # SYS_MODE
-      PUSH    {
-    R0 - R12, R14
-}
+    ; Save the LR and SPSR onto the system mode stack before switching to
+    ; system mode to save the remaining system mode registers
+    SRSDB   sp!, #SYS_MODE
+    CPS     #SYS_MODE
+    PUSH    {R0-R12, R14}
 
-;
-Push the critical nesting count
-LDR R2, = ulCriticalNesting
-          LDR R1, [ R2 ]
-PUSH    {
-    R1
-}
+    ; Push the critical nesting count
+    LDR     R2, =ulCriticalNesting
+    LDR     R1, [R2]
+    PUSH    {R1}
 
-;
-Does the task have a floating point context that needs saving ? If
-;
-ulPortTaskHasFPUContext is 0 then no.
-   LDR R2, = ulPortTaskHasFPUContext
-             LDR R3, [ R2 ]
-CMP R3, # 0
+    ; Does the task have a floating point context that needs saving?  If
+    ; ulPortTaskHasFPUContext is 0 then no.
+    LDR     R2, =ulPortTaskHasFPUContext
+    LDR     R3, [R2]
+    CMP     R3, #0
 
-;
-Save the floating point context,
+    ; Save the floating point context, if any
+    FMRXNE  R1,  FPSCR
+    VPUSHNE {D0-D15}
+    VPUSHNE {D16-D31}
+    PUSHNE  {R1}
 
-if any
-FMRXNE R1, FPSCR
-                        VPUSHNE {
-    D0 - D15
-}
+    ; Save ulPortTaskHasFPUContext itself
+    PUSH    {R3}
 
-VPUSHNE {
-    D16 - D31
-}
-PUSHNE  {
-    R1
-}
+    ; Save the stack pointer in the TCB
+    LDR     R0, =pxCurrentTCB
+    LDR     R1, [R0]
+    STR     SP, [R1]
 
-;
-Save ulPortTaskHasFPUContext itself
-    PUSH    {
-    R3
-}
-
-;
-Save the stack pointer in the TCB
-LDR R0, = pxCurrentTCB
-          LDR R1, [ R0 ]
-STR SP, [ R1 ]
-
-endm
+    endm
 
 ; /**********************************************************************/
 
 portRESTORE_CONTEXT macro
 
-;
-Set the SP to point to the stack of the task being restored.
-   LDR R0, = pxCurrentTCB
-             LDR R1, [ R0 ]
-LDR SP, [ R1 ]
+    ; Set the SP to point to the stack of the task being restored.
+    LDR     R0, =pxCurrentTCB
+    LDR     R1, [R0]
+    LDR     SP, [R1]
 
-;
-Is there a floating point context to restore ? If the restored
-;
-ulPortTaskHasFPUContext is zero then no.
-   LDR R0, = ulPortTaskHasFPUContext
-             POP     {
-    R1
-}
-STR R1, [ R0 ]
-CMP R1, # 0
+    ; Is there a floating point context to restore?  If the restored
+    ; ulPortTaskHasFPUContext is zero then no.
+    LDR     R0, =ulPortTaskHasFPUContext
+    POP     {R1}
+    STR     R1, [R0]
+    CMP     R1, #0
 
-;
-Restore the floating point context,
+    ; Restore the floating point context, if any
+    POPNE   {R0}
+    VPOPNE  {D16-D31}
+    VPOPNE  {D0-D15}
+    VMSRNE  FPSCR, R0
 
-if any
-                           POPNE   {
-    R0
-}
+    ; Restore the critical section nesting depth
+    LDR     R0, =ulCriticalNesting
+    POP     {R1}
+    STR     R1, [R0]
 
-VPOPNE  {
-    D16 - D31
-}
-VPOPNE  {
-    D0 - D15
-}
-VMSRNE FPSCR, R0
+    ; Ensure the priority mask is correct for the critical nesting depth
+    LDR     R2, =portICCPMR_PRIORITY_MASK_REGISTER_ADDRESS
+    CMP     R1, #0
+    MOVEQ   R4, #255
+    LDRNE   R4, =( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT )
+    STR     R4, [r2]
 
-;
-Restore the critical section nesting depth
-LDR R0, = ulCriticalNesting
-          POP     {
-    R1
-}
-STR R1, [ R0 ]
+    ; Restore all system mode registers other than the SP (which is already
+    ; being used)
+    POP     {R0-R12, R14}
 
-;
-Ensure the priority mask is correct
+    ; Return to the task code, loading CPSR on the way.
+    RFEIA   sp!
 
-for the critical nesting depth
-LDR R2, = portICCPMR_PRIORITY_MASK_REGISTER_ADDRESS
-          CMP R1, # 0
-MOVEQ R4, # 255
-LDRNE R4, = ( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT )
-            STR R4, [ r2 ]
-
-;
-Restore all system mode registers other than the SP( which is already
-                                                     ;
-                                                     being used )
-POP
-{
-    R0 - R12, R14
-}
-
-Return to the task code, loading CPSR on the way.
-   RFEIA sp !
-
-endm
+    endm

--- a/portable/IAR/MSP430/portasm.h
+++ b/portable/IAR/MSP430/portasm.h
@@ -31,54 +31,54 @@
 
 portSAVE_CONTEXT macro
 
-IMPORT pxCurrentTCB
-IMPORT usCriticalNesting
+    IMPORT pxCurrentTCB
+    IMPORT usCriticalNesting
 
-/* Save the remaining registers. */
-push r4
-push r5
-push r6
-push r7
-push r8
-push r9
-push r10
-push r11
-push r12
-push r13
-push r14
-push r15
-mov.w &usCriticalNesting, r14
-push r14
-       mov.w &pxCurrentTCB, r12
-       mov.w r1, 0 ( r12 )
-endm
+    /* Save the remaining registers. */
+    push   r4
+    push   r5
+    push   r6
+    push   r7
+    push   r8
+    push   r9
+    push   r10
+    push   r11
+    push   r12
+    push   r13
+    push   r14
+    push   r15
+    mov.w  &usCriticalNesting, r14
+    push   r14
+    mov.w  &pxCurrentTCB, r12
+    mov.w  r1, 0(r12)
+    endm
 /*-----------------------------------------------------------*/
 
 portRESTORE_CONTEXT macro
-mov.w & pxCurrentTCB, r12
-mov.w @r12, r1
-pop r15
-mov.w r15, &usCriticalNesting
-pop r15
-pop r14
-pop r13
-pop r12
-pop r11
-pop r10
-pop r9
-pop r8
-pop r7
-pop r6
-pop r5
-pop r4
+    mov.w  &pxCurrentTCB, r12
+    mov.w  @r12, r1
+    pop    r15
+    mov.w  r15, &usCriticalNesting
+    pop    r15
+    pop    r14
+    pop    r13
+    pop    r12
+    pop    r11
+    pop    r10
+    pop    r9
+    pop    r8
+    pop    r7
+    pop    r6
+    pop    r5
+    pop    r4
 
-/* The last thing on the stack will be the status register.
- * Ensure the power down bits are clear ready for the next
- * time this power down register is popped from the stack. */
-bic.w   # 0xf0, 0 ( SP )
+    /* The last thing on the stack will be the status register.
+     * Ensure the power down bits are clear ready for the next
+     * time this power down register is popped from the stack. */
+    bic.w  #0xf0, 0(SP)
 
-reti
-endm
+    reti
+    endm
 /*-----------------------------------------------------------*/
 
 #endif /* ifndef PORTASM_H */


### PR DESCRIPTION
Description
-----------
Fix a build error in the MSP430 and Cortex A IAR ports caused by whitespace missing in asm macros.  Add whitespace to make sure all instruction mnemonics and assembler directives do not appear in the label field (column 1) of the line.

Test Steps
-----------
Build the msp430_IAR demo with and without this PR.  When building without this PR, the assembler gives the error "Error[14]: Missing #endif" for both serialASM.s43 and portext.s43.  When building with this PR, no error.

Note I did not test the Cortex A ports.  I don't have the IAR compiler/assembler for Cortex A.

Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request. (N/A)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
