### PR TITLE
armv8-m: GCC/ArmClang: Remove redundant constant pools

### DIFF
--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
@@ -56,11 +56,11 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -68,34 +68,34 @@
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst2                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   movs r3, #1                                   \n" /* r3 = 1. */
             "   orrs r2, r3                                   \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -103,7 +103,7 @@
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -114,7 +114,7 @@
             "    msr psp, r3                                  \n"
             "    msr control, r5                              \n"
             "    mov lr, r6                                   \n"
-            "    ldr r4, xSecureContextConst2                 \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "                                                 \n"
             " restore_general_regs_first_task:                \n"
@@ -136,14 +136,6 @@
             " restore_context_done_first_task:                \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xSecureContextConst2: .word xSecureContext      \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -155,12 +147,12 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r3, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r3]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
             "   ldm  r0!, {r1-r3}                               \n" /* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
-            "   ldr  r4, xSecureContextConst2                   \n"
+            "   ldr  r4, =xSecureContext                        \n"
             "   str  r1, [r4]                                   \n" /* Set xSecureContext to this task's value for the same. */
             "   movs r1, #2                                     \n" /* r1 = 2. */
             "   msr  CONTROL, r1                                \n" /* Switch to use PSP in the thread mode. */
@@ -168,10 +160,6 @@
             "   msr  psp, r0                                    \n" /* This is now the new top of stack to use in the task. */
             "   isb                                             \n"
             "   bx   r3                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
-            "xSecureContextConst2: .word xSecureContext         \n"
         );
     }
 
@@ -193,8 +181,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         " running_privileged:                               \n"
         "   movs r0, #1                                     \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "r1", "memory"
     );
 }
@@ -238,7 +224,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -247,9 +233,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -292,9 +275,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " .extern SecureContext_SaveContext               \n"
             " .extern SecureContext_LoadContext               \n"
             "                                                 \n"
-            " ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            " ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             " ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            " ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later.*/
             " ldr r2, [r1]                                    \n" /* r2 = Location in TCB where the context should be saved. */
             "                                                 \n"
@@ -337,11 +320,11 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    cpsie i                                      \n"
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -349,34 +332,34 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    orrs r2, r3                                  \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -384,7 +367,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -395,7 +378,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr psp, r3                                  \n"
             "    msr control, r5                              \n"
             "    mov lr, r6                                   \n"
-            "    ldr r4, xSecureContextConst                  \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "    cbz r0, restore_ns_context                   \n" /* No secure context to restore. */
             "                                                 \n"
@@ -429,14 +412,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xSecureContextConst: .word xSecureContext       \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
         );
     }
 
@@ -450,9 +425,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .extern SecureContext_SaveContext               \n"
             "   .extern SecureContext_LoadContext               \n"
             "                                                   \n"
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later.*/
             "   mrs r2, psp                                     \n" /* Read PSP in r2. */
             "                                                   \n"
@@ -463,7 +438,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov lr, r3                                      \n" /* LR = r3. */
             "   lsls r1, r3, #25                                \n" /* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
             "   bpl save_ns_context                             \n" /* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   subs r2, r2, #12                                \n" /* Make space for xSecureContext, PSPLIM and LR on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -473,7 +448,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   b select_next_task                              \n"
             "                                                   \n"
             " save_ns_context:                                  \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   subs r2, r2, #44                                \n" /* Make space for xSecureContext, PSPLIM, LR and the remaining registers on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -491,16 +466,16 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   bl vTaskSwitchContext                           \n"
             "   cpsie i                                         \n"
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r2, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
             "                                                   \n"
             "   ldmia r2!, {r0, r1, r4}                         \n" /* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
             "   mov lr, r4                                      \n" /* LR = r4. */
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   str r0, [r3]                                    \n" /* Restore the task's xSecureContext. */
             "   cbz r0, restore_ns_context                      \n" /* If there is no secure context for the task, restore the non-secure context. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   push {r2, r4}                                   \n"
             "   bl SecureContext_LoadContext                    \n" /* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
@@ -522,10 +497,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   subs r2, r2, #32                                \n" /* Go back to the low registers. */
             "   ldmia r2!, {r4-r7}                              \n" /* Restore the low registers that are not automatically restored. */
             "   bx lr                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
-            "xSecureContextConst: .word xSecureContext          \n"
         );
     }
 
@@ -588,15 +559,12 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   tst r0, r1                                      \n"
             "   beq stacking_used_msp                           \n"
             "   mrs r0, psp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
             " stacking_used_msp:                                \n"
             "   mrs r0, msp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portasm.c
@@ -56,11 +56,11 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -68,34 +68,34 @@
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    orrs r2, r3                                  \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -103,7 +103,7 @@
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -137,13 +137,6 @@
             " restore_context_done_first_task:                \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -155,7 +148,7 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r1, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r1]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
@@ -169,9 +162,6 @@
             "   msr  psp, r0                                    \n" /* This is now the new top of stack to use in the task. */
             "   isb                                             \n"
             "   bx   r2                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
         );
     }
 
@@ -193,8 +183,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         " running_privileged:                               \n"
         "   movs r0, #1                                     \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "r1", "memory"
     );
 }
@@ -238,7 +226,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -247,9 +235,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -290,7 +275,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
         (
             " .syntax unified                                 \n"
             "                                                 \n"
-            " ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r0, [r2]                                    \n" /* r0 = pxCurrentTCB. */
             " ldr r1, [r0]                                    \n" /* r1 = Location in TCB where the context should be saved. */
             " mrs r2, psp                                     \n" /* r2 = PSP. */
@@ -325,11 +310,11 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    cpsie i                                      \n"
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -337,34 +322,34 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    orrs r2, r3                                  \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -372,7 +357,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -406,13 +391,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
         );
     }
 
@@ -425,7 +403,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .syntax unified                                 \n"
             "                                                   \n"
             "   mrs r0, psp                                     \n" /* Read PSP in r0. */
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   subs r0, r0, #40                                \n" /* Make space for PSPLIM, LR and the remaining registers on the stack. */
             "   str r0, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -446,7 +424,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   bl vTaskSwitchContext                           \n"
             "   cpsie i                                         \n"
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r0, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
             "                                                   \n"
