### PR TITLE
Fix vTaskSuspendAll assertion for critical nesting count

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3830,15 +3830,15 @@ void vTaskSuspendAll( void )
 
         if( xSchedulerRunning != pdFALSE )
         {
-            /* This must never be called from inside a critical section. */
-            configASSERT( portGET_CRITICAL_NESTING_COUNT() == 0 );
-
             /* Writes to uxSchedulerSuspended must be protected by both the task AND ISR locks.
              * We must disable interrupts before we grab the locks in the event that this task is
              * interrupted and switches context before incrementing uxSchedulerSuspended.
              * It is safe to re-enable interrupts after releasing the ISR lock and incrementing
              * uxSchedulerSuspended since that will prevent context switches. */
             ulState = portSET_INTERRUPT_MASK();
+
+            /* This must never be called from inside a critical section. */
+            configASSERT( portGET_CRITICAL_NESTING_COUNT() == 0 );
 
             /* portSOFRWARE_BARRIER() is only implemented for emulated/simulated ports that
              * do not otherwise exhibit real time behaviour. */


### PR DESCRIPTION
Fix vTaskSuspendAll assert for critical nesting count

Description
-----------
Getting current task TCB consist of the following steps:
1. Getting current core ID with `portGET_CORE_ID()`
2. Use current core ID to index `pxCurrentTCBs`

The core to run this task can be changed by the scheduler. If a context switch happens between step 1 and step 2, the core ID may be changed, which results in getting the wrong TCB for the current task.

In this PR:
* Accessing the current task's TCB is performed with interrupt disabled to ensure atomicity.

Test Steps
-----------
Before this PR
There will be assertion in `vTaskSuspendAll()` if running this [XMOS demo](https://github.com/FreeRTOS/FreeRTOS-Community-Supported-Demos/tree/main/XCORE.AI_xClang).
```
xrun --xscope bin/RTOSDemo.xe
Starting Scheduler
Logical Core 0 initializing as FreeRTOS Core 0
Logical Core 2 initializing as FreeRTOS Core 1
Logical Core 3 initializing as FreeRTOS Core 2
Logical Core 4 initializing as FreeRTOS Core 3
Logical Core 5 initializing as FreeRTOS Core 4
Logical Core 6 initializing as FreeRTOS Core 5
Logical Core 7 initializing as FreeRTOS Core 6
FreeRTOS Core 1 initialized
FreeRTOS Core 2 initialized
FreeRTOS Core 3 initialized
Starting Scheduler
FreeRTOS Core 4 initialized
FreeRTOS Core 5 initialized
FreeRTOS Core 6 initialized
FreeRTOS Core 0 initialized
Logical Core 0 initializing as FreeRTOS Core 0
Logical Core 2 initializing as FreeRTOS Core 1
Logical Core 3 initializing as FreeRTOS Core 2
Logical Core 4 initializing as FreeRTOS Core 3
Logical Core 5 initializing as FreeRTOS Core 4
Logical Core 6 initializing as FreeRTOS Core 5
Logical Core 7 initializing as FreeRTOS Core 6
FreeRTOS Core 2 initialized
FreeRTOS Core 3 initialized
FreeRTOS Core 4 initialized
FreeRTOS Core 5 initialized
FreeRTOS Core 6 initialized
FreeRTOS Core 0 initialized
FreeRTOS Core 1 initialized
xrun: Program received signal ET_ECALL, Application exception.
      [Switching to tile[1] core[7] (dual issue)]
      vTaskSuspendAll () at ../../../../../Source\tasks.c:3834

      3834                  configASSERT( portGET_CRITICAL_NESTING_COUNT() == 0 );
      Current language:  auto; currently minimal
make: *** [run] Error 125
```


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
