### PR TITLE
Fix typo in croutine.c

### DIFF
--- a/croutine.c
+++ b/croutine.c
@@ -30,7 +30,7 @@
 #include "task.h"
 #include "croutine.h"
 
-/* Remove the whole file is co-routines are not being used. */
+/* Remove the whole file if co-routines are not being used. */
 #if ( configUSE_CO_ROUTINES != 0 )
 
 /*


### PR DESCRIPTION
Fix typo in croutine.c

Description
-----------
Fixes a small typo in a comment in croutine.c.

Test Steps
-----------
None

Checklist:
----------
None

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
