### PR TITLE
Update default value of configSTACK_DEPTH_TYPE in config file

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2799,9 +2799,9 @@
 
 #ifndef configSTACK_DEPTH_TYPE
 
-/* Defaults to uint16_t for backward compatibility, but can be overridden
- * in FreeRTOSConfig.h if uint16_t is too restrictive. */
-    #define configSTACK_DEPTH_TYPE    uint16_t
+/* Defaults to StackType_t for backward compatibility, but can be overridden
+ * in FreeRTOSConfig.h if StackType_t is too restrictive. */
+    #define configSTACK_DEPTH_TYPE    StackType_t
 #endif
 
 #ifndef configRUN_TIME_COUNTER_TYPE


### PR DESCRIPTION
Description
-----------
This PR updates the default configuration value of configSTACK_DEPTH_TYPE  in FreeRTOS.h configuration file to StackType_t.

Test Steps
-----------
Run and Build [MPU demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/CORTEX_MPU_M7_NUCLEO_H743ZI2_GCC_IAR_Keil) successfully.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Bug reported in issue [986](https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/986)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
