### PR TITLE
event_create(): check malloc() to be non-NULL

### DIFF
--- a/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
+++ b/portable/ThirdParty/GCC/Posix/utils/wait_for_event.c
@@ -43,9 +43,12 @@ struct event * event_create( void )
 {
     struct event * ev = malloc( sizeof( struct event ) );
 
-    ev->event_triggered = false;
-    pthread_mutex_init( &ev->mutex, NULL );
-    pthread_cond_init( &ev->cond, NULL );
+    if( ev )
+    {
+        ev->event_triggered = false;
+        pthread_mutex_init( &ev->mutex, NULL );
+        pthread_cond_init( &ev->cond, NULL );
+    }
     return ev;
 }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------

Check malloc() to return non-NULL before writing data in the function event_create().


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