@@ -463,9 +441,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "   msr psplim, r2                              \n" /* Restore the PSPLIM register value for the task. */
             #endif
             "   bx r3                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
         );
     }
 
@@ -528,15 +503,12 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   tst r0, r1                                      \n"
             "   beq stacking_used_msp                           \n"
             "   mrs r0, psp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
             " stacking_used_msp:                                \n"
             "   mrs r0, msp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    orr r2, #1                                   \n" /* r2 = r1 | 1 i.e. Set the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Enable MPU. */
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -102,7 +102,7 @@
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst2                 \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "                                                 \n"
             " restore_general_regs_first_task:                \n"
@@ -115,14 +115,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xSecureContextConst2: .word xSecureContext      \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -134,12 +126,12 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r3, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r3]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
             "   ldm  r0!, {r1-r3}                               \n" /* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
-            "   ldr  r4, xSecureContextConst2                   \n"
+            "   ldr  r4, =xSecureContext                        \n"
             "   str  r1, [r4]                                   \n" /* Set xSecureContext to this task's value for the same. */
             "   msr  psplim, r2                                 \n" /* Set this task's PSPLIM value. */
             "   movs r1, #2                                     \n" /* r1 = 2. */
@@ -150,9 +142,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r3                                         \n" /* Finally, branch to EXC_RETURN. */
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
-            "xSecureContextConst2: .word xSecureContext         \n"
         );
     }
 
@@ -171,8 +160,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -214,7 +201,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -224,9 +211,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -274,9 +258,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " .extern SecureContext_SaveContext               \n"
             " .extern SecureContext_LoadContext               \n"
             "                                                 \n"
-            " ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            " ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             " ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            " ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             " ldr r2, [r1]                                    \n" /* r2 = Location in TCB where the context should be saved. */
             "                                                 \n"
@@ -325,23 +309,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -359,14 +343,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -375,7 +359,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst                  \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "    cbz r0, restore_ns_context                   \n" /* No secure context to restore. */
             "                                                 \n"
@@ -404,14 +388,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xSecureContextConst: .word xSecureContext       \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -426,9 +402,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .extern SecureContext_SaveContext               \n"
             "   .extern SecureContext_LoadContext               \n"
             "                                                   \n"
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             "   mrs r2, psp                                     \n" /* Read PSP in r2. */
             "                                                   \n"
@@ -440,7 +416,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   lsls r1, r3, #25                                \n" /* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
             "   bpl save_ns_context                             \n" /* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB.*/
             "   subs r2, r2, #12                                \n" /* Make space for xSecureContext, PSPLIM and LR on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -450,7 +426,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   b select_next_task                              \n"
             "                                                   \n"
             " save_ns_context:                                  \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
                 "   tst lr, #0x10                               \n" /* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -475,17 +451,17 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r2, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
             "                                                   \n"
             "   ldmia r2!, {r0, r1, r4}                         \n" /* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
             "   msr psplim, r1                                  \n" /* Restore the PSPLIM register value for the task. */
             "   mov lr, r4                                      \n" /* LR = r4. */
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   str r0, [r3]                                    \n" /* Restore the task's xSecureContext. */
             "   cbz r0, restore_ns_context                      \n" /* If there is no secure context for the task, restore the non-secure context. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   push {r2, r4}                                   \n"
             "   bl SecureContext_LoadContext                    \n" /* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
@@ -505,10 +481,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             #endif /* configENABLE_FPU || configENABLE_MVE */
             "   msr psp, r2                                     \n" /* Remember the new top of stack for the task. */
             "   bx lr                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
-            "xSecureContextConst: .word xSecureContext          \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -566,11 +538,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst2                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -113,13 +113,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -131,7 +124,7 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r1, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r1]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
@@ -145,9 +138,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r2                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
         );
     }
 
@@ -166,8 +156,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -209,7 +197,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -219,9 +207,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -267,7 +252,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
         (
             " .syntax unified                                 \n"
             "                                                 \n"
-            " ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r0, [r2]                                    \n" /* r0 = pxCurrentTCB. */
             " ldr r1, [r0]                                    \n" /* r1 = Location in TCB where the context should be saved. */
             " mrs r2, psp                                     \n" /* r2 = PSP. */
@@ -303,23 +288,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -337,14 +322,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -369,13 +354,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -400,7 +378,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r3, lr                                      \n" /* r3 = LR/EXC_RETURN. */
             "   stmdb r0!, {r2-r11}                             \n" /* Store on the stack - PSPLIM, LR and registers that are not automatically saved. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   str r0, [r1]                                    \n" /* Save the new top of stack in TCB. */
             "                                                   \n"
@@ -412,7 +390,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r0, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
             "                                                   \n"
@@ -427,9 +405,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   msr psplim, r2                                  \n" /* Restore the PSPLIM register value for the task. */
             "   msr psp, r0                                     \n" /* Remember the new top of stack for the task. */
             "   bx r3                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -487,11 +462,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM23/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23/non_secure/portasm.c
@@ -56,11 +56,11 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -68,34 +68,34 @@
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst2                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   movs r3, #1                                   \n" /* r3 = 1. */
             "   orrs r2, r3                                   \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -103,7 +103,7 @@
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -114,7 +114,7 @@
             "    msr psp, r3                                  \n"
             "    msr control, r5                              \n"
             "    mov lr, r6                                   \n"
-            "    ldr r4, xSecureContextConst2                 \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "                                                 \n"
             " restore_general_regs_first_task:                \n"
@@ -136,14 +136,6 @@
             " restore_context_done_first_task:                \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xSecureContextConst2: .word xSecureContext      \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -155,12 +147,12 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r3, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r3]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
             "   ldm  r0!, {r1-r3}                               \n" /* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
-            "   ldr  r4, xSecureContextConst2                   \n"
+            "   ldr  r4, =xSecureContext                        \n"
             "   str  r1, [r4]                                   \n" /* Set xSecureContext to this task's value for the same. */
             "   movs r1, #2                                     \n" /* r1 = 2. */
             "   msr  CONTROL, r1                                \n" /* Switch to use PSP in the thread mode. */
@@ -168,10 +160,6 @@
             "   msr  psp, r0                                    \n" /* This is now the new top of stack to use in the task. */
             "   isb                                             \n"
             "   bx   r3                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
-            "xSecureContextConst2: .word xSecureContext         \n"
         );
     }
 
