### PR TITLE
MPU assert for ARM_CM3_MPU

### DIFF
--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -1115,10 +1115,7 @@ static void prvSetupMPU( void )
         extern uint32_t __privileged_data_end__[];
     #endif /* if defined( __ARMCC_VERSION ) */
 
-    /* The only permitted number of regions are 8 or 16. */
-    configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
-
-    /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+    /* Ensure that the device has the expected MPU type */
     configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
 
     /* Check the expected MPU is present. */

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -1095,12 +1095,25 @@ __attribute__( ( weak ) ) void vPortSetupTimerInterrupt( void )
 
 static void prvSetupMPU( void )
 {
-    extern uint32_t __privileged_functions_start__[];
-    extern uint32_t __privileged_functions_end__[];
-    extern uint32_t __FLASH_segment_start__[];
-    extern uint32_t __FLASH_segment_end__[];
-    extern uint32_t __privileged_data_start__[];
-    extern uint32_t __privileged_data_end__[];
+    #if defined( __ARMCC_VERSION )
+
+        /* Declaration when these variable are defined in code instead of being
+         * exported from linker scripts. */
+        extern uint32_t * __privileged_functions_start__;
+        extern uint32_t * __privileged_functions_end__;
+        extern uint32_t * __FLASH_segment_start__;
+        extern uint32_t * __FLASH_segment_end__;
+        extern uint32_t * __privileged_data_start__;
+        extern uint32_t * __privileged_data_end__;
+    #else
+        /* Declaration when these variable are exported from linker scripts. */
+        extern uint32_t __privileged_functions_start__[];
+        extern uint32_t __privileged_functions_end__[];
+        extern uint32_t __FLASH_segment_start__[];
+        extern uint32_t __FLASH_segment_end__[];
+        extern uint32_t __privileged_data_start__[];
+        extern uint32_t __privileged_data_end__[];
+    #endif /* if defined( __ARMCC_VERSION ) */
 
     /* The only permitted number of regions are 8 or 16. */
     configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
@@ -1235,10 +1248,22 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
                                 StackType_t * pxBottomOfStack,
                                 uint32_t ulStackDepth )
 {
-    extern uint32_t __SRAM_segment_start__[];
-    extern uint32_t __SRAM_segment_end__[];
-    extern uint32_t __privileged_data_start__[];
-    extern uint32_t __privileged_data_end__[];
+    #if defined( __ARMCC_VERSION )
+
+        /* Declaration when these variable are defined in code instead of being
+         * exported from linker scripts. */
+        extern uint32_t * __SRAM_segment_start__;
+        extern uint32_t * __SRAM_segment_end__;
+        extern uint32_t * __privileged_data_start__;
+        extern uint32_t * __privileged_data_end__;
+    #else
+        /* Declaration when these variable are exported from linker scripts. */
+        extern uint32_t __SRAM_segment_start__[];
+        extern uint32_t __SRAM_segment_end__[];
+        extern uint32_t __privileged_data_start__[];
+        extern uint32_t __privileged_data_end__[];
+    #endif /* if defined( __ARMCC_VERSION ) */
+
     int32_t lIndex;
     uint32_t ul;
 

--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -1102,6 +1102,12 @@ static void prvSetupMPU( void )
     extern uint32_t __privileged_data_start__[];
     extern uint32_t __privileged_data_end__[];
 
+    /* The only permitted number of regions are 8 or 16. */
+    configASSERT( ( configTOTAL_MPU_REGIONS == 8 ) || ( configTOTAL_MPU_REGIONS == 16 ) );
+
+    /* Ensure that the configTOTAL_MPU_REGIONS is configured correctly. */
+    configASSERT( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE );
+
     /* Check the expected MPU is present. */
     if( portMPU_TYPE_REG == portEXPECTED_MPU_TYPE_VALUE )
     {

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -90,14 +90,11 @@ typedef unsigned long    UBaseType_t;
 #ifndef configTOTAL_MPU_REGIONS
     /* Define to 8 for backward compatibility. */
     #define configTOTAL_MPU_REGIONS    ( 8UL )
-#endif
-
-/* CM3 only supports 8 MPU regions */
-/* Fail if FreeRTOSConfig.h overwrites configTOTAL_MPU_REGIONS with an invalid value */
-#if ( configTOTAL_MPU_REGIONS != 8 )
+#elif( configTOTAL_MPU_REGIONS != 8UL )
+    /* The Cortex M3 only supports 8 MPU regions. For more information refer to:
+     * https://developer.arm.com/documentation/dui0552/a/cortex-m3-peripherals/optional-memory-protection-unit */
     #error configTOTAL_MPU_REGIONS must be 8 for this port.
-#endif
-
+#endif /* configTOTAL_MPU_REGIONS Check */
 #define portSTACK_REGION                                         ( 3UL )
 #define portGENERAL_PERIPHERALS_REGION                           ( 4UL )
 #define portUNPRIVILEGED_FLASH_REGION                            ( 5UL )

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -86,6 +86,18 @@ typedef unsigned long    UBaseType_t;
 #define portMPU_REGION_CACHEABLE_BUFFERABLE                      ( 0x07UL << 16UL )
 #define portMPU_REGION_EXECUTE_NEVER                             ( 0x01UL << 28UL )
 
+/* MPU settings that can be overriden in FreeRTOSConfig.h. */
+#ifndef configTOTAL_MPU_REGIONS
+    /* Define to 8 for backward compatibility. */
+    #define configTOTAL_MPU_REGIONS    ( 8UL )
+#endif
+
+/* CM3 only supports 8 MPU regions */
+/* Fail if FreeRTOSConfig.h overwrites configTOTAL_MPU_REGIONS with an invalid value */
+#if ( configTOTAL_MPU_REGIONS != 8 )
+    #error configTOTAL_MPU_REGIONS must be 8 for this port.
+#endif
+
 #define portSTACK_REGION                                         ( 3UL )
 #define portGENERAL_PERIPHERALS_REGION                           ( 4UL )
 #define portUNPRIVILEGED_FLASH_REGION                            ( 5UL )


### PR DESCRIPTION
MPU assert for ARM_CM3_MPU

Description
-----------
This PR adds runtime check to see if the target even has a MPU. Copied over from ARM_CM4_MPU. All other CM3 and CM4 ports already have this check.

While I was copying I also copied over support for the external symbols when __ARMCC_VERSION is set.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
- [x] I have tested my changes on a STM32F1, a M3 without MPU, the assert hits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
