### PR TITLE
Improvement for 64bit Windows port

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -246,8 +246,19 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                                FALSE,  /* Start not signalled. */
                                                NULL ); /* No name. */
 
+
+#ifdef 	__x86_64__
+    /* MinGW-w64 compiler reports the warning for the cast operation from TaskFunction_t to LPTHREAD_START_ROUTINE. */
+    /* Disable this warning here by the #pragma option. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
     /* Create the thread itself. */
     pxThreadState->pvThread = CreateThread( NULL, xStackSize, ( LPTHREAD_START_ROUTINE ) pxCode, pvParameters, CREATE_SUSPENDED | STACK_SIZE_PARAM_IS_A_RESERVATION, NULL );
+#ifdef 	__x86_64__
+#pragma GCC diagnostic pop
+#endif
+
     configASSERT( pxThreadState->pvThread ); /* See comment where TerminateThread() is called. */
     SetThreadAffinityMask( pxThreadState->pvThread, 0x01 );
     SetThreadPriorityBoost( pxThreadState->pvThread, TRUE );

--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -247,15 +247,15 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                                NULL ); /* No name. */
 
 
-#ifdef 	__x86_64__
-    /* MinGW-w64 compiler reports the warning for the cast operation from TaskFunction_t to LPTHREAD_START_ROUTINE. */
+#ifdef __GNUC__
+    /* GCC reports the warning for the cast operation from TaskFunction_t to LPTHREAD_START_ROUTINE. */
     /* Disable this warning here by the #pragma option. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
     /* Create the thread itself. */
     pxThreadState->pvThread = CreateThread( NULL, xStackSize, ( LPTHREAD_START_ROUTINE ) pxCode, pvParameters, CREATE_SUSPENDED | STACK_SIZE_PARAM_IS_A_RESERVATION, NULL );
-#ifdef 	__x86_64__
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 

--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -72,9 +72,18 @@ typedef portSTACK_TYPE           StackType_t;
     typedef uint32_t             TickType_t;
     #define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
 
-/* 32/64-bit tick type on a 32/64-bit architecture, so reads of the tick
+/* 32-bit tick type on a 32/64-bit architecture, so reads of the tick
  * count do not need to be guarded with a critical section. */
     #define portTICK_TYPE_IS_ATOMIC    1
+#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS )
+    typedef uint64_t             TickType_t;
+    #define portMAX_DELAY              ( TickType_t ) 0xffffffffffffffffULL
+
+#if defined( __x86_64__ ) || defined( _M_X64 )
+/* 64-bit tick type on a 64-bit architecture, so reads of the tick
+ * count do not need to be guarded with a critical section. */
+    #define portTICK_TYPE_IS_ATOMIC    1
+#endif
 #else
     #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif


### PR DESCRIPTION
<!--- Title -->
Improvement for 64bit Windows port

Description
-----------
<!--- Describe your changes in detail. -->
1. 64bit TickType_t is supported. (MSVC and MinGW)
The case `configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS` is added in portmacro.h.
It is straightforward extension from 16bit and 32bit.
This change is based on the following discussion on the FreeRTOS forum.
https://forums.freertos.org/t/64bit-application-on-freertos-windows-port/19110

2. Unnecessary compiler warning is disabled locally. (MinGW-w64 only)
#pragma for ignoring the warning `cast-function-type` is added in port.c.
MinGW-w64 reports this warning for the for the cast operation from `TaskFunction_t` to `LPTHREAD_START_ROUTINE`.
This warning should be ignored because it is unavoidable. `TaskFunction_t` is an essential type in FreeRTOS and `LPTHREAD_START_ROUTINE` is an essential type in win32api.
This pragma option affects only one line. Other part is not affected.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Define `configTICK_TYPE_WIDTH_IN_BITS` as `TICK_TYPE_WIDTH_64_BITS` in FreeRTOSConfig.h and build FreeRTOS by MinGW-w64 or  x64 platform on MSVC(Visual Studio).

Regression tests are performed.
All combinations of tick type width and compiler type have been tested.
1. TICK_TYPE_WIDTH_32_BITS on MinGW(32bit) and Win32 on MSVC
2. TICK_TYPE_WIDTH_64_BITS on MinGW(32bit) and Win32 on MSVC
3. TICK_TYPE_WIDTH_32_BITS on MinGW-w64 and x64 on MSVC
4. TICK_TYPE_WIDTH_64_BITS on MinGW-w64 and x64 on MSVC

MingW Demo: CodeCoverage configuration runs successfully in all cases. No error is reported in the console. No regression is found on coverage score.
MSVC Demo: Demo application runs successfully. No error is reported in the console.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