@@ -193,8 +181,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         " running_privileged:                               \n"
         "   movs r0, #1                                     \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "r1", "memory"
     );
 }
@@ -238,7 +224,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -247,9 +233,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -292,9 +275,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " .extern SecureContext_SaveContext               \n"
             " .extern SecureContext_LoadContext               \n"
             "                                                 \n"
-            " ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            " ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             " ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            " ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later.*/
             " ldr r2, [r1]                                    \n" /* r2 = Location in TCB where the context should be saved. */
             "                                                 \n"
@@ -337,11 +320,11 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    cpsie i                                      \n"
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -349,34 +332,34 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    orrs r2, r3                                  \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -384,7 +367,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -395,7 +378,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr psp, r3                                  \n"
             "    msr control, r5                              \n"
             "    mov lr, r6                                   \n"
-            "    ldr r4, xSecureContextConst                  \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "    cbz r0, restore_ns_context                   \n" /* No secure context to restore. */
             "                                                 \n"
@@ -429,14 +412,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xSecureContextConst: .word xSecureContext       \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
         );
     }
 
@@ -450,9 +425,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .extern SecureContext_SaveContext               \n"
             "   .extern SecureContext_LoadContext               \n"
             "                                                   \n"
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later.*/
             "   mrs r2, psp                                     \n" /* Read PSP in r2. */
             "                                                   \n"
@@ -463,7 +438,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov lr, r3                                      \n" /* LR = r3. */
             "   lsls r1, r3, #25                                \n" /* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
             "   bpl save_ns_context                             \n" /* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   subs r2, r2, #12                                \n" /* Make space for xSecureContext, PSPLIM and LR on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -473,7 +448,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   b select_next_task                              \n"
             "                                                   \n"
             " save_ns_context:                                  \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   subs r2, r2, #44                                \n" /* Make space for xSecureContext, PSPLIM, LR and the remaining registers on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -491,16 +466,16 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   bl vTaskSwitchContext                           \n"
             "   cpsie i                                         \n"
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r2, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
             "                                                   \n"
             "   ldmia r2!, {r0, r1, r4}                         \n" /* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
             "   mov lr, r4                                      \n" /* LR = r4. */
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   str r0, [r3]                                    \n" /* Restore the task's xSecureContext. */
             "   cbz r0, restore_ns_context                      \n" /* If there is no secure context for the task, restore the non-secure context. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   push {r2, r4}                                   \n"
             "   bl SecureContext_LoadContext                    \n" /* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
@@ -522,10 +497,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   subs r2, r2, #32                                \n" /* Go back to the low registers. */
             "   ldmia r2!, {r4-r7}                              \n" /* Restore the low registers that are not automatically restored. */
             "   bx lr                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
-            "xSecureContextConst: .word xSecureContext          \n"
         );
     }
 
@@ -588,15 +559,12 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   tst r0, r1                                      \n"
             "   beq stacking_used_msp                           \n"
             "   mrs r0, psp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
             " stacking_used_msp:                                \n"
             "   mrs r0, msp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portasm.c
@@ -56,11 +56,11 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -68,34 +68,34 @@
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    orrs r2, r3                                  \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -103,7 +103,7 @@
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -137,13 +137,6 @@
             " restore_context_done_first_task:                \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -155,7 +148,7 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r1, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r1]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
@@ -169,9 +162,6 @@
             "   msr  psp, r0                                    \n" /* This is now the new top of stack to use in the task. */
             "   isb                                             \n"
             "   bx   r2                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
         );
     }
 
@@ -193,8 +183,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         " running_privileged:                               \n"
         "   movs r0, #1                                     \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "r1", "memory"
     );
 }
@@ -238,7 +226,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -247,9 +235,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -290,7 +275,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
         (
             " .syntax unified                                 \n"
             "                                                 \n"
-            " ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r0, [r2]                                    \n" /* r0 = pxCurrentTCB. */
             " ldr r1, [r0]                                    \n" /* r1 = Location in TCB where the context should be saved. */
             " mrs r2, psp                                     \n" /* r2 = PSP. */
@@ -325,11 +310,11 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    cpsie i                                      \n"
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    bics r2, r3                                  \n" /* r2 = r2 & ~r3 i.e. Clear the bit 0 in r2. */
@@ -337,34 +322,34 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read first set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write first set of RBAR/RLAR registers. */
             "    movs r3, #5                                  \n" /* r3 = 5. */
             "    str r3, [r1]                                 \n" /* Program RNR = 5. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read second set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write second set of RBAR/RLAR registers. */
             "    movs r3, #6                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 6. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read third set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write third set of RBAR/RLAR registers. */
             "    movs r3, #7                                  \n" /* r3 = 6. */
             "    str r3, [r1]                                 \n" /* Program RNR = 7. */
             "    ldmia r0!, {r4-r5}                           \n" /* Read fourth set of RBAR/RLAR registers from TCB. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "    stmia r2!, {r4-r5}                           \n" /* Write fourth set of RBAR/RLAR registers. */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    movs r3, #1                                  \n" /* r3 = 1. */
             "    orrs r2, r3                                  \n" /* r2 = r2 | r3 i.e. Set the bit 0 in r2. */
@@ -372,7 +357,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -406,13 +391,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
         );
     }
 
@@ -425,7 +403,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .syntax unified                                 \n"
             "                                                   \n"
             "   mrs r0, psp                                     \n" /* Read PSP in r0. */
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   subs r0, r0, #40                                \n" /* Make space for PSPLIM, LR and the remaining registers on the stack. */
             "   str r0, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -446,7 +424,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   bl vTaskSwitchContext                           \n"
             "   cpsie i                                         \n"
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r0, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
             "                                                   \n"
