### PR TITLE
Changed macro __VFP_FP__ to __ARM_FP 

### DIFF
--- a/portable/GCC/ARM_CM4F/port.c
+++ b/portable/GCC/ARM_CM4F/port.c
@@ -34,7 +34,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-#ifndef __VFP_FP__
+#ifndef __ARM_FP
     #error This port can only be used when the project options are configured to enable hardware floating point support.
 #endif
 

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -40,7 +40,7 @@
 #include "task.h"
 #include "mpu_syscall_numbers.h"
 
-#ifndef __VFP_FP__
+#ifndef __ARM_FP
     #error This port can only be used when the project options are configured to enable hardware floating point support.
 #endif
 

--- a/portable/GCC/ARM_CM7/r0p1/port.c
+++ b/portable/GCC/ARM_CM7/r0p1/port.c
@@ -34,7 +34,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-#ifndef __VFP_FP__
+#ifndef __ARM_FP
     #error This port can only be used when the project options are configured to enable hardware floating point support.
 #endif
 


### PR DESCRIPTION
…

Changed macro `__VFP_FP__` to `__ARM_FP` 

Description
-----------
Changed macro `__VFP_FP__` to `__ARM_FP` for ports GCC/ARM_CM7, GCC/ARM_CM4_MPU, and GCC/ARM_CM4F to accurately reflect if floating point hardware support is enabled. See linked issue for more details, but the macro `__VFP_FP__` is deprecated, and always set to `1` regardless of if floating point is enabled or not.

Test Steps
-----------
- Compiling the affected ports without floating point support enabled (`-mfloat-abi=soft`) now properly throws a compiler error

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Issue ID: 1087
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1087


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
