### PR TITLE
Give queue set queues a unique type number.

### DIFF
--- a/include/queue.h
+++ b/include/queue.h
@@ -71,11 +71,11 @@ typedef struct QueueDefinition   * QueueSetMemberHandle_t;
 
 /* For internal use only.  These definitions *must* match those in queue.c. */
 #define queueQUEUE_TYPE_BASE                  ( ( uint8_t ) 0U )
-#define queueQUEUE_TYPE_SET                   ( ( uint8_t ) 0U )
 #define queueQUEUE_TYPE_MUTEX                 ( ( uint8_t ) 1U )
 #define queueQUEUE_TYPE_COUNTING_SEMAPHORE    ( ( uint8_t ) 2U )
 #define queueQUEUE_TYPE_BINARY_SEMAPHORE      ( ( uint8_t ) 3U )
 #define queueQUEUE_TYPE_RECURSIVE_MUTEX       ( ( uint8_t ) 4U )
+#define queueQUEUE_TYPE_SET                   ( ( uint8_t ) 5U )
 
 /**
  * queue. h


### PR DESCRIPTION


<!--- Title -->

Description
-----------
Discussed here: https://forums.freertos.org/t/tracing-improvements/20097

Changes the value of queueQUEUE_TYPE_SET to a unique value (5) to allow tracers to differentiate between normal queues and queue sets.

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
