### PR TITLE
added configUSE_POSIX_ERRNO to the template FreeRTOSConfig.h

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -53,7 +53,7 @@
  * settings.  Your application will certainly need a different value so set this
  * correctly. This is very often, but not always, equal to the main system clock
  * frequency. */
-#define configCPU_CLOCK_HZ                        ( ( unsigned long ) 20000000 )
+#define configCPU_CLOCK_HZ    ( ( unsigned long ) 20000000 )
 
 /* configSYSTICK_CLOCK_HZ is an optional parameter for ARM Cortex-M ports only.
  *
@@ -77,19 +77,19 @@
 
 /* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz, normally
  * calculated from the configCPU_CLOCK_HZ value. */
-#define configTICK_RATE_HZ                        100
+#define configTICK_RATE_HZ                         100
 
 /* Set configUSE_PREEMPTION to 1 to use pre-emptive scheduling.  Set
  * configUSE_PREEMPTION to 0 to use co-operative scheduling.
  * See https://www.freertos.org/single-core-amp-smp-rtos-scheduling.html. */
-#define configUSE_PREEMPTION                      1
+#define configUSE_PREEMPTION                       1
 
 /* Set configUSE_TIME_SLICING to 1 to have the scheduler switch between Ready
  * state tasks of equal priority on every tick interrupt.  Set
  * configUSE_TIME_SLICING to 0 to prevent the scheduler switching between Ready
  * state tasks just because there was a tick interrupt.  See
  * https://freertos.org/single-core-amp-smp-rtos-scheduling.html. */
-#define configUSE_TIME_SLICING                    0
+#define configUSE_TIME_SLICING                     0
 
 /* Set configUSE_PORT_OPTIMISED_TASK_SELECTION to 1 to select the next task to
  * run using an algorithm optimised to the instruction set of the target
@@ -97,29 +97,29 @@
  * 0 to select the next task to run using a generic C algorithm that works for
  * all FreeRTOS ports.  Not all FreeRTOS ports have this option.  Defaults to 0
  * if left undefined. */
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION   0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
 
 /* Set configUSE_TICKLESS_IDLE to 1 to use the low power tickless mode.  Set to
  * 0 to keep the tick interrupt running at all times.  Not all FreeRTOS ports
  * support tickless mode. See
  * https://www.freertos.org/low-power-tickless-rtos.html Defaults to 0 if left
  * undefined. */
-#define configUSE_TICKLESS_IDLE                   0
+#define configUSE_TICKLESS_IDLE                    0
 
 /* configMAX_PRIORITIES Sets the number of available task priorities.  Tasks can
  * be assigned priorities of 0 to (configMAX_PRIORITIES - 1).  Zero is the
  * lowest priority. */
-#define configMAX_PRIORITIES                      5
+#define configMAX_PRIORITIES                       5
 
 /* configMINIMAL_STACK_SIZE defines the size of the stack used by the Idle task
  * (in words, not in bytes!).  The kernel does not use this constant for any
  * other purpose.  Demo applications use the constant to make the demos somewhat
  * portable across hardware architectures. */
-#define configMINIMAL_STACK_SIZE                  128
+#define configMINIMAL_STACK_SIZE                   128
 
 /* configMAX_TASK_NAME_LEN sets the maximum length (in characters) of a task's
  * human readable name.  Includes the NULL terminator. */
-#define configMAX_TASK_NAME_LEN                   16
+#define configMAX_TASK_NAME_LEN                    16
 
 /* Time is measured in 'ticks' - which is the number of times the tick interrupt
  * has executed since the RTOS kernel was started.
@@ -136,68 +136,68 @@
  *
  * Defining configTICK_TYPE_WIDTH_IN_BITS as TICK_TYPE_WIDTH_64_BITS causes
  * TickType_t to be defined (typedef'ed) as an unsigned 64-bit type. */
-#define configTICK_TYPE_WIDTH_IN_BITS             TICK_TYPE_WIDTH_64_BITS
+#define configTICK_TYPE_WIDTH_IN_BITS              TICK_TYPE_WIDTH_64_BITS
 
 /* Set configIDLE_SHOULD_YIELD to 1 to have the Idle task yield to an
  * application task if there is an Idle priority (priority 0) application task
  * that can run.  Set to 0 to have the Idle task use all of its timeslice.
  * Default to 1 if left undefined. */
-#define configIDLE_SHOULD_YIELD                   1
+#define configIDLE_SHOULD_YIELD                    1
 
 /* Each task has an array of task notifications.
  * configTASK_NOTIFICATION_ARRAY_ENTRIES sets the number of indexes in the
  * array. See https://www.freertos.org/RTOS-task-notifications.html  Defaults to
  * 1 if left undefined. */
-#define configTASK_NOTIFICATION_ARRAY_ENTRIES     1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES      1
 
 /* configQUEUE_REGISTRY_SIZE sets the maximum number of queues and semaphores
  * that can be referenced from the queue registry.  Only required when using a
  * kernel aware debugger.  Defaults to 0 if left undefined. */
-#define configQUEUE_REGISTRY_SIZE                 0
+#define configQUEUE_REGISTRY_SIZE                  0
 
 /* Set configENABLE_BACKWARD_COMPATIBILITY to 1 to map function names and
  * datatypes from old version of FreeRTOS to their latest equivalent.  Defaults
  * to 1 if left undefined. */
-#define configENABLE_BACKWARD_COMPATIBILITY       0
+#define configENABLE_BACKWARD_COMPATIBILITY        0
 
 /* Each task has its own array of pointers that can be used as thread local
  * storage.  configNUM_THREAD_LOCAL_STORAGE_POINTERS set the number of indexes
  * in the array.  See
  * https://www.freertos.org/thread-local-storage-pointers.html Defaults to 0 if
  * left undefined. */
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS   0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    0
 
 /* When configUSE_MINI_LIST_ITEM is set to 0, MiniListItem_t and ListItem_t are
  * both the same. When configUSE_MINI_LIST_ITEM is set to 1, MiniListItem_t
  * contains 3 fewer fields than ListItem_t which saves some RAM at the cost of
  * violating strict aliasing rules which some compilers depend on for
  * optimization. Defaults to 1 if left undefined. */
-#define configUSE_MINI_LIST_ITEM                  1
+#define configUSE_MINI_LIST_ITEM                   1
 
 /* Sets the type used by the parameter to xTaskCreate() that specifies the stack
  * size of the task being created.  The same type is used to return information
  * about stack usage in various other API calls.  Defaults to size_t if left
  * undefined. */
-#define configSTACK_DEPTH_TYPE                    size_t
+#define configSTACK_DEPTH_TYPE                     size_t
 
 /* configMESSAGE_BUFFER_LENGTH_TYPE sets the type used to store the length of
  * each message written to a FreeRTOS message buffer (the length is also written
  * to the message buffer.  Defaults to size_t if left undefined - but that may
  * waste space if messages never go above a length that could be held in a
  * uint8_t. */
-#define configMESSAGE_BUFFER_LENGTH_TYPE          size_t
+#define configMESSAGE_BUFFER_LENGTH_TYPE           size_t
 
 /* If configHEAP_CLEAR_MEMORY_ON_FREE is set to 1, then blocks of memory
  * allocated using pvPortMalloc() will be cleared (i.e. set to zero) when freed
  * using vPortFree(). Defaults to 0 if left undefined. */
-#define configHEAP_CLEAR_MEMORY_ON_FREE           1
+#define configHEAP_CLEAR_MEMORY_ON_FREE            1
 
 /* vTaskList and vTaskGetRunTimeStats APIs take a buffer as a parameter and
  * assume that the length of the buffer is configSTATS_BUFFER_MAX_LENGTH.
  * Defaults to 0xFFFF if left undefined. New applications are recommended to use
  * vTaskListTasks and vTaskGetRunTimeStatistics APIs instead and supply the
  * length of the buffer explicitly to avoid memory corruption. */
-#define configSTATS_BUFFER_MAX_LENGTH             0xFFFF
+#define configSTATS_BUFFER_MAX_LENGTH              0xFFFF
 
 /* Set configUSE_NEWLIB_REENTRANT to 1 to have a newlib reent structure
  * allocated for each task.  Set to 0 to not support newlib reent structures.
@@ -209,7 +209,7 @@
  * provide system-wide implementations of the necessary stubs. Note that (at the
  * time of writing) the current newlib design implements a system-wide malloc()
  * that must be provided with locks. */
-#define configUSE_NEWLIB_REENTRANT                0
+#define configUSE_NEWLIB_REENTRANT                 0
 
 /******************************************************************************/
 /* Software timer related definitions. ****************************************/
@@ -220,27 +220,27 @@
  * FreeRTOS/source/timers.c source file must be included in the build if
  * configUSE_TIMERS is set to 1.  Default to 0 if left undefined.  See
  * https://www.freertos.org/RTOS-software-timer.html. */
-#define configUSE_TIMERS                          1
+#define configUSE_TIMERS                1
 
 /* configTIMER_TASK_PRIORITY sets the priority used by the timer task.  Only
  * used if configUSE_TIMERS is set to 1.  The timer task is a standard FreeRTOS
  * task, so its priority is set like any other task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only
  * used if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_PRIORITY                 ( configMAX_PRIORITIES - 1 )
+#define configTIMER_TASK_PRIORITY       ( configMAX_PRIORITIES - 1 )
 
 /* configTIMER_TASK_STACK_DEPTH sets the size of the stack allocated to the
  * timer task (in words, not in bytes!).  The timer task is a standard FreeRTOS
  * task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html Only
  * used if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_STACK_DEPTH              configMINIMAL_STACK_SIZE
+#define configTIMER_TASK_STACK_DEPTH    configMINIMAL_STACK_SIZE
 
 /* configTIMER_QUEUE_LENGTH sets the length of the queue (the number of discrete
  * items the queue can hold) used to send commands to the timer task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only
  * used if configUSE_TIMERS is set to 1. */
-#define configTIMER_QUEUE_LENGTH                  10
+#define configTIMER_QUEUE_LENGTH        10
 
 /******************************************************************************/
 /* Event Group related definitions. *******************************************/
@@ -251,7 +251,7 @@
  * FreeRTOS/source/event_groups.c source file must be included in the build if
  * configUSE_EVENT_GROUPS is set to 1. Defaults to 1 if left undefined. */
 
-#define configUSE_EVENT_GROUPS                    1
+#define configUSE_EVENT_GROUPS    1
 
 /******************************************************************************/
 /* Stream Buffer related definitions. *****************************************/
@@ -262,7 +262,7 @@
  * FreeRTOS/source/stream_buffer.c source file must be included in the build if
  * configUSE_STREAM_BUFFERS is set to 1. Defaults to 1 if left undefined. */
 
-#define configUSE_STREAM_BUFFERS                  1
+#define configUSE_STREAM_BUFFERS    1
 
 /******************************************************************************/
 /* Memory allocation related definitions. *************************************/
@@ -273,7 +273,7 @@
  * memory in the build.  Set to 0 to exclude the ability to create statically
  * allocated objects from the build.  Defaults to 0 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html. */
-#define configSUPPORT_STATIC_ALLOCATION           1
+#define configSUPPORT_STATIC_ALLOCATION              1
 
 /* Set configSUPPORT_DYNAMIC_ALLOCATION to 1 to include FreeRTOS API functions
  * that create FreeRTOS objects (tasks, queues, etc.) using dynamically
@@ -281,18 +281,18 @@
  * dynamically allocated objects from the build.  Defaults to 1 if left
  * undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html. */
-#define configSUPPORT_DYNAMIC_ALLOCATION          1
+#define configSUPPORT_DYNAMIC_ALLOCATION             1
 
 /* Sets the total size of the FreeRTOS heap, in bytes, when heap_1.c, heap_2.c
  * or heap_4.c are included in the build.  This value is defaulted to 4096 bytes
  * but it must be tailored to each application.  Note the heap will appear in
  * the .bss section.  See https://www.freertos.org/a00111.html. */
-#define configTOTAL_HEAP_SIZE                     4096
+#define configTOTAL_HEAP_SIZE                        4096
 
 /* Set configAPPLICATION_ALLOCATED_HEAP to 1 to have the application allocate
  * the array used as the FreeRTOS heap.  Set to 0 to have the linker allocate
  * the array used as the FreeRTOS heap.  Defaults to 0 if left undefined. */
-#define configAPPLICATION_ALLOCATED_HEAP          0
+#define configAPPLICATION_ALLOCATED_HEAP             0
 
 /* Set configSTACK_ALLOCATION_FROM_SEPARATE_HEAP to 1 to have task stacks
  * allocated from somewhere other than the FreeRTOS heap.  This is useful if you
@@ -300,12 +300,12 @@
  * come from the standard FreeRTOS heap.  The application writer must provide
  * implementations for pvPortMallocStack() and vPortFreeStack() if set to 1.
  * Defaults to 0 if left undefined. */
-#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP 0
+#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP    0
 
 /* Set configENABLE_HEAP_PROTECTOR to 1 to enable bounds checking and
  * obfuscation to internal heap block pointers in heap_4.c and heap_5.c to help
  * catch pointer corruptions. Defaults to 0 if left undefined. */
-#define configENABLE_HEAP_PROTECTOR               0
+#define configENABLE_HEAP_PROTECTOR                  0
 
 /******************************************************************************/
 /* Interrupt nesting behaviour configuration. *********************************/
@@ -315,7 +315,7 @@
  * switch performing interrupts.  Not supported by all FreeRTOS ports.  See
  * https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
  * ARM Cortex-M devices. */
