### PR TITLE
Hygenic tracing hooks

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1017,6 +1017,25 @@
     #define traceTASK_NOTIFY_WAIT( uxIndexToWait )
 #endif
 
+#ifndef traceTASK_NOTIFY_WAIT_EXT
+
+/* Extended version of traceTASK_NOTIFY_WAIT that also exposes value of
+ * ulBitsToClearOnExit, informing the tracer of the state of this task
+ * notification after it has been taken. Note that this hook, unlike
+ * traceTASK_NOTIFY_WAIT, is only called if the notification was successfully
+ * taken. */
+    #define traceTASK_NOTIFY_WAIT_EXT( uxIndexToWait, ulBitsToClearOnExit )    traceTASK_NOTIFY_WAIT( uxIndexToWait )
+#endif
+
+#ifndef traceTASK_NOTIFY_WAIT_FAILED
+
+/* Task notification wait failed. For backwards-compatability, this macro falls
+ * back on traceTASK_NOTIFY_WAIT which was always called, no matter if
+ * successfull or not. */
+    #define traceTASK_NOTIFY_WAIT_FAILED( uxIndexToWait )    traceTASK_NOTIFY_WAIT( uxIndexToWait )
+#endif
+
+
 #ifndef traceTASK_NOTIFY
     #define traceTASK_NOTIFY( uxIndexToNotify )
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -813,6 +813,14 @@
     #define traceQUEUE_PEEK_FROM_ISR_FAILED( pxQueue )
 #endif
 
+#ifndef traceQUEUE_RESET
+    #define traceQUEUE_RESET( pxQueue, xNewQueue )
+#endif
+
+#ifndef traceQUEUE_RESET_FAILED
+    #define traceQUEUE_RESET_FAILED( pxQueue, xNewQueue )
+#endif
+
 #ifndef traceQUEUE_DELETE
     #define traceQUEUE_DELETE( pxQueue )
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -769,8 +769,22 @@
     #define traceQUEUE_SEND( pxQueue )
 #endif
 
+#ifndef traceQUEUE_SEND_EXT
+
+/* Extended version of traceQUEUE_SEND that also reports the copy position
+ * of the sent data. */
+    #define traceQUEUE_SEND_EXT( pxQueue, xCopyPosition )    traceQUEUE_SEND( pxQueue )
+#endif
+
 #ifndef traceQUEUE_SEND_FAILED
     #define traceQUEUE_SEND_FAILED( pxQueue )
+#endif
+
+#ifndef traceQUEUE_SEND_FAILED_EXT
+
+/* Extended version of traceQUEUE_SEND_FAILED that also reports the requested
+ * copy position of the sent data. */
+    #define traceQUEUE_SEND_FAILED_EXT( pxQueue, xCopyPosition )    traceQUEUE_SEND_FAILED( pxQueue )
 #endif
 
 #ifndef traceQUEUE_RECEIVE
@@ -797,8 +811,22 @@
     #define traceQUEUE_SEND_FROM_ISR( pxQueue )
 #endif
 
+#ifndef traceQUEUE_SEND_FROM_ISR_EXT
+
+/* Extended version of traceQUEUE_SEND_FROM_ISR that also reports the copy
+ * position of the sent data. */
+    #define traceQUEUE_SEND_FROM_ISR_EXT( pxQueue, xCopyPosition )    traceQUEUE_SEND_FROM_ISR( pxQueue )
+#endif
+
 #ifndef traceQUEUE_SEND_FROM_ISR_FAILED
     #define traceQUEUE_SEND_FROM_ISR_FAILED( pxQueue )
+#endif
+
+#ifndef traceQUEUE_SEND_FROM_ISR_FAILED_EXT
+
+/* Extended version of traceQUEUE_SEND_FROM_ISR_FAILED that also reports the requested
+ * copy position of the sent data. */
+    #define traceQUEUE_SEND_FROM_ISR_FAILED_EXT( pxQueue, xCopyPosition )    traceQUEUE_SEND_FROM_ISR_FAILED( pxQueue )
 #endif
 
 #ifndef traceQUEUE_RECEIVE_FROM_ISR

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1145,6 +1145,18 @@
     #define traceSTREAM_BUFFER_RECEIVE_FROM_ISR( xStreamBuffer, xReceivedLength )
 #endif
 
