### PR TITLE
 Suppress unused variable in GCC posix prvTimerTickHandler()

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -381,6 +381,8 @@ static uint64_t prvGetTimeNs( void )
 
 static void * prvTimerTickHandler( void * arg )
 {
+    ( void ) arg;
+    
     while( xTimerTickThreadShouldRun )
     {
         /*


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR supress the unused variable `void * arg` in the `prvTimerTickHandler` in the [GCC/Posix/port.c](https://github.com/FreeRTOS/FreeRTOS-Kernel/compare/main...tony-josi-aws:FreeRTOS-Kernel:fix_posix_port_build?expand=1#diff-e52a551c2f42efff2bb76b7f63f1bdd88b6b2d740fe7a66fd684a462201eda4f)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Build check

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
