### PR TITLE
Make configSUPPORT_STATIC_ALLOCATION==1 an error for MPU ports

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -45,7 +45,7 @@
  * reason is that the stack alignment requirements vary for different
  * architectures.*/
 #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) && ( portUSING_MPU_WRAPPERS != 0 ) )
-#error configKERNEL_PROVIDED_STATIC_MEMORY cannot be set to 1 when using an MPU port. The vApplicationGet*TaskMemory() functions must be provided manually.
+    #error configKERNEL_PROVIDED_STATIC_MEMORY cannot be set to 1 when using an MPU port. The vApplicationGet*TaskMemory() functions must be provided manually.
 #endif
 
 /* The MPU ports require MPU_WRAPPERS_INCLUDED_FROM_API_FILE to be defined

--- a/tasks.c
+++ b/tasks.c
@@ -41,6 +41,13 @@
 #include "timers.h"
 #include "stack_macros.h"
 
+/* The default definitions are only available for non-MPU ports. The
+ * reason is that the stack alignment requirements vary for different
+ * architectures.*/
+#if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 1 ) && ( portUSING_MPU_WRAPPERS != 0 ) )
+#error configKERNEL_PROVIDED_STATIC_MEMORY cannot be set to 1 when using an MPU port. The vApplicationGet*TaskMemory() functions must be provided manually.
+#endif
+
 /* The MPU ports require MPU_WRAPPERS_INCLUDED_FROM_API_FILE to be defined
  * for the header files above, but not in this file, in order to generate the
  * correct privileged Vs unprivileged linkage and placement. */


### PR DESCRIPTION
Make configSUPPORT_STATIC_ALLOCATION==1 an error for MPU ports

Description
-----------
The `vApplicationGet*TaskMemory()` functions are not generated for MPU ports even when `configSUPPORT_STATIC_ALLOCATION` is set.  This PR makes setting `configSUPPORT_STATIC_ALLOCATION` for MPU ports an error.  Copied explanation from https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/790#discussion_r1329997898

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