-#define configKERNEL_INTERRUPT_PRIORITY           0
+#define configKERNEL_INTERRUPT_PRIORITY          0
 
 /* configMAX_SYSCALL_INTERRUPT_PRIORITY sets the interrupt priority above which
  * FreeRTOS API calls must not be made.  Interrupts above this priority are
@@ -323,11 +323,11 @@
  * to the highest interrupt priority (0).  Not supported by all FreeRTOS ports.
  * See https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific
  * to ARM Cortex-M devices. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY      0
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY     0
 
 /* Another name for configMAX_SYSCALL_INTERRUPT_PRIORITY - the name used depends
  * on the FreeRTOS port. */
-#define configMAX_API_CALL_INTERRUPT_PRIORITY     0
+#define configMAX_API_CALL_INTERRUPT_PRIORITY    0
 
 /******************************************************************************/
 /* Hook and callback function related definitions. ****************************/
@@ -337,10 +337,10 @@
  * functionality in the build.  Set to 0 to exclude the hook functionality from
  * the build.  The application writer is responsible for providing the hook
  * function for any set to 1.  See https://www.freertos.org/a00016.html. */
-#define configUSE_IDLE_HOOK                       0
-#define configUSE_TICK_HOOK                       0
-#define configUSE_MALLOC_FAILED_HOOK              0
-#define configUSE_DAEMON_TASK_STARTUP_HOOK        0
+#define configUSE_IDLE_HOOK                   0
+#define configUSE_TICK_HOOK                   0
+#define configUSE_MALLOC_FAILED_HOOK          0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK    0
 
 /* Set configUSE_SB_COMPLETED_CALLBACK to 1 to have send and receive completed
  * callbacks for each instance of a stream buffer or message buffer. When the
@@ -348,7 +348,7 @@
  * xStreamBufferCreateStaticWithCallback() (and likewise APIs for message
  * buffer) can be used to create a stream buffer or message buffer instance
  * with application provided callbacks. Defaults to 0 if left undefined. */
-#define configUSE_SB_COMPLETED_CALLBACK           0
+#define configUSE_SB_COMPLETED_CALLBACK       0
 
 /* Set configCHECK_FOR_STACK_OVERFLOW to 1 or 2 for FreeRTOS to check for a
  * stack overflow at the time of a context switch.  Set to 0 to not look for a
@@ -362,7 +362,7 @@
  * configCHECK_FOR_STACK_OVERFLOW is set to 1. See
  * https://www.freertos.org/Stacks-and-stack-overflow-checking.html  Defaults to
  * 0 if left undefined. */
-#define configCHECK_FOR_STACK_OVERFLOW            2
+#define configCHECK_FOR_STACK_OVERFLOW        2
 
 /******************************************************************************/
 /* Run time and task stats gathering related definitions. *********************/
@@ -373,20 +373,20 @@
  * application writer needs to provide a clock source if set to 1.  Defaults to
  * 0 if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html.
  */
-#define configGENERATE_RUN_TIME_STATS             0
+#define configGENERATE_RUN_TIME_STATS           0
 
 /* Set configUSE_TRACE_FACILITY to include additional task structure members
  * are used by trace and visualisation functions and tools.  Set to 0 to exclude
  * the additional information from the structures. Defaults to 0 if left
  * undefined. */
-#define configUSE_TRACE_FACILITY                  0
+#define configUSE_TRACE_FACILITY                0
 
 /* Set to 1 to include the vTaskList() and vTaskGetRunTimeStats() functions in
  * the build.  Set to 0 to exclude these functions from the build.  These two
  * functions introduce a dependency on string formatting functions that would
  * otherwise not exist - hence they are kept separate.  Defaults to 0 if left
  * undefined. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS      0
+#define configUSE_STATS_FORMATTING_FUNCTIONS    0
 
 /******************************************************************************/
 /* Co-routine related definitions. ********************************************/
@@ -396,12 +396,12 @@
  * build, or 0 to omit co-routine functionality from the build. To include
  * co-routines, croutine.c must be included in the project. Defaults to 0 if
  * left undefined. */
-#define configUSE_CO_ROUTINES                     0
+#define configUSE_CO_ROUTINES              0
 
 /* configMAX_CO_ROUTINE_PRIORITIES defines the number of priorities available
  * to the application co-routines. Any number of co-routines can share the same
  * priority. Defaults to 0 if left undefined. */
-#define configMAX_CO_ROUTINE_PRIORITIES           1
+#define configMAX_CO_ROUTINE_PRIORITIES    1
 
 /******************************************************************************/
 /* Debugging assistance. ******************************************************/
@@ -419,8 +419,8 @@
     if( ( x ) == 0 )              \
     {                             \
         taskDISABLE_INTERRUPTS(); \
-        for( ;; )                 \
-            ;                     \
+        for( ; ; )                \
+        ;                         \
     }
 
 /******************************************************************************/
@@ -433,47 +433,47 @@
  * https://www.freertos.org/a00110.html#configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
  * Defaults to 0 if left undefined.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port. */
-#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS 0
+#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS    0
 
 /* Set configTOTAL_MPU_REGIONS to the number of MPU regions implemented on your
  * target hardware.  Normally 8 or 16.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port.  Defaults to 8 if left
  * undefined. */
-#define configTOTAL_MPU_REGIONS                                8
+#define configTOTAL_MPU_REGIONS                                   8
 
 /* configTEX_S_C_B_FLASH allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits
  * for the MPU region covering Flash.  Defaults to 0x07UL (which means TEX=000,
  * S=1, C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_FLASH                                  0x07UL
+#define configTEX_S_C_B_FLASH                                     0x07UL
 
 /* configTEX_S_C_B_SRAM allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits
  * for the MPU region covering RAM. Defaults to 0x07UL (which means TEX=000,
  * S=1, C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_SRAM                                   0x07UL
+#define configTEX_S_C_B_SRAM                                      0x07UL
 
 /* Set configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY to 0 to prevent any privilege
  * escalations originating from outside of the kernel code itself.  Set to 1 to
  * allow application tasks to raise privilege.  Defaults to 1 if left undefined.
  * Only used by the FreeRTOS Cortex-M MPU ports, not the standard ARMv7-M
  * Cortex-M port. */
-#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY            1
+#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY               1
 
 /* Set configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS to 1 to allow unprivileged
  * tasks enter critical sections (effectively mask interrupts). Set to 0 to
  * prevent unprivileged tasks entering critical sections.  Defaults to 1 if left
  * undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not the standard
  * ARMv7-M Cortex-M port. */
-#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS             0
+#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS                0
 
 /* FreeRTOS Kernel version 10.6.0 introduced a new v2 MPU wrapper, namely
  * mpu_wrappers_v2.c. Set configUSE_MPU_WRAPPERS_V1 to 0 to use the new v2 MPU
  * wrapper. Set configUSE_MPU_WRAPPERS_V1 to 1 to use the old v1 MPU wrapper
  * (mpu_wrappers.c). Defaults to 0 if left undefined. */
-#define configUSE_MPU_WRAPPERS_V1                              0
+#define configUSE_MPU_WRAPPERS_V1                                 0
 
 /* When using the v2 MPU wrapper, set configPROTECTED_KERNEL_OBJECT_POOL_SIZE to
  * the total number of kernel objects, which includes tasks, queues, semaphores,
@@ -481,7 +481,7 @@
  * application. The application will not be able to have more than
  * configPROTECTED_KERNEL_OBJECT_POOL_SIZE kernel objects at any point of
  * time. */
-#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE                10
+#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE                   10
 
 /* When using the v2 MPU wrapper, set configSYSTEM_CALL_STACK_SIZE to the size
  * of the system call stack in words. Each task has a statically allocated
@@ -489,7 +489,7 @@
  * calls. For example, if configSYSTEM_CALL_STACK_SIZE is defined as 128 and
  * there are 10 tasks in the application, the total amount of memory used for
  * system call stacks is 128 * 10 = 1280 words. */
-#define configSYSTEM_CALL_STACK_SIZE                           128
+#define configSYSTEM_CALL_STACK_SIZE                              128
 
 /* When using the v2 MPU wrapper, set configENABLE_ACCESS_CONTROL_LIST to 1 to
  * enable Access Control List (ACL) feature. When ACL is enabled, an
@@ -497,7 +497,7 @@
  * than itself. The application writer needs to explicitly grant the
  * unprivileged task access to the kernel objects it needs using the APIs
  * provided for the same. Defaults to 0 if left undefined. */
-#define configENABLE_ACCESS_CONTROL_LIST                       1
+#define configENABLE_ACCESS_CONTROL_LIST                          1
 
 /******************************************************************************/
 /* SMP( Symmetric MultiProcessing ) Specific Configuration definitions. *******/
@@ -517,7 +517,7 @@
  * is able to run. If configRUN_MULTIPLE_PRIORITIES is set to 1, multiple tasks
  * with different priorities may run simultaneously - so a higher and lower
  * priority task may run on different cores at the same time. */
-#define configRUN_MULTIPLE_PRIORITIES                          0
+#define configRUN_MULTIPLE_PRIORITIES             0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
  * configUSE_CORE_AFFINITY to 1 to enable core affinity feature. When core
@@ -525,7 +525,7 @@
  * vTaskCoreAffinityGet APIs can be used to set and retrieve which cores a task
  * can run on. If configUSE_CORE_AFFINITY is set to 0 then the FreeRTOS
  * scheduler is free to run any task on any available core. */
-#define configUSE_CORE_AFFINITY                                0
+#define configUSE_CORE_AFFINITY                   0
 
 /* When using SMP with core affinity feature enabled, set
  * configTASK_DEFAULT_CORE_AFFINITY to change the default core affinity mask for
@@ -535,25 +535,25 @@
  * value is useful, if swapping tasks between cores is not supported (e.g.
  * Tricore) or if legacy code should be controlled. Defaults to tskNO_AFFINITY
  * if left undefined. */
-#define configTASK_DEFAULT_CORE_AFFINITY                       tskNO_AFFINITY
+#define configTASK_DEFAULT_CORE_AFFINITY          tskNO_AFFINITY
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), if
  * configUSE_TASK_PREEMPTION_DISABLE is set to 1, individual tasks can be set to
  * either pre-emptive or co-operative mode using the vTaskPreemptionDisable and
  * vTaskPreemptionEnable APIs. */
-#define configUSE_TASK_PREEMPTION_DISABLE                      0
+#define configUSE_TASK_PREEMPTION_DISABLE         0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
  * configUSE_PASSIVE_IDLE_HOOK to 1 to allow the application writer to use
  * the passive idle task hook to add background functionality without the
  * overhead of a separate task. Defaults to 0 if left undefined. */
-#define configUSE_PASSIVE_IDLE_HOOK                            0
+#define configUSE_PASSIVE_IDLE_HOOK               0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one),
  * configTIMER_SERVICE_TASK_CORE_AFFINITY allows the application writer to set
  * the core affinity of the RTOS Daemon/Timer Service task. Defaults to
  * tskNO_AFFINITY if left undefined. */
-#define configTIMER_SERVICE_TASK_CORE_AFFINITY                 tskNO_AFFINITY
+#define configTIMER_SERVICE_TASK_CORE_AFFINITY    tskNO_AFFINITY
 
 /******************************************************************************/
 /* ARMv8-M secure side port related definitions. ******************************/
@@ -562,7 +562,7 @@
 /* secureconfigMAX_SECURE_CONTEXTS define the maximum number of tasks that can
  *  call into the secure side of an ARMv8-M chip.  Not used by any other ports.
  */
-#define secureconfigMAX_SECURE_CONTEXTS                        5
+#define secureconfigMAX_SECURE_CONTEXTS        5
 
 /* Defines the kernel provided implementation of
  * vApplicationGetIdleTaskMemory() and vApplicationGetTimerTaskMemory()
@@ -570,7 +570,7 @@
  * respectively. The application can provide it's own implementation of
  * vApplicationGetIdleTaskMemory() and vApplicationGetTimerTaskMemory() by
  * setting configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined. */
-#define configKERNEL_PROVIDED_STATIC_MEMORY                    1
+#define configKERNEL_PROVIDED_STATIC_MEMORY    1
 
 /******************************************************************************/
 /* ARMv8-M port Specific Configuration definitions. ***************************/
@@ -580,22 +580,22 @@
  * to enable the TrustZone support in FreeRTOS ARMv8-M ports which allows the
  * non-secure FreeRTOS tasks to call the (non-secure callable) functions
  * exported from secure side. */
-#define configENABLE_TRUSTZONE                                 1
+#define configENABLE_TRUSTZONE            1
 
 /* If the application writer does not want to use TrustZone, but the hardware
  * does not support disabling TrustZone then the entire application (including
  * the FreeRTOS scheduler) can run on the secure side without ever branching to
  * the non-secure side. To do that, in addition to setting
  * configENABLE_TRUSTZONE to 0, also set configRUN_FREERTOS_SECURE_ONLY to 1. */
-#define configRUN_FREERTOS_SECURE_ONLY                         1
+#define configRUN_FREERTOS_SECURE_ONLY    1
 
 /* Set configENABLE_MPU to 1 to enable the Memory Protection Unit (MPU), or 0
  * to leave the Memory Protection Unit disabled. */
-#define configENABLE_MPU                                       1
+#define configENABLE_MPU                  1
 
 /* Set configENABLE_FPU to 1 to enable the Floating Point Unit (FPU), or 0
  * to leave the Floating Point Unit disabled. */
-#define configENABLE_FPU                                       1
+#define configENABLE_FPU                  1
 
 /* Set configENABLE_MVE to 1 to enable the M-Profile Vector Extension (MVE)
  * support, or 0 to leave the MVE support disabled. This option is only
@@ -603,7 +603,7 @@
  * (MVE) is available only on these architectures. configENABLE_MVE must be left
  * undefined, or defined to 0 for the Cortex-M23,Cortex-M33 and Cortex-M35P
  * ports. */
