### PR TITLE
Update xPortRunning before resuming first task

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -353,11 +353,11 @@ BaseType_t xPortStartScheduler( void )
         pxThreadState = ( ThreadState_t * ) *( ( size_t * ) pxCurrentTCB );
         ulCriticalNesting = portNO_CRITICAL_NESTING;
 
-        /* Start the first task. */
-        ResumeThread( pxThreadState->pvThread );
-
         /* The scheduler is now running. */
         xPortRunning = pdTRUE;
+
+        /* Start the first task. */
+        ResumeThread( pxThreadState->pvThread );
 
         /* Handle all simulated interrupts - including yield requests and
          * simulated ticks. */


### PR DESCRIPTION
Description
-----------
The variable `xPortRunning` is now updated before starting the first task.

Test Steps
-----------
Build and Run the following demo - https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/WIN32-MSVC

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://forums.freertos.org/t/possible-bug-in-the-way-prvtimertask-thread-function-is-started-in-win32-port/19959/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
