### PR TITLE
Add default core affinity config value.

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -496,6 +496,15 @@
  * run any task on any available core. */
 #define configUSE_CORE_AFFINITY                   0
 
+/* When using SMP with core affinity feature enabled, set
+ * configTASK_DEFAULT_CORE_AFFINITY to change the default core affinity mask for
+ * tasks created without an affinity mask specified. Setting the define to 1 would
+ * make such tasks run on core 0 and setting it to (1 << portGET_CORE_ID()) would 
+ * make such tasks run on the current core. This config value is useful, if 
+ * swapping tasks between cores is not supported (e.g. Tricore) or if legacy code
+ * should be controlled. Defaults to tskNO_AFFINITY if left undefined. */
+#define configTASK_DEFAULT_CORE_AFFINITY tskNO_AFFINITY
+
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), if
  * configUSE_TASK_PREEMPTION_DISABLE is set to 1, individual tasks can be set to
  * either pre-emptive or co-operative mode using the vTaskPreemptionDisable and

--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -499,11 +499,11 @@
 /* When using SMP with core affinity feature enabled, set
  * configTASK_DEFAULT_CORE_AFFINITY to change the default core affinity mask for
  * tasks created without an affinity mask specified. Setting the define to 1 would
- * make such tasks run on core 0 and setting it to (1 << portGET_CORE_ID()) would 
- * make such tasks run on the current core. This config value is useful, if 
+ * make such tasks run on core 0 and setting it to (1 << portGET_CORE_ID()) would
+ * make such tasks run on the current core. This config value is useful, if
  * swapping tasks between cores is not supported (e.g. Tricore) or if legacy code
  * should be controlled. Defaults to tskNO_AFFINITY if left undefined. */
-#define configTASK_DEFAULT_CORE_AFFINITY tskNO_AFFINITY
+#define configTASK_DEFAULT_CORE_AFFINITY          tskNO_AFFINITY
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), if
  * configUSE_TASK_PREEMPTION_DISABLE is set to 1, individual tasks can be set to

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -486,7 +486,7 @@
 
 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
     #ifndef configTASK_DEFAULT_CORE_AFFINITY
-        #define configTASK_DEFAULT_CORE_AFFINITY tskNO_AFFINITY
+        #define configTASK_DEFAULT_CORE_AFFINITY    tskNO_AFFINITY
     #endif
 #endif
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -484,6 +484,12 @@
     #define configUSE_CORE_AFFINITY    0
 #endif /* configUSE_CORE_AFFINITY */
 
+#if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
+    #ifndef configTASK_DEFAULT_CORE_AFFINITY
+        #define configTASK_DEFAULT_CORE_AFFINITY tskNO_AFFINITY
+    #endif
+#endif
+
 #ifndef configUSE_PASSIVE_IDLE_HOOK
     #define configUSE_PASSIVE_IDLE_HOOK    0
 #endif /* configUSE_PASSIVE_IDLE_HOOK */

--- a/tasks.c
+++ b/tasks.c
@@ -1325,7 +1325,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
             {
                 /* Set the task's affinity before scheduling it. */
-                pxNewTCB->uxCoreAffinityMask = tskNO_AFFINITY;
+                pxNewTCB->uxCoreAffinityMask = configTASK_DEFAULT_CORE_AFFINITY;
             }
             #endif
 
@@ -1442,7 +1442,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
             {
                 /* Set the task's affinity before scheduling it. */
-                pxNewTCB->uxCoreAffinityMask = tskNO_AFFINITY;
+                pxNewTCB->uxCoreAffinityMask = configTASK_DEFAULT_CORE_AFFINITY;
             }
             #endif
 
@@ -1560,7 +1560,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
             {
                 /* Set the task's affinity before scheduling it. */
-                pxNewTCB->uxCoreAffinityMask = tskNO_AFFINITY;
+                pxNewTCB->uxCoreAffinityMask = configTASK_DEFAULT_CORE_AFFINITY;
             }
             #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
 
@@ -1733,7 +1733,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
             {
                 /* Set the task's affinity before scheduling it. */
-                pxNewTCB->uxCoreAffinityMask = tskNO_AFFINITY;
+                pxNewTCB->uxCoreAffinityMask = configTASK_DEFAULT_CORE_AFFINITY;
             }
             #endif
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add a config define to set the default core affinity mask for tasks created without an affinity mask specified via arguments.

Test Steps
-----------
Set configTASK_DEFAULT_CORE_AFFINITY to 1 and check if all tasks created without an affinity mask specified run on core 0.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Closes #993.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
