### PR TITLE
Clarify documentation of xTaskNumber in TaskStatus_t.

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -161,7 +161,7 @@ typedef struct xTASK_STATUS
 {
     TaskHandle_t xHandle;                         /* The handle of the task to which the rest of the information in the structure relates. */
     const char * pcTaskName;                      /* A pointer to the task's name.  This value will be invalid if the task was deleted since the structure was populated! */
-    UBaseType_t xTaskNumber;                      /* A number unique to the task. */
+    UBaseType_t xTaskNumber;                      /* A number unique to the task. Note that this is not the task number that may be modified using vTaskSetTaskNumber() and uxTaskGetTaskNumber(), but a separate TCB-specific and unique identifier automatically assigned on task generation. */
     eTaskState eCurrentState;                     /* The state in which the task existed when the structure was populated. */
     UBaseType_t uxCurrentPriority;                /* The priority at which the task was running (may be inherited) when the structure was populated. */
     UBaseType_t uxBasePriority;                   /* The priority to which the task will return if the task's current priority has been inherited to avoid unbounded priority inversion when obtaining a mutex.  Only valid if configUSE_MUTEXES is defined as 1 in FreeRTOSConfig.h. */


### PR DESCRIPTION


<!--- Title -->

Description
-----------

Discussed here: https://forums.freertos.org/t/tracing-improvements/20097

Adds a note to the (confusingly named) xTaskNumber member of TaskStatus_t explaining that the value is different to the TaskNumber that can be accessed using the vTaskSetTaskNumber and vTaskGetTaskNumber functions.

The value returned is actually the value of uxTCBNumber in the TCB.

Note that documentation on the website should also be updated (https://www.freertos.org/vTaskGetInfo.html#TaskStatus_t). Is this done automatically based on code comments or does this need to be done manually?

Thanks!

<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
N/A

Related Issue
-----------
<!-- If any, please provide issue ID. -->
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
