### PR TITLE
Add Noreturn attribute in template port for static analysis

### DIFF
--- a/examples/cmake_example/main.c
+++ b/examples/cmake_example/main.c
@@ -49,7 +49,7 @@ static void exampleTask( void * parameters );
 
 /*-----------------------------------------------------------*/
 
-static void exampleTask( void * parameters )
+static _Noreturn void exampleTask( void * parameters )
 {
     /* Unused parameters. */
     ( void ) parameters;
@@ -62,7 +62,7 @@ static void exampleTask( void * parameters )
 }
 /*-----------------------------------------------------------*/
 
-void main( void )
+int main( void )
 {
     static StaticTask_t exampleTaskTCB;
     static StackType_t exampleTaskStack[ configMINIMAL_STACK_SIZE ];
@@ -84,6 +84,8 @@ void main( void )
     {
         /* Should not reach here. */
     }
+
+    return 0;
 }
 /*-----------------------------------------------------------*/
 

--- a/examples/cmake_example/main.c
+++ b/examples/cmake_example/main.c
@@ -45,11 +45,11 @@
 
 /*-----------------------------------------------------------*/
 
-static _Noreturn void exampleTask( void * parameters );
+static void exampleTask( void * parameters ) __attribute__( ( noreturn ) );
 
 /*-----------------------------------------------------------*/
 
-static _Noreturn void exampleTask( void * parameters )
+static void exampleTask( void * parameters )
 {
     /* Unused parameters. */
     ( void ) parameters;

--- a/examples/cmake_example/main.c
+++ b/examples/cmake_example/main.c
@@ -45,7 +45,7 @@
 
 /*-----------------------------------------------------------*/
 
-static void exampleTask( void * parameters );
+static _Noreturn void exampleTask( void * parameters );
 
 /*-----------------------------------------------------------*/
 

--- a/portable/template/portmacro.h
+++ b/portable/template/portmacro.h
@@ -105,7 +105,7 @@ extern void vPortYield( void );
 #define portYIELD()                                           vPortYield()
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    __attribute__( ( noreturn ) ) void vFunction( void * pvParameters )
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
 #if ( configNUMBER_OF_CORES > 1 )

--- a/portable/template/portmacro.h
+++ b/portable/template/portmacro.h
@@ -105,7 +105,7 @@ extern void vPortYield( void );
 #define portYIELD()                                           vPortYield()
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */
-#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    __attribute__( ( noreturn ) ) void vFunction( void * pvParameters )
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters ) __attribute__( ( noreturn ) )
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 
 #if ( configNUMBER_OF_CORES > 1 )


### PR DESCRIPTION
Description
-----------
This PR adds the `_Noreturn` attribute in the coverity example configuration where a function is used that does not return.

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[1057](https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1057)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
