### PR TITLE
Enable xTaskGetCurrentTaskHandleForCore() for single core builds

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -3574,9 +3574,7 @@ TaskHandle_t xTaskGetCurrentTaskHandle( void ) PRIVILEGED_FUNCTION;
 /*
  * Return the handle of the task running on specified core.
  */
-#if ( configNUMBER_OF_CORES > 1 )
-    TaskHandle_t xTaskGetCurrentTaskHandleForCore( BaseType_t xCoreID ) PRIVILEGED_FUNCTION;
-#endif
+TaskHandle_t xTaskGetCurrentTaskHandleForCore( BaseType_t xCoreID ) PRIVILEGED_FUNCTION;
 
 /*
  * Shortcut used by the queue implementation to prevent unnecessary call to

--- a/tasks.c
+++ b/tasks.c
@@ -6559,23 +6559,28 @@ static void prvResetNextTaskUnblockTime( void )
 
             return xReturn;
         }
-
-        TaskHandle_t xTaskGetCurrentTaskHandleForCore( BaseType_t xCoreID )
-        {
-            TaskHandle_t xReturn = NULL;
-
-            traceENTER_xTaskGetCurrentTaskHandleForCore( xCoreID );
-
-            if( taskVALID_CORE_ID( xCoreID ) != pdFALSE )
-            {
-                xReturn = pxCurrentTCBs[ xCoreID ];
-            }
-
-            traceRETURN_xTaskGetCurrentTaskHandleForCore( xReturn );
-
-            return xReturn;
-        }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+    TaskHandle_t xTaskGetCurrentTaskHandleForCore( BaseType_t xCoreID )
+    {
+        TaskHandle_t xReturn = NULL;
+
+        traceENTER_xTaskGetCurrentTaskHandleForCore( xCoreID );
+
+        if( taskVALID_CORE_ID( xCoreID ) != pdFALSE )
+        {
+            #if ( configNUMBER_OF_CORES == 1 )
+                xReturn = pxCurrentTCB;
+            #else /* #if ( configNUMBER_OF_CORES == 1 ) */
+                xReturn = pxCurrentTCBs[ xCoreID ];
+        }
+            #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+        }
+
+        traceRETURN_xTaskGetCurrentTaskHandleForCore( xReturn );
+
+        return xReturn;
+    }
 
 #endif /* ( ( INCLUDE_xTaskGetCurrentTaskHandle == 1 ) || ( configUSE_MUTEXES == 1 ) ) */
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------

SMP FreeRTOS applications may call `xTaskGetCurrentTaskHandleForCore()`. However, when the same application is built with `configNUMBER_OF_CORES = 1`,  the function is no longer available.

In general,, `configNUMBER_OF_CORES = 1` should be treated as a special case of an SMP FreeRTOS application, thus any SMP FreeRTOS API should also be callable even when `configNUMBER_OF_CORES = 1`,

Test Steps
-----------

1. Call `xTaskGetCurrentTaskHandleForCore()` in application
2. Set `configNUMBER_OF_CORES = 1` for build.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
