### PR TITLE
Update comment in template FreeRTOSConfig.h

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -283,10 +283,9 @@
 /******************************************************************************/
 
 /* configKERNEL_INTERRUPT_PRIORITY sets the priority of the tick and context
- * switch performing interrupts.  The default value is set to the highest interrupt
- * priority (0).  Not supported by all FreeRTOS ports.  See
- * https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to ARM
- * Cortex-M devices. */
+ * switch performing interrupts.  Not supported by all FreeRTOS ports.  See
+ * https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
+ * ARM Cortex-M devices. */
 #define configKERNEL_INTERRUPT_PRIORITY          0
 
 /* configMAX_SYSCALL_INTERRUPT_PRIORITY sets the interrupt priority above which


### PR DESCRIPTION
Description
-----------
Update the comment for configKERNEL_INTERRUPT_PRIORITY in the template FreeRTOSConfig.h.

It was reported here - https://forums.freertos.org/t/migration-from-v10-5-1-to-v11-0-1-fails-with-new-freertosconfig-h-file/19276/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [NA] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[<!-- If any, please provide issue ID. -->](https://forums.freertos.org/t/migration-from-v10-5-1-to-v11-0-1-fails-with-new-freertosconfig-h-file/19276/)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