-#define configENABLE_MVE                                       1
+#define configENABLE_MVE                  1
 
 /******************************************************************************/
 /* ARMv7-M and ARMv8-M port Specific Configuration definitions. ***************/
@@ -624,7 +624,7 @@
  * configCHECK_HANDLER_INSTALLATION to 0.
  *
  * Defaults to 1 if left undefined. */
-#define configCHECK_HANDLER_INSTALLATION                       1
+#define configCHECK_HANDLER_INSTALLATION    1
 
 /******************************************************************************/
 /* Definitions that include or exclude functionality. *************************/
@@ -632,36 +632,36 @@
 
 /* Set the following configUSE_* constants to 1 to include the named feature in
  * the build, or 0 to exclude the named feature from the build. */
-#define configUSE_TASK_NOTIFICATIONS                           1
-#define configUSE_MUTEXES                                      1
-#define configUSE_RECURSIVE_MUTEXES                            1
-#define configUSE_COUNTING_SEMAPHORES                          1
-#define configUSE_QUEUE_SETS                                   0
-#define configUSE_APPLICATION_TASK_TAG                         0
+#define configUSE_TASK_NOTIFICATIONS           1
+#define configUSE_MUTEXES                      1
+#define configUSE_RECURSIVE_MUTEXES            1
+#define configUSE_COUNTING_SEMAPHORES          1
+#define configUSE_QUEUE_SETS                   0
+#define configUSE_APPLICATION_TASK_TAG         0
 
 /* USE_POSIX_ERRNO enables the task global FreeRTOS_errno variable which will
  * containthe most recent error for that task. */
-#define configUSE_POSIX_ERRNO                                  0
+#define configUSE_POSIX_ERRNO                  0
 
 /* Set the following INCLUDE_* constants to 1 to incldue the named API function,
  * or 0 to exclude the named API function.  Most linkers will remove unused
  * functions even when the constant is 1. */
-#define INCLUDE_vTaskPrioritySet                               1
-#define INCLUDE_uxTaskPriorityGet                              1
-#define INCLUDE_vTaskDelete                                    1
-#define INCLUDE_vTaskSuspend                                   1
-#define INCLUDE_xResumeFromISR                                 1
-#define INCLUDE_vTaskDelayUntil                                1
-#define INCLUDE_vTaskDelay                                     1
-#define INCLUDE_xTaskGetSchedulerState                         1
-#define INCLUDE_xTaskGetCurrentTaskHandle                      1
-#define INCLUDE_uxTaskGetStackHighWaterMark                    0
-#define INCLUDE_xTaskGetIdleTaskHandle                         0
-#define INCLUDE_eTaskGetState                                  0
-#define INCLUDE_xEventGroupSetBitFromISR                       1
-#define INCLUDE_xTimerPendFunctionCall                         0
-#define INCLUDE_xTaskAbortDelay                                0
-#define INCLUDE_xTaskGetHandle                                 0
-#define INCLUDE_xTaskResumeFromISR                             1
+#define INCLUDE_vTaskPrioritySet               1
+#define INCLUDE_uxTaskPriorityGet              1
+#define INCLUDE_vTaskDelete                    1
+#define INCLUDE_vTaskSuspend                   1
+#define INCLUDE_xResumeFromISR                 1
+#define INCLUDE_vTaskDelayUntil                1
+#define INCLUDE_vTaskDelay                     1
+#define INCLUDE_xTaskGetSchedulerState         1
+#define INCLUDE_xTaskGetCurrentTaskHandle      1
+#define INCLUDE_uxTaskGetStackHighWaterMark    0
+#define INCLUDE_xTaskGetIdleTaskHandle         0
+#define INCLUDE_eTaskGetState                  0
+#define INCLUDE_xEventGroupSetBitFromISR       1
+#define INCLUDE_xTimerPendFunctionCall         0
+#define INCLUDE_xTaskAbortDelay                0
+#define INCLUDE_xTaskGetHandle                 0
+#define INCLUDE_xTaskResumeFromISR             1
 
 #endif /* FREERTOS_CONFIG_H */

--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -4,22 +4,23 @@
  *
  * SPDX-License-Identifier: MIT
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation files (the "Software"), to deal in
- * the Software without restriction, including without limitation the rights to
- * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
- * the Software, and to permit persons to whom the Software is furnished to do so,
- * subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
- * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
- * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
@@ -47,11 +48,12 @@
 /******************************************************************************/
 
 /* In most cases, configCPU_CLOCK_HZ must be set to the frequency of the clock
- * that drives the peripheral used to generate the kernels periodic tick interrupt.
- * The default value is set to 20MHz and matches the QEMU demo settings.  Your
- * application will certainly need a different value so set this correctly.
- * This is very often, but not always, equal to the main system clock frequency. */
-#define configCPU_CLOCK_HZ ((unsigned long)20000000)
+ * that drives the peripheral used to generate the kernels periodic tick
+ * interrupt. The default value is set to 20MHz and matches the QEMU demo
+ * settings.  Your application will certainly need a different value so set this
+ * correctly. This is very often, but not always, equal to the main system clock
+ * frequency. */
+#define configCPU_CLOCK_HZ                        ( ( unsigned long ) 20000000 )
 
 /* configSYSTICK_CLOCK_HZ is an optional parameter for ARM Cortex-M ports only.
  *
@@ -59,11 +61,11 @@
  * Cortex-M SysTick timer. Most Cortex-M MCUs run the SysTick timer at the same
  * frequency as the MCU itself - when that is the case configSYSTICK_CLOCK_HZ is
  * not needed and should be left undefined. If the SysTick timer is clocked at a
- * different frequency to the MCU core then set configCPU_CLOCK_HZ to the MCU clock
- * frequency, as normal, and configSYSTICK_CLOCK_HZ to the SysTick clock
+ * different frequency to the MCU core then set configCPU_CLOCK_HZ to the MCU
+ * clock frequency, as normal, and configSYSTICK_CLOCK_HZ to the SysTick clock
  * frequency.  Not used if left undefined.
- * The default value is undefined (commented out).  If you need this value bring it
- * back and set it to a suitable value. */
+ * The default value is undefined (commented out).  If you need this value bring
+ * it back and set it to a suitable value. */
 
 /*
  #define configSYSTICK_CLOCK_HZ                  [Platform specific]
@@ -75,54 +77,56 @@
 
 /* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz, normally
  * calculated from the configCPU_CLOCK_HZ value. */
-#define configTICK_RATE_HZ 100
+#define configTICK_RATE_HZ                        100
 
 /* Set configUSE_PREEMPTION to 1 to use pre-emptive scheduling.  Set
  * configUSE_PREEMPTION to 0 to use co-operative scheduling.
  * See https://www.freertos.org/single-core-amp-smp-rtos-scheduling.html. */
-#define configUSE_PREEMPTION 1
+#define configUSE_PREEMPTION                      1
 
 /* Set configUSE_TIME_SLICING to 1 to have the scheduler switch between Ready
  * state tasks of equal priority on every tick interrupt.  Set
  * configUSE_TIME_SLICING to 0 to prevent the scheduler switching between Ready
  * state tasks just because there was a tick interrupt.  See
  * https://freertos.org/single-core-amp-smp-rtos-scheduling.html. */
-#define configUSE_TIME_SLICING 0
+#define configUSE_TIME_SLICING                    0
 
 /* Set configUSE_PORT_OPTIMISED_TASK_SELECTION to 1 to select the next task to
- * run using an algorithm optimised to the instruction set of the target hardware -
- * normally using a count leading zeros assembly instruction.  Set to 0 to select
- * the next task to run using a generic C algorithm that works for all FreeRTOS
- * ports.  Not all FreeRTOS ports have this option.  Defaults to 0 if left
- * undefined. */
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+ * run using an algorithm optimised to the instruction set of the target
+ * hardware - normally using a count leading zeros assembly instruction.  Set to
+ * 0 to select the next task to run using a generic C algorithm that works for
+ * all FreeRTOS ports.  Not all FreeRTOS ports have this option.  Defaults to 0
+ * if left undefined. */
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION   0
 
 /* Set configUSE_TICKLESS_IDLE to 1 to use the low power tickless mode.  Set to
  * 0 to keep the tick interrupt running at all times.  Not all FreeRTOS ports
- * support tickless mode. See https://www.freertos.org/low-power-tickless-rtos.html
- * Defaults to 0 if left undefined. */
-#define configUSE_TICKLESS_IDLE 0
+ * support tickless mode. See
+ * https://www.freertos.org/low-power-tickless-rtos.html Defaults to 0 if left
+ * undefined. */
+#define configUSE_TICKLESS_IDLE                   0
 
 /* configMAX_PRIORITIES Sets the number of available task priorities.  Tasks can
- * be assigned priorities of 0 to (configMAX_PRIORITIES - 1).  Zero is the lowest
- * priority. */
-#define configMAX_PRIORITIES 5
+ * be assigned priorities of 0 to (configMAX_PRIORITIES - 1).  Zero is the
+ * lowest priority. */
+#define configMAX_PRIORITIES                      5
 
 /* configMINIMAL_STACK_SIZE defines the size of the stack used by the Idle task
- * (in words, not in bytes!).  The kernel does not use this constant for any other
- * purpose.  Demo applications use the constant to make the demos somewhat portable
- * across hardware architectures. */
-#define configMINIMAL_STACK_SIZE 128
+ * (in words, not in bytes!).  The kernel does not use this constant for any
+ * other purpose.  Demo applications use the constant to make the demos somewhat
+ * portable across hardware architectures. */
+#define configMINIMAL_STACK_SIZE                  128
 
 /* configMAX_TASK_NAME_LEN sets the maximum length (in characters) of a task's
  * human readable name.  Includes the NULL terminator. */
-#define configMAX_TASK_NAME_LEN 16
+#define configMAX_TASK_NAME_LEN                   16
 
 /* Time is measured in 'ticks' - which is the number of times the tick interrupt
  * has executed since the RTOS kernel was started.
  * The tick count is held in a variable of type TickType_t.
  *
- * configTICK_TYPE_WIDTH_IN_BITS controls the type (and therefore bit-width) of TickType_t:
+ * configTICK_TYPE_WIDTH_IN_BITS controls the type (and therefore bit-width) of
+ * TickType_t:
  *
  * Defining configTICK_TYPE_WIDTH_IN_BITS as TICK_TYPE_WIDTH_16_BITS causes
  * TickType_t to be defined (typedef'ed) as an unsigned 16-bit type.
@@ -132,79 +136,80 @@
  *
  * Defining configTICK_TYPE_WIDTH_IN_BITS as TICK_TYPE_WIDTH_64_BITS causes
  * TickType_t to be defined (typedef'ed) as an unsigned 64-bit type. */
-#define configTICK_TYPE_WIDTH_IN_BITS TICK_TYPE_WIDTH_64_BITS
+#define configTICK_TYPE_WIDTH_IN_BITS             TICK_TYPE_WIDTH_64_BITS
 
 /* Set configIDLE_SHOULD_YIELD to 1 to have the Idle task yield to an
- * application task if there is an Idle priority (priority 0) application task that
- * can run.  Set to 0 to have the Idle task use all of its timeslice.  Default to 1
- * if left undefined. */
-#define configIDLE_SHOULD_YIELD 1
+ * application task if there is an Idle priority (priority 0) application task
+ * that can run.  Set to 0 to have the Idle task use all of its timeslice.
+ * Default to 1 if left undefined. */
+#define configIDLE_SHOULD_YIELD                   1
 
 /* Each task has an array of task notifications.
- * configTASK_NOTIFICATION_ARRAY_ENTRIES sets the number of indexes in the array.
- * See https://www.freertos.org/RTOS-task-notifications.html  Defaults to 1 if
- * left undefined. */
-#define configTASK_NOTIFICATION_ARRAY_ENTRIES 1
+ * configTASK_NOTIFICATION_ARRAY_ENTRIES sets the number of indexes in the
+ * array. See https://www.freertos.org/RTOS-task-notifications.html  Defaults to
+ * 1 if left undefined. */
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES     1
 
 /* configQUEUE_REGISTRY_SIZE sets the maximum number of queues and semaphores
  * that can be referenced from the queue registry.  Only required when using a
  * kernel aware debugger.  Defaults to 0 if left undefined. */
-#define configQUEUE_REGISTRY_SIZE 0
+#define configQUEUE_REGISTRY_SIZE                 0
 
 /* Set configENABLE_BACKWARD_COMPATIBILITY to 1 to map function names and
- * datatypes from old version of FreeRTOS to their latest equivalent.  Defaults to
- * 1 if left undefined. */
-#define configENABLE_BACKWARD_COMPATIBILITY 0
+ * datatypes from old version of FreeRTOS to their latest equivalent.  Defaults
+ * to 1 if left undefined. */
+#define configENABLE_BACKWARD_COMPATIBILITY       0
 
 /* Each task has its own array of pointers that can be used as thread local
- * storage.  configNUM_THREAD_LOCAL_STORAGE_POINTERS set the number of indexes in
- * the array.  See https://www.freertos.org/thread-local-storage-pointers.html
- * Defaults to 0 if left undefined. */
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 0
+ * storage.  configNUM_THREAD_LOCAL_STORAGE_POINTERS set the number of indexes
+ * in the array.  See
+ * https://www.freertos.org/thread-local-storage-pointers.html Defaults to 0 if
+ * left undefined. */
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS   0
 
 /* When configUSE_MINI_LIST_ITEM is set to 0, MiniListItem_t and ListItem_t are
- * both the same. When configUSE_MINI_LIST_ITEM is set to 1, MiniListItem_t contains
- * 3 fewer fields than ListItem_t which saves some RAM at the cost of violating
- * strict aliasing rules which some compilers depend on for optimization. Defaults
- * to 1 if left undefined. */
-#define configUSE_MINI_LIST_ITEM 1
+ * both the same. When configUSE_MINI_LIST_ITEM is set to 1, MiniListItem_t
+ * contains 3 fewer fields than ListItem_t which saves some RAM at the cost of
+ * violating strict aliasing rules which some compilers depend on for
+ * optimization. Defaults to 1 if left undefined. */
+#define configUSE_MINI_LIST_ITEM                  1
 
 /* Sets the type used by the parameter to xTaskCreate() that specifies the stack
  * size of the task being created.  The same type is used to return information
  * about stack usage in various other API calls.  Defaults to size_t if left
  * undefined. */
