### PR TITLE
Remove unwanted volatile keyword

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -6255,7 +6255,6 @@ static void prvCheckTasksWaitingTermination( void )
                                                      List_t * pxList,
                                                      eTaskState eState )
     {
-        configLIST_VOLATILE TCB_t * pxTCB;
         UBaseType_t uxTask = 0;
         const ListItem_t * pxEndMarker = listGET_END_MARKER( pxList );
         ListItem_t * pxIterator;
@@ -6271,7 +6270,7 @@ static void prvCheckTasksWaitingTermination( void )
                 /* MISRA Ref 11.5.3 [Void pointer assignment] */
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
                 /* coverity[misra_c_2012_rule_11_5_violation] */
-                pxTCB = listGET_LIST_ITEM_OWNER( pxIterator );
+                TCB_t * pxTCB = listGET_LIST_ITEM_OWNER( pxIterator );
 
                 vTaskGetInfo( ( TaskHandle_t ) pxTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
                 uxTask++;

--- a/tasks.c
+++ b/tasks.c
@@ -985,6 +985,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         UBaseType_t uxCurrentPriority = uxTopReadyPriority;
         BaseType_t xTaskScheduled = pdFALSE;
         BaseType_t xDecrementTopPriority = pdTRUE;
+        TCB_t * pxTCB = NULL;
 
         #if ( configUSE_CORE_AFFINITY == 1 )
             const TCB_t * pxPreviousTCB = NULL;
@@ -1043,7 +1044,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                     /* MISRA Ref 11.5.3 [Void pointer assignment] */
                     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
                     /* coverity[misra_c_2012_rule_11_5_violation] */
-                    TCB_t * pxTCB = ( TCB_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
+                    pxTCB = ( TCB_t * ) listGET_LIST_ITEM_OWNER( pxIterator );
 
                     #if ( configRUN_MULTIPLE_PRIORITIES == 0 )
                     {
@@ -4181,6 +4182,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
                                                      const char pcNameToQuery[] )
     {
         TCB_t * pxReturn = NULL;
+        TCB_t * pxTCB = NULL;
         UBaseType_t x;
         char cNextChar;
         BaseType_t xBreakLoop;
@@ -4196,7 +4198,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
                 /* MISRA Ref 11.5.3 [Void pointer assignment] */
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
                 /* coverity[misra_c_2012_rule_11_5_violation] */
-                TCB_t * pxTCB = listGET_LIST_ITEM_OWNER( pxIterator );
+                pxTCB = listGET_LIST_ITEM_OWNER( pxIterator );
 
                 /* Check each character in the name looking for a match or
                  * mismatch. */
@@ -6258,6 +6260,7 @@ static void prvCheckTasksWaitingTermination( void )
         UBaseType_t uxTask = 0;
         const ListItem_t * pxEndMarker = listGET_END_MARKER( pxList );
         ListItem_t * pxIterator;
+        TCB_t * pxTCB = NULL;
 
         if( listCURRENT_LIST_LENGTH( pxList ) > ( UBaseType_t ) 0 )
         {
@@ -6270,7 +6273,7 @@ static void prvCheckTasksWaitingTermination( void )
                 /* MISRA Ref 11.5.3 [Void pointer assignment] */
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
                 /* coverity[misra_c_2012_rule_11_5_violation] */
-                TCB_t * pxTCB = listGET_LIST_ITEM_OWNER( pxIterator );
+                pxTCB = listGET_LIST_ITEM_OWNER( pxIterator );
 
                 vTaskGetInfo( ( TaskHandle_t ) pxTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
                 uxTask++;


### PR DESCRIPTION
Description
-----------
The access macro `listGET_LIST_ITEM_OWNER` returns the owner `( pxListItem )->pvOwner` of a list item, which is a non-volatile variable. Hence this PR removes the `configLIST_VOALTILE` macro for the TCB in the API `prvListTasksWithinSingleList` . 

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] <s>I have tested my changes. No regression in existing tests.</s>
- [ ] <s>I have modified and/or added unit-tests to cover the code changes in this Pull Request.</s>

Related Issue
-----------
#995 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
