### PR TITLE
Add traceQUEUE_SEND{_FROM_ISR,}_EXT and traceQUEUE_RESET hooks.

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -769,6 +769,12 @@
     #define traceQUEUE_SEND( pxQueue )
 #endif
 
+/* Extended version of traceQUEUE_SEND that also reports the copy position
+ * of the sent data. */
+#ifndef traceQUEUE_SEND_EXT
+    #define traceQUEUE_SEND_EXT( pxQueue, xCopyPosition )    traceQUEUE_SEND( pxQueue )
+#endif
+
 #ifndef traceQUEUE_SEND_FAILED
     #define traceQUEUE_SEND_FAILED( pxQueue )
 #endif
@@ -797,6 +803,12 @@
     #define traceQUEUE_SEND_FROM_ISR( pxQueue )
 #endif
 
+/* Extended version of traceQUEUE_SEND_FROM_ISR that also reports the copy 
+ * position of the sent data. */
+#ifndef traceQUEUE_SEND_FROM_ISR_EXT
+     #define traceQUEUE_SEND_FROM_ISR_EXT( pxQueue, xCopyPosition )    traceQUEUE_SEND_FROM_ISR( pxQueue )
+#endif
+
 #ifndef traceQUEUE_SEND_FROM_ISR_FAILED
     #define traceQUEUE_SEND_FROM_ISR_FAILED( pxQueue )
 #endif
@@ -811,6 +823,10 @@
 
 #ifndef traceQUEUE_PEEK_FROM_ISR_FAILED
     #define traceQUEUE_PEEK_FROM_ISR_FAILED( pxQueue )
+#endif
+
+#ifndef traceQUEUE_RESET
+    #define traceQUEUE_RESET( pxQueue, xNewQueue )
 #endif
 
 #ifndef traceQUEUE_DELETE

--- a/queue.c
+++ b/queue.c
@@ -315,6 +315,8 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         /* Check for multiplication overflow. */
         ( ( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
     {
+        traceQUEUE_RESET( pxQueue, xNewQueue );
+
         taskENTER_CRITICAL();
         {
             pxQueue->u.xQueue.pcTail = pxQueue->pcHead + ( pxQueue->uxLength * pxQueue->uxItemSize );
@@ -966,7 +968,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
              * queue is full. */
             if( ( pxQueue->uxMessagesWaiting < pxQueue->uxLength ) || ( xCopyPosition == queueOVERWRITE ) )
             {
-                traceQUEUE_SEND( pxQueue );
+                traceQUEUE_SEND_EXT( pxQueue, xCopyPosition );
 
                 #if ( configUSE_QUEUE_SETS == 1 )
                 {
@@ -1200,7 +1202,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
             const int8_t cTxLock = pxQueue->cTxLock;
             const UBaseType_t uxPreviousMessagesWaiting = pxQueue->uxMessagesWaiting;
 
-            traceQUEUE_SEND_FROM_ISR( pxQueue );
+            traceQUEUE_SEND_FROM_ISR_EXT( pxQueue, xCopyPosition );
 
             /* Semaphores use xQueueGiveFromISR(), so pxQueue will not be a
              *  semaphore or mutex.  That means prvCopyDataToQueue() cannot result
@@ -1382,7 +1384,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
         {
             const int8_t cTxLock = pxQueue->cTxLock;
 
-            traceQUEUE_SEND_FROM_ISR( pxQueue );
+            traceQUEUE_SEND_FROM_ISR_EXT( pxQueue, queueSEND_TO_BACK );
 
             /* A task can only have an inherited priority if it is a mutex
              * holder - and if there is a mutex holder then the mutex cannot be


### PR DESCRIPTION


<!--- Title -->

Description
-----------
The current hooks were not effective at allowing a tracer to track the number of items in a queue, since it could not differentiate between a queueOVERWRITE, queueSEND_TO_BACK, and queueSEND_TO_FRONT send, and could not (efficiently) trace a queue reset.

For sends, this adds extended tracing macros that, if not implemented, fall back on the original tracing macros for backwards compatibility, and introduces a new traceQUEUE_RESET hook.

Discussed here: https://forums.freertos.org/t/queue-tracing/20054/4

Test Steps
-----------
No unit test regressions. My work-in-progress tracer can access the required information. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

I am not aware of any tracing test infrastructure, but would be happy to update it if it is pointed out to me.

Similarly if there is any documentation that I can work on updating, please let me know and I am happy to do so.

Related Issue
-----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