-#define configSTACK_DEPTH_TYPE size_t
+#define configSTACK_DEPTH_TYPE                    size_t
 
 /* configMESSAGE_BUFFER_LENGTH_TYPE sets the type used to store the length of
- * each message written to a FreeRTOS message buffer (the length is also written to
- * the message buffer.  Defaults to size_t if left undefined - but that may waste
- * space if messages never go above a length that could be held in a uint8_t. */
-#define configMESSAGE_BUFFER_LENGTH_TYPE size_t
+ * each message written to a FreeRTOS message buffer (the length is also written
+ * to the message buffer.  Defaults to size_t if left undefined - but that may
+ * waste space if messages never go above a length that could be held in a
+ * uint8_t. */
+#define configMESSAGE_BUFFER_LENGTH_TYPE          size_t
 
-/* If configHEAP_CLEAR_MEMORY_ON_FREE is set to 1, then blocks of memory allocated
- * using pvPortMalloc() will be cleared (i.e. set to zero) when freed using
- * vPortFree(). Defaults to 0 if left undefined. */
-#define configHEAP_CLEAR_MEMORY_ON_FREE 1
+/* If configHEAP_CLEAR_MEMORY_ON_FREE is set to 1, then blocks of memory
+ * allocated using pvPortMalloc() will be cleared (i.e. set to zero) when freed
+ * using vPortFree(). Defaults to 0 if left undefined. */
+#define configHEAP_CLEAR_MEMORY_ON_FREE           1
 
-/* vTaskList and vTaskGetRunTimeStats APIs take a buffer as a parameter and assume
- * that the length of the buffer is configSTATS_BUFFER_MAX_LENGTH. Defaults to
- * 0xFFFF if left undefined.
- * New applications are recommended to use vTaskListTasks and
- * vTaskGetRunTimeStatistics APIs instead and supply the length of the buffer
- * explicitly to avoid memory corruption. */
-#define configSTATS_BUFFER_MAX_LENGTH 0xFFFF
+/* vTaskList and vTaskGetRunTimeStats APIs take a buffer as a parameter and
+ * assume that the length of the buffer is configSTATS_BUFFER_MAX_LENGTH.
+ * Defaults to 0xFFFF if left undefined. New applications are recommended to use
+ * vTaskListTasks and vTaskGetRunTimeStatistics APIs instead and supply the
+ * length of the buffer explicitly to avoid memory corruption. */
+#define configSTATS_BUFFER_MAX_LENGTH             0xFFFF
 
 /* Set configUSE_NEWLIB_REENTRANT to 1 to have a newlib reent structure
  * allocated for each task.  Set to 0 to not support newlib reent structures.
  * Default to 0 if left undefined.
  *
  * Note Newlib support has been included by popular demand, but is not used or
- * tested by the FreeRTOS maintainers themselves. FreeRTOS is not responsible for
- * resulting newlib operation. User must be familiar with newlib and must provide
- * system-wide implementations of the necessary stubs. Note that (at the time of
- * writing) the current newlib design implements a system-wide malloc() that must
- * be provided with locks. */
-#define configUSE_NEWLIB_REENTRANT 0
+ * tested by the FreeRTOS maintainers themselves. FreeRTOS is not responsible
+ * for resulting newlib operation. User must be familiar with newlib and must
+ * provide system-wide implementations of the necessary stubs. Note that (at the
+ * time of writing) the current newlib design implements a system-wide malloc()
+ * that must be provided with locks. */
+#define configUSE_NEWLIB_REENTRANT                0
 
 /******************************************************************************/
 /* Software timer related definitions. ****************************************/
@@ -215,26 +220,27 @@
  * FreeRTOS/source/timers.c source file must be included in the build if
  * configUSE_TIMERS is set to 1.  Default to 0 if left undefined.  See
  * https://www.freertos.org/RTOS-software-timer.html. */
-#define configUSE_TIMERS 1
+#define configUSE_TIMERS                          1
 
 /* configTIMER_TASK_PRIORITY sets the priority used by the timer task.  Only
  * used if configUSE_TIMERS is set to 1.  The timer task is a standard FreeRTOS
  * task, so its priority is set like any other task.  See
- * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
- * if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_PRIORITY (configMAX_PRIORITIES - 1)
+ * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only
+ * used if configUSE_TIMERS is set to 1. */
+#define configTIMER_TASK_PRIORITY                 ( configMAX_PRIORITIES - 1 )
 
 /* configTIMER_TASK_STACK_DEPTH sets the size of the stack allocated to the
  * timer task (in words, not in bytes!).  The timer task is a standard FreeRTOS
- * task.  See https://www.freertos.org/RTOS-software-timer-service-daemon-task.html
- * Only used if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_STACK_DEPTH configMINIMAL_STACK_SIZE
+ * task.  See
+ * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html Only
+ * used if configUSE_TIMERS is set to 1. */
+#define configTIMER_TASK_STACK_DEPTH              configMINIMAL_STACK_SIZE
 
 /* configTIMER_QUEUE_LENGTH sets the length of the queue (the number of discrete
  * items the queue can hold) used to send commands to the timer task.  See
- * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
- * if configUSE_TIMERS is set to 1. */
-#define configTIMER_QUEUE_LENGTH 10
+ * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only
+ * used if configUSE_TIMERS is set to 1. */
+#define configTIMER_QUEUE_LENGTH                  10
 
 /******************************************************************************/
 /* Event Group related definitions. *******************************************/
@@ -245,7 +251,7 @@
  * FreeRTOS/source/event_groups.c source file must be included in the build if
  * configUSE_EVENT_GROUPS is set to 1. Defaults to 1 if left undefined. */
 
-#define configUSE_EVENT_GROUPS 1
+#define configUSE_EVENT_GROUPS                    1
 
 /******************************************************************************/
 /* Stream Buffer related definitions. *****************************************/
@@ -256,7 +262,7 @@
  * FreeRTOS/source/stream_buffer.c source file must be included in the build if
  * configUSE_STREAM_BUFFERS is set to 1. Defaults to 1 if left undefined. */
 
-#define configUSE_STREAM_BUFFERS 1
+#define configUSE_STREAM_BUFFERS                  1
 
 /******************************************************************************/
 /* Memory allocation related definitions. *************************************/
@@ -267,25 +273,26 @@
  * memory in the build.  Set to 0 to exclude the ability to create statically
  * allocated objects from the build.  Defaults to 0 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html. */
-#define configSUPPORT_STATIC_ALLOCATION 1
+#define configSUPPORT_STATIC_ALLOCATION           1
 
 /* Set configSUPPORT_DYNAMIC_ALLOCATION to 1 to include FreeRTOS API functions
- * that create FreeRTOS objects (tasks, queues, etc.) using dynamically allocated
- * memory in the build.  Set to 0 to exclude the ability to create dynamically
- * allocated objects from the build.  Defaults to 1 if left undefined.  See
+ * that create FreeRTOS objects (tasks, queues, etc.) using dynamically
+ * allocated memory in the build.  Set to 0 to exclude the ability to create
+ * dynamically allocated objects from the build.  Defaults to 1 if left
+ * undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html. */
-#define configSUPPORT_DYNAMIC_ALLOCATION 1
+#define configSUPPORT_DYNAMIC_ALLOCATION          1
 
 /* Sets the total size of the FreeRTOS heap, in bytes, when heap_1.c, heap_2.c
- * or heap_4.c are included in the build.  This value is defaulted to 4096 bytes but
- * it must be tailored to each application.  Note the heap will appear in the .bss
- * section.  See https://www.freertos.org/a00111.html. */
-#define configTOTAL_HEAP_SIZE 4096
+ * or heap_4.c are included in the build.  This value is defaulted to 4096 bytes
+ * but it must be tailored to each application.  Note the heap will appear in
+ * the .bss section.  See https://www.freertos.org/a00111.html. */
+#define configTOTAL_HEAP_SIZE                     4096
 
 /* Set configAPPLICATION_ALLOCATED_HEAP to 1 to have the application allocate
- * the array used as the FreeRTOS heap.  Set to 0 to have the linker allocate the
- * array used as the FreeRTOS heap.  Defaults to 0 if left undefined. */
-#define configAPPLICATION_ALLOCATED_HEAP 0
+ * the array used as the FreeRTOS heap.  Set to 0 to have the linker allocate
+ * the array used as the FreeRTOS heap.  Defaults to 0 if left undefined. */
+#define configAPPLICATION_ALLOCATED_HEAP          0
 
 /* Set configSTACK_ALLOCATION_FROM_SEPARATE_HEAP to 1 to have task stacks
  * allocated from somewhere other than the FreeRTOS heap.  This is useful if you
@@ -295,10 +302,10 @@
  * Defaults to 0 if left undefined. */
 #define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP 0
 
-/* Set configENABLE_HEAP_PROTECTOR to 1 to enable bounds checking and obfuscation
- * to internal heap block pointers in heap_4.c and heap_5.c to help catch pointer
- * corruptions. Defaults to 0 if left undefined. */
-#define configENABLE_HEAP_PROTECTOR 0
+/* Set configENABLE_HEAP_PROTECTOR to 1 to enable bounds checking and
+ * obfuscation to internal heap block pointers in heap_4.c and heap_5.c to help
+ * catch pointer corruptions. Defaults to 0 if left undefined. */
+#define configENABLE_HEAP_PROTECTOR               0
 
 /******************************************************************************/
 /* Interrupt nesting behaviour configuration. *********************************/
@@ -308,32 +315,32 @@
  * switch performing interrupts.  Not supported by all FreeRTOS ports.  See
  * https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
  * ARM Cortex-M devices. */
-#define configKERNEL_INTERRUPT_PRIORITY 0
+#define configKERNEL_INTERRUPT_PRIORITY           0
 
 /* configMAX_SYSCALL_INTERRUPT_PRIORITY sets the interrupt priority above which
- * FreeRTOS API calls must not be made.  Interrupts above this priority are never
- * disabled, so never delayed by RTOS activity.  The default value is set to the
- * highest interrupt priority (0).  Not supported by all FreeRTOS ports.
- * See https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
- * ARM Cortex-M devices. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY 0
+ * FreeRTOS API calls must not be made.  Interrupts above this priority are
+ * never disabled, so never delayed by RTOS activity.  The default value is set
+ * to the highest interrupt priority (0).  Not supported by all FreeRTOS ports.
+ * See https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific
+ * to ARM Cortex-M devices. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY      0
 
 /* Another name for configMAX_SYSCALL_INTERRUPT_PRIORITY - the name used depends
  * on the FreeRTOS port. */
-#define configMAX_API_CALL_INTERRUPT_PRIORITY 0
+#define configMAX_API_CALL_INTERRUPT_PRIORITY     0
 
 /******************************************************************************/
 /* Hook and callback function related definitions. ****************************/
 /******************************************************************************/
 
 /* Set the following configUSE_* constants to 1 to include the named hook
- * functionality in the build.  Set to 0 to exclude the hook functionality from the
- * build.  The application writer is responsible for providing the hook function
- * for any set to 1.  See https://www.freertos.org/a00016.html. */
-#define configUSE_IDLE_HOOK 0
-#define configUSE_TICK_HOOK 0
-#define configUSE_MALLOC_FAILED_HOOK 0
-#define configUSE_DAEMON_TASK_STARTUP_HOOK 0
+ * functionality in the build.  Set to 0 to exclude the hook functionality from
+ * the build.  The application writer is responsible for providing the hook
+ * function for any set to 1.  See https://www.freertos.org/a00016.html. */
+#define configUSE_IDLE_HOOK                       0
+#define configUSE_TICK_HOOK                       0
+#define configUSE_MALLOC_FAILED_HOOK              0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK        0
 
 /* Set configUSE_SB_COMPLETED_CALLBACK to 1 to have send and receive completed
  * callbacks for each instance of a stream buffer or message buffer. When the
@@ -341,20 +348,21 @@
  * xStreamBufferCreateStaticWithCallback() (and likewise APIs for message
  * buffer) can be used to create a stream buffer or message buffer instance
  * with application provided callbacks. Defaults to 0 if left undefined. */
-#define configUSE_SB_COMPLETED_CALLBACK 0
+#define configUSE_SB_COMPLETED_CALLBACK           0
 
 /* Set configCHECK_FOR_STACK_OVERFLOW to 1 or 2 for FreeRTOS to check for a
  * stack overflow at the time of a context switch.  Set to 0 to not look for a
  * stack overflow.  If configCHECK_FOR_STACK_OVERFLOW is 1 then the check only
- * looks for the stack pointer being out of bounds when a task's context is saved
- * to its stack - this is fast but somewhat ineffective.  If
- * configCHECK_FOR_STACK_OVERFLOW is 2 then the check looks for a pattern written
- * to the end of a task's stack having been overwritten.  This is slower, but will
- * catch most (but not all) stack overflows.  The application writer must provide
- * the stack overflow callback when configCHECK_FOR_STACK_OVERFLOW is set to 1.
- * See https://www.freertos.org/Stacks-and-stack-overflow-checking.html  Defaults
- * to 0 if left undefined. */
-#define configCHECK_FOR_STACK_OVERFLOW 2
+ * looks for the stack pointer being out of bounds when a task's context is
+ * saved to its stack - this is fast but somewhat ineffective.  If
+ * configCHECK_FOR_STACK_OVERFLOW is 2 then the check looks for a pattern
+ * written to the end of a task's stack having been overwritten.  This is
+ * slower, but will catch most (but not all) stack overflows.  The application
+ * writer must provide the stack overflow callback when
+ * configCHECK_FOR_STACK_OVERFLOW is set to 1. See
+ * https://www.freertos.org/Stacks-and-stack-overflow-checking.html  Defaults to
+ * 0 if left undefined. */
+#define configCHECK_FOR_STACK_OVERFLOW            2
 
 /******************************************************************************/
 /* Run time and task stats gathering related definitions. *********************/
@@ -362,22 +370,23 @@
 
 /* Set configGENERATE_RUN_TIME_STATS to 1 to have FreeRTOS collect data on the
  * processing time used by each task.  Set to 0 to not collect the data.  The
- * application writer needs to provide a clock source if set to 1.  Defaults to 0
- * if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html. */
-#define configGENERATE_RUN_TIME_STATS 0
+ * application writer needs to provide a clock source if set to 1.  Defaults to
+ * 0 if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html.
+ */
+#define configGENERATE_RUN_TIME_STATS             0
 
 /* Set configUSE_TRACE_FACILITY to include additional task structure members
  * are used by trace and visualisation functions and tools.  Set to 0 to exclude
  * the additional information from the structures. Defaults to 0 if left
  * undefined. */
-#define configUSE_TRACE_FACILITY 0
+#define configUSE_TRACE_FACILITY                  0
 
 /* Set to 1 to include the vTaskList() and vTaskGetRunTimeStats() functions in
  * the build.  Set to 0 to exclude these functions from the build.  These two
  * functions introduce a dependency on string formatting functions that would
  * otherwise not exist - hence they are kept separate.  Defaults to 0 if left
  * undefined. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS 0
+#define configUSE_STATS_FORMATTING_FUNCTIONS      0
 
 /******************************************************************************/
 /* Co-routine related definitions. ********************************************/
@@ -385,14 +394,14 @@
 
 /* Set configUSE_CO_ROUTINES to 1 to include co-routine functionality in the
  * build, or 0 to omit co-routine functionality from the build. To include
- * co-routines, croutine.c must be included in the project. Defaults to 0 if left
- * undefined. */
-#define configUSE_CO_ROUTINES 0
+ * co-routines, croutine.c must be included in the project. Defaults to 0 if
+ * left undefined. */
+#define configUSE_CO_ROUTINES                     0
 
 /* configMAX_CO_ROUTINE_PRIORITIES defines the number of priorities available
  * to the application co-routines. Any number of co-routines can share the same
  * priority. Defaults to 0 if left undefined. */
-#define configMAX_CO_ROUTINE_PRIORITIES 1
+#define configMAX_CO_ROUTINE_PRIORITIES           1
 
 /******************************************************************************/
 /* Debugging assistance. ******************************************************/
@@ -403,14 +412,14 @@
  * at all (i.e. comment out or delete the definitions) to completely remove
  * assertions.  configASSERT() can be defined to anything you want, for example
  * you can call a function if an assert fails that passes the filename and line
- * number of the failing assert (for example, "vAssertCalled( __FILE__, __LINE__ )"
- * or it can simple disable interrupts and sit in a loop to halt all execution
- * on the failing line for viewing in a debugger. */
-#define configASSERT(x)           \
-    if ((x) == 0)                 \
+ * number of the failing assert (for example, "vAssertCalled( __FILE__, __LINE__
+ * )" or it can simple disable interrupts and sit in a loop to halt all
+ * execution on the failing line for viewing in a debugger. */
+#define configASSERT( x )         \
+    if( ( x ) == 0 )              \
     {                             \
         taskDISABLE_INTERRUPTS(); \
-        for (;;)                  \
+        for( ;; )                 \
             ;                     \
     }
 
@@ -420,50 +429,51 @@
 
 /* If configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS is set to 1 then
  * the application writer can provide functions that execute in privileged mode.
- * See: https://www.freertos.org/a00110.html#configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
- * Defaults to 0 if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports,
- * not the standard ARMv7-M Cortex-M port. */
+ * See:
+ * https://www.freertos.org/a00110.html#configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
+ * Defaults to 0 if left undefined.  Only used by the FreeRTOS Cortex-M MPU
+ * ports, not the standard ARMv7-M Cortex-M port. */
 #define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS 0
 
 /* Set configTOTAL_MPU_REGIONS to the number of MPU regions implemented on your
  * target hardware.  Normally 8 or 16.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port.  Defaults to 8 if left
  * undefined. */
-#define configTOTAL_MPU_REGIONS 8
+#define configTOTAL_MPU_REGIONS                                8
 
 /* configTEX_S_C_B_FLASH allows application writers to override the default
- * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
- * the MPU region covering Flash.  Defaults to 0x07UL (which means TEX=000, S=1,
- * C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
- * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_FLASH 0x07UL
+ * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits
+ * for the MPU region covering Flash.  Defaults to 0x07UL (which means TEX=000,
+ * S=1, C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU
+ * ports, not the standard ARMv7-M Cortex-M port. */
+#define configTEX_S_C_B_FLASH                                  0x07UL
 
 /* configTEX_S_C_B_SRAM allows application writers to override the default
- * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
- * the MPU region covering RAM. Defaults to 0x07UL (which means TEX=000, S=1, C=1,
- * B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
- * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_SRAM 0x07UL
+ * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits
+ * for the MPU region covering RAM. Defaults to 0x07UL (which means TEX=000,
+ * S=1, C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU
+ * ports, not the standard ARMv7-M Cortex-M port. */
+#define configTEX_S_C_B_SRAM                                   0x07UL
 
 /* Set configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY to 0 to prevent any privilege
  * escalations originating from outside of the kernel code itself.  Set to 1 to
  * allow application tasks to raise privilege.  Defaults to 1 if left undefined.
- * Only used by the FreeRTOS Cortex-M MPU ports, not the standard ARMv7-M Cortex-M
- * port. */
-#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY 1
+ * Only used by the FreeRTOS Cortex-M MPU ports, not the standard ARMv7-M
+ * Cortex-M port. */
+#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY            1
 
 /* Set configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS to 1 to allow unprivileged
  * tasks enter critical sections (effectively mask interrupts). Set to 0 to
  * prevent unprivileged tasks entering critical sections.  Defaults to 1 if left
  * undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not the standard
  * ARMv7-M Cortex-M port. */
-#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS 0
+#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS             0
 
 /* FreeRTOS Kernel version 10.6.0 introduced a new v2 MPU wrapper, namely
  * mpu_wrappers_v2.c. Set configUSE_MPU_WRAPPERS_V1 to 0 to use the new v2 MPU
  * wrapper. Set configUSE_MPU_WRAPPERS_V1 to 1 to use the old v1 MPU wrapper
  * (mpu_wrappers.c). Defaults to 0 if left undefined. */
-#define configUSE_MPU_WRAPPERS_V1 0
+#define configUSE_MPU_WRAPPERS_V1                              0
 
 /* When using the v2 MPU wrapper, set configPROTECTED_KERNEL_OBJECT_POOL_SIZE to
  * the total number of kernel objects, which includes tasks, queues, semaphores,
@@ -471,7 +481,7 @@
  * application. The application will not be able to have more than
  * configPROTECTED_KERNEL_OBJECT_POOL_SIZE kernel objects at any point of
  * time. */
-#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE 10
+#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE                10
 
 /* When using the v2 MPU wrapper, set configSYSTEM_CALL_STACK_SIZE to the size
  * of the system call stack in words. Each task has a statically allocated
@@ -479,7 +489,7 @@
  * calls. For example, if configSYSTEM_CALL_STACK_SIZE is defined as 128 and
  * there are 10 tasks in the application, the total amount of memory used for
  * system call stacks is 128 * 10 = 1280 words. */
-#define configSYSTEM_CALL_STACK_SIZE 128
+#define configSYSTEM_CALL_STACK_SIZE                           128
 
 /* When using the v2 MPU wrapper, set configENABLE_ACCESS_CONTROL_LIST to 1 to
  * enable Access Control List (ACL) feature. When ACL is enabled, an
@@ -487,14 +497,14 @@
  * than itself. The application writer needs to explicitly grant the
  * unprivileged task access to the kernel objects it needs using the APIs
  * provided for the same. Defaults to 0 if left undefined. */
-#define configENABLE_ACCESS_CONTROL_LIST 1
+#define configENABLE_ACCESS_CONTROL_LIST                       1
 
 /******************************************************************************/
 /* SMP( Symmetric MultiProcessing ) Specific Configuration definitions. *******/
 /******************************************************************************/
 
-/* Set configNUMBER_OF_CORES to the number of available processor cores. Defaults
- * to 1 if left undefined. */
+/* Set configNUMBER_OF_CORES to the number of available processor cores.
+ * Defaults to 1 if left undefined. */
 
 /*
  #define configNUMBER_OF_CORES                     [Num of available cores]
@@ -507,58 +517,60 @@
  * is able to run. If configRUN_MULTIPLE_PRIORITIES is set to 1, multiple tasks
  * with different priorities may run simultaneously - so a higher and lower
  * priority task may run on different cores at the same time. */
-#define configRUN_MULTIPLE_PRIORITIES 0
+#define configRUN_MULTIPLE_PRIORITIES                          0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
  * configUSE_CORE_AFFINITY to 1 to enable core affinity feature. When core
- * affinity feature is enabled, the vTaskCoreAffinitySet and vTaskCoreAffinityGet
- * APIs can be used to set and retrieve which cores a task can run on. If
- * configUSE_CORE_AFFINITY is set to 0 then the FreeRTOS scheduler is free to
- * run any task on any available core. */
-#define configUSE_CORE_AFFINITY 0
+ * affinity feature is enabled, the vTaskCoreAffinitySet and
+ * vTaskCoreAffinityGet APIs can be used to set and retrieve which cores a task
+ * can run on. If configUSE_CORE_AFFINITY is set to 0 then the FreeRTOS
+ * scheduler is free to run any task on any available core. */
+#define configUSE_CORE_AFFINITY                                0
 
 /* When using SMP with core affinity feature enabled, set
  * configTASK_DEFAULT_CORE_AFFINITY to change the default core affinity mask for
- * tasks created without an affinity mask specified. Setting the define to 1 would
- * make such tasks run on core 0 and setting it to (1 << portGET_CORE_ID()) would
- * make such tasks run on the current core. This config value is useful, if
- * swapping tasks between cores is not supported (e.g. Tricore) or if legacy code
- * should be controlled. Defaults to tskNO_AFFINITY if left undefined. */
-#define configTASK_DEFAULT_CORE_AFFINITY tskNO_AFFINITY
+ * tasks created without an affinity mask specified. Setting the define to 1
+ * would make such tasks run on core 0 and setting it to (1 <<
+ * portGET_CORE_ID()) would make such tasks run on the current core. This config
+ * value is useful, if swapping tasks between cores is not supported (e.g.
+ * Tricore) or if legacy code should be controlled. Defaults to tskNO_AFFINITY
+ * if left undefined. */
+#define configTASK_DEFAULT_CORE_AFFINITY                       tskNO_AFFINITY
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), if
  * configUSE_TASK_PREEMPTION_DISABLE is set to 1, individual tasks can be set to
  * either pre-emptive or co-operative mode using the vTaskPreemptionDisable and
  * vTaskPreemptionEnable APIs. */
-#define configUSE_TASK_PREEMPTION_DISABLE 0
+#define configUSE_TASK_PREEMPTION_DISABLE                      0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
  * configUSE_PASSIVE_IDLE_HOOK to 1 to allow the application writer to use
- * the passive idle task hook to add background functionality without the overhead
- * of a separate task. Defaults to 0 if left undefined. */
-#define configUSE_PASSIVE_IDLE_HOOK 0
+ * the passive idle task hook to add background functionality without the
+ * overhead of a separate task. Defaults to 0 if left undefined. */
+#define configUSE_PASSIVE_IDLE_HOOK                            0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one),
  * configTIMER_SERVICE_TASK_CORE_AFFINITY allows the application writer to set
  * the core affinity of the RTOS Daemon/Timer Service task. Defaults to
  * tskNO_AFFINITY if left undefined. */
-#define configTIMER_SERVICE_TASK_CORE_AFFINITY tskNO_AFFINITY
+#define configTIMER_SERVICE_TASK_CORE_AFFINITY                 tskNO_AFFINITY
 
 /******************************************************************************/
 /* ARMv8-M secure side port related definitions. ******************************/
 /******************************************************************************/
 
 /* secureconfigMAX_SECURE_CONTEXTS define the maximum number of tasks that can
- *  call into the secure side of an ARMv8-M chip.  Not used by any other ports. */
-#define secureconfigMAX_SECURE_CONTEXTS 5
+ *  call into the secure side of an ARMv8-M chip.  Not used by any other ports.
+ */
+#define secureconfigMAX_SECURE_CONTEXTS                        5
 
 /* Defines the kernel provided implementation of
  * vApplicationGetIdleTaskMemory() and vApplicationGetTimerTaskMemory()
- * to provide the memory that is used by the Idle task and Timer task respectively.
- * The application can provide it's own implementation of
+ * to provide the memory that is used by the Idle task and Timer task
+ * respectively. The application can provide it's own implementation of
  * vApplicationGetIdleTaskMemory() and vApplicationGetTimerTaskMemory() by
  * setting configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined. */
-#define configKERNEL_PROVIDED_STATIC_MEMORY 1
+#define configKERNEL_PROVIDED_STATIC_MEMORY                    1
 
 /******************************************************************************/
 /* ARMv8-M port Specific Configuration definitions. ***************************/
@@ -568,47 +580,51 @@
  * to enable the TrustZone support in FreeRTOS ARMv8-M ports which allows the
  * non-secure FreeRTOS tasks to call the (non-secure callable) functions
  * exported from secure side. */
-#define configENABLE_TRUSTZONE 1
+#define configENABLE_TRUSTZONE                                 1
 
-/* If the application writer does not want to use TrustZone, but the hardware does
- * not support disabling TrustZone then the entire application (including the FreeRTOS
- * scheduler) can run on the secure side without ever branching to the non-secure side.
- * To do that, in addition to setting configENABLE_TRUSTZONE to 0, also set
- * configRUN_FREERTOS_SECURE_ONLY to 1. */
-#define configRUN_FREERTOS_SECURE_ONLY 1
+/* If the application writer does not want to use TrustZone, but the hardware
+ * does not support disabling TrustZone then the entire application (including
+ * the FreeRTOS scheduler) can run on the secure side without ever branching to
+ * the non-secure side. To do that, in addition to setting
+ * configENABLE_TRUSTZONE to 0, also set configRUN_FREERTOS_SECURE_ONLY to 1. */
+#define configRUN_FREERTOS_SECURE_ONLY                         1
 
 /* Set configENABLE_MPU to 1 to enable the Memory Protection Unit (MPU), or 0
  * to leave the Memory Protection Unit disabled. */
-#define configENABLE_MPU 1
+#define configENABLE_MPU                                       1
 
 /* Set configENABLE_FPU to 1 to enable the Floating Point Unit (FPU), or 0
  * to leave the Floating Point Unit disabled. */
-#define configENABLE_FPU 1
+#define configENABLE_FPU                                       1
 
-/* Set configENABLE_MVE to 1 to enable the M-Profile Vector Extension (MVE) support,
- * or 0 to leave the MVE support disabled. This option is only applicable to Cortex-M55
- * and Cortex-M85 ports as M-Profile Vector Extension (MVE) is available only on
- * these architectures. configENABLE_MVE must be left undefined, or defined to 0
- * for the Cortex-M23,Cortex-M33 and Cortex-M35P ports. */
-#define configENABLE_MVE 1
+/* Set configENABLE_MVE to 1 to enable the M-Profile Vector Extension (MVE)
+ * support, or 0 to leave the MVE support disabled. This option is only
+ * applicable to Cortex-M55 and Cortex-M85 ports as M-Profile Vector Extension
+ * (MVE) is available only on these architectures. configENABLE_MVE must be left
+ * undefined, or defined to 0 for the Cortex-M23,Cortex-M33 and Cortex-M35P
+ * ports. */
+#define configENABLE_MVE                                       1
 
 /******************************************************************************/
 /* ARMv7-M and ARMv8-M port Specific Configuration definitions. ***************/
 /******************************************************************************/
 
-/* Set configCHECK_HANDLER_INSTALLATION to 1 to enable additional asserts to verify
- * that the application has correctly installed FreeRTOS interrupt handlers.
+/* Set configCHECK_HANDLER_INSTALLATION to 1 to enable additional asserts to
+ * verify that the application has correctly installed FreeRTOS interrupt
+ * handlers.
  *
- * An application can install FreeRTOS interrupt handlers in one of the following ways:
- *   1. Direct Routing  -  Install the functions vPortSVCHandler and xPortPendSVHandler
- *                         for SVC call and PendSV interrupts respectively.
+ * An application can install FreeRTOS interrupt handlers in one of the
+ * following ways:
+ *   1. Direct Routing  -  Install the functions vPortSVCHandler and
+ * xPortPendSVHandler for SVC call and PendSV interrupts respectively.
  *   2. Indirect Routing - Install separate handlers for SVC call and PendSV
- *                         interrupts and route program control from those handlers
- *                         to vPortSVCHandler and xPortPendSVHandler functions.
- * The applications that use Indirect Routing must set configCHECK_HANDLER_INSTALLATION to 0.
+ *                         interrupts and route program control from those
+ * handlers to vPortSVCHandler and xPortPendSVHandler functions. The
+ * applications that use Indirect Routing must set
+ * configCHECK_HANDLER_INSTALLATION to 0.
  *
  * Defaults to 1 if left undefined. */
-#define configCHECK_HANDLER_INSTALLATION 1
+#define configCHECK_HANDLER_INSTALLATION                       1
 
 /******************************************************************************/
 /* Definitions that include or exclude functionality. *************************/
@@ -616,36 +632,36 @@
 
 /* Set the following configUSE_* constants to 1 to include the named feature in
  * the build, or 0 to exclude the named feature from the build. */
-#define configUSE_TASK_NOTIFICATIONS 1
-#define configUSE_MUTEXES 1
-#define configUSE_RECURSIVE_MUTEXES 1
-#define configUSE_COUNTING_SEMAPHORES 1
-#define configUSE_QUEUE_SETS 0
-#define configUSE_APPLICATION_TASK_TAG 0
+#define configUSE_TASK_NOTIFICATIONS                           1
+#define configUSE_MUTEXES                                      1
+#define configUSE_RECURSIVE_MUTEXES                            1
+#define configUSE_COUNTING_SEMAPHORES                          1
+#define configUSE_QUEUE_SETS                                   0
+#define configUSE_APPLICATION_TASK_TAG                         0
 
 /* USE_POSIX_ERRNO enables the task global FreeRTOS_errno variable which will
  * containthe most recent error for that task. */
-#define configUSE_POSIX_ERRNO 0
+#define configUSE_POSIX_ERRNO                                  0
 
 /* Set the following INCLUDE_* constants to 1 to incldue the named API function,
  * or 0 to exclude the named API function.  Most linkers will remove unused
  * functions even when the constant is 1. */
-#define INCLUDE_vTaskPrioritySet 1
-#define INCLUDE_uxTaskPriorityGet 1
-#define INCLUDE_vTaskDelete 1
-#define INCLUDE_vTaskSuspend 1
-#define INCLUDE_xResumeFromISR 1
-#define INCLUDE_vTaskDelayUntil 1
-#define INCLUDE_vTaskDelay 1
-#define INCLUDE_xTaskGetSchedulerState 1
-#define INCLUDE_xTaskGetCurrentTaskHandle 1
-#define INCLUDE_uxTaskGetStackHighWaterMark 0
-#define INCLUDE_xTaskGetIdleTaskHandle 0
-#define INCLUDE_eTaskGetState 0
-#define INCLUDE_xEventGroupSetBitFromISR 1
-#define INCLUDE_xTimerPendFunctionCall 0
-#define INCLUDE_xTaskAbortDelay 0
-#define INCLUDE_xTaskGetHandle 0
-#define INCLUDE_xTaskResumeFromISR 1
+#define INCLUDE_vTaskPrioritySet                               1
+#define INCLUDE_uxTaskPriorityGet                              1
+#define INCLUDE_vTaskDelete                                    1
+#define INCLUDE_vTaskSuspend                                   1
+#define INCLUDE_xResumeFromISR                                 1
+#define INCLUDE_vTaskDelayUntil                                1
+#define INCLUDE_vTaskDelay                                     1
+#define INCLUDE_xTaskGetSchedulerState                         1
+#define INCLUDE_xTaskGetCurrentTaskHandle                      1
+#define INCLUDE_uxTaskGetStackHighWaterMark                    0
+#define INCLUDE_xTaskGetIdleTaskHandle                         0
+#define INCLUDE_eTaskGetState                                  0
+#define INCLUDE_xEventGroupSetBitFromISR                       1
+#define INCLUDE_xTimerPendFunctionCall                         0
+#define INCLUDE_xTaskAbortDelay                                0
+#define INCLUDE_xTaskGetHandle                                 0
+#define INCLUDE_xTaskResumeFromISR                             1
 
 #endif /* FREERTOS_CONFIG_H */

--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -51,7 +51,7 @@
  * The default value is set to 20MHz and matches the QEMU demo settings.  Your
  * application will certainly need a different value so set this correctly.
  * This is very often, but not always, equal to the main system clock frequency. */
-#define configCPU_CLOCK_HZ    ( ( unsigned long ) 20000000 )
+#define configCPU_CLOCK_HZ ((unsigned long)20000000)
 
 /* configSYSTICK_CLOCK_HZ is an optional parameter for ARM Cortex-M ports only.
  *
@@ -75,19 +75,19 @@
 
 /* configTICK_RATE_HZ sets frequency of the tick interrupt in Hz, normally
  * calculated from the configCPU_CLOCK_HZ value. */
-#define configTICK_RATE_HZ                         100
+#define configTICK_RATE_HZ 100
 
 /* Set configUSE_PREEMPTION to 1 to use pre-emptive scheduling.  Set
  * configUSE_PREEMPTION to 0 to use co-operative scheduling.
  * See https://www.freertos.org/single-core-amp-smp-rtos-scheduling.html. */
-#define configUSE_PREEMPTION                       1
+#define configUSE_PREEMPTION 1
 
 /* Set configUSE_TIME_SLICING to 1 to have the scheduler switch between Ready
  * state tasks of equal priority on every tick interrupt.  Set
  * configUSE_TIME_SLICING to 0 to prevent the scheduler switching between Ready
  * state tasks just because there was a tick interrupt.  See
  * https://freertos.org/single-core-amp-smp-rtos-scheduling.html. */
-#define configUSE_TIME_SLICING                     0
+#define configUSE_TIME_SLICING 0
 
 /* Set configUSE_PORT_OPTIMISED_TASK_SELECTION to 1 to select the next task to
  * run using an algorithm optimised to the instruction set of the target hardware -
@@ -95,28 +95,28 @@
  * the next task to run using a generic C algorithm that works for all FreeRTOS
  * ports.  Not all FreeRTOS ports have this option.  Defaults to 0 if left
  * undefined. */
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
 
 /* Set configUSE_TICKLESS_IDLE to 1 to use the low power tickless mode.  Set to
  * 0 to keep the tick interrupt running at all times.  Not all FreeRTOS ports
  * support tickless mode. See https://www.freertos.org/low-power-tickless-rtos.html
  * Defaults to 0 if left undefined. */
-#define configUSE_TICKLESS_IDLE                    0
+#define configUSE_TICKLESS_IDLE 0
 
 /* configMAX_PRIORITIES Sets the number of available task priorities.  Tasks can
  * be assigned priorities of 0 to (configMAX_PRIORITIES - 1).  Zero is the lowest
  * priority. */
-#define configMAX_PRIORITIES                       5
+#define configMAX_PRIORITIES 5
 
 /* configMINIMAL_STACK_SIZE defines the size of the stack used by the Idle task
  * (in words, not in bytes!).  The kernel does not use this constant for any other
  * purpose.  Demo applications use the constant to make the demos somewhat portable
  * across hardware architectures. */
-#define configMINIMAL_STACK_SIZE                   128
+#define configMINIMAL_STACK_SIZE 128
 
 /* configMAX_TASK_NAME_LEN sets the maximum length (in characters) of a task's
  * human readable name.  Includes the NULL terminator. */
-#define configMAX_TASK_NAME_LEN                    16
+#define configMAX_TASK_NAME_LEN 16
 
 /* Time is measured in 'ticks' - which is the number of times the tick interrupt
  * has executed since the RTOS kernel was started.
@@ -132,59 +132,59 @@
  *
  * Defining configTICK_TYPE_WIDTH_IN_BITS as TICK_TYPE_WIDTH_64_BITS causes
  * TickType_t to be defined (typedef'ed) as an unsigned 64-bit type. */
-#define configTICK_TYPE_WIDTH_IN_BITS              TICK_TYPE_WIDTH_64_BITS
+#define configTICK_TYPE_WIDTH_IN_BITS TICK_TYPE_WIDTH_64_BITS
 
 /* Set configIDLE_SHOULD_YIELD to 1 to have the Idle task yield to an
  * application task if there is an Idle priority (priority 0) application task that
  * can run.  Set to 0 to have the Idle task use all of its timeslice.  Default to 1
  * if left undefined. */
-#define configIDLE_SHOULD_YIELD                    1
+#define configIDLE_SHOULD_YIELD 1
 
 /* Each task has an array of task notifications.
  * configTASK_NOTIFICATION_ARRAY_ENTRIES sets the number of indexes in the array.
  * See https://www.freertos.org/RTOS-task-notifications.html  Defaults to 1 if
  * left undefined. */
-#define configTASK_NOTIFICATION_ARRAY_ENTRIES      1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES 1
 
 /* configQUEUE_REGISTRY_SIZE sets the maximum number of queues and semaphores
  * that can be referenced from the queue registry.  Only required when using a
  * kernel aware debugger.  Defaults to 0 if left undefined. */
-#define configQUEUE_REGISTRY_SIZE                  0
+#define configQUEUE_REGISTRY_SIZE 0
 
 /* Set configENABLE_BACKWARD_COMPATIBILITY to 1 to map function names and
  * datatypes from old version of FreeRTOS to their latest equivalent.  Defaults to
  * 1 if left undefined. */
-#define configENABLE_BACKWARD_COMPATIBILITY        0
+#define configENABLE_BACKWARD_COMPATIBILITY 0
 
 /* Each task has its own array of pointers that can be used as thread local
  * storage.  configNUM_THREAD_LOCAL_STORAGE_POINTERS set the number of indexes in
  * the array.  See https://www.freertos.org/thread-local-storage-pointers.html
  * Defaults to 0 if left undefined. */
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS    0
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 0
 
 /* When configUSE_MINI_LIST_ITEM is set to 0, MiniListItem_t and ListItem_t are
  * both the same. When configUSE_MINI_LIST_ITEM is set to 1, MiniListItem_t contains
  * 3 fewer fields than ListItem_t which saves some RAM at the cost of violating
  * strict aliasing rules which some compilers depend on for optimization. Defaults
  * to 1 if left undefined. */
-#define configUSE_MINI_LIST_ITEM                   1
+#define configUSE_MINI_LIST_ITEM 1
 
 /* Sets the type used by the parameter to xTaskCreate() that specifies the stack
  * size of the task being created.  The same type is used to return information
  * about stack usage in various other API calls.  Defaults to size_t if left
  * undefined. */
-#define configSTACK_DEPTH_TYPE                     size_t
+#define configSTACK_DEPTH_TYPE size_t
 
 /* configMESSAGE_BUFFER_LENGTH_TYPE sets the type used to store the length of
  * each message written to a FreeRTOS message buffer (the length is also written to
  * the message buffer.  Defaults to size_t if left undefined - but that may waste
  * space if messages never go above a length that could be held in a uint8_t. */
-#define configMESSAGE_BUFFER_LENGTH_TYPE           size_t
+#define configMESSAGE_BUFFER_LENGTH_TYPE size_t
 
 /* If configHEAP_CLEAR_MEMORY_ON_FREE is set to 1, then blocks of memory allocated
  * using pvPortMalloc() will be cleared (i.e. set to zero) when freed using
  * vPortFree(). Defaults to 0 if left undefined. */
-#define configHEAP_CLEAR_MEMORY_ON_FREE            1
+#define configHEAP_CLEAR_MEMORY_ON_FREE 1
 
 /* vTaskList and vTaskGetRunTimeStats APIs take a buffer as a parameter and assume
  * that the length of the buffer is configSTATS_BUFFER_MAX_LENGTH. Defaults to
@@ -192,7 +192,7 @@
  * New applications are recommended to use vTaskListTasks and
  * vTaskGetRunTimeStatistics APIs instead and supply the length of the buffer
  * explicitly to avoid memory corruption. */
-#define configSTATS_BUFFER_MAX_LENGTH              0xFFFF
+#define configSTATS_BUFFER_MAX_LENGTH 0xFFFF
 
 /* Set configUSE_NEWLIB_REENTRANT to 1 to have a newlib reent structure
  * allocated for each task.  Set to 0 to not support newlib reent structures.
@@ -204,7 +204,7 @@
  * system-wide implementations of the necessary stubs. Note that (at the time of
  * writing) the current newlib design implements a system-wide malloc() that must
  * be provided with locks. */
-#define configUSE_NEWLIB_REENTRANT                 0
+#define configUSE_NEWLIB_REENTRANT 0
 
 /******************************************************************************/
 /* Software timer related definitions. ****************************************/
@@ -215,26 +215,26 @@
  * FreeRTOS/source/timers.c source file must be included in the build if
  * configUSE_TIMERS is set to 1.  Default to 0 if left undefined.  See
  * https://www.freertos.org/RTOS-software-timer.html. */
-#define configUSE_TIMERS                1
+#define configUSE_TIMERS 1
 
 /* configTIMER_TASK_PRIORITY sets the priority used by the timer task.  Only
  * used if configUSE_TIMERS is set to 1.  The timer task is a standard FreeRTOS
  * task, so its priority is set like any other task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
  * if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_PRIORITY       ( configMAX_PRIORITIES - 1 )
+#define configTIMER_TASK_PRIORITY (configMAX_PRIORITIES - 1)
 
 /* configTIMER_TASK_STACK_DEPTH sets the size of the stack allocated to the
  * timer task (in words, not in bytes!).  The timer task is a standard FreeRTOS
  * task.  See https://www.freertos.org/RTOS-software-timer-service-daemon-task.html
  * Only used if configUSE_TIMERS is set to 1. */
-#define configTIMER_TASK_STACK_DEPTH    configMINIMAL_STACK_SIZE
+#define configTIMER_TASK_STACK_DEPTH configMINIMAL_STACK_SIZE
 
 /* configTIMER_QUEUE_LENGTH sets the length of the queue (the number of discrete
  * items the queue can hold) used to send commands to the timer task.  See
  * https://www.freertos.org/RTOS-software-timer-service-daemon-task.html  Only used
  * if configUSE_TIMERS is set to 1. */
-#define configTIMER_QUEUE_LENGTH        10
+#define configTIMER_QUEUE_LENGTH 10
 
 /******************************************************************************/
 /* Event Group related definitions. *******************************************/
@@ -245,7 +245,7 @@
  * FreeRTOS/source/event_groups.c source file must be included in the build if
  * configUSE_EVENT_GROUPS is set to 1. Defaults to 1 if left undefined. */
 
-#define configUSE_EVENT_GROUPS    1
+#define configUSE_EVENT_GROUPS 1
 
 /******************************************************************************/
 /* Stream Buffer related definitions. *****************************************/
@@ -256,7 +256,7 @@
  * FreeRTOS/source/stream_buffer.c source file must be included in the build if
  * configUSE_STREAM_BUFFERS is set to 1. Defaults to 1 if left undefined. */
 
-#define configUSE_STREAM_BUFFERS    1
+#define configUSE_STREAM_BUFFERS 1
 
 /******************************************************************************/
 /* Memory allocation related definitions. *************************************/
@@ -267,25 +267,25 @@
  * memory in the build.  Set to 0 to exclude the ability to create statically
  * allocated objects from the build.  Defaults to 0 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html. */
-#define configSUPPORT_STATIC_ALLOCATION              1
+#define configSUPPORT_STATIC_ALLOCATION 1
 
 /* Set configSUPPORT_DYNAMIC_ALLOCATION to 1 to include FreeRTOS API functions
  * that create FreeRTOS objects (tasks, queues, etc.) using dynamically allocated
  * memory in the build.  Set to 0 to exclude the ability to create dynamically
  * allocated objects from the build.  Defaults to 1 if left undefined.  See
  * https://www.freertos.org/Static_Vs_Dynamic_Memory_Allocation.html. */
-#define configSUPPORT_DYNAMIC_ALLOCATION             1
+#define configSUPPORT_DYNAMIC_ALLOCATION 1
 
 /* Sets the total size of the FreeRTOS heap, in bytes, when heap_1.c, heap_2.c
  * or heap_4.c are included in the build.  This value is defaulted to 4096 bytes but
  * it must be tailored to each application.  Note the heap will appear in the .bss
  * section.  See https://www.freertos.org/a00111.html. */
-#define configTOTAL_HEAP_SIZE                        4096
+#define configTOTAL_HEAP_SIZE 4096
 
 /* Set configAPPLICATION_ALLOCATED_HEAP to 1 to have the application allocate
  * the array used as the FreeRTOS heap.  Set to 0 to have the linker allocate the
  * array used as the FreeRTOS heap.  Defaults to 0 if left undefined. */
-#define configAPPLICATION_ALLOCATED_HEAP             0
+#define configAPPLICATION_ALLOCATED_HEAP 0
 
 /* Set configSTACK_ALLOCATION_FROM_SEPARATE_HEAP to 1 to have task stacks
  * allocated from somewhere other than the FreeRTOS heap.  This is useful if you
@@ -293,12 +293,12 @@
  * come from the standard FreeRTOS heap.  The application writer must provide
  * implementations for pvPortMallocStack() and vPortFreeStack() if set to 1.
  * Defaults to 0 if left undefined. */
-#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP    0
+#define configSTACK_ALLOCATION_FROM_SEPARATE_HEAP 0
 
 /* Set configENABLE_HEAP_PROTECTOR to 1 to enable bounds checking and obfuscation
  * to internal heap block pointers in heap_4.c and heap_5.c to help catch pointer
  * corruptions. Defaults to 0 if left undefined. */
-#define configENABLE_HEAP_PROTECTOR                  0
+#define configENABLE_HEAP_PROTECTOR 0
 
 /******************************************************************************/
 /* Interrupt nesting behaviour configuration. *********************************/
@@ -308,7 +308,7 @@
  * switch performing interrupts.  Not supported by all FreeRTOS ports.  See
  * https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
  * ARM Cortex-M devices. */
-#define configKERNEL_INTERRUPT_PRIORITY          0
+#define configKERNEL_INTERRUPT_PRIORITY 0
 
 /* configMAX_SYSCALL_INTERRUPT_PRIORITY sets the interrupt priority above which
  * FreeRTOS API calls must not be made.  Interrupts above this priority are never
@@ -316,11 +316,11 @@
  * highest interrupt priority (0).  Not supported by all FreeRTOS ports.
  * See https://www.freertos.org/RTOS-Cortex-M3-M4.html for information specific to
  * ARM Cortex-M devices. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY     0
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY 0
 
 /* Another name for configMAX_SYSCALL_INTERRUPT_PRIORITY - the name used depends
  * on the FreeRTOS port. */
-#define configMAX_API_CALL_INTERRUPT_PRIORITY    0
+#define configMAX_API_CALL_INTERRUPT_PRIORITY 0
 
 /******************************************************************************/
 /* Hook and callback function related definitions. ****************************/
@@ -330,10 +330,10 @@
  * functionality in the build.  Set to 0 to exclude the hook functionality from the
  * build.  The application writer is responsible for providing the hook function
  * for any set to 1.  See https://www.freertos.org/a00016.html. */
-#define configUSE_IDLE_HOOK                   0
-#define configUSE_TICK_HOOK                   0
-#define configUSE_MALLOC_FAILED_HOOK          0
-#define configUSE_DAEMON_TASK_STARTUP_HOOK    0
+#define configUSE_IDLE_HOOK 0
+#define configUSE_TICK_HOOK 0
+#define configUSE_MALLOC_FAILED_HOOK 0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK 0
 
 /* Set configUSE_SB_COMPLETED_CALLBACK to 1 to have send and receive completed
  * callbacks for each instance of a stream buffer or message buffer. When the
@@ -341,7 +341,7 @@
  * xStreamBufferCreateStaticWithCallback() (and likewise APIs for message
  * buffer) can be used to create a stream buffer or message buffer instance
  * with application provided callbacks. Defaults to 0 if left undefined. */
-#define configUSE_SB_COMPLETED_CALLBACK       0
+#define configUSE_SB_COMPLETED_CALLBACK 0
 
 /* Set configCHECK_FOR_STACK_OVERFLOW to 1 or 2 for FreeRTOS to check for a
  * stack overflow at the time of a context switch.  Set to 0 to not look for a
@@ -354,7 +354,7 @@
  * the stack overflow callback when configCHECK_FOR_STACK_OVERFLOW is set to 1.
  * See https://www.freertos.org/Stacks-and-stack-overflow-checking.html  Defaults
  * to 0 if left undefined. */
-#define configCHECK_FOR_STACK_OVERFLOW        2
+#define configCHECK_FOR_STACK_OVERFLOW 2
 
 /******************************************************************************/
 /* Run time and task stats gathering related definitions. *********************/
@@ -364,20 +364,20 @@
  * processing time used by each task.  Set to 0 to not collect the data.  The
  * application writer needs to provide a clock source if set to 1.  Defaults to 0
  * if left undefined.  See https://www.freertos.org/rtos-run-time-stats.html. */
-#define configGENERATE_RUN_TIME_STATS           0
+#define configGENERATE_RUN_TIME_STATS 0
 
 /* Set configUSE_TRACE_FACILITY to include additional task structure members
  * are used by trace and visualisation functions and tools.  Set to 0 to exclude
  * the additional information from the structures. Defaults to 0 if left
  * undefined. */
-#define configUSE_TRACE_FACILITY                0
+#define configUSE_TRACE_FACILITY 0
 
 /* Set to 1 to include the vTaskList() and vTaskGetRunTimeStats() functions in
  * the build.  Set to 0 to exclude these functions from the build.  These two
  * functions introduce a dependency on string formatting functions that would
  * otherwise not exist - hence they are kept separate.  Defaults to 0 if left
  * undefined. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS    0
+#define configUSE_STATS_FORMATTING_FUNCTIONS 0
 
 /******************************************************************************/
 /* Co-routine related definitions. ********************************************/
@@ -387,12 +387,12 @@
  * build, or 0 to omit co-routine functionality from the build. To include
  * co-routines, croutine.c must be included in the project. Defaults to 0 if left
  * undefined. */
-#define configUSE_CO_ROUTINES              0
+#define configUSE_CO_ROUTINES 0
 
 /* configMAX_CO_ROUTINE_PRIORITIES defines the number of priorities available
  * to the application co-routines. Any number of co-routines can share the same
  * priority. Defaults to 0 if left undefined. */
-#define configMAX_CO_ROUTINE_PRIORITIES    1
+#define configMAX_CO_ROUTINE_PRIORITIES 1
 
 /******************************************************************************/
 /* Debugging assistance. ******************************************************/
@@ -406,12 +406,12 @@
  * number of the failing assert (for example, "vAssertCalled( __FILE__, __LINE__ )"
  * or it can simple disable interrupts and sit in a loop to halt all execution
  * on the failing line for viewing in a debugger. */
-#define configASSERT( x )         \
-    if( ( x ) == 0 )              \
+#define configASSERT(x)           \
+    if ((x) == 0)                 \
     {                             \
         taskDISABLE_INTERRUPTS(); \
-        for( ; ; )                \
-        ;                         \
+        for (;;)                  \
+            ;                     \
     }
 
 /******************************************************************************/
@@ -423,47 +423,47 @@
  * See: https://www.freertos.org/a00110.html#configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS
  * Defaults to 0 if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports,
  * not the standard ARMv7-M Cortex-M port. */
-#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS    0
+#define configINCLUDE_APPLICATION_DEFINED_PRIVILEGED_FUNCTIONS 0
 
 /* Set configTOTAL_MPU_REGIONS to the number of MPU regions implemented on your
  * target hardware.  Normally 8 or 16.  Only used by the FreeRTOS Cortex-M MPU
  * ports, not the standard ARMv7-M Cortex-M port.  Defaults to 8 if left
  * undefined. */
-#define configTOTAL_MPU_REGIONS                                   8
+#define configTOTAL_MPU_REGIONS 8
 
 /* configTEX_S_C_B_FLASH allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
  * the MPU region covering Flash.  Defaults to 0x07UL (which means TEX=000, S=1,
  * C=1, B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
  * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_FLASH                                     0x07UL
+#define configTEX_S_C_B_FLASH 0x07UL
 
 /* configTEX_S_C_B_SRAM allows application writers to override the default
  * values for the for TEX, Shareable (S), Cacheable (C) and Bufferable (B) bits for
  * the MPU region covering RAM. Defaults to 0x07UL (which means TEX=000, S=1, C=1,
  * B=1) if left undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not
  * the standard ARMv7-M Cortex-M port. */
-#define configTEX_S_C_B_SRAM                                      0x07UL
+#define configTEX_S_C_B_SRAM 0x07UL
 
 /* Set configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY to 0 to prevent any privilege
  * escalations originating from outside of the kernel code itself.  Set to 1 to
  * allow application tasks to raise privilege.  Defaults to 1 if left undefined.
  * Only used by the FreeRTOS Cortex-M MPU ports, not the standard ARMv7-M Cortex-M
  * port. */
-#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY               1
+#define configENFORCE_SYSTEM_CALLS_FROM_KERNEL_ONLY 1
 
 /* Set configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS to 1 to allow unprivileged
  * tasks enter critical sections (effectively mask interrupts). Set to 0 to
  * prevent unprivileged tasks entering critical sections.  Defaults to 1 if left
  * undefined.  Only used by the FreeRTOS Cortex-M MPU ports, not the standard
  * ARMv7-M Cortex-M port. */
-#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS                0
+#define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS 0
 
 /* FreeRTOS Kernel version 10.6.0 introduced a new v2 MPU wrapper, namely
  * mpu_wrappers_v2.c. Set configUSE_MPU_WRAPPERS_V1 to 0 to use the new v2 MPU
  * wrapper. Set configUSE_MPU_WRAPPERS_V1 to 1 to use the old v1 MPU wrapper
  * (mpu_wrappers.c). Defaults to 0 if left undefined. */
-#define configUSE_MPU_WRAPPERS_V1                                 0
+#define configUSE_MPU_WRAPPERS_V1 0
 
 /* When using the v2 MPU wrapper, set configPROTECTED_KERNEL_OBJECT_POOL_SIZE to
  * the total number of kernel objects, which includes tasks, queues, semaphores,
@@ -471,7 +471,7 @@
  * application. The application will not be able to have more than
  * configPROTECTED_KERNEL_OBJECT_POOL_SIZE kernel objects at any point of
  * time. */
-#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE                   10
+#define configPROTECTED_KERNEL_OBJECT_POOL_SIZE 10
 
 /* When using the v2 MPU wrapper, set configSYSTEM_CALL_STACK_SIZE to the size
  * of the system call stack in words. Each task has a statically allocated
@@ -479,7 +479,7 @@
  * calls. For example, if configSYSTEM_CALL_STACK_SIZE is defined as 128 and
  * there are 10 tasks in the application, the total amount of memory used for
  * system call stacks is 128 * 10 = 1280 words. */
-#define configSYSTEM_CALL_STACK_SIZE                              128
+#define configSYSTEM_CALL_STACK_SIZE 128
 
 /* When using the v2 MPU wrapper, set configENABLE_ACCESS_CONTROL_LIST to 1 to
  * enable Access Control List (ACL) feature. When ACL is enabled, an
@@ -487,7 +487,7 @@
  * than itself. The application writer needs to explicitly grant the
  * unprivileged task access to the kernel objects it needs using the APIs
  * provided for the same. Defaults to 0 if left undefined. */
-#define configENABLE_ACCESS_CONTROL_LIST                          1
+#define configENABLE_ACCESS_CONTROL_LIST 1
 
 /******************************************************************************/
 /* SMP( Symmetric MultiProcessing ) Specific Configuration definitions. *******/
@@ -507,7 +507,7 @@
  * is able to run. If configRUN_MULTIPLE_PRIORITIES is set to 1, multiple tasks
  * with different priorities may run simultaneously - so a higher and lower
  * priority task may run on different cores at the same time. */
-#define configRUN_MULTIPLE_PRIORITIES             0
+#define configRUN_MULTIPLE_PRIORITIES 0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
  * configUSE_CORE_AFFINITY to 1 to enable core affinity feature. When core
@@ -515,7 +515,7 @@
  * APIs can be used to set and retrieve which cores a task can run on. If
  * configUSE_CORE_AFFINITY is set to 0 then the FreeRTOS scheduler is free to
  * run any task on any available core. */
-#define configUSE_CORE_AFFINITY                   0
+#define configUSE_CORE_AFFINITY 0
 
 /* When using SMP with core affinity feature enabled, set
  * configTASK_DEFAULT_CORE_AFFINITY to change the default core affinity mask for
@@ -524,26 +524,25 @@
  * make such tasks run on the current core. This config value is useful, if
  * swapping tasks between cores is not supported (e.g. Tricore) or if legacy code
  * should be controlled. Defaults to tskNO_AFFINITY if left undefined. */
-#define configTASK_DEFAULT_CORE_AFFINITY          tskNO_AFFINITY
+#define configTASK_DEFAULT_CORE_AFFINITY tskNO_AFFINITY
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), if
  * configUSE_TASK_PREEMPTION_DISABLE is set to 1, individual tasks can be set to
  * either pre-emptive or co-operative mode using the vTaskPreemptionDisable and
  * vTaskPreemptionEnable APIs. */
-#define configUSE_TASK_PREEMPTION_DISABLE         0
+#define configUSE_TASK_PREEMPTION_DISABLE 0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
  * configUSE_PASSIVE_IDLE_HOOK to 1 to allow the application writer to use
  * the passive idle task hook to add background functionality without the overhead
  * of a separate task. Defaults to 0 if left undefined. */
-#define configUSE_PASSIVE_IDLE_HOOK               0
+#define configUSE_PASSIVE_IDLE_HOOK 0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one),
  * configTIMER_SERVICE_TASK_CORE_AFFINITY allows the application writer to set
  * the core affinity of the RTOS Daemon/Timer Service task. Defaults to
  * tskNO_AFFINITY if left undefined. */
-#define configTIMER_SERVICE_TASK_CORE_AFFINITY    tskNO_AFFINITY
-
+#define configTIMER_SERVICE_TASK_CORE_AFFINITY tskNO_AFFINITY
 
 /******************************************************************************/
 /* ARMv8-M secure side port related definitions. ******************************/
@@ -551,7 +550,7 @@
 
 /* secureconfigMAX_SECURE_CONTEXTS define the maximum number of tasks that can
  *  call into the secure side of an ARMv8-M chip.  Not used by any other ports. */
-#define secureconfigMAX_SECURE_CONTEXTS        5
+#define secureconfigMAX_SECURE_CONTEXTS 5
 
 /* Defines the kernel provided implementation of
  * vApplicationGetIdleTaskMemory() and vApplicationGetTimerTaskMemory()
@@ -559,7 +558,7 @@
  * The application can provide it's own implementation of
  * vApplicationGetIdleTaskMemory() and vApplicationGetTimerTaskMemory() by
  * setting configKERNEL_PROVIDED_STATIC_MEMORY to 0 or leaving it undefined. */
-#define configKERNEL_PROVIDED_STATIC_MEMORY    1
+#define configKERNEL_PROVIDED_STATIC_MEMORY 1
 
 /******************************************************************************/
 /* ARMv8-M port Specific Configuration definitions. ***************************/
@@ -569,29 +568,29 @@
  * to enable the TrustZone support in FreeRTOS ARMv8-M ports which allows the
  * non-secure FreeRTOS tasks to call the (non-secure callable) functions
  * exported from secure side. */
-#define configENABLE_TRUSTZONE            1
+#define configENABLE_TRUSTZONE 1
 
 /* If the application writer does not want to use TrustZone, but the hardware does
  * not support disabling TrustZone then the entire application (including the FreeRTOS
  * scheduler) can run on the secure side without ever branching to the non-secure side.
  * To do that, in addition to setting configENABLE_TRUSTZONE to 0, also set
  * configRUN_FREERTOS_SECURE_ONLY to 1. */
-#define configRUN_FREERTOS_SECURE_ONLY    1
+#define configRUN_FREERTOS_SECURE_ONLY 1
 
 /* Set configENABLE_MPU to 1 to enable the Memory Protection Unit (MPU), or 0
  * to leave the Memory Protection Unit disabled. */
-#define configENABLE_MPU                  1
+#define configENABLE_MPU 1
 
 /* Set configENABLE_FPU to 1 to enable the Floating Point Unit (FPU), or 0
  * to leave the Floating Point Unit disabled. */
-#define configENABLE_FPU                  1
+#define configENABLE_FPU 1
 
 /* Set configENABLE_MVE to 1 to enable the M-Profile Vector Extension (MVE) support,
  * or 0 to leave the MVE support disabled. This option is only applicable to Cortex-M55
  * and Cortex-M85 ports as M-Profile Vector Extension (MVE) is available only on
  * these architectures. configENABLE_MVE must be left undefined, or defined to 0
  * for the Cortex-M23,Cortex-M33 and Cortex-M35P ports. */
-#define configENABLE_MVE                  1
+#define configENABLE_MVE 1
 
 /******************************************************************************/
 /* ARMv7-M and ARMv8-M port Specific Configuration definitions. ***************/
@@ -609,7 +608,7 @@
  * The applications that use Indirect Routing must set configCHECK_HANDLER_INSTALLATION to 0.
  *
  * Defaults to 1 if left undefined. */
-#define configCHECK_HANDLER_INSTALLATION    1
+#define configCHECK_HANDLER_INSTALLATION 1
 
 /******************************************************************************/
 /* Definitions that include or exclude functionality. *************************/
@@ -617,32 +616,36 @@
 
 /* Set the following configUSE_* constants to 1 to include the named feature in
  * the build, or 0 to exclude the named feature from the build. */
-#define configUSE_TASK_NOTIFICATIONS           1
-#define configUSE_MUTEXES                      1
-#define configUSE_RECURSIVE_MUTEXES            1
-#define configUSE_COUNTING_SEMAPHORES          1
-#define configUSE_QUEUE_SETS                   0
-#define configUSE_APPLICATION_TASK_TAG         0
+#define configUSE_TASK_NOTIFICATIONS 1
+#define configUSE_MUTEXES 1
+#define configUSE_RECURSIVE_MUTEXES 1
+#define configUSE_COUNTING_SEMAPHORES 1
+#define configUSE_QUEUE_SETS 0
+#define configUSE_APPLICATION_TASK_TAG 0
+
+/* USE_POSIX_ERRNO enables the task global FreeRTOS_errno variable which will
+ * containthe most recent error for that task. */
+#define configUSE_POSIX_ERRNO 0
 
 /* Set the following INCLUDE_* constants to 1 to incldue the named API function,
  * or 0 to exclude the named API function.  Most linkers will remove unused
  * functions even when the constant is 1. */
-#define INCLUDE_vTaskPrioritySet               1
-#define INCLUDE_uxTaskPriorityGet              1
-#define INCLUDE_vTaskDelete                    1
-#define INCLUDE_vTaskSuspend                   1
-#define INCLUDE_xResumeFromISR                 1
-#define INCLUDE_vTaskDelayUntil                1
-#define INCLUDE_vTaskDelay                     1
-#define INCLUDE_xTaskGetSchedulerState         1
-#define INCLUDE_xTaskGetCurrentTaskHandle      1
-#define INCLUDE_uxTaskGetStackHighWaterMark    0
-#define INCLUDE_xTaskGetIdleTaskHandle         0
-#define INCLUDE_eTaskGetState                  0
-#define INCLUDE_xEventGroupSetBitFromISR       1
-#define INCLUDE_xTimerPendFunctionCall         0
-#define INCLUDE_xTaskAbortDelay                0
-#define INCLUDE_xTaskGetHandle                 0
-#define INCLUDE_xTaskResumeFromISR             1
+#define INCLUDE_vTaskPrioritySet 1
+#define INCLUDE_uxTaskPriorityGet 1
+#define INCLUDE_vTaskDelete 1
+#define INCLUDE_vTaskSuspend 1
+#define INCLUDE_xResumeFromISR 1
+#define INCLUDE_vTaskDelayUntil 1
+#define INCLUDE_vTaskDelay 1
+#define INCLUDE_xTaskGetSchedulerState 1
+#define INCLUDE_xTaskGetCurrentTaskHandle 1
+#define INCLUDE_uxTaskGetStackHighWaterMark 0
+#define INCLUDE_xTaskGetIdleTaskHandle 0
+#define INCLUDE_eTaskGetState 0
+#define INCLUDE_xEventGroupSetBitFromISR 1
+#define INCLUDE_xTimerPendFunctionCall 0
+#define INCLUDE_xTaskAbortDelay 0
+#define INCLUDE_xTaskGetHandle 0
+#define INCLUDE_xTaskResumeFromISR 1
 
 #endif /* FREERTOS_CONFIG_H */


### PR DESCRIPTION
configUSE_POSIX_ERRNO was missing so now it is added.

.clang-format reformatted the file somewhat.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
