### PR TITLE
Add vPortGenerateSimulatedInterruptFromWindowsThread in MSVC port

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -177,28 +177,7 @@ static DWORD WINAPI prvSimulatedPeripheralTimer( LPVOID lpParameter )
             Sleep( portTICK_PERIOD_MS );
         }
 
-        if( xPortRunning == pdTRUE )
-        {
-            configASSERT( xPortRunning );
-
-            /* Can't proceed if in a critical section as pvInterruptEventMutex won't
-             * be available. */
-            WaitForSingleObject( pvInterruptEventMutex, INFINITE );
-
-            /* The timer has expired, generate the simulated tick event. */
-            ulPendingInterrupts |= ( 1 << portINTERRUPT_TICK );
-
-            /* The interrupt is now pending - notify the simulated interrupt
-             * handler thread.  Must be outside of a critical section to get here so
-             * the handler thread can execute immediately pvInterruptEventMutex is
-             * released. */
-            configASSERT( ulCriticalNesting == 0UL );
-            SetEvent( pvInterruptEvent );
-
-            /* Give back the mutex so the simulated interrupt handler unblocks
-             * and can access the interrupt handler variables. */
-            ReleaseMutex( pvInterruptEventMutex );
-        }
+        vPortGenerateSimulatedInterruptFromNative( portINTERRUPT_TICK );
     }
 
     return 0;
@@ -632,6 +611,32 @@ void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber )
              * sure. */
             WaitForSingleObject( pxThreadState->pvYieldEvent, INFINITE );
         }
+    }
+}
+/*-----------------------------------------------------------*/
+
+void vPortGenerateSimulatedInterruptFromNative( uint32_t ulInterruptNumber )
+{
+    if( xPortRunning == pdTRUE )
+    {
+        /* Can't proceed if in a critical section as pvInterruptEventMutex won't
+         * be available. */
+        WaitForSingleObject( pvInterruptEventMutex, INFINITE );
+
+        /* Pending a user defined interrupt to be handled in simulated interrupt
+         * handler thread. */
+        ulPendingInterrupts |= ( 1 << ulInterruptNumber );
+
+        /* The interrupt is now pending - notify the simulated interrupt
+         * handler thread.  Must be outside of a critical section to get here so
+         * the handler thread can execute immediately pvInterruptEventMutex is
+         * released. */
+        configASSERT( ulCriticalNesting == 0UL );
+        SetEvent( pvInterruptEvent );
+
+        /* Give back the mutex so the simulated interrupt handler unblocks
+         * and can access the interrupt handler variables. */
+        ReleaseMutex( pvInterruptEventMutex );
     }
 }
 /*-----------------------------------------------------------*/

--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -177,7 +177,7 @@ static DWORD WINAPI prvSimulatedPeripheralTimer( LPVOID lpParameter )
             Sleep( portTICK_PERIOD_MS );
         }
 
-        vPortGenerateSimulatedInterruptFromNative( portINTERRUPT_TICK );
+        vPortGenerateSimulatedInterruptFromWindowsThread( portINTERRUPT_TICK );
     }
 
     return 0;
@@ -615,7 +615,7 @@ void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber )
 }
 /*-----------------------------------------------------------*/
 
-void vPortGenerateSimulatedInterruptFromNative( uint32_t ulInterruptNumber )
+void vPortGenerateSimulatedInterruptFromWindowsThread( uint32_t ulInterruptNumber )
 {
     if( xPortRunning == pdTRUE )
     {

--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -199,9 +199,9 @@ void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber );
  * Raise a simulated interrupt represented by the bit mask in ulInterruptMask.
  * Each bit can be used to represent an individual interrupt - with the first
  * two bits being used for the Yield and Tick interrupts respectively. This function
- * can be called in a native windows thread.
+ * can be called in a windows thread.
  */
-void vPortGenerateSimulatedInterruptFromNative( uint32_t ulInterruptNumber );
+void vPortGenerateSimulatedInterruptFromWindowsThread( uint32_t ulInterruptNumber );
 
 /*
  * Install an interrupt handler to be called by the simulated interrupt handler

--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -184,8 +184,9 @@ void vPortExitCritical( void );
 #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
-#define portINTERRUPT_YIELD    ( 0UL )
-#define portINTERRUPT_TICK     ( 1UL )
+#define portINTERRUPT_YIELD                        ( 0UL )
+#define portINTERRUPT_TICK                         ( 1UL )
+#define portINTERRUPT_APPLICATION_DEFINED_START    ( 2UL )
 
 /*
  * Raise a simulated interrupt represented by the bit mask in ulInterruptMask.
@@ -193,6 +194,14 @@ void vPortExitCritical( void );
  * two bits being used for the Yield and Tick interrupts respectively.
  */
 void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber );
+
+/*
+ * Raise a simulated interrupt represented by the bit mask in ulInterruptMask.
+ * Each bit can be used to represent an individual interrupt - with the first
+ * two bits being used for the Yield and Tick interrupts respectively. This function
+ * can be called in a native windows thread.
+ */
+void vPortGenerateSimulatedInterruptFromNative( uint32_t ulInterruptNumber );
 
 /*
  * Install an interrupt handler to be called by the simulated interrupt handler


### PR DESCRIPTION
Add vPortGenerateSimulatedInterruptFromWindowsThread in MSVC port

Description
-----------
In the MSVC port of FreeRTOS, native Windows threads execute concurrently with FreeRTOS tasks and simulated interrupt handlers. Calling a FreeRTOS API from within a native Windows thread can lead to race conditions due to the concurrent execution. One way to enable synchronization between native Windows threads and FreeRTOS tasks is to make use of simulated interrupts. When a native Windows thread needs to invoke a FreeRTOS API, it generates a simulated interrupt and calls the FromISR API within the interrupt service routine (ISR).

The existing `vPortGenerateSimulatedInterrupt` function is designed to be called from within a FreeRTOS task, and it references the current thread structure. To facilitate calling FreeRTOS APIs from native Windows threads, this pull request introduces a new API function, `vPortGenerateSimulatedInterruptFromWindowsThread`. This function allows native Windows threads to generate simulated interrupts and subsequently call FreeRTOS APIs through the FromISR API, ensuring proper synchronization with FreeRTOS tasks.

Existing [tick timer](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/8e07366994f81354a2d4556ca1da9f73dab781e6/portable/MSVC-MingW/port.c#L140) is an example of generating simulated interrupt from native windows thread.
Another example is the cellular comm interface in this [commit](https://github.com/chinglee-iot/FreeRTOS/commit/e94069b28c528f8f5548d1f5c595ad2490090ffe). Comm interface can generate simulated interrupt to notify FreeRTOS task when UART RX data is received.

In this PR
* Add vPortGenerateSimulatedInterruptFromWindowsThread to enable native windows thread to synchronize with FreeRTOS task through simulated interrupt.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
