### PR TITLE
freertos-mpu: Add Privileged eXecute Never MPU attribute support

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -53,30 +53,33 @@
  * The tskKERNEL_VERSION_MAJOR, tskKERNEL_VERSION_MINOR, tskKERNEL_VERSION_BUILD
  * values will reflect the last released version number.
  */
-#define tskKERNEL_VERSION_NUMBER       "V11.1.0+"
-#define tskKERNEL_VERSION_MAJOR        11
-#define tskKERNEL_VERSION_MINOR        1
-#define tskKERNEL_VERSION_BUILD        0
+#define tskKERNEL_VERSION_NUMBER                      "V11.1.0+"
+#define tskKERNEL_VERSION_MAJOR                       11
+#define tskKERNEL_VERSION_MINOR                       1
+#define tskKERNEL_VERSION_BUILD                       0
 
 /* MPU region parameters passed in ulParameters
  * of MemoryRegion_t struct. */
-#define tskMPU_REGION_READ_ONLY        ( 1U << 0U )
-#define tskMPU_REGION_READ_WRITE       ( 1U << 1U )
-#define tskMPU_REGION_EXECUTE_NEVER    ( 1U << 2U )
-#define tskMPU_REGION_NORMAL_MEMORY    ( 1U << 3U )
-#define tskMPU_REGION_DEVICE_MEMORY    ( 1U << 4U )
+#define tskMPU_REGION_READ_ONLY                       ( 1U << 0U )
+#define tskMPU_REGION_READ_WRITE                      ( 1U << 1U )
+#define tskMPU_REGION_EXECUTE_NEVER                   ( 1U << 2U )
+#define tskMPU_REGION_NORMAL_MEMORY                   ( 1U << 3U )
+#define tskMPU_REGION_DEVICE_MEMORY                   ( 1U << 4U )
+#if ( portHAS_ARMV8_1_M_EXTENSION == 1 )
+    #define tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER    ( 1U << 5U )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* MPU region permissions stored in MPU settings to
  * authorize access requests. */
-#define tskMPU_READ_PERMISSION         ( 1U << 0U )
-#define tskMPU_WRITE_PERMISSION        ( 1U << 1U )
+#define tskMPU_READ_PERMISSION        ( 1U << 0U )
+#define tskMPU_WRITE_PERMISSION       ( 1U << 1U )
 
 /* The direct to task notification feature used to have only a single notification
  * per task.  Now there is an array of notifications per task that is dimensioned by
  * configTASK_NOTIFICATION_ARRAY_ENTRIES.  For backward compatibility, any use of the
  * original direct to task notification defaults to using the first index in the
  * array. */
-#define tskDEFAULT_INDEX_TO_NOTIFY     ( 0 )
+#define tskDEFAULT_INDEX_TO_NOTIFY    ( 0 )
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -65,9 +65,9 @@
 #define tskMPU_REGION_EXECUTE_NEVER                   ( 1U << 2U )
 #define tskMPU_REGION_NORMAL_MEMORY                   ( 1U << 3U )
 #define tskMPU_REGION_DEVICE_MEMORY                   ( 1U << 4U )
-#if ( portHAS_ARMV8_1_M_EXTENSION == 1 )
+#if ( portARMV8M_MINOR_VERSION >= 1 )
     #define tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER    ( 1U << 5U )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* MPU region permissions stored in MPU settings to
  * authorize access requests. */

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM55/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM85/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -50,7 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      0
+#define portARMV8M_MINOR_VERSION         0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -50,6 +50,7 @@
  */
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM55/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM85/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -166,73 +166,78 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to manipulate the MPU.
  */
-#define portMPU_TYPE_REG                        ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
-#define portMPU_CTRL_REG                        ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
-#define portMPU_RNR_REG                         ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
+#define portMPU_TYPE_REG                            ( *( ( volatile uint32_t * ) 0xe000ed90 ) )
+#define portMPU_CTRL_REG                            ( *( ( volatile uint32_t * ) 0xe000ed94 ) )
+#define portMPU_RNR_REG                             ( *( ( volatile uint32_t * ) 0xe000ed98 ) )
 
