### PR TITLE
Fix traceMALLOC() allocated bytes

### DIFF
--- a/portable/ARMv8M/secure/heap/secure_heap.c
+++ b/portable/ARMv8M/secure/heap/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/ARMv8M/secure/heap/secure_heap.c
+++ b/portable/ARMv8M/secure/heap/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM23/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM23/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM23/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM23/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM33/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM33/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM33/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM33/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM35P/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM35P/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM35P/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM35P/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM55/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM55/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM55/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM55/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM85/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM85/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/GCC/ARM_CM85/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM85/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM23/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM23/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM23/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM23/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM33/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM33/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM33/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM33/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM35P/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM35P/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM35P/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM35P/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM55/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM55/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM55/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM55/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM85/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM85/secure/secure_heap.c
@@ -256,6 +256,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* If this is the first call to malloc then the heap will require
      * initialisation to setup the list of free blocks. */
@@ -360,7 +361,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    xWantedSize = pxBlock->xBlockSize;
+                    mtCOVERAGE_TEST_MARKER();
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -373,6 +374,8 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+
+                xAllocatedBlockSize = pxBlock->xBlockSize;
 
                 /* The block is being returned - it is allocated and owned by
                  * the application and has no "next" block. */
@@ -394,10 +397,10 @@ void * pvPortMalloc( size_t xWantedSize )
         mtCOVERAGE_TEST_MARKER();
     }
 
-    traceMALLOC( pvReturn, xWantedSize );
+    traceMALLOC( pvReturn, xAllocatedBlockSize );
 
     /* Prevent compiler warnings when trace macros are not used. */
-    ( void ) xWantedSize;
+    ( void ) xAllocatedBlockSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/IAR/ARM_CM85/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM85/secure/secure_heap.c
@@ -360,7 +360,7 @@ void * pvPortMalloc( size_t xWantedSize )
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    xWantedSize = pxBlock->xBlockSize;
                 }
 
                 xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -395,6 +395,9 @@ void * pvPortMalloc( size_t xWantedSize )
     }
 
     traceMALLOC( pvReturn, xWantedSize );
+
+    /* Prevent compiler warnings when trace macros are not used. */
+    ( void ) xWantedSize;
 
     #if ( secureconfigUSE_MALLOC_FAILED_HOOK == 1 )
     {

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -160,6 +160,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     if( xWantedSize > 0 )
     {
@@ -258,12 +259,10 @@ void * pvPortMalloc( size_t xWantedSize )
                          * iterate to find the right place to insert new block. */
                         prvInsertBlockIntoFreeList( ( pxNewBlockLink ) );
                     }
-                    else
-                    {
-                        xWantedSize = pxBlock->xBlockSize;
-                    }
 
                     xFreeBytesRemaining -= pxBlock->xBlockSize;
+
+                    xAllocatedBlockSize = pxBlock->xBlockSize;
 
                     /* The block is being returned - it is allocated and owned
                      * by the application and has no "next" block. */
@@ -273,10 +272,10 @@ void * pvPortMalloc( size_t xWantedSize )
             }
         }
 
-        traceMALLOC( pvReturn, xWantedSize );
+        traceMALLOC( pvReturn, xAllocatedBlockSize );
 
         /* Prevent compiler warnings when trace macros are not used. */
-        ( void ) xWantedSize;
+        ( void ) xAllocatedBlockSize;
     }
     ( void ) xTaskResumeAll();
 

--- a/portable/MemMang/heap_2.c
+++ b/portable/MemMang/heap_2.c
@@ -258,6 +258,10 @@ void * pvPortMalloc( size_t xWantedSize )
                          * iterate to find the right place to insert new block. */
                         prvInsertBlockIntoFreeList( ( pxNewBlockLink ) );
                     }
+                    else
+                    {
+                        xWantedSize = pxBlock->xBlockSize;
+                    }
 
                     xFreeBytesRemaining -= pxBlock->xBlockSize;
 
@@ -270,6 +274,9 @@ void * pvPortMalloc( size_t xWantedSize )
         }
 
         traceMALLOC( pvReturn, xWantedSize );
+
+        /* Prevent compiler warnings when trace macros are not used. */
+        ( void ) xWantedSize;
     }
     ( void ) xTaskResumeAll();
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -177,6 +177,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     if( xWantedSize > 0 )
     {
@@ -288,7 +289,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     }
                     else
                     {
-                        xWantedSize = pxBlock->xBlockSize;
+                        mtCOVERAGE_TEST_MARKER();
                     }
 
                     xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -301,6 +302,8 @@ void * pvPortMalloc( size_t xWantedSize )
                     {
                         mtCOVERAGE_TEST_MARKER();
                     }
