### PR TITLE
Define portNOP in RP2040 port

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -278,7 +278,7 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
 #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
-#define portNOP()
+#define portNOP()               __asm volatile ( "nop" )
 
 #define portMEMORY_BARRIER()    __asm volatile ( "" ::: "memory" )
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Define portNOP in RP2040 port. This is used in [on target test](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Test/Target) for busy looping.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