+#ifndef traceSTREAM_BUFFER_SET_TRIGGER_LEVEL
+    #define traceSTREAM_BUFFER_SET_TRIGGER_LEVEL( xStreamBuffer, xTriggerLevel )
+#endif
+
+#ifndef traceSTREAM_BUFFER_SET_TRIGGER_LEVEL_FAILED
+    #define traceSTREAM_BUFFER_SET_TRIGGER_LEVEL_FAILED( xStreamBuffer )
+#endif
+
+#ifndef traceSTREAM_BUFFER_SET_NOTIFICATION_INDEX
+    #define traceSTREAM_BUFFER_SET_NOTIFICATION_INDEX( xStreamBuffer, uxNotificationIndex )
+#endif
+
 #ifndef traceENTER_xEventGroupCreateStatic
     #define traceENTER_xEventGroupCreateStatic( pxEventGroupBuffer )
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -873,11 +873,18 @@
 #endif
 
 #ifndef traceTASK_DELAY_UNTIL
-    #define traceTASK_DELAY_UNTIL( x )
+    #define traceTASK_DELAY_UNTIL( xTimeToWake )
 #endif
 
 #ifndef traceTASK_DELAY
     #define traceTASK_DELAY()
+#endif
+
+#ifndef traceTASK_DELAY_EXT
+
+/* Extended version of traceTASK_DELAY that also exposes the number of ticks
+ * to delay for. */
+    #define traceTASK_DELAY_EXT( xTicksToDelay )    traceTASK_DELAY()
 #endif
 
 #ifndef traceTASK_PRIORITY_SET

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -757,6 +757,13 @@
     #define traceCREATE_COUNTING_SEMAPHORE()
 #endif
 
+#ifndef traceCREATE_COUNTING_SEMAPHORE_EXT
+
+/* Extended version of traceCREATE_COUNTING_SEMAPHORE that also exposes the queue
+ * handle after the initial count has been set */
+    #define traceCREATE_COUNTING_SEMAPHORE_EXT( xHandle )    traceCREATE_COUNTING_SEMAPHORE()
+#endif
+
 #ifndef traceCREATE_COUNTING_SEMAPHORE_FAILED
     #define traceCREATE_COUNTING_SEMAPHORE_FAILED()
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -992,6 +992,23 @@
     #define traceTASK_NOTIFY_TAKE( uxIndexToWait )
 #endif
 
+#ifndef traceTASK_NOTIFY_TAKE_EXT
+
+/* Extended version of traceTASK_NOTIFY_TAKE that also exposes value of
+ * xClearCountOnExit, informing the tracer of the state of this task
+ * notification after it has been taken. Note that this hook, unlike traceTASK_NOTIFY_TAKE,
+ * is only called if the notification was successfully taken. */
+    #define traceTASK_NOTIFY_TAKE_EXT( uxIndexToWait, xClearCountOnExit )    traceTASK_NOTIFY_TAKE( uxIndexToWait )
+#endif
+
+#ifndef traceTASK_NOTIFY_TAKE_FAILED
+
+/* Task notification take failed. For backwards-compatability, this macro falls
+ * back on traceTASK_NOTIFY_TAKE which was always called, no matter if
+ * successfull or not. */
+    #define traceTASK_NOTIFY_TAKE_FAILED( uxIndexToWait )    traceTASK_NOTIFY_TAKE( uxIndexToWait )
+#endif
+
 #ifndef traceTASK_NOTIFY_WAIT_BLOCK
     #define traceTASK_NOTIFY_WAIT_BLOCK( uxIndexToWait )
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1029,6 +1029,14 @@
     #define traceTASK_NOTIFY_GIVE_FROM_ISR( uxIndexToNotify )
 #endif
 
+#ifndef traceTASK_NOTIFY_STATE_CLEAR
+    #define traceTASK_NOTIFY_STATE_CLEAR( pxTCB, uxIndexToNotify )
+#endif
+
+#ifndef traceTASK_NOTIFY_VALUE_CLEAR
+    #define traceTASK_NOTIFY_VALUE_CLEAR( pxTCB, uxIndexToNotify, ulBitsToClear )
+#endif
+
 #ifndef traceISR_EXIT_TO_SCHEDULER
     #define traceISR_EXIT_TO_SCHEDULER()
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1021,12 +1021,33 @@
     #define traceTASK_NOTIFY( uxIndexToNotify )
 #endif
 
