### PR TITLE
typo: add space to examples/template_configuration/FreeRTOSConfig.h

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -640,7 +640,7 @@
 #define configUSE_APPLICATION_TASK_TAG         0
 
 /* USE_POSIX_ERRNO enables the task global FreeRTOS_errno variable which will
- * containthe most recent error for that task. */
+ * contain the most recent error for that task. */
 #define configUSE_POSIX_ERRNO                  0
 
 /* Set the following INCLUDE_* constants to 1 to incldue the named API function,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Just a minimal typo in comments. A space char added between words.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
