### PR TITLE
Change UBaseType_t to BaseType_t for a boolean variable

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3895,9 +3895,9 @@ void vTaskSuspendAll( void )
     static TickType_t prvGetExpectedIdleTime( void )
     {
         TickType_t xReturn;
-        UBaseType_t uxHigherPriorityReadyTasks = pdFALSE;
+        BaseType_t xHigherPriorityReadyTasks = pdFALSE;
 
-        /* uxHigherPriorityReadyTasks takes care of the case where
+        /* xHigherPriorityReadyTasks takes care of the case where
          * configUSE_PREEMPTION is 0, so there may be tasks above the idle priority
          * task that are in the Ready state, even though the idle task is
          * running. */
@@ -3905,7 +3905,7 @@ void vTaskSuspendAll( void )
         {
             if( uxTopReadyPriority > tskIDLE_PRIORITY )
             {
-                uxHigherPriorityReadyTasks = pdTRUE;
+                xHigherPriorityReadyTasks = pdTRUE;
             }
         }
         #else
@@ -3919,7 +3919,7 @@ void vTaskSuspendAll( void )
              * care of the case where the co-operative scheduler is in use. */
             if( uxTopReadyPriority > uxLeastSignificantBit )
             {
-                uxHigherPriorityReadyTasks = pdTRUE;
+                xHigherPriorityReadyTasks = pdTRUE;
             }
         }
         #endif /* if ( configUSE_PORT_OPTIMISED_TASK_SELECTION == 0 ) */
@@ -3935,7 +3935,7 @@ void vTaskSuspendAll( void )
              * processed. */
             xReturn = 0;
         }
-        else if( uxHigherPriorityReadyTasks != pdFALSE )
+        else if( xHigherPriorityReadyTasks != pdFALSE )
         {
             /* There are tasks in the Ready state that have a priority above the
              * idle priority.  This path can only be reached if


### PR DESCRIPTION
Description
-----------
MISRA-C 2012 rule 10.4 states that : _Both operands of an operator in which the usual arithmetic conversions are performed shall have the same _essential type category__.

In tasks.c , Line 3937
`else if( uxHigherPriorityReadyTasks != pdFALSE )`

Where `uxHigherPriorityReadyTasks` is an unsigned char and `pdFALSE` is a signed char, thereby violating the rule.

This PR addresses this issue by making the variable `xHigherPriorityReadyTasks` a signed char.

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1066 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