+#ifndef traceTASK_NOTIFY_EXT
+
+/* Extended version of traceTASK_NOTIFY that also exposes the task being
+ * notified, and if/how the notification value was modified. */
+    #define traceTASK_NOTIFY_EXT( pxTCB, uxIndexToNotify, eAction, xReturn )    traceTASK_NOTIFY( uxIndexToNotify )
+#endif
+
 #ifndef traceTASK_NOTIFY_FROM_ISR
     #define traceTASK_NOTIFY_FROM_ISR( uxIndexToNotify )
 #endif
 
+#ifndef traceTASK_NOTIFY_FROM_ISR_EXT
+
+/* Extended version of traceTASK_NOTIFY_FROM_ISR that also exposes the task
+ * being notified, and if/how the notification value was modified. */
+    #define traceTASK_NOTIFY_FROM_ISR_EXT( pxTCB, uxIndexToNotify, eAction, xReturn )    traceTASK_NOTIFY_FROM_ISR( uxIndexToNotify )
+#endif
+
 #ifndef traceTASK_NOTIFY_GIVE_FROM_ISR
     #define traceTASK_NOTIFY_GIVE_FROM_ISR( uxIndexToNotify )
+#endif
+
+#ifndef traceTASK_NOTIFY_GIVE_FROM_ISR_EXT
+
+/* Extended version of traceTASK_NOTIFY_GIVE_FROM_ISR that also exposes the task
+ * being notified. */
+    #define traceTASK_NOTIFY_GIVE_FROM_ISR_EXT( pxTCB, uxIndexToNotify )    traceTASK_NOTIFY_GIVE_FROM_ISR( uxIndexToNotify )
 #endif
 
 #ifndef traceTASK_NOTIFY_STATE_CLEAR

