### PR TITLE
list.c: improve code comments to point to official documentation about problems which may cause code to get stuck inside of list.c

### DIFF
--- a/list.c
+++ b/list.c
@@ -184,16 +184,14 @@ void vListInsert( List_t * const pxList,
         *   4) Using a queue or semaphore before it has been initialised or
         *      before the scheduler has been started (are interrupts firing
         *      before vTaskStartScheduler() has been called?).
-        *     - This includes initializing binary semaphores before taking them. If
-        *       you create one with `xSemaphoreCreateBinary()` or
-        *       `xSemaphoreCreateBinaryStatic()`, you must call `xSemaphoreGive()`
-        *       before calling `xSemaphoreTake(). See:
-        *       https://freertos.org/xSemaphoreCreateBinaryStatic.html:
-        *       > The semaphore is created in the 'empty' state, meaning the
-        *       > semaphore must first be given using the xSemaphoreGive() API
-        *       > function before it can subsequently be taken (obtained) using the
-        *       > xSemaphoreTake() function.
-        *   5) If the FreeRTOS port supports interrupt nesting then ensure that
+        *   5) Attempting to 'take' binary semaphores created using
+        *      `xSemaphoreCreateBinary()` or `xSemaphoreCreateBinaryStatic()`
+        *      APIs, before 'giving' them. Binary semaphores created using
+        *      `xSemaphoreCreateBinary()` or `xSemaphoreCreateBinaryStatic()`,
+        *      are created in a state such that the semaphore must first be
+        *      'given' using xSemaphoreGive() API before it can be 'taken' using
+        *      xSemaphoreTake() API.
+        *   6) If the FreeRTOS port supports interrupt nesting then ensure that
         *      the priority of the tick interrupt is at or below
         *      configMAX_SYSCALL_INTERRUPT_PRIORITY.
         **********************************************************************/
@@ -201,7 +199,7 @@ void vListInsert( List_t * const pxList,
         for( pxIterator = ( ListItem_t * ) &( pxList->xListEnd ); pxIterator->pxNext->xItemValue <= xValueOfInsertion; pxIterator = pxIterator->pxNext )
         {
             /* There is nothing to do here, just iterating to the wanted
-             * insertion position. 
+             * insertion position.
              * IF YOU FIND YOUR CODE STUCK HERE, SEE THE NOTE JUST ABOVE.
              */
         }

--- a/list.c
+++ b/list.c
@@ -184,6 +184,15 @@ void vListInsert( List_t * const pxList,
         *   4) Using a queue or semaphore before it has been initialised or
         *      before the scheduler has been started (are interrupts firing
         *      before vTaskStartScheduler() has been called?).
+        *     - This includes initializing binary semaphores before taking them. If
+        *       you create one with `xSemaphoreCreateBinary()` or
+        *       `xSemaphoreCreateBinaryStatic()`, you must call `xSemaphoreGive()`
+        *       before calling `xSemaphoreTake(). See:
+        *       https://freertos.org/xSemaphoreCreateBinaryStatic.html:
+        *       > The semaphore is created in the 'empty' state, meaning the
+        *       > semaphore must first be given using the xSemaphoreGive() API
+        *       > function before it can subsequently be taken (obtained) using the
+        *       > xSemaphoreTake() function.
         *   5) If the FreeRTOS port supports interrupt nesting then ensure that
         *      the priority of the tick interrupt is at or below
         *      configMAX_SYSCALL_INTERRUPT_PRIORITY.

--- a/list.c
+++ b/list.c
@@ -201,7 +201,9 @@ void vListInsert( List_t * const pxList,
         for( pxIterator = ( ListItem_t * ) &( pxList->xListEnd ); pxIterator->pxNext->xItemValue <= xValueOfInsertion; pxIterator = pxIterator->pxNext )
         {
             /* There is nothing to do here, just iterating to the wanted
-             * insertion position. */
+             * insertion position. 
+             * IF YOU FIND YOUR CODE STUCK HERE, SEE THE NOTE JUST ABOVE.
+             */
         }
     }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Improve comments to help people when debugging. This would have saved me weeks of time. An uninitialized binary semaphore (ie: one which has not been given yet) will result in getting stuck inside of `vListInsert()`. You must give it before taking it. 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Create a semaphore, start the scheduler, try to take it. You'll get stuck in a debugger inside the for loop in `VListInsert()`. 

Now, right after creating it, but before starting the scheduler, give it. Start the scheduler. Now, when it is taken it works fine. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

_Can someone please run necessary tests on your end to ensure this is behavior you see too?_

Related Issue
-----------
<!-- If any, please provide issue ID. -->
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
