### PR TITLE
Fix MISRA directive 4.7 warning

### DIFF
--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -269,7 +269,7 @@
                 }
             }
         }
-        xTaskResumeAll();
+        ( void ) xTaskResumeAll();
 
         return lFreeIndex;
     }


### PR DESCRIPTION
Description
-----------
The MISRA C Directive 4.7 states that : _If a function returns error information, then that error information shall be tested_.
In this code, since we are not testing the return value of `xTaskResumeAll()` , it is encased with typecast _void_ to remove the warning.

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
