### PR TITLE
Remove run state assertion in prvCheckForRunStateChange

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -845,10 +845,11 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
             portENABLE_INTERRUPTS();
 
-            /* Enabling interrupts should cause this core to immediately
-             * service the pending interrupt and yield. If the run state is still
-             * yielding here then that is a problem. */
-            configASSERT( pxThisTCB->xTaskRunState != taskTASK_SCHEDULED_TO_YIELD );
+            /* Enabling interrupts should cause this core to immediately service
+             * the pending interrupt and yield. After servicing the pending interrupt,
+             * the task needs to re-evaluate its run state within this loop, as
+             * other cores may have requested this task to yield, potentially altering
+             * its run state. */
 
             portDISABLE_INTERRUPTS();
             portGET_TASK_LOCK();


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Address the problem in this [thread](https://forums.freertos.org/t/smp-porting-checklist-a53-4-as-reference/14499/29).

https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/76eb44382178237197a2c4982f9d99e8d64c9599/tasks.c#L846-L853
In `prvCheckForRunStateChange()`, enabling interrupts should cause this core to immediately service the pending interrupt and yield. Upon the next scheduling of the task, the assertion `configASSERT(pxThisTCB->xTaskRunState != taskTASK_SCHEDULED_TO_YIELD);` may not be true, as other cores could have requested a yield for this task before it evaluates its run state within the assertion. To address this, the task re-evaluates its run state in critical section within a loop until it is eligible for execution, which is the current implementation. Consequently, this assertion should be removed to ensure correct behavior.

In this PR:
* Remove run state assertion in `prvCheckForRunStateChange()` as it doesn't account for the possibility that the task run state could be modified by another task after interrupt is enabled and checking the run state of a task should be performed in a critical section.

Test Steps
-----------
Forum user helps to test this on a Cortex A53 SMP port, with this PR. The main_full demo can run for 5 hours without problem.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request. - https://github.com/FreeRTOS/FreeRTOS/pull/1231

Related Issue
-----------
[Forum thread](https://forums.freertos.org/t/smp-porting-checklist-a53-4-as-reference/14499/29).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
