### PR TITLE
Adding SMP coverity example

### DIFF
--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -86,3 +86,42 @@ jobs:
           echo "::endgroup::"
           echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }} "
           echo "${COV_SCAN_UPLOAD_STATUS}" | grep -q -e 'Build successfully submitted' || echo >&2 "Error submitting build for analysis: ${COV_SCAN_UPLOAD_STATUS}"
+
+      - env:
+            stepName: Coverity Build for SMP FreeRTOS
+            COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+            COVERITY_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        shell: bash
+        run: |
+            # ${{ env.stepName }}
+            echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+  
+            export PATH="$PATH:${{env.cov_scan_path}}"
+            cmake -S ./examples/cmake_example/ -B build -DFREERTOS_SMP_EXAMPLE=1
+            cd build
+            cov-build --dir cov-int make -j
+            # Move the report out of the build directory
+            tar czvf ../gcc_freertos_kernel_smp_sample_build.tgz cov-int
+  
+            echo "::endgroup::"
+            echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }} "
+
+      - env:
+            stepName: Upload FreeRTOS SMP Coverity Report for Scan
+            COVERITY_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+            COVERITY_EMAIL: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        shell: bash
+        run: |
+            # ${{ env.stepName }}
+            echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+  
+            COV_SCAN_UPLOAD_STATUS=$(curl --form token=${COVERITY_TOKEN} \
+              --form email=${COVERITY_EMAIL} \
+              --form file=@gcc_freertos_kernel_smp_sample_build.tgz \
+              --form version="Mainline" \
+              --form description="FreeRTOS Kernel SMP Commit Scan" \
+              https://scan.coverity.com/builds?project=FreeRTOS-Kernel)
+  
+            echo "::endgroup::"
+            echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }} "
+            echo "${COV_SCAN_UPLOAD_STATUS}" | grep -q -e 'Build successfully submitted' || echo >&2 "Error submitting build for analysis: ${COV_SCAN_UPLOAD_STATUS}"

