### PR TITLE
Fix for mismatched op-types on line 3937 on tasks.c - Issue 1066

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -52,6 +52,15 @@ _Ref 8.6.1_
    definitions or no definition. FreeRTOS hook functions are implemented in
    the application and therefore, have no definition in the Kernel code.
 
+#### Rule 10.4
+
+MISRA C:2012 Rule 10.4
+
+Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category
+
+_Ref 10.4.1_
+ - This is a basic comparison of positive values only. 
+
 #### Rule 11.1
 MISRA C:2012 Rule 11.1: Conversions shall not be performed between a pointer to
 function and any other type.

--- a/tasks.c
+++ b/tasks.c
@@ -3935,6 +3935,9 @@ void vTaskSuspendAll( void )
              * processed. */
             xReturn = 0;
         }
+        /* MISRA Ref 10.4.1 [Mismatched Operand Types] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-104 */
+        /* codesonar[misra_c_2012_rule_10_4_violation] */
         else if( uxHigherPriorityReadyTasks != pdFALSE )
         {
             /* There are tasks in the Ready state that have a priority above the


### PR DESCRIPTION
Fix for MISRA C 2012 Rule 10.4 violation: Mismatched operand types, see description in #1066 

Description
-----------
No code changes, added a deviation in MISRA.md and comments into tasks.c

Test Steps
-----------
No code changes

Checklist:
----------
- I did not re-run tests as there are no code changes

Related Issue
-----------
- #1066 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
