### PR TITLE
Add traceSTARTING_SCHEDULER tracing hook.

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -624,7 +624,7 @@
 #ifndef traceSTARTING_SCHEDULER
 
 /* Called after all idle tasks and timer task (if enabled) have been created
- * succesfully, just before the scheduler is started. */
+ * successfully, just before the scheduler is started. */
     #define traceSTARTING_SCHEDULER( xIdleTaskHandles )
 #endif
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -621,6 +621,13 @@
     #define traceTASK_SWITCHED_IN()
 #endif
 
+#ifndef traceSTARTING_SCHEDULER
+
+/* Called after all idle tasks and timer task (if enabled) have been created
+ * succesfully, just before the scheduler is started. */
+    #define traceSTARTING_SCHEDULER( xIdleTaskHandles )
+#endif
+
 #ifndef traceINCREASE_TICK_COUNT
 
 /* Called before stepping the tick count after waking from tickless idle

--- a/tasks.c
+++ b/tasks.c
@@ -3732,10 +3732,10 @@ void vTaskStartScheduler( void )
 
         traceTASK_SWITCHED_IN();
 
+        traceSTARTING_SCHEDULER( xIdleTaskHandles );
+
         /* Setting up the timer tick is hardware specific and thus in the
          * portable interface. */
-
-        traceSTARTING_SCHEDULER( xIdleTaskHandles );
 
         /* The return value for xPortStartScheduler is not required
          * hence using a void datatype. */

--- a/tasks.c
+++ b/tasks.c
@@ -3735,6 +3735,8 @@ void vTaskStartScheduler( void )
         /* Setting up the timer tick is hardware specific and thus in the
          * portable interface. */
 
+        traceSTARTING_SCHEDULER( xIdleTaskHandles );
+
         /* The return value for xPortStartScheduler is not required
          * hence using a void datatype. */
         ( void ) xPortStartScheduler();


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Discussed here: https://forums.freertos.org/t/tracing-improvements/20097

This hook enables tracers to run code on startup after all RTOS resources are created and to detect that the scheduler is starting without relying on traceENTER/traceEXIT macros.

It also provides tracers access to the task handle of all IDLE tasks, allowing them to be identified unambiguously and without relying on INCLUDE_xTaskGetIdleTaskHandle.

Notes: 
I  had another think about the above discussion regarding a `traceTASK_IS_IDLE_TASK` and `traceTASK_IS_TIMER_TASK` hook. I agree that they are probably very specific and maybe not the best solution. Instead I propose a `traceSTARTING_SCHEDULER` hook that is called just before `xPortStartScheduler` and exposes the idle task TCBs.

This is probably a much more generic solution. It allows tracers to cleanly detect that the scheduler has started, and gives them an opportunity to inject code after the idle and timer tasks have been created. This allows a tracer to, if they wish, identify those tasks unambiguously.

I opted to expose `xIdleTaskHandles` as a macro parameter so the tracer does not have rely on "unhygienically" accessing this static variable or on `INCLUDE_xTaskGetIdleTaskHandle` being enabled.

I am happy for feedback here if you think this is appropriate.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
The CMOCK test suite in https://github.com/FreeRTOS/FreeRTOS continues to pass with no regressions, after the fallback tracing hook has also been added to the duplicate FreeRTOS.h header file in that repo used during mock code generation:

```diff
diff --git a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
index bd7b65c10..1e6b6a72f 100644
--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
@@ -565,6 +565,13 @@
     #define traceTASK_SWITCHED_IN()
 #endif
 
+#ifndef traceSTARTING_SCHEDULER
+
+/* Called after all idle tasks and timer task (if enabled) have been created
+ * sucesfully, just before the scheduler is started. */
+    #define traceSTARTING_SCHEDULER( xIdleTaskHandles )
+#endif
+
 #ifndef traceINCREASE_TICK_COUNT
 
 /* Called before stepping the tick count after waking from tickless idle

```

Please let me know how, if you are looking at merging, how I should go about updating this?

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
