### PR TITLE
Move Header Includes Before Extern C

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -49,12 +49,6 @@
  */
 #include <stdint.h> /* READ COMMENT ABOVE. */
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /* Acceptable values for configTICK_TYPE_WIDTH_IN_BITS. */
 #define TICK_TYPE_WIDTH_16_BITS    0
 #define TICK_TYPE_WIDTH_32_BITS    1
@@ -128,6 +122,12 @@
     #include "picolibc-freertos.h"
 
 #endif /* if ( configUSE_PICOLIBC_TLS == 1 ) */
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 #ifndef configUSE_C_RUNTIME_TLS_SUPPORT
     #define configUSE_C_RUNTIME_TLS_SUPPORT    0

--- a/include/portable.h
+++ b/include/portable.h
@@ -94,13 +94,13 @@
     #define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP    0
 #endif
 
+#include "mpu_wrappers.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
-
-#include "mpu_wrappers.h"
 
 /*
  * Setup the stack of a new task so it is ready to be placed under the

--- a/include/queue.h
+++ b/include/queue.h
@@ -34,13 +34,13 @@
     #error "include FreeRTOS.h" must appear in source files before "include queue.h"
 #endif
 
+#include "task.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
-
-#include "task.h"
 
 /**
  * Type by which queues are referenced.  For example, a call to xQueueCreate()


### PR DESCRIPTION
The:
```
#ifdef __cplusplus
    extern "C" {
#endif
```
should come after any other includes.