@@ -463,9 +441,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "   msr psplim, r2                              \n" /* Restore the PSPLIM register value for the task. */
             #endif
             "   bx r3                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
         );
     }
 
@@ -528,15 +503,12 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   tst r0, r1                                      \n"
             "   beq stacking_used_msp                           \n"
             "   mrs r0, psp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
             " stacking_used_msp:                                \n"
             "   mrs r0, msp                                     \n"
-            "   ldr r2, svchandler_address_const                \n"
+            "   ldr r2, =vPortSVCHandler_C                      \n"
             "   bx r2                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM33/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM33/non_secure/mpu_wrappers_v2_asm.c
@@ -1720,6 +1720,7 @@
         }
 
     #endif /* #if ( configUSE_EVENT_GROUPS == 1 ) */
+
 /*-----------------------------------------------------------*/
 
     #if ( configUSE_EVENT_GROUPS == 1 )

--- a/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    orr r2, #1                                   \n" /* r2 = r1 | 1 i.e. Set the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Enable MPU. */
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -102,7 +102,7 @@
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst2                 \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "                                                 \n"
             " restore_general_regs_first_task:                \n"
@@ -115,14 +115,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xSecureContextConst2: .word xSecureContext      \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -134,12 +126,12 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r3, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r3]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
             "   ldm  r0!, {r1-r3}                               \n" /* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
-            "   ldr  r4, xSecureContextConst2                   \n"
+            "   ldr  r4, =xSecureContext                        \n"
             "   str  r1, [r4]                                   \n" /* Set xSecureContext to this task's value for the same. */
             "   msr  psplim, r2                                 \n" /* Set this task's PSPLIM value. */
             "   movs r1, #2                                     \n" /* r1 = 2. */
@@ -150,9 +142,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r3                                         \n" /* Finally, branch to EXC_RETURN. */
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
-            "xSecureContextConst2: .word xSecureContext         \n"
         );
     }
 
@@ -171,8 +160,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -214,7 +201,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -224,9 +211,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -274,9 +258,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " .extern SecureContext_SaveContext               \n"
             " .extern SecureContext_LoadContext               \n"
             "                                                 \n"
-            " ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            " ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             " ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            " ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             " ldr r2, [r1]                                    \n" /* r2 = Location in TCB where the context should be saved. */
             "                                                 \n"
@@ -325,23 +309,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -359,14 +343,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -375,7 +359,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst                  \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "    cbz r0, restore_ns_context                   \n" /* No secure context to restore. */
             "                                                 \n"
@@ -404,14 +388,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xSecureContextConst: .word xSecureContext       \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -426,9 +402,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .extern SecureContext_SaveContext               \n"
             "   .extern SecureContext_LoadContext               \n"
             "                                                   \n"
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             "   mrs r2, psp                                     \n" /* Read PSP in r2. */
             "                                                   \n"
@@ -440,7 +416,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   lsls r1, r3, #25                                \n" /* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
             "   bpl save_ns_context                             \n" /* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB.*/
             "   subs r2, r2, #12                                \n" /* Make space for xSecureContext, PSPLIM and LR on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -450,7 +426,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   b select_next_task                              \n"
             "                                                   \n"
             " save_ns_context:                                  \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
                 "   tst lr, #0x10                               \n" /* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -475,17 +451,17 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r2, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
             "                                                   \n"
             "   ldmia r2!, {r0, r1, r4}                         \n" /* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
             "   msr psplim, r1                                  \n" /* Restore the PSPLIM register value for the task. */
             "   mov lr, r4                                      \n" /* LR = r4. */
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   str r0, [r3]                                    \n" /* Restore the task's xSecureContext. */
             "   cbz r0, restore_ns_context                      \n" /* If there is no secure context for the task, restore the non-secure context. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   push {r2, r4}                                   \n"
             "   bl SecureContext_LoadContext                    \n" /* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
@@ -505,10 +481,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             #endif /* configENABLE_FPU || configENABLE_MVE */
             "   msr psp, r2                                     \n" /* Remember the new top of stack for the task. */
             "   bx lr                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
-            "xSecureContextConst: .word xSecureContext          \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -566,11 +538,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst2                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -113,13 +113,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -131,7 +124,7 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r1, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r1]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
@@ -145,9 +138,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r2                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
         );
     }
 
@@ -166,8 +156,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -209,7 +197,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -219,9 +207,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -267,7 +252,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
         (
             " .syntax unified                                 \n"
             "                                                 \n"
-            " ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r0, [r2]                                    \n" /* r0 = pxCurrentTCB. */
             " ldr r1, [r0]                                    \n" /* r1 = Location in TCB where the context should be saved. */
             " mrs r2, psp                                     \n" /* r2 = PSP. */
@@ -303,23 +288,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -337,14 +322,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -369,13 +354,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -400,7 +378,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r3, lr                                      \n" /* r3 = LR/EXC_RETURN. */
             "   stmdb r0!, {r2-r11}                             \n" /* Store on the stack - PSPLIM, LR and registers that are not automatically saved. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   str r0, [r1]                                    \n" /* Save the new top of stack in TCB. */
             "                                                   \n"
@@ -412,7 +390,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r0, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
             "                                                   \n"
@@ -427,9 +405,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   msr psplim, r2                                  \n" /* Restore the PSPLIM register value for the task. */
             "   msr psp, r0                                     \n" /* Remember the new top of stack for the task. */
             "   bx r3                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -487,11 +462,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM35P/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM35P/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    orr r2, #1                                   \n" /* r2 = r1 | 1 i.e. Set the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Enable MPU. */
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -102,7 +102,7 @@
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst2                 \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "                                                 \n"
             " restore_general_regs_first_task:                \n"
@@ -115,14 +115,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xSecureContextConst2: .word xSecureContext      \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -134,12 +126,12 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r3, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r3]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
             "   ldm  r0!, {r1-r3}                               \n" /* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
-            "   ldr  r4, xSecureContextConst2                   \n"
+            "   ldr  r4, =xSecureContext                        \n"
             "   str  r1, [r4]                                   \n" /* Set xSecureContext to this task's value for the same. */
             "   msr  psplim, r2                                 \n" /* Set this task's PSPLIM value. */
             "   movs r1, #2                                     \n" /* r1 = 2. */
