### PR TITLE
Add check for if the scheduler is running to MPU ports

### DIFF
--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -1352,7 +1352,15 @@ BaseType_t xPortIsAuthorizedToAccessBuffer( const void * pvBuffer,
     BaseType_t xAccessGranted = pdFALSE;
     const xMPU_SETTINGS * xTaskMpuSettings = xTaskGetMPUSettings( NULL ); /* Calling task's MPU settings. */
 
-    if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
+    if( xSchedulerRunning == pdFALSE )
+    {
+        /* Grant access to all the kernel objects before the scheduler
+         * is started. It is necessary because there is no task running
+         * yet and therefore, we cannot use the permissions of any
+         * task. */
+        xAccessGranted = pdTRUE;
+    }
+    else if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
     {
         xAccessGranted = pdTRUE;
     }

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -1523,7 +1523,15 @@ BaseType_t xPortIsAuthorizedToAccessBuffer( const void * pvBuffer,
     BaseType_t xAccessGranted = pdFALSE;
     const xMPU_SETTINGS * xTaskMpuSettings = xTaskGetMPUSettings( NULL ); /* Calling task's MPU settings. */
 
-    if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
+    if( xSchedulerRunning == pdFALSE )
+    {
+        /* Grant access to all the kernel objects before the scheduler
+         * is started. It is necessary because there is no task running
+         * yet and therefore, we cannot use the permissions of any
+         * task. */
+        xAccessGranted = pdTRUE;
+    }
+    else if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
     {
         xAccessGranted = pdTRUE;
     }

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -1253,7 +1253,15 @@ BaseType_t xPortIsAuthorizedToAccessBuffer( const void * pvBuffer,
     BaseType_t xAccessGranted = pdFALSE;
     const xMPU_SETTINGS * xTaskMpuSettings = xTaskGetMPUSettings( NULL ); /* Calling task's MPU settings. */
 
-    if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
+    if( xSchedulerRunning == pdFALSE )
+    {
+        /* Grant access to all the kernel objects before the scheduler
+         * is started. It is necessary because there is no task running
+         * yet and therefore, we cannot use the permissions of any
+         * task. */
+        xAccessGranted = pdTRUE;
+    }
+    else if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
     {
         xAccessGranted = pdTRUE;
     }

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -1508,7 +1508,16 @@ BaseType_t xPortIsAuthorizedToAccessBuffer( const void * pvBuffer,
     BaseType_t xAccessGranted = pdFALSE;
     const xMPU_SETTINGS * xTaskMpuSettings = xTaskGetMPUSettings( NULL ); /* Calling task's MPU settings. */
 
-    if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
+    
+    if( xSchedulerRunning == pdFALSE )
+    {
+        /* Grant access to all the kernel objects before the scheduler
+         * is started. It is necessary because there is no task running
+         * yet and therefore, we cannot use the permissions of any
+         * task. */
+        xAccessGranted = pdTRUE;
+    }
+    else if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
     {
         xAccessGranted = pdTRUE;
     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add a check for if the scheduler is running to [xPortIsAuthorizedToAccessBuffer()](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/portable/GCC/ARM_CM4_MPU/port.c#L1517).

This fixes an issue where before the scheduler is started APIs can fail as the TCB pointed to by pxCurrentTCB may not have access to requested APIs.


Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Call [xTimerStart()](https://github.com/FreeRTOS/FreeRTOS/blob/main/FreeRTOS/Demo/CORTEX_MPU_Static_Simulator_Keil_GCC/main.c#L499), which calls [MPU_xTimerGenericCommandFromTask](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/portable/Common/mpu_wrappers_v2.c#L3437):
```
xReturn = MPU_xTimerGenericCommandFromTaskEntry( &( xParams ) );
```

Which calls [MPU_xTimerGenericCommandFromTaskEntry](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/portable/GCC/ARM_CM4_MPU/mpu_wrappers_v2_asm.c#L1492)
```
BaseType_t MPU_xTimerGenericCommandFromTaskEntry(
    const xTimerGenericCommandFromTaskParams_t * pxParams
 ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
    {
        __asm volatile
        (
            " .syntax unified                                               \n"
            " .extern MPU_xTimerGenericCommandFromTaskImpl                  \n"
            "                                                               \n"
            " push {r0}                                                     \n"
            " mrs r0, control                                               \n"
            " tst r0, #1                                                    \n"
            " bne MPU_xTimerGenericCommandFromTask_Unpriv                   \n"
            " MPU_xTimerGenericCommandFromTask_Priv:                        \n"
            "     pop {r0}                                                  \n"
            "     b MPU_xTimerGenericCommandFromTaskImpl                    \n"
```

This calls [MPU_xTimerGenericCommandFromTaskImpl](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/portable/Common/mpu_wrappers_v2.c#L3459):
```
xAreParamsReadable = xPortIsAuthorizedToAccessBuffer( pxParams,
                                            sizeof( xTimerGenericCommandFromTaskParams_t ),
                                            tskMPU_READ_PERMISSION );
}
```
Which calls [xPortIsAuthorizedToAccessBuffer](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/portable/GCC/ARM_CM4_MPU/port.c#L1517)
This loads pxCurrentTCB to check if you are allowed to start the timer

```
BaseType_t xPortIsAuthorizedToAccessBuffer(
    const void * pvBuffer,
    uint32_t ulBufferLength,
    uint32_t ulAccessRequested
) /* PRIVILEGED_FUNCTION */
{
    uint32_t i, ulBufferStartAddress, ulBufferEndAddress;
    BaseType_t xAccessGranted = pdFALSE;
    const xMPU_SETTINGS * xTaskMpuSettings = xTaskGetMPUSettings( NULL ); /* Calling task's MPU settings. */

    if( ( xTaskMpuSettings->ulTaskFlags & portTASK_IS_PRIVILEGED_FLAG ) == portTASK_IS_PRIVILEGED_FLAG )
    {
            xAccessGranted = pdTRUE;
    }
    else
    {
        <CHECK_IF_ACCESS_ALLOWED>
```
However, there's no actual calling task that made this call. It just checks whatever [TCB](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/tasks.c#L439) happens to be there.

A check is needed for when the scheduler is not running yet, as at this point the current [TCB](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.0.1/tasks.c#L439) is irrelevant to the operation being performed.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
