### PR TITLE
Update the memory alignment within the Cortex-R5 port asm code

### DIFF
--- a/portable/GCC/ARM_CR5/portASM.S
+++ b/portable/GCC/ARM_CR5/portASM.S
@@ -76,8 +76,8 @@
 
         /* Save the floating point context, if any. */
         FMRXNE  R1,  FPSCR
-        VPUSHNE {D0-D15}
         PUSHNE  {R1}
+        VPUSHNE {D0-D15}
 
         /* Save ulPortTaskHasFPUContext itself. */
         PUSH    {R3}
@@ -110,8 +110,8 @@
         CMP     R1, #0
 
         /* Restore the floating point context, if any. */
-        POPNE   {R0}
         VPOPNE  {D0-D15}
+        POPNE   {R0}
         VMSRNE  FPSCR, R0
     #endif /* __ARM_FP */
 
@@ -147,8 +147,15 @@
 FreeRTOS_SWI_Handler:
     /* Save the context of the current task and select a new task to run. */
     portSAVE_CONTEXT
+
+    /* Ensure bit 2 of the stack pointer is clear. */
+    MOV     r2, sp
+    AND     r2, r2, #4
+    SUB     sp, sp, r2
+
     LDR R0, vTaskSwitchContextConst
     BLX R0
+
     portRESTORE_CONTEXT
 
 
@@ -255,6 +262,11 @@ switch_before_exit:
     MSR     SPSR_cxsf, LR
     POP     {LR}
     portSAVE_CONTEXT
+
+    /* Ensure bit 2 of the stack pointer is clear. */
+    MOV     r2, sp
+    AND     r2, r2, #4
+    SUB     sp, sp, r2
 
     /* Call the function that selects the new task to execute.
     vTaskSwitchContext() if vTaskSwitchContext() uses LDRD or STRD


### PR DESCRIPTION
Update alignment in ARM_CR5 port.

This is the same patch as 553caa18ced4906cf5060823ada7a10e73c7b535 provided by Richard Barry for issue #426 (ARM_CA9).

<!--- Title -->

Description
-----------
ARM_CA9 and ARM_CR5 are very close. This patch was applied to ARM_CA9, so it
might also make sense to apply it to ARM_CR5.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
This was just observed by looking at the changes between A9 and R5, no real
testing was conducted.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