--- a/MISRA.md
+++ b/MISRA.md
@@ -18,6 +18,15 @@ with ( Assuming rule 8.4 violation; with justification in point 1 ):
 grep 'MISRA Ref 8.4.1' . -rI
 ```
 
+#### Dir 4.7
+MISRA C:2012 Dir 4.7: If a function returns error information, then that error
+information shall be tested.
+
+_Ref 4.7.1_
+ - The return value of `taskENTER_CRITICAL_FROM_ISR` is the interrupt mask of the
+   port. Error information won't be returned by this function and no need to perform
+   a check on the return value.
+
 #### Rule 8.4
 
 MISRA C:2012 Rule 8.4: A compatible declaration shall be visible when an

--- a/MISRA.md
+++ b/MISRA.md
@@ -23,9 +23,8 @@ MISRA C:2012 Dir 4.7: If a function returns error information, then that error
 information shall be tested.
 
 _Ref 4.7.1_
- - The return value of `taskENTER_CRITICAL_FROM_ISR` is the interrupt mask of the
-   port. Error information won't be returned by this function and no need to perform
-   a check on the return value.
+ - `taskENTER_CRITICAL_FROM_ISR` returns the interrupt mask and not any error
+    information. Therefore, there is no need test the return value.
 
 #### Rule 8.4
 

--- a/event_groups.c
+++ b/event_groups.c
@@ -529,6 +529,9 @@
 
         traceENTER_xEventGroupGetBitsFromISR( xEventGroup );
 
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
         {
             uxReturn = pxEventBits->uxEventBits;

--- a/examples/coverity/CMakeLists.txt
+++ b/examples/coverity/CMakeLists.txt
@@ -23,6 +23,12 @@ target_include_directories(freertos_config
                            INTERFACE
                            ./)
 
+if (DEFINED FREERTOS_SMP_EXAMPLE AND FREERTOS_SMP_EXAMPLE STREQUAL "1")
+    message(STATUS "Build FreeRTOS SMP example")
+    # Adding the following configurations to build SMP template port
+    add_compile_options( -DconfigNUMBER_OF_CORES=2 -DconfigUSE_PASSIVE_IDLE_HOOK=0 )
+endif()
+
 # Select the heap. Values between 1-5 will pick a heap.
 set(FREERTOS_HEAP "3" CACHE STRING "" FORCE)
 

--- a/examples/coverity/README.md
+++ b/examples/coverity/README.md
@@ -34,8 +34,13 @@ commands in a terminal:
   cov-configure --force --compiler cc --comptype gcc
   ~~~
 2. Create the build files using CMake in a `build` directory:
+  Singe core FreeRTOS:
   ~~~
   cmake -B build -S examples/coverity
+  ~~~
+  SMP FreeRTOS:
+  ~~~
+  cmake -B build -S examples/coverity -DFREERTOS_SMP_EXAMPLE=1
   ~~~
 3. Build the (pseudo) application:
   ~~~
@@ -47,7 +52,7 @@ commands in a terminal:
   ~~~
   cov-analyze --dir ./cov-out \
     --coding-standard-config ../examples/coverity/coverity_misra.config \
-    --tu-pattern "file('[A-Za-z_]+\.c')"
+    --tu-pattern "file('[A-Za-z_]+\.c') && ( ! file('main.c') ) && ( ! file('port.c') )"
   ~~~
 5. Generate the HTML report:
   ~~~

--- a/examples/coverity/README.md
+++ b/examples/coverity/README.md
@@ -34,11 +34,13 @@ commands in a terminal:
   cov-configure --force --compiler cc --comptype gcc
   ~~~
 2. Create the build files using CMake in a `build` directory:
-  Singe core FreeRTOS:
+
+Singe core FreeRTOS:
   ~~~
   cmake -B build -S examples/coverity
   ~~~
-  SMP FreeRTOS:
+
+SMP FreeRTOS:
   ~~~
   cmake -B build -S examples/coverity -DFREERTOS_SMP_EXAMPLE=1
   ~~~

--- a/queue.c
+++ b/queue.c
@@ -1190,6 +1190,9 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
      * read, instead return a flag to say whether a context switch is required or
      * not (i.e. has a task with a higher priority than us been woken by this
      * post). */
+    /* MISRA Ref 4.7.1 [Return value shall be checked] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+    /* coverity[misra_c_2012_directive_4_7_violation] */
     uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
     {
         if( ( pxQueue->uxMessagesWaiting < pxQueue->uxLength ) || ( xCopyPosition == queueOVERWRITE ) )
@@ -1365,6 +1368,9 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
      * link: https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
     portASSERT_IF_INTERRUPT_PRIORITY_INVALID();
 
+    /* MISRA Ref 4.7.1 [Return value shall be checked] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+    /* coverity[misra_c_2012_directive_4_7_violation] */
     uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
     {
         const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
@@ -2055,6 +2061,9 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
      * link: https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
     portASSERT_IF_INTERRUPT_PRIORITY_INVALID();
 
+    /* MISRA Ref 4.7.1 [Return value shall be checked] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+    /* coverity[misra_c_2012_directive_4_7_violation] */
     uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
     {
         const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
@@ -2153,6 +2162,9 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
      * link: https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
     portASSERT_IF_INTERRUPT_PRIORITY_INVALID();
 
+    /* MISRA Ref 4.7.1 [Return value shall be checked] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+    /* coverity[misra_c_2012_directive_4_7_violation] */
     uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
     {
         /* Cannot block in an ISR, so check there is data available. */

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -676,6 +676,9 @@ BaseType_t xStreamBufferResetFromISR( StreamBufferHandle_t xStreamBuffer )
     #endif
 
     /* Can only reset a message buffer if there are no tasks blocked on it. */
+    /* MISRA Ref 4.7.1 [Return value shall be checked] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+    /* coverity[misra_c_2012_directive_4_7_violation] */
     uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
     {
         if( ( pxStreamBuffer->xTaskWaitingToReceive == NULL ) && ( pxStreamBuffer->xTaskWaitingToSend == NULL ) )
@@ -972,6 +975,9 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
         /* Was a task waiting for the data? */
         if( prvBytesInBuffer( pxStreamBuffer ) >= pxStreamBuffer->xTriggerLevelBytes )
         {
+            /* MISRA Ref 4.7.1 [Return value shall be checked] */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+            /* coverity[misra_c_2012_directive_4_7_violation] */
             prvSEND_COMPLETE_FROM_ISR( pxStreamBuffer, pxHigherPriorityTaskWoken );
         }
         else
@@ -1245,6 +1251,9 @@ size_t xStreamBufferReceiveFromISR( StreamBufferHandle_t xStreamBuffer,
         /* Was a task waiting for space in the buffer? */
         if( xReceivedLength != ( size_t ) 0 )
         {
+            /* MISRA Ref 4.7.1 [Return value shall be checked] */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+            /* coverity[misra_c_2012_directive_4_7_violation] */
             prvRECEIVE_COMPLETED_FROM_ISR( pxStreamBuffer, pxHigherPriorityTaskWoken );
         }
         else
@@ -1397,6 +1406,9 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
 
     configASSERT( pxStreamBuffer );
 
+    /* MISRA Ref 4.7.1 [Return value shall be checked] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+    /* coverity[misra_c_2012_directive_4_7_violation] */
     uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
     {
         if( ( pxStreamBuffer )->xTaskWaitingToReceive != NULL )
@@ -1433,6 +1445,9 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
 
     configASSERT( pxStreamBuffer );
 
+    /* MISRA Ref 4.7.1 [Return value shall be checked] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+    /* coverity[misra_c_2012_directive_4_7_violation] */
     uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
     {
         if( ( pxStreamBuffer )->xTaskWaitingToSend != NULL )

--- a/tasks.c
+++ b/tasks.c
@@ -881,7 +881,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         configASSERT( portGET_CRITICAL_NESTING_COUNT() > 0U );
 
         #if ( configRUN_MULTIPLE_PRIORITIES == 0 )
-
             /* No task should yield for this one if it is a lower priority
              * than priority level of currently ready tasks. */
             if( pxTCB->uxPriority >= uxTopReadyPriority )
@@ -2666,6 +2665,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
          * https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         portASSERT_IF_INTERRUPT_PRIORITY_INVALID();
 
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
         {
             /* If null is passed in here then it is the priority of the calling
@@ -2737,6 +2739,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
          * https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         portASSERT_IF_INTERRUPT_PRIORITY_INVALID();
 
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
         {
             /* If null is passed in here then it is the base priority of the calling
@@ -3354,12 +3359,10 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         configASSERT( xTaskToResume );
 
         #if ( configNUMBER_OF_CORES == 1 )
-
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. */
             if( ( pxTCB != pxCurrentTCB ) && ( pxTCB != NULL ) )
         #else
-
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. It is also impossible to resume a task
              * that is actively running on another core but it is not safe
@@ -3433,6 +3436,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
          * https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         portASSERT_IF_INTERRUPT_PRIORITY_INVALID();
 
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
         {
             if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
@@ -4989,6 +4995,9 @@ BaseType_t xTaskIncrementTick( void )
 
         /* Save the hook function in the TCB.  A critical section is required as
          * the value can be accessed from an interrupt. */
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
         {
             xReturn = pxTCB->pxTaskTag;
@@ -7974,6 +7983,9 @@ TickType_t uxTaskResetEventItemValue( void )
 
         pxTCB = xTaskToNotify;
 
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
         {
             if( pulPreviousNotificationValue != NULL )
@@ -8133,6 +8145,9 @@ TickType_t uxTaskResetEventItemValue( void )
 
         pxTCB = xTaskToNotify;
 
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
         {
             ucOriginalNotifyState = pxTCB->ucNotifyState[ uxIndexToNotify ];

--- a/tasks.c
+++ b/tasks.c
@@ -881,6 +881,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         configASSERT( portGET_CRITICAL_NESTING_COUNT() > 0U );
 
         #if ( configRUN_MULTIPLE_PRIORITIES == 0 )
+
             /* No task should yield for this one if it is a lower priority
              * than priority level of currently ready tasks. */
             if( pxTCB->uxPriority >= uxTopReadyPriority )
@@ -3359,10 +3360,12 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         configASSERT( xTaskToResume );
 
         #if ( configNUMBER_OF_CORES == 1 )
+
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. */
             if( ( pxTCB != pxCurrentTCB ) && ( pxTCB != NULL ) )
         #else
+
             /* The parameter cannot be NULL as it is impossible to resume the
              * currently executing task. It is also impossible to resume a task
              * that is actively running on another core but it is not safe


### PR DESCRIPTION
Adding SMP coverity example

Description
-----------
In this PR:
* Add SMP coverity example. User can reference the ./examples/coverity/README.md to run coverity with SMP FreeRTOS.
* Suppress MISRA C:2012 directive 4.7 by comment. The return value of `taskENTER_CRITICAL_FROM_ISR()` is the interrupt mask. No error information will be returned by this function and no need to perform a check.

Test Steps
-----------
Run coverity 2023.6.1 with the following command should shows no violations.
Single core
```
cmake -B build -S examples/coverity
```
SMP
```
cmake -B build -S examples/coverity -DFREERTOS_SMP_EXAMPLE=1
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
