### PR TITLE
Update for unpaired critical section in vTaskSuspend

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3107,10 +3107,6 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * pxTCB;
 
-        #if ( configNUMBER_OF_CORES > 1 )
-            BaseType_t xTaskRunningOnCore;
-        #endif
-
         traceENTER_vTaskSuspend( xTaskToSuspend );
 
         taskENTER_CRITICAL();
@@ -3120,10 +3116,6 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             pxTCB = prvGetTCBFromHandle( xTaskToSuspend );
 
             traceTASK_SUSPEND( pxTCB );
-
-            #if ( configNUMBER_OF_CORES > 1 )
-                xTaskRunningOnCore = pxTCB->xTaskRunState;
-            #endif
 
             /* Remove task from the ready/delayed list and place in the
              * suspended list. */
@@ -3164,26 +3156,25 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
             #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
         }
+        taskEXIT_CRITICAL();
+
+        if( xSchedulerRunning != pdFALSE )
+        {
+            /* Reset the next expected unblock time in case it referred to the
+             * task that is now in the Suspended state. */
+            taskENTER_CRITICAL();
+            {
+                prvResetNextTaskUnblockTime();
+            }
+            taskEXIT_CRITICAL();
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
 
         #if ( configNUMBER_OF_CORES == 1 )
         {
-            taskEXIT_CRITICAL();
-
-            if( xSchedulerRunning != pdFALSE )
-            {
-                /* Reset the next expected unblock time in case it referred to the
-                 * task that is now in the Suspended state. */
-                taskENTER_CRITICAL();
-                {
-                    prvResetNextTaskUnblockTime();
-                }
-                taskEXIT_CRITICAL();
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
             if( pxTCB == pxCurrentTCB )
             {
                 if( xSchedulerRunning != pdFALSE )
@@ -3218,47 +3209,39 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
         #else /* #if ( configNUMBER_OF_CORES == 1 ) */
         {
-            if( xSchedulerRunning != pdFALSE )
+            /* Enter critical section here to check run state of a task. */
+            taskENTER_CRITICAL();
             {
-                /* Reset the next expected unblock time in case it referred to the
-                 * task that is now in the Suspended state. */
-                prvResetNextTaskUnblockTime();
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
-            {
-                if( xSchedulerRunning != pdFALSE )
+                if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
                 {
-                    if( xTaskRunningOnCore == ( BaseType_t ) portGET_CORE_ID() )
+                    if( xSchedulerRunning != pdFALSE )
                     {
-                        /* The current task has just been suspended. */
-                        configASSERT( uxSchedulerSuspended == 0 );
-                        vTaskYieldWithinAPI();
+                        if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+                        {
+                            /* The current task has just been suspended. */
+                            configASSERT( uxSchedulerSuspended == 0 );
+                            vTaskYieldWithinAPI();
+                        }
+                        else
+                        {
+                            prvYieldCore( pxTCB->xTaskRunState );
+                        }
                     }
                     else
                     {
-                        prvYieldCore( xTaskRunningOnCore );
+                        /* This code path is not possible because only Idle tasks are
+                         * assigned a core before the scheduler is started ( i.e.
+                         * taskTASK_IS_RUNNING is only true for idle tasks before
+                         * the scheduler is started ) and idle tasks cannot be
+                         * suspended. */
+                        mtCOVERAGE_TEST_MARKER();
                     }
                 }
                 else
                 {
-                    /* This code path is not possible because only Idle tasks are
-                     * assigned a core before the scheduler is started ( i.e.
-                     * taskTASK_IS_RUNNING is only true for idle tasks before
-                     * the scheduler is started ) and idle tasks cannot be
-                     * suspended. */
                     mtCOVERAGE_TEST_MARKER();
                 }
             }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
             taskEXIT_CRITICAL();
         }
         #endif /* #if ( configNUMBER_OF_CORES == 1 ) */


### PR DESCRIPTION
Update for unpaired critical section in vTaskSuspend

Description
-----------
* Move the `taskEXIT_CRITICAL` out of the macro to improve readability.

Unit test is updated in this PR : https://github.com/FreeRTOS/FreeRTOS/pull/1160

Test Steps
-----------


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
