### PR TITLE
Not using pxIndex to iterate ready list in trace utility

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -282,7 +282,8 @@ typedef struct xLIST
  * \page listGET_OWNER_OF_NEXT_ENTRY listGET_OWNER_OF_NEXT_ENTRY
  * \ingroup LinkedList
  */
-#define listGET_OWNER_OF_NEXT_ENTRY( pxTCB, pxList )                                           \
+#if ( configNUMBER_OF_CORES == 1 )
+    #define listGET_OWNER_OF_NEXT_ENTRY( pxTCB, pxList )                                       \
     do {                                                                                       \
         List_t * const pxConstList = ( pxList );                                               \
         /* Increment the index to the next item and return the item, ensuring */               \
@@ -294,6 +295,13 @@ typedef struct xLIST
         }                                                                                      \
         ( pxTCB ) = ( pxConstList )->pxIndex->pvOwner;                                         \
     } while( 0 )
+#else /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+/* This function is not required in SMP. FreeRTOS SMP scheduler doesn't use
+ * pxIndex and it should always points to the xListEnd. Not defining this macro
+ * here to prevent updating pxIndex.
+ */
+#endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
 /*
  * Version of uxListRemove() that does not return a value.  Provided as a slight

--- a/include/list.h
+++ b/include/list.h
@@ -298,7 +298,7 @@ typedef struct xLIST
 #else /* #if ( configNUMBER_OF_CORES == 1 ) */
 
 /* This function is not required in SMP. FreeRTOS SMP scheduler doesn't use
- * pxIndex and it should always points to the xListEnd. Not defining this macro
+ * pxIndex and it should always point to the xListEnd. Not defining this macro
  * here to prevent updating pxIndex.
  */
 #endif /* #if ( configNUMBER_OF_CORES == 1 ) */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
`pxIndex` in `List_t` should only be used when selecting next task to run. Altering `pxIndex` of a ready list will cause the scheduler unable to select the right task to run.

Use `prvListTasksWithinSingleList` as an example. 

`prvListTasksWithinSingleList` is called in `uxTaskGetSystemState` and `pxIndex` is used to traverse the ready list in `listGET_OWNER_OF_NEXT_ENTRY`. This will cause the `pxIndex` points to a different task after `uxTaskGetSystemState` is called. Single core FreeRTOS make use of `pxIndex` to select next task to run. The scheduler will select wrong task since the `pxIndex` is moved. This also causes problem In FreeRTOS SMP as `pxIndex` is not moved in SMP and it should always point to `xListEnd`.

**Example code**
```c
TaskStatus_t xTaskStatusArray[ 32 ];

void vTestTask( void * pvParam )
{
    /* Break point 1 to observe the pxReadyTaskLists[1]. */    

    uxTaskGetSystemState( xTaskStatusArray,
                          32,
                          NULL );

    /* Break point 2 to observe the pxReadyTaskLists[1] again to see if pxIndex is changed. */

    for(;;);
}

void test_main( void )
{
    uint32_t i;

    /* This is the only running task in single core FreeRTOS due to highest priority. */
    xTaskCreate( vTestTask, "TestTask", configMINIMAL_STACK_SIZE, NULL, 2, NULL );

    for( i = 1; i < 10; i++ )
    {
        xTaskCreate( vTestTask, "TestTask", configMINIMAL_STACK_SIZE, NULL, 1, NULL );
    }

    vTaskStartScheduler();
}
```

The result shows that print pxReadyTasksLists[1].pxIndex points to different items in the list after calling `uxTaskGetSystemState`.
>**Break point 1 to observe pxIndex before calling uxTaskGetSystemState**
Thread 2 "TestTask" hit Breakpoint 1, vTestTask (pvParam=0x0) at main.c:158
158         uxTaskGetSystemState( xTaskStatusArray,
(gdb) print pxReadyTasksLists[1]
$1 = {uxNumberOfItems = 9, **pxIndex = 0x55555565e418** <pxReadyTasksLists+56>, xListEnd = {xItemValue = 18446744073709551615,
    pxNext = 0x5555556b6918, pxPrevious = 0x5555556d7ba8}}
(gdb) print &pxReadyTasksLists[1].xListEnd
$2 = (MiniListItem_t *) 0x55555565e418 <pxReadyTasksLists+56>
(gdb) n
162         for(;;);

>**Break point 2 to observe pxIndex again**
(gdb) print pxReadyTasksLists[1]
$3 = {uxNumberOfItems = 9, **pxIndex = 0x5555556b6918**, xListEnd = {xItemValue = 18446744073709551615, pxNext = 0x5555556b6918,
    pxPrevious = 0x5555556d7ba8}}
(gdb)


### In this PR
* Use for loop to traverse a ready list for trace utility instead of listGET_OWNER_OF_NEXT_ENTRY


Test Steps
-----------
Running the example above. `pxIndex` should not be changed after `uxTaskGetSystemState` is called.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request. - https://github.com/FreeRTOS/FreeRTOS/pull/1186

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
