### PR TITLE
Add in CI-CD builds of the Cortex-Rx MPU Demos

### DIFF
--- a/.github/workflows/kernel-demos.yml
+++ b/.github/workflows/kernel-demos.yml
@@ -289,6 +289,16 @@ jobs:
         working-directory: FreeRTOS/Demo/CORTEX_MPU_M3_MPS2_QEMU_GCC
         run: make -j
 
+      - name: Build CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC Demo
+        shell: bash
+        working-directory: FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC
+        run: cmake -S . -B build && make -j -C build all
+
+      - name: Build CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC Demo
+        shell: bash
+        working-directory: FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC
+        run: cmake -S . -B build && make -j -C build all
+
       - name: Build CORTEX_LM3S102_GCC Demo
         shell: bash
         working-directory: FreeRTOS/Demo/CORTEX_LM3S102_GCC


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
As part of FreeRTOS-Kernel CI-CD checks build the [FreeRTOS/FreeRTOS](https://github.com/FreeRTOS/FreeRTOS) demos for the [CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/CORTEX_MPU_R4F_TI_RM46_HERCULES_GCC ) and [CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/CORTEX_MPU_R5F_TI_RM57_HERCULES_GCC).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
This change is blocked by: https://github.com/FreeRTOS/FreeRTOS/pull/1200, which fixes a build issue with the current mainline version of the Kernel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
