### PR TITLE
Revert the change introduced in PR #1051

### DIFF
--- a/list.c
+++ b/list.c
@@ -184,14 +184,7 @@ void vListInsert( List_t * const pxList,
         *   4) Using a queue or semaphore before it has been initialised or
         *      before the scheduler has been started (are interrupts firing
         *      before vTaskStartScheduler() has been called?).
-        *   5) Attempting to 'take' binary semaphores created using
-        *      `xSemaphoreCreateBinary()` or `xSemaphoreCreateBinaryStatic()`
-        *      APIs, before 'giving' them. Binary semaphores created using
-        *      `xSemaphoreCreateBinary()` or `xSemaphoreCreateBinaryStatic()`,
-        *      are created in a state such that the semaphore must first be
-        *      'given' using xSemaphoreGive() API before it can be 'taken' using
-        *      xSemaphoreTake() API.
-        *   6) If the FreeRTOS port supports interrupt nesting then ensure that
+        *   5) If the FreeRTOS port supports interrupt nesting then ensure that
         *      the priority of the tick interrupt is at or below
         *      configMAX_SYSCALL_INTERRUPT_PRIORITY.
         **********************************************************************/


### PR DESCRIPTION
Description
-----------
As pointed out by Jeff Tenney, the comment introduced in the PR is not accurate.

Test Steps
-----------
I verified using the following code snippet:

```c
void Task( void * param )
{
    SemaphoreHandle_t xBinarySem;

    ( void ) param;

    xBinarySem = xSemaphoreCreateBinary();

    xSemaphoreTake( xBinarySem, portMAX_DELAY );

    for( ;; )
    {
        HAL_GPIO_TogglePin( LD1_GPIO_Port, LD1_Pin );
        vTaskDelay( pdMS_TO_TICKS( 1000 ) );
    }
}

void app_main( void )
{
    xTaskCreate( Task,
                 "Task",
                 configMINIMAL_STACK_SIZE,
                 NULL,
                 tskIDLE_PRIORITY | portPRIVILEGE_BIT,
                 NULL );

    vTaskStartScheduler();

    for( ;; );
}
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [NA] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
