### PR TITLE
Fix MISRA C 2012 Rule 14.4 Violations.

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -180,7 +180,7 @@
         UBaseType_t uxTopPriority = uxTopReadyPriority;                            \
                                                                                    \
         /* Find the highest priority queue that contains ready tasks. */           \
-        while( listLIST_IS_EMPTY( &( pxReadyTasksLists[ uxTopPriority ] ) ) != 0 ) \
+        while( listLIST_IS_EMPTY( &( pxReadyTasksLists[ uxTopPriority ] ) ) != pdFALSE ) \
         {                                                                          \
             configASSERT( uxTopPriority );                                         \
             --uxTopPriority;                                                       \

--- a/tasks.c
+++ b/tasks.c
@@ -175,17 +175,17 @@
 /*-----------------------------------------------------------*/
 
     #if ( configNUMBER_OF_CORES == 1 )
-        #define taskSELECT_HIGHEST_PRIORITY_TASK()                                 \
-    do {                                                                           \
-        UBaseType_t uxTopPriority = uxTopReadyPriority;                            \
-                                                                                   \
-        /* Find the highest priority queue that contains ready tasks. */           \
+        #define taskSELECT_HIGHEST_PRIORITY_TASK()                                       \
+    do {                                                                                 \
+        UBaseType_t uxTopPriority = uxTopReadyPriority;                                  \
+                                                                                         \
+        /* Find the highest priority queue that contains ready tasks. */                 \
         while( listLIST_IS_EMPTY( &( pxReadyTasksLists[ uxTopPriority ] ) ) != pdFALSE ) \
-        {                                                                          \
-            configASSERT( uxTopPriority );                                         \
-            --uxTopPriority;                                                       \
-        }                                                                          \
-                                                                                   \
+        {                                                                                \
+            configASSERT( uxTopPriority );                                               \
+            --uxTopPriority;                                                             \
+        }                                                                                \
+                                                                                         \
         /* listGET_OWNER_OF_NEXT_ENTRY indexes through the list, so the tasks of \
          * the  same priority get an equal share of the processor time. */                    \
         listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCB, &( pxReadyTasksLists[ uxTopPriority ] ) ); \

--- a/tasks.c
+++ b/tasks.c
@@ -175,17 +175,17 @@
 /*-----------------------------------------------------------*/
 
     #if ( configNUMBER_OF_CORES == 1 )
-        #define taskSELECT_HIGHEST_PRIORITY_TASK()                            \
-    do {                                                                      \
-        UBaseType_t uxTopPriority = uxTopReadyPriority;                       \
-                                                                              \
-        /* Find the highest priority queue that contains ready tasks. */      \
-        while( listLIST_IS_EMPTY( &( pxReadyTasksLists[ uxTopPriority ] ) ) ) \
-        {                                                                     \
-            configASSERT( uxTopPriority );                                    \
-            --uxTopPriority;                                                  \
-        }                                                                     \
-                                                                              \
+        #define taskSELECT_HIGHEST_PRIORITY_TASK()                                 \
+    do {                                                                           \
+        UBaseType_t uxTopPriority = uxTopReadyPriority;                            \
+                                                                                   \
+        /* Find the highest priority queue that contains ready tasks. */           \
+        while( listLIST_IS_EMPTY( &( pxReadyTasksLists[ uxTopPriority ] ) ) != 0 ) \
+        {                                                                          \
+            configASSERT( uxTopPriority );                                         \
+            --uxTopPriority;                                                       \
+        }                                                                          \
+                                                                                   \
         /* listGET_OWNER_OF_NEXT_ENTRY indexes through the list, so the tasks of \
          * the  same priority get an equal share of the processor time. */                    \
         listGET_OWNER_OF_NEXT_ENTRY( pxCurrentTCB, &( pxReadyTasksLists[ uxTopPriority ] ) ); \


### PR DESCRIPTION
<!--- Title -->

Description
-----------
MISRA rule 14.4 - The controlling expression of an if statement and the controlling expression of an iteration-statement shall have essentially boolean type. 
   - macro listLIST_IS_EMPTY() returns pdTrue or pdFalse which are not of the essentially bool type (_Bool). By comparing the value it returns against 0, the expression evaluates to essentially boolean type.
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
