### PR TITLE
Add daemon task startup hook / timer task creation consistency check

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -324,7 +324,7 @@
 
 #if ( configUSE_DAEMON_TASK_STARTUP_HOOK != 0 )
     #if ( configUSE_TIMERS == 0 )
-        #error configUSE_DAEMON_TASK_STARTUP_HOOK is set, but the daemon task isn't created because configUSE_TIMERS is 0.
+        #error configUSE_DAEMON_TASK_STARTUP_HOOK is set, but the daemon task isnt created because configUSE_TIMERS is 0.
     #endif
 #endif
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -324,7 +324,7 @@
 
 #if ( configUSE_DAEMON_TASK_STARTUP_HOOK != 0 )
     #if ( configUSE_TIMERS == 0 )
-        #error configUSE_DAEMON_TASK_STARTUP_HOOK is set, but the daemon task isnt created because configUSE_TIMERS is 0.
+        #error configUSE_DAEMON_TASK_STARTUP_HOOK is set, but the daemon task is not created because configUSE_TIMERS is 0.
     #endif
 #endif
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -298,10 +298,6 @@
     #endif
 #endif
 
-#ifndef configUSE_DAEMON_TASK_STARTUP_HOOK
-    #define configUSE_DAEMON_TASK_STARTUP_HOOK    0
-#endif
-
 #ifndef configUSE_APPLICATION_TASK_TAG
     #define configUSE_APPLICATION_TASK_TAG    0
 #endif
@@ -320,6 +316,16 @@
 
 #ifndef configUSE_TIMERS
     #define configUSE_TIMERS    0
+#endif
+
+#ifndef configUSE_DAEMON_TASK_STARTUP_HOOK
+    #define configUSE_DAEMON_TASK_STARTUP_HOOK    0
+#endif
+
+#if ( configUSE_DAEMON_TASK_STARTUP_HOOK != 0 )
+    #if( configUSE_TIMERS == 0 )
+        #error configUSE_DAEMON_TASK_STARTUP_HOOK is set, but the daemon task isn't created because configUSE_TIMERS is 0.
+    #endif
 #endif
 
 #ifndef configUSE_COUNTING_SEMAPHORES

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -322,7 +322,7 @@
     #define configUSE_DAEMON_TASK_STARTUP_HOOK    0
 #endif
 
-#if ( configUSE_DAEMON_TASK_STARTUP_HOOK != 0 )
+#if( configUSE_DAEMON_TASK_STARTUP_HOOK != 0 )
     #if( configUSE_TIMERS == 0 )
         #error configUSE_DAEMON_TASK_STARTUP_HOOK is set, but the daemon task isn't created because configUSE_TIMERS is 0.
     #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -322,8 +322,8 @@
     #define configUSE_DAEMON_TASK_STARTUP_HOOK    0
 #endif
 
-#if( configUSE_DAEMON_TASK_STARTUP_HOOK != 0 )
-    #if( configUSE_TIMERS == 0 )
+#if ( configUSE_DAEMON_TASK_STARTUP_HOOK != 0 )
+    #if ( configUSE_TIMERS == 0 )
         #error configUSE_DAEMON_TASK_STARTUP_HOOK is set, but the daemon task isn't created because configUSE_TIMERS is 0.
     #endif
 #endif


### PR DESCRIPTION
Description
-----------
Add a compile time check that emits a helpful error message if the user attempts to create a daemon task startup hook without also creating the timer/daemon task.

The timer/daemon task startup hook runs in the context of the timer/daemon task.  Therefore, it won't run even if configUSE_DAEMON_TASK_STARTUP_HOOK is set to 1 if the timer task isn't created.  The timer task is only created if configUSE_TIMERS is not equal to 0.  


Test Steps
-----------
Manually checked as requires multiple compilations with different configurations.

Checklist:
----------
- [x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
