### PR TITLE
Assign idle task to each core before the SMP scheduler start

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2108,29 +2108,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                if( ( pxNewTCB->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U )
-                {
-                    BaseType_t xCoreID;
-
-                    /* Check if a core is free. */
-                    for( xCoreID = ( BaseType_t ) 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
-                    {
-                        if( pxCurrentTCBs[ xCoreID ] == NULL )
-                        {
-                            pxNewTCB->xTaskRunState = xCoreID;
-                            pxCurrentTCBs[ xCoreID ] = pxNewTCB;
-                            break;
-                        }
-                        else
-                        {
-                            mtCOVERAGE_TEST_MARKER();
-                        }
-                    }
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
+                /* All the cores start with idle tasks before the SMP scheduler
+                 * is running. Idle tasks are assigned to cores when they are
+                 * created in prvCreateIdleTasks(). */
             }
 
             uxTaskNumber++;
@@ -3645,7 +3625,17 @@ static BaseType_t prvCreateIdleTasks( void )
         }
         else
         {
-            mtCOVERAGE_TEST_MARKER();
+            #if ( configNUMBER_OF_CORES == 1 )
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+            #else
+            {
+                /* Assign idle task to each core before SMP scheduler is running. */
+                xIdleTaskHandles[ xCoreID ]->xTaskRunState = xCoreID;
+                pxCurrentTCBs[ xCoreID ] = xIdleTaskHandles[ xCoreID ];
+            }
+            #endif
         }
     }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
All the cores start with idle tasks before the SMP scheduler is running.

In this PR:
* Assign idle task to each core when they are created in `prvCreateIdleTasks()`.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
