### PR TITLE
Update unpaired critical section in vTaskDelete for readability

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2190,7 +2190,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     void vTaskDelete( TaskHandle_t xTaskToDelete )
     {
         TCB_t * pxTCB;
-        BaseType_t xDeleteTaskInIdleTask = pdFALSE;
+        BaseType_t xDeleteTCBInIdleTask = pdFALSE;
 
         traceENTER_vTaskDelete( xTaskToDelete );
 
@@ -2248,8 +2248,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                  * portPRE_TASK_DELETE_HOOK() does not return in the Win32 port. */
                 traceTASK_DELETE( pxTCB );
 
-                /* Delete the task in idle task. */
-                xDeleteTaskInIdleTask = pdTRUE;
+                /* Delete the task TCB in idle task. */
+                xDeleteTCBInIdleTask = pdTRUE;
 
                 /* The pre-delete hook is primarily for the Windows simulator,
                  * in which Windows specific clean up operations are performed,
@@ -2277,7 +2277,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* If the task is not deleting itself, call prvDeleteTCB from outside of
          * critical section. If a task deletes itself, prvDeleteTCB is called
          * from prvCheckTasksWaitingTermination which is called from Idle task. */
-        if( xDeleteTaskInIdleTask != pdTRUE )
+        if( xDeleteTCBInIdleTask != pdTRUE )
         {
             prvDeleteTCB( pxTCB );
         }

--- a/tasks.c
+++ b/tasks.c
@@ -2301,8 +2301,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             #else /* #if ( configNUMBER_OF_CORES == 1 ) */
             {
                 /* Rescheduling a running task is handled differently if it is running
-                 * on other cores. Checking a task running core needs to be performed
-                 * in critical section. */
+                 * on core other than current core. Checking a task running core needs
+                 * to be performed in critical section. */
                 taskENTER_CRITICAL();
                 {
                     if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )

--- a/tasks.c
+++ b/tasks.c
@@ -2300,8 +2300,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
             #else /* #if ( configNUMBER_OF_CORES == 1 ) */
             {
-                /* Checking running state of a task needs to be performed in
-                 * critical section. */
+                /* It is important to use critical section here because checking
+                 * run state of a task must be done inside a critical section. */
                 taskENTER_CRITICAL();
                 {
                     if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )

--- a/tasks.c
+++ b/tasks.c
@@ -2300,8 +2300,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
             #else /* #if ( configNUMBER_OF_CORES == 1 ) */
             {
-                /* It is important to use critical section here because checking
-                 * run state of a task must be done inside a critical section. */
+                /* It is important to use critical section here because
+                 * checking run state of a task must be done inside a
+                 * critical section. */
                 taskENTER_CRITICAL();
                 {
                     if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )

--- a/tasks.c
+++ b/tasks.c
@@ -2291,7 +2291,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 if( pxTCB == pxCurrentTCB )
                 {
                     configASSERT( uxSchedulerSuspended == 0 );
-                    portYIELD_WITHIN_API();
+                    taskYIELD_WITHIN_API();
                 }
                 else
                 {
@@ -2300,9 +2300,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
             #else /* #if ( configNUMBER_OF_CORES == 1 ) */
             {
-                /* Rescheduling a running task is handled differently if it is running
-                 * on core other than current core. Checking a task running core needs
-                 * to be performed in critical section. */
+                /* Checking running state of a task needs to be performed in
+                 * critical section. */
                 taskENTER_CRITICAL();
                 {
                     if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
@@ -2310,7 +2309,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                         if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
                         {
                             configASSERT( uxSchedulerSuspended == 0 );
-                            vTaskYieldWithinAPI();
+                            taskYIELD_WITHIN_API();
                         }
                         else
                         {


### PR DESCRIPTION
Update unpaired critical section in vTaskDelete for readability

Description
-----------
The implementation in vTaskDelete increase cognitive load as the critical section is unpaired due to single core and SMP implementation.

In this PR:
* Update the implementation to fix the unpaired critical section.
* Move the prvDeleteTCB out of the critical section


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