-#define portMPU_RBAR_REG                        ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
-#define portMPU_RLAR_REG                        ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
+#define portMPU_RBAR_REG                            ( *( ( volatile uint32_t * ) 0xe000ed9c ) )
+#define portMPU_RLAR_REG                            ( *( ( volatile uint32_t * ) 0xe000eda0 ) )
 
-#define portMPU_RBAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
-#define portMPU_RLAR_A1_REG                     ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
+#define portMPU_RBAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda4 ) )
+#define portMPU_RLAR_A1_REG                         ( *( ( volatile uint32_t * ) 0xe000eda8 ) )
 
-#define portMPU_RBAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edac ) )
-#define portMPU_RLAR_A2_REG                     ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
+#define portMPU_RBAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edac ) )
+#define portMPU_RLAR_A2_REG                         ( *( ( volatile uint32_t * ) 0xe000edb0 ) )
 
-#define portMPU_RBAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
-#define portMPU_RLAR_A3_REG                     ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
+#define portMPU_RBAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb4 ) )
+#define portMPU_RLAR_A3_REG                         ( *( ( volatile uint32_t * ) 0xe000edb8 ) )
 
-#define portMPU_MAIR0_REG                       ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
-#define portMPU_MAIR1_REG                       ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
+#define portMPU_MAIR0_REG                           ( *( ( volatile uint32_t * ) 0xe000edc0 ) )
+#define portMPU_MAIR1_REG                           ( *( ( volatile uint32_t * ) 0xe000edc4 ) )
 
-#define portMPU_RBAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
-#define portMPU_RLAR_ADDRESS_MASK               ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RBAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
+#define portMPU_RLAR_ADDRESS_MASK                   ( 0xffffffe0 ) /* Must be 32-byte aligned. */
 
-#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK    ( 3UL << 1UL )
+#define portMPU_RBAR_ACCESS_PERMISSIONS_MASK        ( 3UL << 1UL )
 
-#define portMPU_MAIR_ATTR0_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR0_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR0_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR0_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR1_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR1_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR1_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR1_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR2_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR2_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR2_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR2_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR3_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR3_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR3_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR3_MASK                     ( 0xff000000 )
 
-#define portMPU_MAIR_ATTR4_POS                  ( 0UL )
-#define portMPU_MAIR_ATTR4_MASK                 ( 0x000000ff )
+#define portMPU_MAIR_ATTR4_POS                      ( 0UL )
+#define portMPU_MAIR_ATTR4_MASK                     ( 0x000000ff )
 
-#define portMPU_MAIR_ATTR5_POS                  ( 8UL )
-#define portMPU_MAIR_ATTR5_MASK                 ( 0x0000ff00 )
+#define portMPU_MAIR_ATTR5_POS                      ( 8UL )
+#define portMPU_MAIR_ATTR5_MASK                     ( 0x0000ff00 )
 
-#define portMPU_MAIR_ATTR6_POS                  ( 16UL )
-#define portMPU_MAIR_ATTR6_MASK                 ( 0x00ff0000 )
+#define portMPU_MAIR_ATTR6_POS                      ( 16UL )
+#define portMPU_MAIR_ATTR6_MASK                     ( 0x00ff0000 )
 
-#define portMPU_MAIR_ATTR7_POS                  ( 24UL )
-#define portMPU_MAIR_ATTR7_MASK                 ( 0xff000000 )
+#define portMPU_MAIR_ATTR7_POS                      ( 24UL )
+#define portMPU_MAIR_ATTR7_MASK                     ( 0xff000000 )
 
-#define portMPU_RLAR_ATTR_INDEX0                ( 0UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX1                ( 1UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX2                ( 2UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX3                ( 3UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX4                ( 4UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX5                ( 5UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX6                ( 6UL << 1UL )
-#define portMPU_RLAR_ATTR_INDEX7                ( 7UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX0                    ( 0UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX1                    ( 1UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX2                    ( 2UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX3                    ( 3UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX4                    ( 4UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX5                    ( 5UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX6                    ( 6UL << 1UL )
+#define portMPU_RLAR_ATTR_INDEX7                    ( 7UL << 1UL )
 
