### PR TITLE
Add a check for configENABLE_MVE to M23, M33 ports

### DIFF
--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -61,7 +61,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -57,6 +57,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -59,10 +59,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -61,7 +61,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -57,6 +57,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -59,10 +59,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
@@ -57,6 +57,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M35.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
@@ -61,7 +61,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M35.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
@@ -59,10 +59,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -64,10 +64,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -62,6 +62,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -66,7 +66,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -60,6 +60,15 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M35.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M35.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -61,7 +61,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -57,6 +57,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -59,10 +59,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -61,7 +61,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -57,6 +57,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -59,10 +59,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacro.h
@@ -57,6 +57,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M35.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/GCC/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacro.h
@@ -61,7 +61,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M35.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacro.h
@@ -59,10 +59,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -57,6 +57,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M35.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -61,7 +61,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M35.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -59,10 +59,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M23.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M23.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M23.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -64,10 +64,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -62,6 +62,15 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Critical section management.
  */

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -66,7 +66,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -60,6 +60,15 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M33.
+    #endif
+#endif
+
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
 
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M33.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
     #endif
 #endif
 

--- a/portable/IAR/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M35.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M35.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
 #endif
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -65,7 +65,7 @@
     #define configENABLE_MVE    0
 #else
     #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be 0 for the Cortex-M35.
+        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
     #endif
 #endif
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -60,6 +60,14 @@
 #if ( configTOTAL_MPU_REGIONS == 16 )
     #error 16 MPU regions are not yet supported for this port.
 #endif
+
+#ifndef configENABLE_MVE
+    #define configENABLE_MVE    0
+#else
+    #if( configENABLE_MVE != 0 )
+        #error configENABLE_MVE must be 0 for the Cortex-M35.
+    #endif
+#endif
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -63,10 +63,8 @@
 
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
-#else
-    #if( configENABLE_MVE != 0 )
-        #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
-    #endif
+#elif( configENABLE_MVE != 0 )
+    #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M35.
 #endif
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
`configENABLE_MVE` is only applicable to Cortex-M55 and Cortex-M85 ports. It must not be defined to 1 for other ARMv8_m ports.

Test Steps
-----------
Built M23 and M33 example projects locally.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://forums.freertos.org/t/status-of-the-gcc-arm-cm55-and-ntz-ports/19042


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
