### PR TITLE
Fix gcc warning in posix port

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -180,7 +180,7 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     thread->xDying = pdFALSE;
 
     /* Ensure ulStackSize is at least PTHREAD_STACK_MIN */
-    ulStackSize = (ulStackSize < PTHREAD_STACK_MIN) ? PTHREAD_STACK_MIN : ulStackSize;
+    ulStackSize = (ulStackSize < ( size_t ) ( PTHREAD_STACK_MIN ) ) ? ( size_t ) ( PTHREAD_STACK_MIN ) : ulStackSize;
 
     pthread_attr_init( &xThreadAttributes );
     iRet = pthread_attr_setstacksize( &xThreadAttributes, ulStackSize );


### PR DESCRIPTION
Description
-----------

Fix warning from "gcc -Wsign-compare" in the file
portable/ThirdParty/GCC/Posix/port.c since PTHREAD_STACK_MIN is used from system headers.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