@@ -150,9 +142,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r3                                         \n" /* Finally, branch to EXC_RETURN. */
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
-            "xSecureContextConst2: .word xSecureContext         \n"
         );
     }
 
@@ -171,8 +160,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -214,7 +201,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -224,9 +211,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -274,9 +258,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " .extern SecureContext_SaveContext               \n"
             " .extern SecureContext_LoadContext               \n"
             "                                                 \n"
-            " ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            " ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             " ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            " ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             " ldr r2, [r1]                                    \n" /* r2 = Location in TCB where the context should be saved. */
             "                                                 \n"
@@ -325,23 +309,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -359,14 +343,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -375,7 +359,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst                  \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "    cbz r0, restore_ns_context                   \n" /* No secure context to restore. */
             "                                                 \n"
@@ -404,14 +388,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xSecureContextConst: .word xSecureContext       \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -426,9 +402,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .extern SecureContext_SaveContext               \n"
             "   .extern SecureContext_LoadContext               \n"
             "                                                   \n"
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             "   mrs r2, psp                                     \n" /* Read PSP in r2. */
             "                                                   \n"
@@ -440,7 +416,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   lsls r1, r3, #25                                \n" /* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
             "   bpl save_ns_context                             \n" /* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB.*/
             "   subs r2, r2, #12                                \n" /* Make space for xSecureContext, PSPLIM and LR on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -450,7 +426,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   b select_next_task                              \n"
             "                                                   \n"
             " save_ns_context:                                  \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
                 "   tst lr, #0x10                               \n" /* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -475,17 +451,17 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r2, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
             "                                                   \n"
             "   ldmia r2!, {r0, r1, r4}                         \n" /* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
             "   msr psplim, r1                                  \n" /* Restore the PSPLIM register value for the task. */
             "   mov lr, r4                                      \n" /* LR = r4. */
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   str r0, [r3]                                    \n" /* Restore the task's xSecureContext. */
             "   cbz r0, restore_ns_context                      \n" /* If there is no secure context for the task, restore the non-secure context. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   push {r2, r4}                                   \n"
             "   bl SecureContext_LoadContext                    \n" /* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
@@ -505,10 +481,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             #endif /* configENABLE_FPU || configENABLE_MVE */
             "   msr psp, r2                                     \n" /* Remember the new top of stack for the task. */
             "   bx lr                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
-            "xSecureContextConst: .word xSecureContext          \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -566,11 +538,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst2                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -113,13 +113,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -131,7 +124,7 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r1, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r1]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
@@ -145,9 +138,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r2                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
         );
     }
 
@@ -166,8 +156,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -209,7 +197,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -219,9 +207,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -267,7 +252,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
         (
             " .syntax unified                                 \n"
             "                                                 \n"
-            " ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r0, [r2]                                    \n" /* r0 = pxCurrentTCB. */
             " ldr r1, [r0]                                    \n" /* r1 = Location in TCB where the context should be saved. */
             " mrs r2, psp                                     \n" /* r2 = PSP. */
@@ -303,23 +288,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -337,14 +322,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -369,13 +354,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -400,7 +378,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r3, lr                                      \n" /* r3 = LR/EXC_RETURN. */
             "   stmdb r0!, {r2-r11}                             \n" /* Store on the stack - PSPLIM, LR and registers that are not automatically saved. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   str r0, [r1]                                    \n" /* Save the new top of stack in TCB. */
             "                                                   \n"
@@ -412,7 +390,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r0, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
             "                                                   \n"
@@ -427,9 +405,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   msr psplim, r2                                  \n" /* Restore the PSPLIM register value for the task. */
             "   msr psp, r0                                     \n" /* Remember the new top of stack for the task. */
             "   bx r3                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -487,11 +462,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM55/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    orr r2, #1                                   \n" /* r2 = r1 | 1 i.e. Set the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Enable MPU. */
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -102,7 +102,7 @@
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst2                 \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "                                                 \n"
             " restore_general_regs_first_task:                \n"
@@ -115,14 +115,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xSecureContextConst2: .word xSecureContext      \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -134,12 +126,12 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r3, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r3]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
             "   ldm  r0!, {r1-r3}                               \n" /* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
-            "   ldr  r4, xSecureContextConst2                   \n"
+            "   ldr  r4, =xSecureContext                        \n"
             "   str  r1, [r4]                                   \n" /* Set xSecureContext to this task's value for the same. */
             "   msr  psplim, r2                                 \n" /* Set this task's PSPLIM value. */
             "   movs r1, #2                                     \n" /* r1 = 2. */
@@ -150,9 +142,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r3                                         \n" /* Finally, branch to EXC_RETURN. */
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
-            "xSecureContextConst2: .word xSecureContext         \n"
         );
     }
 
@@ -171,8 +160,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -214,7 +201,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -224,9 +211,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -274,9 +258,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " .extern SecureContext_SaveContext               \n"
             " .extern SecureContext_LoadContext               \n"
             "                                                 \n"
-            " ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            " ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             " ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            " ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             " ldr r2, [r1]                                    \n" /* r2 = Location in TCB where the context should be saved. */
             "                                                 \n"
@@ -325,23 +309,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -359,14 +343,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -375,7 +359,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst                  \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "    cbz r0, restore_ns_context                   \n" /* No secure context to restore. */
             "                                                 \n"
@@ -404,14 +388,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xSecureContextConst: .word xSecureContext       \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -426,9 +402,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .extern SecureContext_SaveContext               \n"
             "   .extern SecureContext_LoadContext               \n"
             "                                                   \n"
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             "   mrs r2, psp                                     \n" /* Read PSP in r2. */
             "                                                   \n"
