### PR TITLE
fix typos in comments: interace -> interface, swtich -> switch

### DIFF
--- a/portable/GCC/ARM_AARCH64/README.md
+++ b/portable/GCC/ARM_AARCH64/README.md
@@ -20,4 +20,4 @@ This port is generic and can be used as a starting point for Armv8-A
 application processors.
 
 * ARM_AARCH64
-    * Memory mapped interace to access Arm GIC registers
+    * Memory mapped interface to access Arm GIC registers

--- a/portable/GCC/ARM_AARCH64_SRE/README.md
+++ b/portable/GCC/ARM_AARCH64_SRE/README.md
@@ -20,4 +20,4 @@ This port is generic and can be used as a starting point for Armv8-A
 application processors.
 
 * ARM_AARCH64_SRE
-    * System Register interace to access Arm GIC registers
+    * System Register interface to access Arm GIC registers

--- a/portable/GCC/ARM_CA53_64_BIT/README.md
+++ b/portable/GCC/ARM_CA53_64_BIT/README.md
@@ -4,7 +4,7 @@ Initial port to support Armv8-A architecture in FreeRTOS kernel was written for
 Arm Cortex-A53 processor.
 
 * ARM_CA53_64_BIT
-    * Memory mapped interace to access Arm GIC registers
+    * Memory mapped interface to access Arm GIC registers
 
 This port is generic and can be used as a starting point for other Armv8-A
 application processors. Therefore, the port `ARM_CA53_64_BIT` is renamed as
@@ -13,4 +13,4 @@ should migrate to renamed port `ARM_AARCH64`.
 
 **NOTE**
 
-This port uses memory mapped interace to access Arm GIC registers.
+This port uses memory mapped interface to access Arm GIC registers.

--- a/portable/GCC/ARM_CA53_64_BIT_SRE/README.md
+++ b/portable/GCC/ARM_CA53_64_BIT_SRE/README.md
@@ -4,7 +4,7 @@ Initial port to support Armv8-A architecture in FreeRTOS kernel was written for
 Arm Cortex-A53 processor.
 
 * ARM_CA53_64_BIT_SRE
-    * System Register interace to access Arm GIC registers
+    * System Register interface to access Arm GIC registers
 
 This port is generic and can be used as a starting point for other Armv8-A
 application processors. Therefore, the port `ARM_AARCH64_SRE` is renamed as
@@ -13,4 +13,4 @@ should migrate to renamed port `ARM_AARCH64_SRE`.
 
 **NOTE**
 
-This port uses System Register interace to access Arm GIC registers.
+This port uses System Register interface to access Arm GIC registers.

--- a/portable/GCC/ARM_CA9/portASM.S
+++ b/portable/GCC/ARM_CA9/portASM.S
@@ -246,7 +246,7 @@ exit_without_switch:
     MOVS    PC, LR
 
 switch_before_exit:
-    /* A context swtich is to be performed.  Clear the context switch pending
+    /* A context switch is to be performed.  Clear the context switch pending
     flag. */
     MOV     r0, #0
     STR     r0, [r1]

--- a/portable/GCC/ARM_CR5/portASM.S
+++ b/portable/GCC/ARM_CR5/portASM.S
@@ -242,7 +242,7 @@ exit_without_switch:
     MOVS    PC, LR
 
 switch_before_exit:
-    /* A context swtich is to be performed.  Clear the context switch pending
+    /* A context switch is to be performed.  Clear the context switch pending
     flag. */
     MOV     r0, #0
     STR     r0, [r1]

--- a/portable/GCC/ARM_CRx_MPU/portASM.S
+++ b/portable/GCC/ARM_CRx_MPU/portASM.S
@@ -446,7 +446,7 @@ FreeRTOS_IRQ_Handler:
      * ulPortInterruptNesting. */
     STR     R1, [R0]
 
-    /* Context swtich is only performed when interrupt nesting count is 0. */
+    /* Context switch is only performed when interrupt nesting count is 0. */
     CMP     R1, #0
     BNE     exit_without_switch
 
@@ -464,7 +464,7 @@ exit_without_switch:
     RFE     SP!
 
 switch_before_exit:
-    /* A context swtich is to be performed. Clear ulPortYieldRequired. R1 holds
+    /* A context switch is to be performed. Clear ulPortYieldRequired. R1 holds
      * the address of ulPortYieldRequired. */
     MOV     R0, #0
     STR     R0, [R1]

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -223,7 +223,7 @@ exit_without_switch:
     MOVS    PC, LR
 
 switch_before_exit:
-    /* A context swtich is to be performed.  Clear the context switch pending
+    /* A context switch is to be performed.  Clear the context switch pending
     flag. */
     MOV     r0, #0
     STR     r0, [r1]

--- a/portable/IAR/ARM_CRx_No_GIC/portASM.s
+++ b/portable/IAR/ARM_CRx_No_GIC/portASM.s
@@ -215,7 +215,7 @@ exit_without_switch:
     MOVS    PC, LR
 
 switch_before_exit:
-    /* A context swtich is to be performed.  Clear the context switch pending
+    /* A context switch is to be performed.  Clear the context switch pending
     flag. */
     MOV     r0, #0
     STR     r0, [r1]

--- a/portable/RVDS/ARM_CA9/portASM.s
+++ b/portable/RVDS/ARM_CA9/portASM.s
@@ -143,7 +143,7 @@ exit_without_switch
     MOVS    PC, LR
 
 switch_before_exit
-    ; A context swtich is to be performed.  Clear the context switch pending
+    ; A context switch is to be performed.  Clear the context switch pending
     ; flag.
     MOV     r0, #0
     STR     r0, [r1]

--- a/portable/ThirdParty/CDK/T-HEAD_CK802/port.c
+++ b/portable/ThirdParty/CDK/T-HEAD_CK802/port.c
@@ -32,7 +32,7 @@ extern void vPortStartTask( void );
  * will be set to 0 prior to the first task being started. */
 portLONG ulCriticalNesting = 0x9999UL;
 
-/* Used to record one tack want to swtich task after enter critical area, we need know it
+/* Used to record one tack want to switch task after enter critical area, we need know it
  * and implement task switch after exit critical area */
 portLONG pendsvflag = 0;
 

--- a/portable/ThirdParty/XCC/Xtensa/xtensa_context.h
+++ b/portable/ThirdParty/XCC/Xtensa/xtensa_context.h
@@ -254,7 +254,7 @@ STRUCT_END(XtSolFrame)
     The contents of a non-running thread's CPENABLE register.
     It represents the co-processors owned (and whose state is still needed)
     by the thread. When a thread is preempted, its CPENABLE is saved here.
-    When a thread solicits a context-swtich, its CPENABLE is cleared - the
+    When a thread solicits a context-switch, its CPENABLE is cleared - the
     compiler has saved the (caller-saved) co-proc state if it needs to.
     When a non-running thread loses ownership of a CP, its bit is cleared.
     When a thread runs, it's XT_CPENABLE is loaded into the CPENABLE reg.


### PR DESCRIPTION
Fix typos in comments: interace -> interface, swtich -> switch.

<!--- Title -->

Description
-----------
Just about typos in source code comments.

Test Steps
-----------
Using grep to find all occurances of the typos. ;-)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Thanks a lot for FreeRTOS,

Florian La Roche