-#define portMPU_RLAR_REGION_ENABLE              ( 1UL )
+#define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
+
+#if (portHAS_ARMV8_1_M_EXTENSION == 1)
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+    #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
+#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
 /* Enable privileged access to unmapped region. */
-#define portMPU_PRIV_BACKGROUND_ENABLE_BIT      ( 1UL << 2UL )
+#define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
 
 /* Enable MPU. */
-#define portMPU_ENABLE_BIT                      ( 1UL << 0UL )
+#define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register. */
-#define portEXPECTED_MPU_TYPE_VALUE             ( configTOTAL_MPU_REGIONS << 8UL )
+/* Expected value of the portMPU_TYPE register.     */
+#define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
  * RBAR (Region Base Address Register) value. */
@@ -1879,6 +1884,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                 /* End Address. */
                 xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR = ( ulRegionEndAddress ) |
                                                                           ( portMPU_RLAR_REGION_ENABLE );
+
+                /* PXN. */
+                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                    if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
+                    {
+                        xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
+                    }
+                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -225,10 +225,11 @@ typedef void ( * portISR_t )( void );
 
 #define portMPU_RLAR_REGION_ENABLE                  ( 1UL )
 
-#if (portHAS_ARMV8_1_M_EXTENSION == 1)
-    /* Enable Privileged eXecute Never MPU attribute for the selected memory region. */
+#if ( portARMV8M_MINOR_VERSION >= 1 )
+    /* Enable Privileged eXecute Never MPU attribute for the selected memory
+     * region. */
     #define portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER   ( 1UL << 4UL )
-#endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+#endif /* portARMV8M_MINOR_VERSION >= 1 */
 
 /* Enable privileged access to unmapped region. */
 #define portMPU_PRIV_BACKGROUND_ENABLE_BIT          ( 1UL << 2UL )
@@ -236,7 +237,7 @@ typedef void ( * portISR_t )( void );
 /* Enable MPU. */
 #define portMPU_ENABLE_BIT                          ( 1UL << 0UL )
 
-/* Expected value of the portMPU_TYPE register.     */
+/* Expected value of the portMPU_TYPE register. */
 #define portEXPECTED_MPU_TYPE_VALUE                 ( configTOTAL_MPU_REGIONS << 8UL )
 
 /* Extract first address of the MPU region as encoded in the
@@ -1886,12 +1887,14 @@ void vPortEndScheduler( void ) /* PRIVILEGED_FUNCTION */
                                                                           ( portMPU_RLAR_REGION_ENABLE );
 
                 /* PXN. */
-                #if (portHAS_ARMV8_1_M_EXTENSION == 1)
+                #if ( portARMV8M_MINOR_VERSION >= 1 )
+                {
                     if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER ) != 0 )
                     {
                         xMPUSettings->xRegionsSettings[ ulRegionNumber ].ulRLAR |= ( portMPU_RLAR_PRIVILEGED_EXECUTE_NEVER );
                     }
-                #endif /* portHAS_ARMV8_1_M_EXTENSION == 1 */
+                }
+                #endif /* portARMV8M_MINOR_VERSION >= 1 */
 
                 /* Normal memory/ Device memory. */
                 if( ( xRegions[ lIndex ].ulParameters & tskMPU_REGION_DEVICE_MEMORY ) != 0 )

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -55,7 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
-#define portHAS_ARMV8_1_M_EXTENSION      1
+#define portARMV8M_MINOR_VERSION         1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -55,6 +55,7 @@
  */
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
+#define portHAS_ARMV8_1_M_EXTENSION      1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
A new MPU region attribute Privileged eXecute Never (PXN) is introduced in Armv8.1-M architecture, where if an MPU region has PXN attribute set and the processor attempts to execute the code inside with privileged level, the Memory Management Fault exception would be triggered, with IACCVIOL bit in MemManage Fault State Register set to 1. The PXN feature allows privileged software to ensure specific application tasks (threads) to execute in unprivileged level only.

This PR adds the new MPU region attribute Privileged eXecute Never (PXN) support to the Armv8.1-M architecture port variants.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