@@ -440,7 +416,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   lsls r1, r3, #25                                \n" /* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
             "   bpl save_ns_context                             \n" /* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB.*/
             "   subs r2, r2, #12                                \n" /* Make space for xSecureContext, PSPLIM and LR on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -450,7 +426,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   b select_next_task                              \n"
             "                                                   \n"
             " save_ns_context:                                  \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
                 "   tst lr, #0x10                               \n" /* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -475,17 +451,17 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r2, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
             "                                                   \n"
             "   ldmia r2!, {r0, r1, r4}                         \n" /* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
             "   msr psplim, r1                                  \n" /* Restore the PSPLIM register value for the task. */
             "   mov lr, r4                                      \n" /* LR = r4. */
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   str r0, [r3]                                    \n" /* Restore the task's xSecureContext. */
             "   cbz r0, restore_ns_context                      \n" /* If there is no secure context for the task, restore the non-secure context. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   push {r2, r4}                                   \n"
             "   bl SecureContext_LoadContext                    \n" /* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
@@ -505,10 +481,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             #endif /* configENABLE_FPU || configENABLE_MVE */
             "   msr psp, r2                                     \n" /* Remember the new top of stack for the task. */
             "   bx lr                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
-            "xSecureContextConst: .word xSecureContext          \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -566,11 +538,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst2                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -113,13 +113,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -131,7 +124,7 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r1, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r1]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
@@ -145,9 +138,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r2                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
         );
     }
 
@@ -166,8 +156,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -209,7 +197,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -219,9 +207,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -267,7 +252,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
         (
             " .syntax unified                                 \n"
             "                                                 \n"
-            " ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r0, [r2]                                    \n" /* r0 = pxCurrentTCB. */
             " ldr r1, [r0]                                    \n" /* r1 = Location in TCB where the context should be saved. */
             " mrs r2, psp                                     \n" /* r2 = PSP. */
@@ -303,23 +288,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -337,14 +322,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -369,13 +354,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -400,7 +378,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r3, lr                                      \n" /* r3 = LR/EXC_RETURN. */
             "   stmdb r0!, {r2-r11}                             \n" /* Store on the stack - PSPLIM, LR and registers that are not automatically saved. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   str r0, [r1]                                    \n" /* Save the new top of stack in TCB. */
             "                                                   \n"
@@ -412,7 +390,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r0, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
             "                                                   \n"
@@ -427,9 +405,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   msr psplim, r2                                  \n" /* Restore the PSPLIM register value for the task. */
             "   msr psp, r0                                     \n" /* Remember the new top of stack for the task. */
             "   bx r3                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -487,11 +462,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM85/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM85/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    orr r2, #1                                   \n" /* r2 = r1 | 1 i.e. Set the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Enable MPU. */
             "    dsb                                          \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r3, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -102,7 +102,7 @@
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst2                 \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "                                                 \n"
             " restore_general_regs_first_task:                \n"
@@ -115,14 +115,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xSecureContextConst2: .word xSecureContext      \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -134,12 +126,12 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r3, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r3]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
             "   ldm  r0!, {r1-r3}                               \n" /* Read from stack - r1 = xSecureContext, r2 = PSPLIM and r3 = EXC_RETURN. */
-            "   ldr  r4, xSecureContextConst2                   \n"
+            "   ldr  r4, =xSecureContext                        \n"
             "   str  r1, [r4]                                   \n" /* Set xSecureContext to this task's value for the same. */
             "   msr  psplim, r2                                 \n" /* Set this task's PSPLIM value. */
             "   movs r1, #2                                     \n" /* r1 = 2. */
@@ -150,9 +142,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r3                                         \n" /* Finally, branch to EXC_RETURN. */
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
-            "xSecureContextConst2: .word xSecureContext         \n"
         );
     }
 
@@ -171,8 +160,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -214,7 +201,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -224,9 +211,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -274,9 +258,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " .extern SecureContext_SaveContext               \n"
             " .extern SecureContext_LoadContext               \n"
             "                                                 \n"
-            " ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            " ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             " ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            " ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             " ldr r2, [r1]                                    \n" /* r2 = Location in TCB where the context should be saved. */
             "                                                 \n"
@@ -325,23 +309,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r3]                                 \n" /* r0 = pxCurrentTCB.*/
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -359,14 +343,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r3, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r3, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r1, [r3]                                 \n" /* r1 = pxCurrentTCB.*/
             "    ldr r2, [r1]                                 \n" /* r2 = Location of saved context in TCB. */
             "                                                 \n"
@@ -375,7 +359,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr psp, r3                                  \n"
             "    msr psplim, r4                               \n"
             "    msr control, r5                              \n"
-            "    ldr r4, xSecureContextConst                  \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "    ldr r4, =xSecureContext                      \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "    str r0, [r4]                                 \n" /* Restore xSecureContext. */
             "    cbz r0, restore_ns_context                   \n" /* No secure context to restore. */
             "                                                 \n"
@@ -404,14 +388,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r2, [r1]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xSecureContextConst: .word xSecureContext       \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -426,9 +402,9 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   .extern SecureContext_SaveContext               \n"
             "   .extern SecureContext_LoadContext               \n"
             "                                                   \n"
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   ldr r0, [r3]                                    \n" /* Read xSecureContext - Value of xSecureContext must be in r0 as it is used as a parameter later. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB - Value of pxCurrentTCB must be in r1 as it is used as a parameter later. */
             "   mrs r2, psp                                     \n" /* Read PSP in r2. */
             "                                                   \n"
@@ -440,7 +416,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   lsls r1, r3, #25                                \n" /* r1 = r3 << 25. Bit[6] of EXC_RETURN is 1 if secure stack was used, 0 if non-secure stack was used to store stack frame. */
             "   bpl save_ns_context                             \n" /* bpl - branch if positive or zero. If r1 >= 0 ==> Bit[6] in EXC_RETURN is 0 i.e. non-secure stack was used. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB.*/
             "   subs r2, r2, #12                                \n" /* Make space for xSecureContext, PSPLIM and LR on the stack. */
             "   str r2, [r1]                                    \n" /* Save the new top of stack in TCB. */
