### PR TITLE
Replace volatile with configLIST_VOLATILE for uxNumberOfItems

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -172,7 +172,7 @@ typedef struct xLIST_ITEM ListItem_t;
 typedef struct xLIST
 {
     listFIRST_LIST_INTEGRITY_CHECK_VALUE      /**< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */
-    volatile UBaseType_t uxNumberOfItems;
+    configLIST_VOLATILE UBaseType_t uxNumberOfItems;
     ListItem_t * configLIST_VOLATILE pxIndex; /**< Used to walk through the list.  Points to the last item returned by a call to listGET_OWNER_OF_NEXT_ENTRY (). */
     MiniListItem_t xListEnd;                  /**< List item that contains the maximum possible item value meaning it is always at the end of the list and is therefore used as a marker. */
     listSECOND_LIST_INTEGRITY_CHECK_VALUE     /**< Set to a known value if configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES is set to 1. */


### PR DESCRIPTION
Description
-----------
This PR updates use of the volatile qualifier with uxNumberOfItems to configLIST_VOLATILE to be inline with the use of this macro across the rest of the file.

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] <s>I have tested my changes. No regression in existing tests. </s>
- [ ] <s>I have modified and/or added unit-tests to cover the code changes in this Pull Request.</s>

Related Issue
-----------
#995 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
