### PR TITLE
Fix compilation warning about undelcared pthread_setname_np

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -49,12 +49,10 @@
 * only or serialized with a FreeRTOS primitive such as a binary
 * semaphore or mutex.
 *----------------------------------------------------------*/
-#include "portmacro.h"
-
 #ifdef __linux__
-    #define __USE_GNU
+    #define _GNU_SOURCE
 #endif
-
+#include "portmacro.h"
 #include <errno.h>
 #include <pthread.h>
 #include <limits.h>

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -61,9 +61,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <sys/times.h>
-#ifndef __APPLE__
-    #include <sys/prctl.h>
-#endif
+#include <sys/prctl.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -51,6 +51,9 @@
 *----------------------------------------------------------*/
 #include "portmacro.h"
 
+#ifdef __linux__
+    #define __USE_GNU
+#endif
 
 #include <errno.h>
 #include <pthread.h>
@@ -61,7 +64,6 @@
 #include <string.h>
 #include <sys/time.h>
 #include <sys/times.h>
-#include <sys/prctl.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -139,7 +141,7 @@ static void prvPortSetCurrentThreadName(char * pxThreadName)
 #ifdef __APPLE__
     pthread_setname_np(pxThreadName);
 #else
-    prctl( PR_SET_NAME, pxThreadName );
+    pthread_setname_np(pthread_self(), pxThreadName);
 #endif
 }
 /*-----------------------------------------------------------*/

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -51,9 +51,6 @@
 *----------------------------------------------------------*/
 #include "portmacro.h"
 
-#ifdef __linux__
-    #define __USE_GNU
-#endif
 
 #include <errno.h>
 #include <pthread.h>
@@ -64,6 +61,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <sys/times.h>
+#include <sys/prctl.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -141,7 +139,7 @@ static void prvPortSetCurrentThreadName(char * pxThreadName)
 #ifdef __APPLE__
     pthread_setname_np(pxThreadName);
 #else
-    pthread_setname_np(pthread_self(), pxThreadName);
+    prctl( PR_SET_NAME, pxThreadName );
 #endif
 }
 /*-----------------------------------------------------------*/

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -61,7 +61,9 @@
 #include <string.h>
 #include <sys/time.h>
 #include <sys/times.h>
-#include <sys/prctl.h>
+#ifndef __APPLE__
+    #include <sys/prctl.h>
+#endif
 #include <time.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Description
-----------
Use `_GNU_SOURCE` macro instead of `__USE_GNU` and define it before including portmacro.h. The reason is that portmacro.h includes limits.h which in-turn includes features.h - this results in `__USE_GNU` getting incorrectly undefined. 

Test Steps
-----------
1. use glibc2.24 and gcc 6.3.0 build sucess
2. use glibc2.35 and gcc 11.3.0 build sucess

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1077 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