@@ -450,7 +426,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   b select_next_task                              \n"
             "                                                   \n"
             " save_ns_context:                                  \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             #if ( ( configENABLE_FPU == 1 ) || ( configENABLE_MVE == 1 ) )
                 "   tst lr, #0x10                               \n" /* Test Bit[4] in LR. Bit[4] of EXC_RETURN is 0 if the Extended Stack Frame is in use. */
@@ -475,17 +451,17 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r2, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r2 now points to the top of stack. */
             "                                                   \n"
             "   ldmia r2!, {r0, r1, r4}                         \n" /* Read from stack - r0 = xSecureContext, r1 = PSPLIM and r4 = LR. */
             "   msr psplim, r1                                  \n" /* Restore the PSPLIM register value for the task. */
             "   mov lr, r4                                      \n" /* LR = r4. */
-            "   ldr r3, xSecureContextConst                     \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
+            "   ldr r3, =xSecureContext                         \n" /* Read the location of xSecureContext i.e. &( xSecureContext ). */
             "   str r0, [r3]                                    \n" /* Restore the task's xSecureContext. */
             "   cbz r0, restore_ns_context                      \n" /* If there is no secure context for the task, restore the non-secure context. */
-            "   ldr r3, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r3, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r3]                                    \n" /* Read pxCurrentTCB. */
             "   push {r2, r4}                                   \n"
             "   bl SecureContext_LoadContext                    \n" /* Restore the secure context. Params are in r0 and r1. r0 = xSecureContext and r1 = pxCurrentTCB. */
@@ -505,10 +481,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             #endif /* configENABLE_FPU || configENABLE_MVE */
             "   msr psp, r2                                     \n" /* Remember the new top of stack for the task. */
             "   bx lr                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
-            "xSecureContextConst: .word xSecureContext          \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -566,11 +538,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portasm.c
@@ -52,23 +52,23 @@
             " .syntax unified                                 \n"
             "                                                 \n"
             " program_mpu_first_task:                         \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst2                       \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const2                         \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst2                           \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst2                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -86,14 +86,14 @@
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst2                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context_first_task:                     \n"
-            "    ldr r2, pxCurrentTCBConst2                   \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -113,13 +113,6 @@
             "    mov r0, #0                                   \n"
             "    msr basepri, r0                              \n" /* Ensure that interrupts are enabled when the first task starts. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst2: .word pxCurrentTCB          \n"
-            " xMPUCTRLConst2: .word 0xe000ed94                \n"
-            " xMAIR0Const2: .word 0xe000edc0                  \n"
-            " xRNRConst2: .word 0xe000ed98                    \n"
-            " xRBARConst2: .word 0xe000ed9c                   \n"
         );
     }
 
@@ -131,7 +124,7 @@
         (
             "   .syntax unified                                 \n"
             "                                                   \n"
-            "   ldr  r2, pxCurrentTCBConst2                     \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr  r2, =pxCurrentTCB                          \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr  r1, [r2]                                   \n" /* Read pxCurrentTCB. */
             "   ldr  r0, [r1]                                   \n" /* Read top of stack from TCB - The first item in pxCurrentTCB is the task top of stack. */
             "                                                   \n"
@@ -145,9 +138,6 @@
             "   mov  r0, #0                                     \n"
             "   msr  basepri, r0                                \n" /* Ensure that interrupts are enabled when the first task starts. */
             "   bx   r2                                         \n" /* Finally, branch to EXC_RETURN. */
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst2: .word pxCurrentTCB             \n"
         );
     }
 
@@ -166,8 +156,6 @@ BaseType_t xIsPrivileged( void ) /* __attribute__ (( naked )) */
         "   movne r0, #0                                    \n" /* CONTROL[0]!=0. Return false to indicate that the processor is not privileged. */
         "   moveq r0, #1                                    \n" /* CONTROL[0]==0. Return true to indicate that the processor is privileged. */
         "   bx lr                                           \n" /* Return. */
-        "                                                   \n"
-        "   .align 4                                        \n"
         ::: "r0", "memory"
     );
 }
@@ -209,7 +197,7 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r0, xVTORConst                              \n" /* Use the NVIC offset register to locate the stack. */
+        "   ldr r0, =0xe000ed08                             \n" /* Use the NVIC offset register to locate the stack. */
         "   ldr r0, [r0]                                    \n" /* Read the VTOR register which gives the address of vector table. */
         "   ldr r0, [r0]                                    \n" /* The first entry in vector table is stack pointer. */
         "   msr msp, r0                                     \n" /* Set the MSP back to the start of the stack. */
@@ -219,9 +207,6 @@ void vStartFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
         "   isb                                             \n"
         "   svc %0                                          \n" /* System call to start the first task. */
         "   nop                                             \n"
-        "                                                   \n"
-        "   .align 4                                        \n"
-        "xVTORConst: .word 0xe000ed08                       \n"
         ::"i" ( portSVC_START_SCHEDULER ) : "memory"
     );
 }
