### PR TITLE
Add missing Extern "C" to MSVC portmacro.h

### DIFF
--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -40,6 +40,10 @@
 #include <mmsystem.h>
 #include <winbase.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /******************************************************************************
 *   Defines
 ******************************************************************************/
@@ -214,5 +218,9 @@ void vPortGenerateSimulatedInterruptFromWindowsThread( uint32_t ulInterruptNumbe
  */
 void vPortSetInterruptHandler( uint32_t ulInterruptNumber,
                                uint32_t ( * pvHandler )( void ) );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ifndef PORTMACRO_H */


### PR DESCRIPTION
Add missing `Extern "C"` to MSVC portmacro.h as a fix for issue #1064

Description
-----------
It appears that in merge request https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1047 The C++ block was reduced to not include the transitive header includes. This makes sense but revealed the lack of the `extern "C"` guard in the MSVC-MingW/portmacro.h header.

Test Steps
-----------
 compile a project for the MSVC-MingW simulator and there will be undefined references.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
introduced in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1047


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
