### PR TITLE
Revert "Fix MISRA C 2012 Rule 13.3 Violations"

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -326,7 +326,7 @@ typedef struct xLIST
         }                                                                        \
                                                                                  \
         ( pxItemToRemove )->pxContainer = NULL;                                  \
-        ( ( pxList )->uxNumberOfItems ) -= ( UBaseType_t ) 1U;                   \
+        ( pxList->uxNumberOfItems )--;                                           \
     } while( 0 )
 
 /*
@@ -363,17 +363,17 @@ typedef struct xLIST
                                                                                 \
         /* Insert a new list item into ( pxList ), but rather than sort the list, \
          * makes the new list item the last item to be removed by a call to \
-         * listGET_OWNER_OF_NEXT_ENTRY(). */                   \
-        ( pxNewListItem )->pxNext = pxIndex;                   \
-        ( pxNewListItem )->pxPrevious = pxIndex->pxPrevious;   \
-                                                               \
-        pxIndex->pxPrevious->pxNext = ( pxNewListItem );       \
-        pxIndex->pxPrevious = ( pxNewListItem );               \
-                                                               \
-        /* Remember which list the item is in. */              \
-        ( pxNewListItem )->pxContainer = ( pxList );           \
-                                                               \
-        ( ( pxList )->uxNumberOfItems ) += ( UBaseType_t ) 1U; \
+         * listGET_OWNER_OF_NEXT_ENTRY(). */                 \
+        ( pxNewListItem )->pxNext = pxIndex;                 \
+        ( pxNewListItem )->pxPrevious = pxIndex->pxPrevious; \
+                                                             \
+        pxIndex->pxPrevious->pxNext = ( pxNewListItem );     \
+        pxIndex->pxPrevious = ( pxNewListItem );             \
+                                                             \
+        /* Remember which list the item is in. */            \
+        ( pxNewListItem )->pxContainer = ( pxList );         \
+                                                             \
+        ( ( pxList )->uxNumberOfItems )++;                   \
     } while( 0 )
 
 /*

--- a/list.c
+++ b/list.c
@@ -130,7 +130,7 @@ void vListInsertEnd( List_t * const pxList,
     /* Remember which list the item is in. */
     pxNewListItem->pxContainer = pxList;
 
-    ( pxList->uxNumberOfItems ) += ( UBaseType_t ) 1U;
+    ( pxList->uxNumberOfItems )++;
 
     traceRETURN_vListInsertEnd();
 }
@@ -205,12 +205,11 @@ void vListInsert( List_t * const pxList,
      * item later. */
     pxNewListItem->pxContainer = pxList;
 
-    ( pxList->uxNumberOfItems ) += ( UBaseType_t ) 1U;
+    ( pxList->uxNumberOfItems )++;
 
     traceRETURN_vListInsert();
 }
 /*-----------------------------------------------------------*/
-
 
 UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
 {
@@ -219,6 +218,8 @@ UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
     List_t * const pxList = pxItemToRemove->pxContainer;
 
     traceENTER_uxListRemove( pxItemToRemove );
+
+
 
     pxItemToRemove->pxNext->pxPrevious = pxItemToRemove->pxPrevious;
     pxItemToRemove->pxPrevious->pxNext = pxItemToRemove->pxNext;
@@ -237,7 +238,7 @@ UBaseType_t uxListRemove( ListItem_t * const pxItemToRemove )
     }
 
     pxItemToRemove->pxContainer = NULL;
-    ( pxList->uxNumberOfItems ) -= ( UBaseType_t ) 1U;
+    ( pxList->uxNumberOfItems )--;
 
     traceRETURN_uxListRemove( pxList->uxNumberOfItems );
 

--- a/tasks.c
+++ b/tasks.c
@@ -255,7 +255,7 @@
         pxTemp = pxDelayedTaskList;                                               \
         pxDelayedTaskList = pxOverflowDelayedTaskList;                            \
         pxOverflowDelayedTaskList = pxTemp;                                       \
-        xNumOfOverflows += ( BaseType_t ) 1;                                      \
+        xNumOfOverflows++;                                                        \
         prvResetNextTaskUnblockTime();                                            \
     } while( 0 )
 
@@ -2021,7 +2021,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
          * updated. */
         taskENTER_CRITICAL();
         {
-            uxCurrentNumberOfTasks += ( UBaseType_t ) 1U;
+            uxCurrentNumberOfTasks++;
 
             if( pxCurrentTCB == NULL )
             {
@@ -3815,7 +3815,7 @@ void vTaskSuspendAll( void )
 
         /* The scheduler is suspended if uxSchedulerSuspended is non-zero.  An increment
          * is used to allow calls to vTaskSuspendAll() to nest. */
-        uxSchedulerSuspended += ( UBaseType_t ) 1U;
+        ++uxSchedulerSuspended;
 
         /* Enforces ordering for ports and optimised compilers that may otherwise place
          * the above increment elsewhere. */
@@ -3968,7 +3968,7 @@ BaseType_t xTaskResumeAll( void )
              * previous call to vTaskSuspendAll(). */
             configASSERT( uxSchedulerSuspended != 0U );
 
-            uxSchedulerSuspended -= ( UBaseType_t ) 1U;
+            --uxSchedulerSuspended;
             portRELEASE_TASK_LOCK();
 
             if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
@@ -4968,7 +4968,7 @@ BaseType_t xTaskIncrementTick( void )
     }
     else
     {
-        xPendedTicks += 1U;
+        ++xPendedTicks;
 
         /* The tick hook gets called at regular intervals, even if the
          * scheduler is locked. */


### PR DESCRIPTION
Reverts FreeRTOS/FreeRTOS-Kernel#988 
After further discussion, this PR does not appropriately address this issue and that the use of the volatile qualifier with uxNumberOfItems should be updated to be configLIST_VOLATILE to be inline with the use of this macro across the rest of the file which will be done in a PR following this one. 