@@ -267,7 +252,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
         (
             " .syntax unified                                 \n"
             "                                                 \n"
-            " ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            " ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             " ldr r0, [r2]                                    \n" /* r0 = pxCurrentTCB. */
             " ldr r1, [r0]                                    \n" /* r1 = Location in TCB where the context should be saved. */
             " mrs r2, psp                                     \n" /* r2 = PSP. */
@@ -303,23 +288,23 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "    msr basepri, r0                              \n" /* Enable interrupts. */
             "                                                 \n"
             " program_mpu:                                    \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB. */
             "                                                 \n"
             "    dmb                                          \n" /* Complete outstanding transfers before disabling MPU. */
-            "    ldr r1, xMPUCTRLConst                        \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "    ldr r1, =0xe000ed94                          \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "    ldr r2, [r1]                                 \n" /* Read the value of MPU_CTRL. */
             "    bic r2, #1                                   \n" /* r2 = r2 & ~1 i.e. Clear the bit 0 in r2. */
             "    str r2, [r1]                                 \n" /* Disable MPU. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to MAIR0 in TCB. */
             "    ldr r1, [r0]                                 \n" /* r1 = *r0 i.e. r1 = MAIR0. */
-            "    ldr r2, xMAIR0Const                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
+            "    ldr r2, =0xe000edc0                          \n" /* r2 = 0xe000edc0 [Location of MAIR0]. */
             "    str r1, [r2]                                 \n" /* Program MAIR0. */
             "                                                 \n"
             "    adds r0, #4                                  \n" /* r0 = r0 + 4. r0 now points to first RBAR in TCB. */
-            "    ldr r1, xRNRConst                            \n" /* r1 = 0xe000ed98 [Location of RNR]. */
-            "    ldr r2, xRBARConst                           \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
+            "    ldr r1, =0xe000ed98                          \n" /* r1 = 0xe000ed98 [Location of RNR]. */
+            "    ldr r2, =0xe000ed9c                          \n" /* r2 = 0xe000ed9c [Location of RBAR]. */
             "                                                 \n"
             "    movs r3, #4                                  \n" /* r3 = 4. */
             "    str r3, [r1]                                 \n" /* Program RNR = 4. */
@@ -337,14 +322,14 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
                 "    stmia r2, {r4-r11}                           \n" /* Write 4 set of RBAR/RLAR registers using alias registers. */
             #endif /* configTOTAL_MPU_REGIONS == 16 */
             "                                                 \n"
-            "   ldr r1, xMPUCTRLConst                         \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
+            "   ldr r1, =0xe000ed94                           \n" /* r1 = 0xe000ed94 [Location of MPU_CTRL]. */
             "   ldr r2, [r1]                                  \n" /* Read the value of MPU_CTRL. */
             "   orr r2, #1                                    \n" /* r2 = r2 | 1 i.e. Set the bit 0 in r2. */
             "   str r2, [r1]                                  \n" /* Enable MPU. */
             "   dsb                                           \n" /* Force memory writes before continuing. */
             "                                                 \n"
             " restore_context:                                \n"
-            "    ldr r2, pxCurrentTCBConst                    \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "    ldr r2, =pxCurrentTCB                        \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "    ldr r0, [r2]                                 \n" /* r0 = pxCurrentTCB.*/
             "    ldr r1, [r0]                                 \n" /* r1 = Location of saved context in TCB. */
             "                                                 \n"
@@ -369,13 +354,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             " restore_context_done:                           \n"
             "    str r1, [r0]                                 \n" /* Save the location where the context should be saved next as the first member of TCB. */
             "    bx lr                                        \n"
-            "                                                 \n"
-            " .align 4                                        \n"
-            " pxCurrentTCBConst: .word pxCurrentTCB           \n"
-            " xMPUCTRLConst: .word 0xe000ed94                 \n"
-            " xMAIR0Const: .word 0xe000edc0                   \n"
-            " xRNRConst: .word 0xe000ed98                     \n"
-            " xRBARConst: .word 0xe000ed9c                    \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -400,7 +378,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r3, lr                                      \n" /* r3 = LR/EXC_RETURN. */
             "   stmdb r0!, {r2-r11}                             \n" /* Store on the stack - PSPLIM, LR and registers that are not automatically saved. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   str r0, [r1]                                    \n" /* Save the new top of stack in TCB. */
             "                                                   \n"
@@ -412,7 +390,7 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   mov r0, #0                                      \n" /* r0 = 0. */
             "   msr basepri, r0                                 \n" /* Enable interrupts. */
             "                                                   \n"
-            "   ldr r2, pxCurrentTCBConst                       \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
+            "   ldr r2, =pxCurrentTCB                           \n" /* Read the location of pxCurrentTCB i.e. &( pxCurrentTCB ). */
             "   ldr r1, [r2]                                    \n" /* Read pxCurrentTCB. */
             "   ldr r0, [r1]                                    \n" /* The first item in pxCurrentTCB is the task top of stack. r0 now points to the top of stack. */
             "                                                   \n"
@@ -427,9 +405,6 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   msr psplim, r2                                  \n" /* Restore the PSPLIM register value for the task. */
             "   msr psp, r0                                     \n" /* Remember the new top of stack for the task. */
             "   bx r3                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "pxCurrentTCBConst: .word pxCurrentTCB              \n"
             ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY )
         );
     }
@@ -487,11 +462,8 @@ void vClearInterruptMask( __attribute__( ( unused ) ) uint32_t ulMask ) /* __att
             "   ite eq                                          \n"
             "   mrseq r0, msp                                   \n"
             "   mrsne r0, psp                                   \n"
-            "   ldr r1, svchandler_address_const                \n"
+            "   ldr r1, =vPortSVCHandler_C                      \n"
             "   bx r1                                           \n"
-            "                                                   \n"
-            "   .align 4                                        \n"
-            "svchandler_address_const: .word vPortSVCHandler_C  \n"
         );
     }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Currently in Armv8-M GCC/ArmClang ports, constant pool is used to define literals needed for `ldr` instruction. However, those constant pools are defined with `.align 4` which increases code size. Instead of defining the constant pool with `.align 4`, let the compiler hanlde the constant pool and the required alignment.

Benchmarking these changes using Cortex-M85 (Corstone-315) and blinky application in https://github.com/FreeRTOS/iot-reference-arm-corstone3xx/tree/main/applications/blinky shows a code size reduction of `72 bytes (GCC)` and `56 bytes (ArmClang)`.

Additional info:
Armv8-M IAR port doesn't use any constant pool. With these changes all three ports GCC/ArmClang/IAR are aligned.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Validated the changes using GCC and ArmClang and using blinky application in https://github.com/FreeRTOS/iot-reference-arm-corstone3xx/tree/main/applications/blinky and:
* Cortex-M85 (Corstone-315)
* Cortex-M55 (Corstone-300)

Still to validate:
* Cortex-M23
* Cortex-M33

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