+
+                    xAllocatedBlockSize = pxBlock->xBlockSize;
 
                     /* The block is being returned - it is allocated and owned
                      * by the application and has no "next" block. */
@@ -323,10 +326,10 @@ void * pvPortMalloc( size_t xWantedSize )
             mtCOVERAGE_TEST_MARKER();
         }
 
-        traceMALLOC( pvReturn, xWantedSize );
+        traceMALLOC( pvReturn, xAllocatedBlockSize );
 
         /* Prevent compiler warnings when trace macros are not used. */
-        ( void ) xWantedSize;
+        ( void ) xAllocatedBlockSize;
     }
     ( void ) xTaskResumeAll();
 

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -288,7 +288,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     }
                     else
                     {
-                        mtCOVERAGE_TEST_MARKER();
+                        xWantedSize = pxBlock->xBlockSize;
                     }
 
                     xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -324,6 +324,9 @@ void * pvPortMalloc( size_t xWantedSize )
         }
 
         traceMALLOC( pvReturn, xWantedSize );
+
+        /* Prevent compiler warnings when trace macros are not used. */
+        ( void ) xWantedSize;
     }
     ( void ) xTaskResumeAll();
 

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -316,7 +316,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     }
                     else
                     {
-                        mtCOVERAGE_TEST_MARKER();
+                        xWantedSize = pxBlock->xBlockSize;
                     }
 
                     xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -352,6 +352,9 @@ void * pvPortMalloc( size_t xWantedSize )
         }
 
         traceMALLOC( pvReturn, xWantedSize );
+
+        /* Prevent compiler warnings when trace macros are not used. */
+        ( void ) xWantedSize;
     }
     ( void ) xTaskResumeAll();
 

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -212,6 +212,7 @@ void * pvPortMalloc( size_t xWantedSize )
     BlockLink_t * pxNewBlockLink;
     void * pvReturn = NULL;
     size_t xAdditionalRequiredSize;
+    size_t xAllocatedBlockSize = 0;
 
     /* The heap must be initialised before the first call to
      * pvPortMalloc(). */
@@ -316,7 +317,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     }
                     else
                     {
-                        xWantedSize = pxBlock->xBlockSize;
+                        mtCOVERAGE_TEST_MARKER();
                     }
 
                     xFreeBytesRemaining -= pxBlock->xBlockSize;
@@ -329,6 +330,8 @@ void * pvPortMalloc( size_t xWantedSize )
                     {
                         mtCOVERAGE_TEST_MARKER();
                     }
+
+                    xAllocatedBlockSize = pxBlock->xBlockSize;
 
                     /* The block is being returned - it is allocated and owned
                      * by the application and has no "next" block. */
@@ -351,10 +354,10 @@ void * pvPortMalloc( size_t xWantedSize )
             mtCOVERAGE_TEST_MARKER();
         }
 
-        traceMALLOC( pvReturn, xWantedSize );
+        traceMALLOC( pvReturn, xAllocatedBlockSize );
 
         /* Prevent compiler warnings when trace macros are not used. */
-        ( void ) xWantedSize;
+        ( void ) xAllocatedBlockSize;
     }
     ( void ) xTaskResumeAll();
 


### PR DESCRIPTION
Description
-----------
Update the call to traceMALLOC() to pass the actual size of the allocated block for secure_heap, heap2, heap4 and heap5.

Test Steps
-----------
test code:
```c
// hook to freertos kernel
#define traceMALLOC( pvAddress, uiSize ) trace_malloc(pvAddress, uiSize)
#define traceFREE( pvAddress, uiSize )   trace_free(pvAddress, uiSize)
```
```c
static int trace_enable = 0;
static uint32_t malloc_total = 0;
static uint32_t free_total = 0;

void trace_malloc(void *ptr, uint32_t size){
    if(trace_enable){
        printf("=malloc= %p, %lu\r\n", ptr, size);
        malloc_total += size;
    }
}

void trace_free(void *ptr, uint32_t size){
    if(trace_enable){
        printf("= free = %p, %lu\r\n", ptr, size);
        free_total += size;
    }
}

int test_unit(void){
    trace_enable = 1;

    void *p1 = pvPortMalloc(1016);
    void *p2 = pvPortMalloc(1016);
    void *p3 = pvPortMalloc(1016);

    vPortFree(p2);

    p2 = pvPortMalloc(1008);

    vPortFree(p1);
    vPortFree(p2);
    vPortFree(p3);

    trace_enable = 0;

    printf("malloc total: %lu\r\n", malloc_total);
    printf(" free  total: %lu\r\n", free_total);

    return 0;
}
```

Before the change, `malloc_total` and `free_total` printed by the above code are not same. After the change, they are same. 

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1078 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
