### PR TITLE
Remove PRIVILEGED_FUNCTION from function definition in xMessageBufferNextLengthBytes

### DIFF
--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -795,7 +795,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * \ingroup MessageBufferManagement
  */
 #define xMessageBufferNextLengthBytes( xMessageBuffer ) \
-    xStreamBufferNextMessageLengthBytes( xMessageBuffer ) PRIVILEGED_FUNCTION;
+    xStreamBufferNextMessageLengthBytes( xMessageBuffer )
 
 /**
  * message_buffer.h


### PR DESCRIPTION
Description
-----------
The PRIVILEGED_FUNCTION attribute should not be added during function definition, but during the function declaration. 

Test Steps
-----------
MPU soak test for Message buffer on STM32H743ZI

_Before applying the patch_

 Compilation fails with the error
```
Error[Pe065]: expected a ";" after __attribute__ in the definition for PRIVILEGED_FUNCTION
```
 
 _After applying the patch_
 
  Compilation is successful.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
