### PR TITLE
Fix MacOS Posix port

### DIFF
--- a/.github/workflows/kernel-demos.yml
+++ b/.github/workflows/kernel-demos.yml
@@ -58,7 +58,13 @@ jobs:
 
   POSIX-GCC:
     name: Native GCC
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the FreeRTOS/FreeRTOS Repository
         uses: actions/checkout@v3
@@ -76,6 +82,7 @@ jobs:
 
       - name: Install GCC
         shell: bash
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get -y update
           sudo apt-get -y install build-essential

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -266,9 +266,10 @@ BaseType_t xPortStartScheduler( void )
      */
     xSchedulerEnd = pdFALSE;
 
-    /* Reset the pthread_once_t structure. This is required if the port
-     * starts the scheduler again. */
-    hSigSetupThread = PTHREAD_ONCE_INIT;
+    /* Reset pthread_once_t, needed to restart the scheduler again.
+     * memset the internal struct members for MacOS/Linux Compatability */
+    memset( ( void * ) &hSigSetupThread.__sig, _PTHREAD_ONCE_SIG_init, sizeof(_PTHREAD_ONCE_SIG_init));
+    memset( ( void * ) &hSigSetupThread.__opaque, 0, sizeof(hSigSetupThread.__opaque));
 
     /* Restore original signal mask. */
     ( void ) pthread_sigmask( SIG_SETMASK, &xSchedulerOriginalSignalMask, NULL );

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -285,8 +285,6 @@ BaseType_t xPortStartScheduler( void )
     /* Reset pthread_once_t, needed to restart the scheduler again.
      * memset the internal struct members for MacOS/Linux Compatability */
     #if __APPLE__
-        /* Restarting the scheduler is currently unsupported on MacOS. */
-        configASSERT( pdFALSE );
         hSigSetupThread.__sig = _PTHREAD_ONCE_SIG_init;
         memset( ( void * ) &hSigSetupThread.__opaque, 0, sizeof(hSigSetupThread.__opaque));
     #else /* Linux PTHREAD library*/

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -270,7 +270,9 @@ BaseType_t xPortStartScheduler( void )
     /* Reset pthread_once_t, needed to restart the scheduler again.
      * memset the internal struct members for MacOS/Linux Compatability */
     #if __APPLE__
-        memset( ( void * ) &hSigSetupThread.__sig, _PTHREAD_ONCE_SIG_init, sizeof(_PTHREAD_ONCE_SIG_init));
+        /* Restarting the scheduler is currently unsupported on MacOS. */
+        configASSERT( pdFALSE );
+        hSigSetupThread.__sig = _PTHREAD_ONCE_SIG_init;
         memset( ( void * ) &hSigSetupThread.__opaque, 0, sizeof(hSigSetupThread.__opaque));
     #else /* Linux PTHREAD library*/
         hSigSetupThread = PTHREAD_ONCE_INIT;

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -53,6 +53,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -268,9 +269,13 @@ BaseType_t xPortStartScheduler( void )
 
     /* Reset pthread_once_t, needed to restart the scheduler again.
      * memset the internal struct members for MacOS/Linux Compatability */
-    memset( ( void * ) &hSigSetupThread.__sig, _PTHREAD_ONCE_SIG_init, sizeof(_PTHREAD_ONCE_SIG_init));
-    memset( ( void * ) &hSigSetupThread.__opaque, 0, sizeof(hSigSetupThread.__opaque));
-
+    #if __APPLE__
+        memset( ( void * ) &hSigSetupThread.__sig, _PTHREAD_ONCE_SIG_init, sizeof(_PTHREAD_ONCE_SIG_init));
+        memset( ( void * ) &hSigSetupThread.__opaque, 0, sizeof(hSigSetupThread.__opaque));
+    #else /* Linux PTHREAD library*/
+        hSigSetupThread = PTHREAD_ONCE_INIT;
+    #endif /* __APPLE__*/
+    
     /* Restore original signal mask. */
     ( void ) pthread_sigmask( SIG_SETMASK, &xSchedulerOriginalSignalMask, NULL );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Changes in #914 have caused the Posix GCC FreeRTOS Port to fail to build on MacOS
This PR fixes this issue by wrapping the resetting of a variable used when stopping the scheduler in an OS type check.
This PR also adds a Matrix configuration to the GitHub kernel-demo workflow to build the Posix Demos on MacOS

The exact commit that introduced the breaking change, per the git blame, can be found [here](https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/7ba4124c785e400cb0e8c3c17a49f390e90ba77e)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