--- a/queue.c
+++ b/queue.c
@@ -970,7 +970,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
              * queue is full. */
             if( ( pxQueue->uxMessagesWaiting < pxQueue->uxLength ) || ( xCopyPosition == queueOVERWRITE ) )
             {
-                traceQUEUE_SEND( pxQueue );
+                traceQUEUE_SEND_EXT( pxQueue, xCopyPosition );
 
                 #if ( configUSE_QUEUE_SETS == 1 )
                 {
@@ -1084,7 +1084,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
 
                     /* Return to the original privilege level before exiting
                      * the function. */
-                    traceQUEUE_SEND_FAILED( pxQueue );
+                    traceQUEUE_SEND_FAILED_EXT( pxQueue, xCopyPosition );
                     traceRETURN_xQueueGenericSend( errQUEUE_FULL );
 
                     return errQUEUE_FULL;
@@ -1149,7 +1149,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
             prvUnlockQueue( pxQueue );
             ( void ) xTaskResumeAll();
 
-            traceQUEUE_SEND_FAILED( pxQueue );
+            traceQUEUE_SEND_FAILED_EXT( pxQueue, xCopyPosition );
             traceRETURN_xQueueGenericSend( errQUEUE_FULL );
 
             return errQUEUE_FULL;
@@ -1204,7 +1204,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
             const int8_t cTxLock = pxQueue->cTxLock;
             const UBaseType_t uxPreviousMessagesWaiting = pxQueue->uxMessagesWaiting;
 
-            traceQUEUE_SEND_FROM_ISR( pxQueue );
+            traceQUEUE_SEND_FROM_ISR_EXT( pxQueue, xCopyPosition );
 
             /* Semaphores use xQueueGiveFromISR(), so pxQueue will not be a
              *  semaphore or mutex.  That means prvCopyDataToQueue() cannot result
@@ -1318,7 +1318,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
         }
         else
         {
-            traceQUEUE_SEND_FROM_ISR_FAILED( pxQueue );
+            traceQUEUE_SEND_FROM_ISR_FAILED_EXT( pxQueue, xCopyPosition );
             xReturn = errQUEUE_FULL;
         }
     }
@@ -1386,7 +1386,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
         {
             const int8_t cTxLock = pxQueue->cTxLock;
 
-            traceQUEUE_SEND_FROM_ISR( pxQueue );
+            traceQUEUE_SEND_FROM_ISR_EXT( pxQueue, queueSEND_TO_BACK );
 
             /* A task can only have an inherited priority if it is a mutex
              * holder - and if there is a mutex holder then the mutex cannot be
@@ -1491,7 +1491,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
         }
         else
         {
-            traceQUEUE_SEND_FROM_ISR_FAILED( pxQueue );
+            traceQUEUE_SEND_FROM_ISR_FAILED_EXT( pxQueue, xCopyPosition );
             xReturn = errQUEUE_FULL;
         }
     }

--- a/queue.c
+++ b/queue.c
@@ -355,10 +355,14 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
             }
         }
         taskEXIT_CRITICAL();
+
+        traceQUEUE_RESET( pxQueue, xNewQueue );
     }
     else
     {
         xReturn = pdFAIL;
+
+        traceQUEUE_RESET_FAILED( pxQueue, xNewQueue );
     }
 
     configASSERT( xReturn != pdFAIL );

--- a/queue.c
+++ b/queue.c
@@ -880,7 +880,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             {
                 ( ( Queue_t * ) xHandle )->uxMessagesWaiting = uxInitialCount;
 
-                traceCREATE_COUNTING_SEMAPHORE();
+                traceCREATE_COUNTING_SEMAPHORE_EXT( xHandle );
             }
             else
             {
@@ -919,7 +919,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             {
                 ( ( Queue_t * ) xHandle )->uxMessagesWaiting = uxInitialCount;
 
-                traceCREATE_COUNTING_SEMAPHORE();
+                traceCREATE_COUNTING_SEMAPHORE_EXT( xHandle );
             }
             else
             {

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -737,11 +737,13 @@ BaseType_t xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
      * buffer before a task that is waiting for data is unblocked. */
     if( xTriggerLevel < pxStreamBuffer->xLength )
     {
+        traceSTREAM_BUFFER_SET_TRIGGER_LEVEL( xStreamBuffer, xTriggerLevel );
         pxStreamBuffer->xTriggerLevelBytes = xTriggerLevel;
         xReturn = pdPASS;
     }
     else
     {
+        traceSTREAM_BUFFER_SET_TRIGGER_LEVEL_FAILED( xStreamBuffer );
         xReturn = pdFALSE;
     }
 
@@ -1661,6 +1663,8 @@ void vStreamBufferSetStreamBufferNotificationIndex( StreamBufferHandle_t xStream
 
     /* Check that the task notification index is valid. */
     configASSERT( uxNotificationIndex < configTASK_NOTIFICATION_ARRAY_ENTRIES );
+
+    traceSTREAM_BUFFER_SET_NOTIFICATION_INDEX( xStreamBuffer, uxNotificationIndex );
 
     pxStreamBuffer->uxNotificationIndex = uxNotificationIndex;
 

--- a/tasks.c
+++ b/tasks.c
@@ -2446,7 +2446,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             {
                 configASSERT( uxSchedulerSuspended == 1U );
 
-                traceTASK_DELAY();
+                traceTASK_DELAY_EXT( xTicksToDelay );
 
                 /* A task that is removed from the event list while the
                  * scheduler is suspended will not get placed in the ready

--- a/tasks.c
+++ b/tasks.c
@@ -7903,7 +7903,7 @@ TickType_t uxTaskResetEventItemValue( void )
                     break;
             }
 
-            traceTASK_NOTIFY( uxIndexToNotify );
+            traceTASK_NOTIFY_EXT( pxTCB, uxIndexToNotify, eAction, xReturn );
 
             /* If the task is in the blocked state specifically to wait for a
              * notification then unblock it now. */
@@ -8045,7 +8045,7 @@ TickType_t uxTaskResetEventItemValue( void )
                     break;
             }
 
-            traceTASK_NOTIFY_FROM_ISR( uxIndexToNotify );
+            traceTASK_NOTIFY_FROM_ISR_EXT( pxTCB, uxIndexToNotify, eAction, xReturn );
 
             /* If the task is in the blocked state specifically to wait for a
              * notification then unblock it now. */

--- a/tasks.c
+++ b/tasks.c
@@ -8248,6 +8248,8 @@ TickType_t uxTaskResetEventItemValue( void )
          * its notification state cleared. */
         pxTCB = prvGetTCBFromHandle( xTask );
 
+        traceTASK_NOTIFY_STATE_CLEAR( pxTCB, uxIndexToClear );
+
         taskENTER_CRITICAL();
         {
             if( pxTCB->ucNotifyState[ uxIndexToClear ] == taskNOTIFICATION_RECEIVED )
@@ -8286,6 +8288,8 @@ TickType_t uxTaskResetEventItemValue( void )
         /* If null is passed in here then it is the calling task that is having
          * its notification state cleared. */
         pxTCB = prvGetTCBFromHandle( xTask );
+
+        traceTASK_NOTIFY_VALUE_CLEAR( pxTCB, uxIndexToClear, ulBitsToClear );
 
         taskENTER_CRITICAL();
         {

--- a/tasks.c
+++ b/tasks.c
@@ -7682,11 +7682,12 @@ TickType_t uxTaskResetEventItemValue( void )
 
         taskENTER_CRITICAL();
         {
-            traceTASK_NOTIFY_TAKE( uxIndexToWaitOn );
             ulReturn = pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ];
 
             if( ulReturn != 0U )
             {
+                traceTASK_NOTIFY_TAKE_EXT( uxIndexToWaitOn, xClearCountOnExit );
+
                 if( xClearCountOnExit != pdFALSE )
                 {
                     pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] = ( uint32_t ) 0U;
@@ -7698,6 +7699,7 @@ TickType_t uxTaskResetEventItemValue( void )
             }
             else
             {
+                traceTASK_NOTIFY_TAKE_FAILED( uxIndexToWaitOn );
                 mtCOVERAGE_TEST_MARKER();
             }
 

--- a/tasks.c
+++ b/tasks.c
@@ -7741,6 +7741,8 @@ TickType_t uxTaskResetEventItemValue( void )
                 /* Only block if a notification is not already pending. */
                 if( pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] != taskNOTIFICATION_RECEIVED )
                 {
+                    traceTASK_NOTIFY_VALUE_CLEAR( pxCurrentTCB, uxIndexToWaitOn, ulBitsToClearOnEntry );
+
                     /* Clear bits in the task's notification value as bits may get
                      * set by the notifying task or interrupt. This can be used
                      * to clear the value to zero. */
@@ -7792,8 +7794,6 @@ TickType_t uxTaskResetEventItemValue( void )
 
         taskENTER_CRITICAL();
         {
-            traceTASK_NOTIFY_WAIT( uxIndexToWaitOn );
-
             if( pulNotificationValue != NULL )
             {
                 /* Output the current notification value, which may or may not
@@ -7808,12 +7808,14 @@ TickType_t uxTaskResetEventItemValue( void )
             if( pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] != taskNOTIFICATION_RECEIVED )
             {
                 /* A notification was not received. */
+                traceTASK_NOTIFY_WAIT_FAILED( uxIndexToWaitOn );
                 xReturn = pdFALSE;
             }
             else
             {
                 /* A notification was already pending or a notification was
                  * received while the task was waiting. */
+                traceTASK_NOTIFY_WAIT_EXT( uxIndexToWaitOn, ulBitsToClearOnExit );
                 pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] &= ~ulBitsToClearOnExit;
                 xReturn = pdTRUE;
             }


### PR DESCRIPTION
Description
-----------

Hi! After the long back-and-forth on the forum (https://forums.freertos.org/t/tracing-improvements/20097), here is the PR that implements the changes to the tracing macro semantics discussed.

I have begun to referring to it as "hygienic" tracing macros, that provide all the information a tracer would reasonably require solely through:

- Explicit parameters
- `pxCurrentTCB`

I have gone through the tracing hooks of both systemview and tracealyzer and (hopefully) cover all the information that they previously accessed "un-hygienically".

Please note the individual commit messages: I have tried to justify and explain every change there.

Furthermore, I have marked this as a draft because I expect some discussion and changes. I already have a few points that I would like to raise:

- I have stuck to replacing hooks with an `_EXT` version that falls back on the "legacy" hook which should behave
  identically. Is this how you wish to proceed? Or is there any interest in introducing breaking changes to clean
  up the API significantly? Are you happy with this naming scheme?

- The only variable that the documentation explicitly allows accessing in an "unhyigienic"/not through explicit
  hook arguments is `pxCurrentTCB`. I have stuck with this, and not added that to any hooks. I presume that that is
  such a core part of the FreeRTOS kernel, that it would be OK to continue to allow tracers to explicitly depend on this.
  Or would you rather see this changed as well? I expect that to be very invasive, and most hooks to be replaced with an
  `_EXT` version.

- There is a large number of API operations that "may block and then succeed/fail" (queue receive/send/peek, streambuffer tx/rx, event group wait/sync....). Most of these operations featured 3 hooks:

  `BLOCKING_ON_OPERATION` (or similar), if the task blocks to complete, and then an `OPERATION` if successfully and `OPERATION_FAILED` hook if not. The exception here are APIs like EventGroups, which seemingly don't have a clear notion of what "success" would be and instead have a `_END` macro that also inidcates if a timeout occured.

  I have not yet updated any of the 'BLOCKING_ON_OPERATION' hooks because I am not decided what exactly they should expose.

  In my eyes, it makes sense to expose everything that relates to the reason the task would wait again:
  
  - The value of `xTicksToDelay`
  - In the case of stream buffers, the number of bytes to receive
  - In the case of event groups, if waiting for one of a set of events or all of a set of events to occur
  - etc...

  Does that seem reasonable?

  If so, I would like to ask for a bit of support because I don't 100% understand how the timeout mechanism for (for example) queues works. As far as I can tell, the task blocking on a queue can be woken before the queue is ready and the timeout occured? If so, how can this happen? In that case, `xTaskChekForTimeOut` will figure out how many ticks of timeout are left, update `xTicksToWait` and again block, presumably triggering a second call to the `BLOCKING_ON` macro. It seems therefor reasonable to have the `BLOCKING_ON` macro expose the current value of xTicksToWait? Or should it expose the initial value of xTicksToWait again?

 - On a first pass through the timer API and hooks I did not spot anything that seemed to require updates, but I will have another look.

- Should the stream buffer receive/send hooks expose both the amount of data to receive/send that was requested, and the amount that was actually received/sent?


Look forward to your feedback!

Test Steps
-----------
CMock tests continue to pass if the following tracing hooks are added to the duplicate FreeRTOS.h in the main FreeRTOS repo:

```diff
diff --git a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
index bd7b65c10..2833c6185 100644
--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
@@ -774,13 +774,20 @@
 #endif
 
 #ifndef traceTASK_DELAY_UNTIL
-    #define traceTASK_DELAY_UNTIL( x )
+    #define traceTASK_DELAY_UNTIL( xTimeToWake )
 #endif
 
 #ifndef traceTASK_DELAY
     #define traceTASK_DELAY()
 #endif
 
+#ifndef traceTASK_DELAY_EXT
+
+/* Extended version of traceTASK_DELAY that also exposes the number of ticks
+ * to delay for. */
+    #define traceTASK_DELAY_EXT( xTicksToDelay )    traceTASK_DELAY()
+#endif
+
 #ifndef traceTASK_PRIORITY_SET
     #define traceTASK_PRIORITY_SET( pxTask, uxNewPriority )
 #endif
@@ -893,6 +900,23 @@
     #define traceTASK_NOTIFY_TAKE( uxIndexToWait )
 #endif
 
+#ifndef traceTASK_NOTIFY_TAKE_EXT
+
+/* Extended version of traceTASK_NOTIFY_TAKE that also exposes value of
+ * xClearCountOnExit, informing the tracer of the state of this task
+ * notification after it has been taken. Note that this hook, unlike traceTASK_NOTIFY_TAKE,
+ * is only called if the notification was successfully taken. */
+    #define traceTASK_NOTIFY_TAKE_EXT( uxIndexToWait, xClearCountOnExit )    traceTASK_NOTIFY_TAKE( uxIndexToWait )
+#endif
+
+#ifndef traceTASK_NOTIFY_TAKE_FAILED
+
+/* Task notification take failed. For backwards-compatability, this macro falls
+ * back on traceTASK_NOTIFY_TAKE which was always called, no matter if
+ * successfull or not. */
+    #define traceTASK_NOTIFY_TAKE_FAILED( uxIndexToWait )    traceTASK_NOTIFY_TAKE( uxIndexToWait )
+#endif
+
 #ifndef traceTASK_NOTIFY_WAIT_BLOCK
     #define traceTASK_NOTIFY_WAIT_BLOCK( uxIndexToWait )
 #endif
@@ -901,18 +925,66 @@
     #define traceTASK_NOTIFY_WAIT( uxIndexToWait )
 #endif
 
+#ifndef traceTASK_NOTIFY_WAIT_EXT
+
+/* Extended version of traceTASK_NOTIFY_WAIT that also exposes value of
+ * ulBitsToClearOnExit, informing the tracer of the state of this task
+ * notification after it has been taken. Note that this hook, unlike
+ * traceTASK_NOTIFY_WAIT, is only called if the notification was successfully
+ * taken. */
+    #define traceTASK_NOTIFY_WAIT_EXT( uxIndexToWait, ulBitsToClearOnExit )    traceTASK_NOTIFY_WAIT( uxIndexToWait )
+#endif
+
+#ifndef traceTASK_NOTIFY_WAIT_FAILED
+
+/* Task notification wait failed. For backwards-compatability, this macro falls
+ * back on traceTASK_NOTIFY_WAIT which was always called, no matter if
+ * successfull or not. */
+    #define traceTASK_NOTIFY_WAIT_FAILED( uxIndexToWait )    traceTASK_NOTIFY_WAIT( uxIndexToWait )
+#endif
+
+
 #ifndef traceTASK_NOTIFY
     #define traceTASK_NOTIFY( uxIndexToNotify )
 #endif
 
+#ifndef traceTASK_NOTIFY_EXT
+
+/* Extended version of traceTASK_NOTIFY that also exposes the task being
+ * notified, and if/how the notification value was modified. */
+    #define traceTASK_NOTIFY_EXT( pxTCB, uxIndexToNotify, eAction, xReturn )    traceTASK_NOTIFY( uxIndexToNotify )
+#endif
+
 #ifndef traceTASK_NOTIFY_FROM_ISR
     #define traceTASK_NOTIFY_FROM_ISR( uxIndexToNotify )
 #endif
 
+#ifndef traceTASK_NOTIFY_FROM_ISR_EXT
+
+/* Extended version of traceTASK_NOTIFY_FROM_ISR that also exposes the task
+ * being notified, and if/how the notification value was modified. */
+    #define traceTASK_NOTIFY_FROM_ISR_EXT( pxTCB, uxIndexToNotify, eAction, xReturn )    traceTASK_NOTIFY_FROM_ISR( uxIndexToNotify )
+#endif
+
 #ifndef traceTASK_NOTIFY_GIVE_FROM_ISR
     #define traceTASK_NOTIFY_GIVE_FROM_ISR( uxIndexToNotify )
 #endif
 
+#ifndef traceTASK_NOTIFY_GIVE_FROM_ISR_EXT
+
+/* Extended version of traceTASK_NOTIFY_GIVE_FROM_ISR that also exposes the task
+ * being notified. */
+    #define traceTASK_NOTIFY_GIVE_FROM_ISR_EXT( pxTCB, uxIndexToNotify )    traceTASK_NOTIFY_GIVE_FROM_ISR( uxIndexToNotify )
+#endif
+
+#ifndef traceTASK_NOTIFY_STATE_CLEAR
+    #define traceTASK_NOTIFY_STATE_CLEAR( pxTCB, uxIndexToNotify )
+#endif
+
+#ifndef traceTASK_NOTIFY_VALUE_CLEAR
+    #define traceTASK_NOTIFY_VALUE_CLEAR( pxTCB, uxIndexToNotify, ulBitsToClear )
+#endif
+
 #ifndef traceISR_EXIT_TO_SCHEDULER
     #define traceISR_EXIT_TO_SCHEDULER()
 #endif

```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
