### PR TITLE
Fix small bugs in Kernel

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -2,11 +2,11 @@
 
 FreeRTOS-Kernel conforms to [MISRA C:2012](https://www.misra.org.uk/misra-c)
 guidelines, with the deviations listed below. Compliance is checked with
-Coverity static analysis. Since the FreeRTOS kernel is designed for
-small-embedded devices, it needs to have a very small memory footprint and
-has to be efficient. To achieve that and to increase the performance, it
-deviates from some MISRA rules. The specific deviations, suppressed inline,
-are listed below.
+Coverity static analysis version 2023.6.1. Since the FreeRTOS kernel is
+designed for small-embedded devices, it needs to have a very small memory
+footprint and has to be efficient. To achieve that and to increase the
+performance, it deviates from some MISRA rules. The specific deviations,
+suppressed inline, are listed below.
 
 Additionally, [MISRA configuration file](examples/coverity/coverity_misra.config)
 contains project wide deviations.

--- a/examples/coverity/CMakeLists.txt
+++ b/examples/coverity/CMakeLists.txt
@@ -2,8 +2,9 @@ cmake_minimum_required(VERSION 3.15)
 
 project(coverity)
 
-set(FREERTOS_KERNEL_PATH "../../")
-FILE(GLOB FREERTOS_KERNEL_SOURCE ${FREERTOS_KERNEL_PATH}*.c)
+set(FREERTOS_KERNEL_PATH "../..")
+FILE(GLOB FREERTOS_KERNEL_SOURCE ${FREERTOS_KERNEL_PATH}/*.c)
+FILE(GLOB FREERTOS_PORT_CODE ${FREERTOS_KERNEL_PATH}/portable/template/*.c)
 
 # Coverity incorrectly infers the type of pdTRUE and pdFALSE as boolean because
 # of their names. This generates multiple false positive warnings about type
@@ -12,8 +13,8 @@ FILE(GLOB FREERTOS_KERNEL_SOURCE ${FREERTOS_KERNEL_PATH}*.c)
 # fixes the issue of incorrectly inferring the type of pdTRUE and pdFALSE as
 # boolean.
 add_custom_target(fix_source ALL
-                  COMMAND sed -i -b -e 's/pdFALSE/pdFAIL/g' -e 's/pdTRUE/pdPASS/g' ${FREERTOS_KERNEL_SOURCE}
-                  DEPENDS ${FREERTOS_KERNEL_SOURCE})
+                  COMMAND sed -i -b -e 's/pdFALSE/pdFAIL/g' -e 's/pdTRUE/pdPASS/g' ${FREERTOS_KERNEL_SOURCE} ${FREERTOS_PORT_CODE}
+                  DEPENDS ${FREERTOS_KERNEL_SOURCE} ${FREERTOS_PORT_CODE})
 
 # Add the freertos_config for FreeRTOS-Kernel.
 add_library(freertos_config INTERFACE)

--- a/examples/coverity/coverity_misra.config
+++ b/examples/coverity/coverity_misra.config
@@ -1,97 +1,91 @@
-// MISRA C-2012 Rules
-
 {
-    version : "2.0",
-    standard : "c2012",
-    title: "Coverity MISRA Configuration",
-    deviations : [
-        // Disable the following rules.
+    "version" : "2.0",
+    "standard" : "c2012",
+    "title": "Coverity MISRA Configuration",
+    "deviations" : [
         {
-            deviation: "Rule 3.1",
-            reason: "We post HTTP links in code comments which contain // inside comments blocks."
+            "deviation": "Rule 3.1",
+            "reason": "We post HTTP links in code comments which contain // inside comments blocks."
         },
         {
-            deviation: "Rule 14.4",
-            reason: "do while( 0 ) pattern is used in macros to prevent extra semi-colon."
-        },
-
-        // Disable the following advisory rules and directives.
-        {
-            deviation: "Directive 4.4",
-            reason: "Code snippet is used in comment to help explanation."
+            "deviation": "Rule 14.4",
+            "reason": "do while( 0 ) pattern is used in macros to prevent extra semi-colon."
         },
         {
-            deviation: "Directive 4.5",
-            reason: "Allow names that MISRA considers ambiguous."
+            "deviation": "Directive 4.4",
+            "reason": "Code snippet is used in comment to help explanation."
         },
         {
-            deviation: "Directive 4.6",
-            reason: "Allow port to use primitive type with typedefs."
+            "deviation": "Directive 4.5",
+            "reason": "Allow names that MISRA considers ambiguous."
         },
         {
-            deviation: "Directive 4.8",
-            reason: "HeapRegion_t and HeapStats_t are used only in heap files but declared in portable.h which is included in multiple source files. As a result, these definitions appear in multiple source files where they are not used."
+            "deviation": "Directive 4.6",
+            "reason": "Allow port to use primitive type with typedefs."
         },
         {
-            deviation: "Directive 4.9",
-            reason: "FreeRTOS-Kernel is optimised to work on small micro-controllers. To achieve that, function-like macros are used."
+            "deviation": "Directive 4.8",
+            "reason": "HeapRegion_t and HeapStats_t are used only in heap files but declared in portable.h which is included in multiple source files. As a result, these definitions appear in multiple source files where they are not used."
         },
         {
-            deviation: "Rule 2.3",
-            reason: "FreeRTOS defines types which is used in application."
+            "deviation": "Directive 4.9",
+            "reason": "FreeRTOS-Kernel is optimised to work on small micro-controllers. To achieve that, function-like macros are used."
         },
         {
-            deviation: "Rule 2.4",
-            reason: "Allow to define unused tag."
+            "deviation": "Rule 2.3",
+            "reason": "FreeRTOS defines types which is used in application."
         },
         {
-            deviation: "Rule 2.5",
-            reason: "Allow to define unused macro."
+            "deviation": "Rule 2.4",
+            "reason": "Allow to define unused tag."
         },
         {
-            deviation: "Rule 5.9",
-            reason: "Allow to define identifier with the same name in structure and global variable."
+            "deviation": "Rule 2.5",
+            "reason": "Allow to define unused macro."
         },
         {
-            deviation: "Rule 8.7",
-            reason: "API functions are not used by the library outside of the files they are defined; however, they must be externally visible in order to be used by an application."
+            "deviation": "Rule 5.9",
+            "reason": "Allow to define identifier with the same name in structure and global variable."
         },
         {
-            deviation: "Rule 8.9",
-            reason: "Allow to object to be defined in wider scope for debug purpose."
+            "deviation": "Rule 8.7",
+            "reason": "API functions are not used by the library outside of the files they are defined; however, they must be externally visible in order to be used by an application."
         },
         {
-            deviation: "Rule 8.13",
-            reason: "Allow to not to use const-qualified type for callback function."
+            "deviation": "Rule 8.9",
+            "reason": "Allow to object to be defined in wider scope for debug purpose."
         },
         {
-            deviation: "Rule 11.4",
-            reason: "Allow to convert between a pointer to object and an interger type for stack alignment."
+            "deviation": "Rule 8.13",
+            "reason": "Allow to not to use const-qualified type for callback function."
         },
         {
-            deviation: "Rule 15.4",
-            reason: "Allow to use multiple break statements in a loop."
+            "deviation": "Rule 11.4",
+            "reason": "Allow to convert between a pointer to object and an interger type for stack alignment."
         },
         {
-            deviation: "Rule 15.5",
-            reason: "Allow to use multiple points of exit."
+            "deviation": "Rule 15.4",
+            "reason": "Allow to use multiple break statements in a loop."
         },
         {
-            deviation: "Rule 17.8",
-            reason: "Allow to update the parameters of a function."
+            "deviation": "Rule 15.5",
+            "reason": "Allow to use multiple points of exit."
         },
         {
-            deviation: "Rule 18.4",
-            reason: "Allow to use pointer arithmetic."
+            "deviation": "Rule 17.8",
+            "reason": "Allow to update the parameters of a function."
         },
         {
-            deviation: "Rule 19.2",
-            reason: "Allow to use union."
+            "deviation": "Rule 18.4",
+            "reason": "Allow to use pointer arithmetic."
         },
         {
-            deviation: "Rule 20.5",
-            reason: "Allow to use #undef for MPU wrappers."
+            "deviation": "Rule 19.2",
+            "reason": "Allow to use union."
+        },
+        {
+            "deviation": "Rule 20.5",
+            "reason": "Allow to use #undef for MPU wrappers."
         }
     ]
 }
-

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -96,6 +96,10 @@
     #define configNUMBER_OF_CORES    1
 #endif
 
+#ifndef configUSE_MALLOC_FAILED_HOOK
+    #define configUSE_MALLOC_FAILED_HOOK    0
+#endif
+
 /* Basic FreeRTOS definitions. */
 #include "projdefs.h"
 
@@ -2647,10 +2651,6 @@
 
 #ifndef portCONFIGURE_TIMER_FOR_RUN_TIME_STATS
     #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
-#endif
-
-#ifndef configUSE_MALLOC_FAILED_HOOK
-    #define configUSE_MALLOC_FAILED_HOOK    0
 #endif
 
 #ifndef portPRIVILEGE_BIT

--- a/include/portable.h
+++ b/include/portable.h
@@ -178,7 +178,7 @@ void vPortGetHeapStats( HeapStats_t * pxHeapStats );
 /*
  * Map to the memory management routines required for the port.
  */
-void * pvPortMalloc( size_t xSize ) PRIVILEGED_FUNCTION;
+void * pvPortMalloc( size_t xWantedSize ) PRIVILEGED_FUNCTION;
 void * pvPortCalloc( size_t xNum,
                      size_t xSize ) PRIVILEGED_FUNCTION;
 void vPortFree( void * pv ) PRIVILEGED_FUNCTION;

--- a/portable/ThirdParty/GCC/Posix/portmacro.h
+++ b/portable/ThirdParty/GCC/Posix/portmacro.h
@@ -64,7 +64,7 @@ typedef long             BaseType_t;
 typedef unsigned long    UBaseType_t;
 
 typedef unsigned long    TickType_t;
-#define portMAX_DELAY              ( TickType_t ) ULONG_MAX
+#define portMAX_DELAY              ( ( TickType_t ) ULONG_MAX )
 
 #define portTICK_TYPE_IS_ATOMIC    1
 

--- a/portable/template/port.c
+++ b/portable/template/port.c
@@ -19,6 +19,10 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                      TaskFunction_t pxCode,
                                      void * pvParameters )
 {
+    ( void ) pxTopOfStack;
+    ( void ) pvParameters;
+    ( void ) * pxCode;
+
     return NULL;
 }
 

--- a/tasks.c
+++ b/tasks.c
@@ -3507,7 +3507,7 @@ static BaseType_t prvCreateIdleTasks( void )
     BaseType_t xIdleTaskNameIndex;
 
     /* Make sure that the below for loop doesn't go over the configIDLE_TASK_NAME macro. */
-    configASSERT( sizeof( configIDLE_TASK_NAME ) >= configMAX_TASK_NAME_LEN );
+    //configASSERT( sizeof( configIDLE_TASK_NAME ) >= configMAX_TASK_NAME_LEN );
 
     for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < ( BaseType_t ) configMAX_TASK_NAME_LEN; xIdleTaskNameIndex++ )
     {
@@ -3520,8 +3520,10 @@ static BaseType_t prvCreateIdleTasks( void )
         {
             break;
         }
-        else if( xIdleTaskNameIndex >= ( ( BaseType_t ) sizeof( configIDLE_TASK_NAME ) ) )
+        else if( xIdleTaskNameIndex >= ( BaseType_t ) sizeof( configIDLE_TASK_NAME ) )
         {
+            /* Break out of the loop so that we do not exceed the string
+             * configIDLE_TASK_NAME.  */
             break;
         }
         else

--- a/tasks.c
+++ b/tasks.c
@@ -3506,6 +3506,9 @@ static BaseType_t prvCreateIdleTasks( void )
     TaskFunction_t pxIdleTaskFunction = NULL;
     BaseType_t xIdleTaskNameIndex;
 
+    /* Make sure that the below for loop doesn't go over the configIDLE_TASK_NAME macro. */
+    configASSERT( sizeof( configIDLE_TASK_NAME ) >= configMAX_TASK_NAME_LEN );
+
     for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < ( BaseType_t ) configMAX_TASK_NAME_LEN; xIdleTaskNameIndex++ )
     {
         cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
@@ -3514,6 +3517,10 @@ static BaseType_t prvCreateIdleTasks( void )
          * configMAX_TASK_NAME_LEN characters just in case the memory after the
          * string is not accessible (extremely unlikely). */
         if( cIdleName[ xIdleTaskNameIndex ] == ( char ) 0x00 )
+        {
+            break;
+        }
+        else if( xIdleTaskNameIndex >= sizeof( configIDLE_TASK_NAME ) )
         {
             break;
         }

--- a/tasks.c
+++ b/tasks.c
@@ -3506,9 +3506,6 @@ static BaseType_t prvCreateIdleTasks( void )
     TaskFunction_t pxIdleTaskFunction = NULL;
     BaseType_t xIdleTaskNameIndex;
 
-    /* Make sure that the below for loop doesn't go over the configIDLE_TASK_NAME macro. */
-    //configASSERT( sizeof( configIDLE_TASK_NAME ) >= configMAX_TASK_NAME_LEN );
-
     for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < ( BaseType_t ) configMAX_TASK_NAME_LEN; xIdleTaskNameIndex++ )
     {
         cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
@@ -3518,12 +3515,6 @@ static BaseType_t prvCreateIdleTasks( void )
          * string is not accessible (extremely unlikely). */
         if( cIdleName[ xIdleTaskNameIndex ] == ( char ) 0x00 )
         {
-            break;
-        }
-        else if( xIdleTaskNameIndex >= ( BaseType_t ) sizeof( configIDLE_TASK_NAME ) )
-        {
-            /* Break out of the loop so that we do not exceed the string
-             * configIDLE_TASK_NAME.  */
             break;
         }
         else

--- a/tasks.c
+++ b/tasks.c
@@ -3520,7 +3520,7 @@ static BaseType_t prvCreateIdleTasks( void )
         {
             break;
         }
-        else if( xIdleTaskNameIndex >= sizeof( configIDLE_TASK_NAME ) )
+        else if( xIdleTaskNameIndex >= ( ( BaseType_t ) sizeof( configIDLE_TASK_NAME ) ) )
         {
             break;
         }


### PR DESCRIPTION
- Move the default value of `configUSE_MALLOC_FAILED_HOOK` as it is used in "portable.h"
- Add extra parenthesis in the definition of `portMAX_DELAY`.
- ~~Add check in the function `prvCreateIdleTasks` so that when the length of `configIDLE_TASK_NAME` is less than `configMAX_TASK_NAME_LEN` we do not go over `configIDLE_TASK_NAME`.~~

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
