### PR TITLE
Update ARM_CRx_No_GIC port

### DIFF
--- a/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -83,10 +83,12 @@
 /*-----------------------------------------------------------*/
 
 /*
- * Starts the first task executing.  This function is necessarily written in
+ * Starts the first task executing.  These functions are necessarily written in
  * assembly code so is implemented in portASM.s.
  */
 extern void vPortRestoreTaskContext( void );
+extern void vPortInitialiseFPSCR( void );
+extern uint32_t ulReadValueAPSR( void );
 
 /*
  * Used to catch tasks that attempt to return from their implementing function.
@@ -218,7 +220,7 @@ BaseType_t xPortStartScheduler( void )
 
     /* Only continue if the CPU is not in User mode.  The CPU must be in a
      * Privileged mode for the scheduler to start. */
-    __asm volatile ( "MRS %0, APSR" : "=r" ( ulAPSR )::"memory" );
+    ulAPSR = ulReadValueAPSR();
 
     ulAPSR &= portAPSR_MODE_BITS_MASK;
     configASSERT( ulAPSR != portAPSR_USER_MODE );
@@ -312,14 +314,11 @@ void FreeRTOS_Tick_Handler( void )
 
 void vPortTaskUsesFPU( void )
 {
-    //uint32_t ulInitialFPSCR = 0;
-
     /* A task is registering the fact that it needs an FPU context.  Set the
      * FPU flag (which is saved as part of the task context). */
     ulPortTaskHasFPUContext = pdTRUE;
 
     /* Initialise the floating point status register. */
     vPortInitialiseFPSCR();
-    /*__asm volatile ( "FMXR  FPSCR, %0" ::"r" ( ulInitialFPSCR ) : "memory" );*/
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -82,7 +82,11 @@
 #endif
 
 /* The space on the stack required to hold the FPU registers. */
-#define portFPU_REGISTER_WORDS     ( ( 16 * 2 ) + 1 ) /* D0-D15 and FPSCR. */
+#if ( configFPU_D32 == 1 )
+    #define portFPU_REGISTER_WORDS     ( ( 32 * 2 ) + 1 ) /* D0-D31 and FPSCR. */
+#else
+    #define portFPU_REGISTER_WORDS     ( ( 16 * 2 ) + 1 ) /* D0-D15 and FPSCR. */
+#endif /* configFPU_D32 */
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -319,7 +319,7 @@ void vPortTaskUsesFPU( void )
     ulPortTaskHasFPUContext = pdTRUE;
 
     /* Initialise the floating point status register. */
-    vSetupFPU();
+    vPortInitialiseFPSCR();
     /*__asm volatile ( "FMXR  FPSCR, %0" ::"r" ( ulInitialFPSCR ) : "memory" );*/
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -312,13 +312,14 @@ void FreeRTOS_Tick_Handler( void )
 
 void vPortTaskUsesFPU( void )
 {
-    uint32_t ulInitialFPSCR = 0;
+    //uint32_t ulInitialFPSCR = 0;
 
     /* A task is registering the fact that it needs an FPU context.  Set the
      * FPU flag (which is saved as part of the task context). */
     ulPortTaskHasFPUContext = pdTRUE;
 
     /* Initialise the floating point status register. */
-    __asm volatile ( "FMXR  FPSCR, %0" ::"r" ( ulInitialFPSCR ) : "memory" );
+    vSetupFPU();
+    /*__asm volatile ( "FMXR  FPSCR, %0" ::"r" ( ulInitialFPSCR ) : "memory" );*/
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -28,6 +28,7 @@
 
 /* Standard includes. */
 #include <stdlib.h>
+#include <string.h>
 
 /* Scheduler includes. */
 #include "FreeRTOS.h"
@@ -80,10 +81,16 @@
     #define portTASK_RETURN_ADDRESS    prvTaskExitError
 #endif
 
+/* The space on the stack required to hold the FPU registers. */
+#if ( configFPU_D32 == 1 )
+    #define portFPU_REGISTER_WORDS     ( ( 32 * 2 ) + 1 ) /* D0-D31 and FPSCR. */
+#else
+    #define portFPU_REGISTER_WORDS     ( ( 16 * 2 ) + 1 ) /* D0-D15 and FPSCR. */
+#endif
 /*-----------------------------------------------------------*/
 
 /*
- * These functions are necessarily written in assembly code, so are implemented 
+ * These functions are necessarily written in assembly code, so are implemented
  * in portASM.S.
  */
 extern void vPortRestoreTaskContext( void );
@@ -186,12 +193,33 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     /* The task will start with a critical nesting count of 0 as interrupts are
      * enabled. */
     *pxTopOfStack = portNO_CRITICAL_NESTING;
-    pxTopOfStack--;
 
-    /* The task will start without a floating point context.  A task that uses
-     * the floating point hardware must call vPortTaskUsesFPU() before executing
-     * any floating point instructions. */
-    *pxTopOfStack = portNO_FLOATING_POINT_CONTEXT;
+    #if ( configUSE_TASK_FPU_SUPPORT == 1 )
+    {
+        /* The task will start without a floating point context.  A task that uses
+         * the floating point hardware must call vPortTaskUsesFPU() before executing
+         * any floating point instructions. */
+        pxTopOfStack--;
+        *pxTopOfStack = portNO_FLOATING_POINT_CONTEXT;
+    }
+    #elif ( configUSE_TASK_FPU_SUPPORT == 2 )
+    {
+        /* The task will start with a floating point context.  Leave enough
+         * space for the registers - and ensure they are initialised to 0. */
+        pxTopOfStack -= portFPU_REGISTER_WORDS;
+        memset( pxTopOfStack, 0x00, portFPU_REGISTER_WORDS * sizeof( StackType_t ) );
+
+        /* Initialise the slot containing ulPortTaskHasFPUContext to true as
+         * the task starts with a floating point context. */
+        pxTopOfStack--;
+        *pxTopOfStack = pdTRUE;
+        ulPortTaskHasFPUContext = pdTRUE;
+    }
+    #else
+    {
+        #error "Invalid configUSE_TASK_FPU_SUPPORT value - configUSE_TASK_FPU_SUPPORT must be set to 1, 2, or left undefined."
+    }
+    #endif /* if ( configUSE_TASK_FPU_SUPPORT == 1 ) */
 
     return pxTopOfStack;
 }
@@ -312,13 +340,17 @@ void FreeRTOS_Tick_Handler( void )
 }
 /*-----------------------------------------------------------*/
 
-void vPortTaskUsesFPU( void )
-{
-    /* A task is registering the fact that it needs an FPU context.  Set the
-     * FPU flag (which is saved as part of the task context). */
-    ulPortTaskHasFPUContext = pdTRUE;
+#if ( configUSE_TASK_FPU_SUPPORT != 2 )
 
-    /* Initialise the floating point status register. */
-    vPortInitialiseFPSCR();
-}
+    void vPortTaskUsesFPU( void )
+    {
+        /* A task is registering the fact that it needs an FPU context.  Set the
+         * FPU flag (which is saved as part of the task context). */
+        ulPortTaskHasFPUContext = pdTRUE;
+
+        /* Initialise the floating point status register. */
+        vPortInitialiseFPSCR();
+    }
+
+#endif /* configUSE_TASK_FPU_SUPPORT */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -82,11 +82,8 @@
 #endif
 
 /* The space on the stack required to hold the FPU registers. */
-#if ( configFPU_D32 == 1 )
-    #define portFPU_REGISTER_WORDS     ( ( 32 * 2 ) + 1 ) /* D0-D31 and FPSCR. */
-#else
-    #define portFPU_REGISTER_WORDS     ( ( 16 * 2 ) + 1 ) /* D0-D15 and FPSCR. */
-#endif
+#define portFPU_REGISTER_WORDS     ( ( 16 * 2 ) + 1 ) /* D0-D15 and FPSCR. */
+
 /*-----------------------------------------------------------*/
 
 /*

--- a/portable/GCC/ARM_CRx_No_GIC/port.c
+++ b/portable/GCC/ARM_CRx_No_GIC/port.c
@@ -83,12 +83,12 @@
 /*-----------------------------------------------------------*/
 
 /*
- * Starts the first task executing.  These functions are necessarily written in
- * assembly code so is implemented in portASM.s.
+ * These functions are necessarily written in assembly code, so are implemented 
+ * in portASM.S.
  */
 extern void vPortRestoreTaskContext( void );
 extern void vPortInitialiseFPSCR( void );
-extern uint32_t ulReadValueAPSR( void );
+extern uint32_t ulReadAPSR( void );
 
 /*
  * Used to catch tasks that attempt to return from their implementing function.
@@ -220,7 +220,7 @@ BaseType_t xPortStartScheduler( void )
 
     /* Only continue if the CPU is not in User mode.  The CPU must be in a
      * Privileged mode for the scheduler to start. */
-    ulAPSR = ulReadValueAPSR();
+    ulAPSR = ulReadAPSR();
 
     ulAPSR &= portAPSR_MODE_BITS_MASK;
     configASSERT( ulAPSR != portAPSR_USER_MODE );

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -80,6 +80,9 @@
     /* Save the floating point context, if any. */
     VMRSNE  R1,  FPSCR
     VPUSHNE {D0-D15}
+#if configFPU_D32 == 1
+    VPUSHNE {D16-D31}
+#endif /* configFPU_D32 */
     PUSHNE  {R1}
 
     /* Save ulPortTaskHasFPUContext itself. */

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -34,8 +34,6 @@
     .set IRQ_MODE,  0x12
 
     /* Variables and functions. */
-    .extern ulMaxAPIPriorityMask
-    .extern _freertos_vector_table
     .extern pxCurrentTCB
     .extern vTaskSwitchContext
     .extern vApplicationIRQHandler
@@ -48,30 +46,31 @@
     .global FreeRTOS_SVC_Handler
     .global vPortRestoreTaskContext
     .global vPortInitialiseFPSCR
-    .global ulReadValueAPSR
+    .global ulReadAPSR
 
+/*-----------------------------------------------------------*/
 
 .macro portSAVE_CONTEXT
 
     /* Save the LR and SPSR onto the system mode stack before switching to
-    system mode to save the remaining system mode registers. */
+     * system mode to save the remaining system mode registers. */
     SRSDB   sp!, #SYS_MODE
     CPS     #SYS_MODE
     PUSH    {R0-R12, R14}
 
     /* Push the critical nesting count. */
-    LDR     R2, ulCriticalNestingConst
+    LDR     R2, =ulCriticalNesting
     LDR     R1, [R2]
     PUSH    {R1}
 
     /* Does the task have a floating point context that needs saving?  If
-    ulPortTaskHasFPUContext is 0 then no. */
-    LDR     R2, ulPortTaskHasFPUContextConst
+     * ulPortTaskHasFPUContext is 0 then no. */
+    LDR     R2, =ulPortTaskHasFPUContext
     LDR     R3, [R2]
     CMP     R3, #0
 
     /* Save the floating point context, if any. */
-    FMRXNE  R1,  FPSCR
+    VMRSNE  R1,  FPSCR
     VPUSHNE {D0-D15}
 #if configFPU_D32 == 1
     VPUSHNE {D16-D31}
@@ -82,24 +81,24 @@
     PUSH    {R3}
 
     /* Save the stack pointer in the TCB. */
-    LDR     R0, pxCurrentTCBConst
+    LDR     R0, =pxCurrentTCB
     LDR     R1, [R0]
     STR     SP, [R1]
 
     .endm
 
-; /**********************************************************************/
+/*-----------------------------------------------------------*/
 
 .macro portRESTORE_CONTEXT
 
     /* Set the SP to point to the stack of the task being restored. */
-    LDR     R0, pxCurrentTCBConst
+    LDR     R0, =pxCurrentTCB
     LDR     R1, [R0]
     LDR     SP, [R1]
 
     /* Is there a floating point context to restore?  If the restored
-    ulPortTaskHasFPUContext is zero then no. */
-    LDR     R0, ulPortTaskHasFPUContextConst
+     * ulPortTaskHasFPUContext is zero then no. */
+    LDR     R0, =ulPortTaskHasFPUContext
     POP     {R1}
     STR     R1, [R0]
     CMP     R1, #0
@@ -113,7 +112,7 @@
     VMSRNE  FPSCR, R0
 
     /* Restore the critical section nesting depth. */
-    LDR     R0, ulCriticalNestingConst
+    LDR     R0, =ulCriticalNesting
     POP     {R1}
     STR     R1, [R0]
 
@@ -126,25 +125,25 @@
 
     .endm
 
+/*-----------------------------------------------------------*/
 
-
-
-/******************************************************************************
+/*
  * SVC handler is used to yield.
- *****************************************************************************/
+ */
 .align 4
 .type FreeRTOS_SVC_Handler, %function
 FreeRTOS_SVC_Handler:
     /* Save the context of the current task and select a new task to run. */
     portSAVE_CONTEXT
-    LDR R0, vTaskSwitchContextConst
-    BLX R0
+    BLX vTaskSwitchContext
     portRESTORE_CONTEXT
 
 
-/******************************************************************************
+/*-----------------------------------------------------------*/
+
+/*
  * vPortRestoreTaskContext is used to start the scheduler.
- *****************************************************************************/
+ */
 .align 4
 .type vPortRestoreTaskContext, %function
 vPortRestoreTaskContext:
@@ -152,25 +151,30 @@ vPortRestoreTaskContext:
     CPS     #SYS_MODE
     portRESTORE_CONTEXT
 
+/*-----------------------------------------------------------*/
 
-/******************************************************************************
- * vPortInitialiseFPSCR is used to initialize the FPSCR context.
- *****************************************************************************/
+/*
+ * vPortInitialiseFPSCR is used to initialize the FPSCR register.
+ */
 .align 4
 .type vPortInitialiseFPSCR, %function
 vPortInitialiseFPSCR:
     MOV     R0, #0
-    FMXR    FPSCR, R0
+    VMSR    FPSCR, R0
     BX      LR
 
-/******************************************************************************
- * ulReadValueAPSR is used to read the value of APSR context.
- *****************************************************************************/
+/*-----------------------------------------------------------*/
+
+/*
+ * ulReadAPSR is used to read the value of APSR context.
+ */
 .align 4
-.type ulReadValueAPSR, %function
-ulReadValueAPSR:
+.type ulReadAPSR, %function
+ulReadAPSR:
     MRS R0, APSR
     BX LR
+
+/*-----------------------------------------------------------*/
 
 .align 4
 .type FreeRTOS_IRQ_Handler, %function
@@ -184,29 +188,28 @@ FreeRTOS_IRQ_Handler:
     PUSH    {lr}
 
     /* Change to supervisor mode to allow reentry. */
-    CPS     #0x13
+    CPS     #SVC_MODE
 
     /* Push used registers. */
     PUSH    {r0-r3, r12}
 
     /* Increment nesting count.  r3 holds the address of ulPortInterruptNesting
-    for future use.  r1 holds the original ulPortInterruptNesting value for
-    future use. */
-    LDR     r3, ulPortInterruptNestingConst
+     * for future use.  r1 holds the original ulPortInterruptNesting value for
+     * future use. */
+    LDR     r3, =ulPortInterruptNesting
     LDR     r1, [r3]
     ADD     r0, r1, #1
     STR     r0, [r3]
 
     /* Ensure bit 2 of the stack pointer is clear.  r2 holds the bit 2 value for
-    future use. */
+     * future use. */
     MOV     r0, sp
     AND     r2, r0, #4
     SUB     sp, sp, r2
 
     /* Call the interrupt handler. */
     PUSH    {r0-r3, lr}
-    LDR     r1, vApplicationIRQHandlerConst
-    BLX     r1
+    BLX     vApplicationIRQHandler
     POP     {r0-r3, lr}
     ADD     sp, sp, r2
 
@@ -215,7 +218,7 @@ FreeRTOS_IRQ_Handler:
     ISB
 
     /* Write to the EOI register. */
-    LDR     r0, ulICCEOIRConst
+    LDR     r0, =ulICCEOIR
     LDR     r2, [r0]
     STR     r0, [r2]
 
@@ -227,16 +230,16 @@ FreeRTOS_IRQ_Handler:
     BNE     exit_without_switch
 
     /* Did the interrupt request a context switch?  r1 holds the address of
-    ulPortYieldRequired and r0 the value of ulPortYieldRequired for future
-    use. */
-    LDR     r1, ulPortYieldRequiredConst
+     * ulPortYieldRequired and r0 the value of ulPortYieldRequired for future
+     * use. */
+    LDR     r1, =ulPortYieldRequired
     LDR     r0, [r1]
     CMP     r0, #0
     BNE     switch_before_exit
 
 exit_without_switch:
     /* No context switch.  Restore used registers, LR_irq and SPSR before
-    returning. */
+     * returning. */
     POP     {r0-r3, r12}
     CPS     #IRQ_MODE
     POP     {LR}
@@ -246,12 +249,12 @@ exit_without_switch:
 
 switch_before_exit:
     /* A context switch is to be performed.  Clear the context switch pending
-    flag. */
+     * flag. */
     MOV     r0, #0
     STR     r0, [r1]
 
     /* Restore used registers, LR-irq and SPSR before saving the context
-    to the task stack. */
+     * to the task stack. */
     POP     {r0-r3, r12}
     CPS     #IRQ_MODE
     POP     {LR}
@@ -260,23 +263,15 @@ switch_before_exit:
     portSAVE_CONTEXT
 
     /* Call the function that selects the new task to execute.
-    vTaskSwitchContext() if vTaskSwitchContext() uses LDRD or STRD
-    instructions, or 8 byte aligned stack allocated data.  LR does not need
-    saving as a new LR will be loaded by portRESTORE_CONTEXT anyway. */
-    LDR     R0, vTaskSwitchContextConst
-    BLX     R0
+     * vTaskSwitchContext() if vTaskSwitchContext() uses LDRD or STRD
+     * instructions, or 8 byte aligned stack allocated data.  LR does not need
+     * saving as a new LR will be loaded by portRESTORE_CONTEXT anyway. */
+    BLX     vTaskSwitchContext
 
     /* Restore the context of, and branch to, the task selected to execute
-    next. */
+     * next. */
     portRESTORE_CONTEXT
 
-ulICCEOIRConst: .word ulICCEOIR
-pxCurrentTCBConst: .word pxCurrentTCB
-ulCriticalNestingConst: .word ulCriticalNesting
-ulPortTaskHasFPUContextConst: .word ulPortTaskHasFPUContext
-vTaskSwitchContextConst: .word vTaskSwitchContext
-vApplicationIRQHandlerConst: .word vApplicationIRQHandler
-ulPortInterruptNestingConst: .word ulPortInterruptNesting
-ulPortYieldRequiredConst: .word ulPortYieldRequired
+/*-----------------------------------------------------------*/
 
 .end

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -53,6 +53,7 @@
     .global vPortEnableInterrupts
     .global vPortDisableInterrupts
     .global ulPortSetInterruptMaskFromISR
+    .global ulPortCountLeadingZeros
 
     .weak   vApplicationSVCHandler
 /*-----------------------------------------------------------*/
@@ -233,6 +234,21 @@ ulPortSetInterruptMaskFromISR:
 .type vApplicationSVCHandler, %function
 vApplicationSVCHandler:
     B vApplicationSVCHandler
+
+/*-----------------------------------------------------------*/
+
+/*
+ * UBaseType_t ulPortCountLeadingZeros( UBaseType_t ulBitmap );
+ *
+ * According to the Procedure Call Standard for the ARM Architecture (AAPCS):
+ * - Parameter ulBitmap is passed in R0.
+ * - Return value must be in R0.
+ */
+.align 4
+.type ulPortCountLeadingZeros, %function
+ulPortCountLeadingZeros:
+    CLZ     R0, R0
+    BX      LR
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -48,6 +48,7 @@
     .global FreeRTOS_SVC_Handler
     .global vPortRestoreTaskContext
     .global vPortInitialiseFPSCR
+    .global ulReadValueAPSR
 
 
 .macro portSAVE_CONTEXT
@@ -161,6 +162,15 @@ vPortInitialiseFPSCR:
     MOV     R0, #0
     FMXR    FPSCR, R0
     BX      LR
+
+/******************************************************************************
+ * ulReadValueAPSR is used to read the value of APSR context.
+ *****************************************************************************/
+.align 4
+.type ulReadValueAPSR, %function
+ulReadValueAPSR:
+    MRS R0, APSR
+    BX LR
 
 .align 4
 .type FreeRTOS_IRQ_Handler, %function

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -28,6 +28,7 @@
 
     .text
     .arm
+    .syntax unified
 
     .set SYS_MODE,   0x1f
     .set SVC_MODE,   0x13
@@ -53,6 +54,7 @@
     .global vPortDisableInterrupts
     .global ulPortSetInterruptMaskFromISR
 
+    .weak   vApplicationSVCHandler
 /*-----------------------------------------------------------*/
 
 .macro portSAVE_CONTEXT
@@ -129,20 +131,6 @@
     RFEIA   sp!
 
     .endm
-
-/*-----------------------------------------------------------*/
-
-/*
- * SVC handler is used to yield.
- */
-.align 4
-.type FreeRTOS_SVC_Handler, %function
-FreeRTOS_SVC_Handler:
-    /* Save the context of the current task and select a new task to run. */
-    portSAVE_CONTEXT
-    BLX vTaskSwitchContext
-    portRESTORE_CONTEXT
-
 
 /*-----------------------------------------------------------*/
 
@@ -235,6 +223,51 @@ ulPortSetInterruptMaskFromISR:
     DSB
     ISB
     BX      LR
+
+/*-----------------------------------------------------------*/
+
+/*
+ * void vApplicationSVCHandler( uint32_t ulSvcNumber );
+ */
+.align 4
+.type vApplicationSVCHandler, %function
+vApplicationSVCHandler:
+    B vApplicationSVCHandler
+
+/*-----------------------------------------------------------*/
+
+/*
+ * SVC handler is used to yield.
+ */
+.align 4
+.type FreeRTOS_SVC_Handler, %function
+FreeRTOS_SVC_Handler:
+    PUSH    { R0-R1 }
+
+    /* ---------------------------- Get Caller SVC Number ---------------------------- */
+    MRS     R0, SPSR               /* R0 = CPSR at the time of SVC. */
+    TST     R0, #0x20              /* Check Thumb bit (5) in CPSR. */
+    LDRHNE  R0, [LR, #-0x2]        /* If Thumb, load halfword. */
+    BICNE   R0, R0, #0xFF00        /* And extract immidiate field (i.e. SVC number). */
+    LDREQ   R0, [LR, #-0x4]        /* If ARM, load word. */
+    BICEQ   R0, R0, #0xFF000000    /* And extract immidiate field (i.e. SVC number). */
+
+    /* --------------------------------- SVC Routing --------------------------------- */
+    CMP     R0, #0
+    BEQ     svcPortYield
+    BNE     svcApplicationCall
+
+svcPortYield:
+    POP     { R0-R1 }
+    portSAVE_CONTEXT
+    BLX     vTaskSwitchContext
+    portRESTORE_CONTEXT
+
+svcApplicationCall:
+    POP     { R0-R1 }
+    portSAVE_CONTEXT
+    BLX     vApplicationSVCHandler
+    portRESTORE_CONTEXT
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -47,6 +47,7 @@
     .global FreeRTOS_IRQ_Handler
     .global FreeRTOS_SVC_Handler
     .global vPortRestoreTaskContext
+    .global vPortInitialiseFPSCR
 
 
 .macro portSAVE_CONTEXT
@@ -149,15 +150,17 @@ vPortRestoreTaskContext:
     /* Switch to system mode. */
     CPS     #SYS_MODE
     portRESTORE_CONTEXT
-    
+
+
+/******************************************************************************
+ * vPortInitialiseFPSCR is used to initialize the FPSCR context.
+ *****************************************************************************/
 .align 4
-.type vSetupFPU, %function
-vSetupFPU:
-    PUSH  { R0 }
-    MOV   R0, #0x0
-    FMXR  FPSCR, R0
-    POP   { R0 }
-    BX 	  LR
+.type vPortInitialiseFPSCR, %function
+vPortInitialiseFPSCR:
+    MOV     R0, #0
+    FMXR    FPSCR, R0
+    BX      LR
 
 .align 4
 .type FreeRTOS_IRQ_Handler, %function

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -29,9 +29,10 @@
     .text
     .arm
 
-    .set SYS_MODE,  0x1f
-    .set SVC_MODE,  0x13
-    .set IRQ_MODE,  0x12
+    .set SYS_MODE,   0x1f
+    .set SVC_MODE,   0x13
+    .set IRQ_MODE,   0x12
+    .set CPSR_I_BIT, 0x80
 
     /* Variables and functions. */
     .extern pxCurrentTCB
@@ -47,6 +48,10 @@
     .global vPortRestoreTaskContext
     .global vPortInitialiseFPSCR
     .global ulReadAPSR
+    .global vPortYield
+    .global vPortEnableInterrupts
+    .global vPortDisableInterrupts
+    .global ulPortSetInterruptMaskFromISR
 
 /*-----------------------------------------------------------*/
 
@@ -142,6 +147,8 @@ FreeRTOS_SVC_Handler:
 /*-----------------------------------------------------------*/
 
 /*
+ * void vPortRestoreTaskContext( void );
+ *
  * vPortRestoreTaskContext is used to start the scheduler.
  */
 .align 4
@@ -154,6 +161,8 @@ vPortRestoreTaskContext:
 /*-----------------------------------------------------------*/
 
 /*
+ * void vPortInitialiseFPSCR( void );
+ *
  * vPortInitialiseFPSCR is used to initialize the FPSCR register.
  */
 .align 4
@@ -166,13 +175,66 @@ vPortInitialiseFPSCR:
 /*-----------------------------------------------------------*/
 
 /*
+ * uint32_t ulReadAPSR( void );
+ *
  * ulReadAPSR is used to read the value of APSR context.
  */
 .align 4
 .type ulReadAPSR, %function
 ulReadAPSR:
     MRS R0, APSR
-    BX LR
+    BX  LR
+
+/*-----------------------------------------------------------*/
+
+/*
+ * void vPortYield( void );
+ */
+.align 4
+.type vPortYield, %function
+vPortYield:
+    SVC 0
+    ISB
+    BX  LR
+
+/*-----------------------------------------------------------*/
+
+/*
+ * void vPortEnableInterrupts( void );
+ */
+.align 4
+.type vPortEnableInterrupts, %function
+vPortEnableInterrupts:
+    CPSIE   I
+    BX      LR
+
+/*-----------------------------------------------------------*/
+
+/*
+ * void vPortDisableInterrupts( void );
+ */
+.align 4
+.type vPortDisableInterrupts, %function
+vPortDisableInterrupts:
+    CPSID    I
+    DSB
+    ISB
+    BX      LR
+
+/*-----------------------------------------------------------*/
+
+/*
+ * uint32_t ulPortSetInterruptMaskFromISR( void );
+ */
+.align 4
+.type ulPortSetInterruptMaskFromISR, %function
+ulPortSetInterruptMaskFromISR:
+    MRS     R0, CPSR
+    AND     R0, R0, #CPSR_I_BIT
+    CPSID   I
+    DSB
+    ISB
+    BX      LR
 
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -149,6 +149,15 @@ vPortRestoreTaskContext:
     /* Switch to system mode. */
     CPS     #SYS_MODE
     portRESTORE_CONTEXT
+    
+.align 4
+.type vSetupFPU, %function
+vSetupFPU:
+    PUSH  { R0 }
+    MOV   R0, #0x0
+    FMXR  FPSCR, R0
+    POP   { R0 }
+    BX 	  LR
 
 .align 4
 .type FreeRTOS_IRQ_Handler, %function

--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -62,7 +62,7 @@
 
     /* Save the LR and SPSR onto the system mode stack before switching to
      * system mode to save the remaining system mode registers. */
-    SRSDB   sp!, #SYS_MODE
+    SRSDB   SP!, #SYS_MODE
     CPS     #SYS_MODE
     PUSH    {R0-R12, R14}
 
@@ -80,9 +80,6 @@
     /* Save the floating point context, if any. */
     VMRSNE  R1,  FPSCR
     VPUSHNE {D0-D15}
-#if configFPU_D32 == 1
-    VPUSHNE {D16-D31}
-#endif /* configFPU_D32 */
     PUSHNE  {R1}
 
     /* Save ulPortTaskHasFPUContext itself. */
@@ -129,7 +126,7 @@
     POP     {R0-R12, R14}
 
     /* Return to the task code, loading CPSR on the way. */
-    RFEIA   sp!
+    RFEIA   SP!
 
     .endm
 
@@ -291,67 +288,68 @@ svcApplicationCall:
 .type FreeRTOS_IRQ_Handler, %function
 FreeRTOS_IRQ_Handler:
     /* Return to the interrupted instruction. */
-    SUB     lr, lr, #4
+    SUB     LR, LR, #4
 
     /* Push the return address and SPSR. */
-    PUSH    {lr}
-    MRS     lr, SPSR
-    PUSH    {lr}
+    PUSH    {LR}
+    MRS     LR, SPSR
+    PUSH    {LR}
 
     /* Change to supervisor mode to allow reentry. */
     CPS     #SVC_MODE
 
     /* Push used registers. */
-    PUSH    {r0-r3, r12}
+    PUSH    {R0-R3, R12}
 
     /* Increment nesting count.  r3 holds the address of ulPortInterruptNesting
      * for future use.  r1 holds the original ulPortInterruptNesting value for
      * future use. */
-    LDR     r3, =ulPortInterruptNesting
-    LDR     r1, [r3]
-    ADD     r0, r1, #1
-    STR     r0, [r3]
+    LDR     R3, =ulPortInterruptNesting
+    LDR     R1, [R3]
+    ADD     R0, R1, #1
+    STR     R0, [R3]
 
     /* Ensure bit 2 of the stack pointer is clear.  r2 holds the bit 2 value for
      * future use. */
-    MOV     r0, sp
-    AND     r2, r0, #4
-    SUB     sp, sp, r2
+    MOV     R0, SP
+    AND     R2, R0, #4
+    SUB     SP, SP, R2
 
     /* Call the interrupt handler. */
-    PUSH    {r0-r3, lr}
+    PUSH    {R0-R3, LR}
     BLX     vApplicationIRQHandler
-    POP     {r0-r3, lr}
-    ADD     sp, sp, r2
+    POP     {R0-R3, LR}
+    ADD     SP, SP, R2
 
+    /* Disable IRQs incase vApplicationIRQHandler enabled them for re-entry. */
     CPSID   i
     DSB
     ISB
 
     /* Write to the EOI register. */
-    LDR     r0, =ulICCEOIR
-    LDR     r2, [r0]
-    STR     r0, [r2]
+    LDR     R0, =ulICCEOIR
+    LDR     R2, [R0]
+    STR     R0, [R2]
 
     /* Restore the old nesting count. */
-    STR     r1, [r3]
+    STR     R1, [R3]
 
     /* A context switch is never performed if the nesting count is not 0. */
-    CMP     r1, #0
+    CMP     R1, #0
     BNE     exit_without_switch
 
     /* Did the interrupt request a context switch?  r1 holds the address of
      * ulPortYieldRequired and r0 the value of ulPortYieldRequired for future
      * use. */
-    LDR     r1, =ulPortYieldRequired
-    LDR     r0, [r1]
-    CMP     r0, #0
+    LDR     R1, =ulPortYieldRequired
+    LDR     R0, [R1]
+    CMP     R0, #0
     BNE     switch_before_exit
 
 exit_without_switch:
     /* No context switch.  Restore used registers, LR_irq and SPSR before
      * returning. */
-    POP     {r0-r3, r12}
+    POP     {R0-R3, R12}
     CPS     #IRQ_MODE
     POP     {LR}
     MSR     SPSR_cxsf, LR
@@ -361,12 +359,12 @@ exit_without_switch:
 switch_before_exit:
     /* A context switch is to be performed.  Clear the context switch pending
      * flag. */
-    MOV     r0, #0
-    STR     r0, [r1]
+    MOV     R0, #0
+    STR     R0, [R1]
 
     /* Restore used registers, LR-irq and SPSR before saving the context
      * to the task stack. */
-    POP     {r0-r3, r12}
+    POP     {R0-R3, R12}
     CPS     #IRQ_MODE
     POP     {LR}
     MSR     SPSR_cxsf, LR

--- a/portable/GCC/ARM_CRx_No_GIC/portmacro.h
+++ b/portable/GCC/ARM_CRx_No_GIC/portmacro.h
@@ -59,7 +59,7 @@ typedef long             BaseType_t;
 typedef unsigned long    UBaseType_t;
 
 typedef uint32_t         TickType_t;
-#define portMAX_DELAY              ( TickType_t ) 0xffffffffUL
+#define portMAX_DELAY    ( TickType_t ) 0xffffffffUL
 
 /* 32-bit tick type on a 32-bit architecture, so reads of the tick count do
  * not need to be guarded with a critical section. */
@@ -92,10 +92,11 @@ typedef uint32_t         TickType_t;
     __asm volatile ( "SWI 0     \n" \
                      "ISB         " ::: "memory" );
 
+/*-----------------------------------------------------------*/
 
-/*-----------------------------------------------------------
-* Critical section control
-*----------------------------------------------------------*/
+/*
+ * Critical section management.
+ */
 
 extern void vPortEnterCritical( void );
 extern void vPortExitCritical( void );
@@ -163,19 +164,15 @@ void vPortTaskUsesFPU( void );
 
 #if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
 
-/* Store/clear the ready priorities in a bit map. */
+    /* Store, clear and get the ready priorities in a bit map. */
     #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
     #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
-
-/*-----------------------------------------------------------*/
-
-    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )    uxTopPriority = ( 31UL - ( uint32_t ) __builtin_clz( uxReadyPriorities ) )
+    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )  uxTopPriority = ( 31UL - ( uint32_t ) __builtin_clz( uxReadyPriorities ) )
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
 #define portNOP()               __asm volatile ( "NOP" )
-#define portINLINE    __inline
-
+#define portINLINE              __inline
 #define portMEMORY_BARRIER()    __asm volatile ( "" ::: "memory" )
 
 /* *INDENT-OFF* */

--- a/portable/GCC/ARM_CRx_No_GIC/portmacro.h
+++ b/portable/GCC/ARM_CRx_No_GIC/portmacro.h
@@ -149,8 +149,8 @@ UBaseType_t ulPortCountLeadingZeros( UBaseType_t ulBitmap );
 #if ( configUSE_TASK_FPU_SUPPORT != 2 )
     void vPortTaskUsesFPU( void );
 #else
-    /* Each task has an FPU context already, so define this function away to
-     * nothing to prevent it from being called accidentally. */
+    /* Each task has an FPU context already, so define this function as a
+     *no-op. */
     #define vPortTaskUsesFPU()
 #endif
 #define portTASK_USES_FLOATING_POINT()    vPortTaskUsesFPU()

--- a/portable/GCC/ARM_CRx_No_GIC/portmacro.h
+++ b/portable/GCC/ARM_CRx_No_GIC/portmacro.h
@@ -132,6 +132,15 @@ extern uint32_t ulPortSetInterruptMaskFromISR( void );
  * handler for whichever peripheral is used to generate the RTOS tick. */
 void FreeRTOS_Tick_Handler( void );
 
+/**
+ * @brief Returns the number of leading zeros in a 32 bit variable.
+ *
+ * @param[in] ulBitmap 32-Bit number to count leading zeros in.
+ *
+ * @return The number of leading zeros in ulBitmap.
+ */
+UBaseType_t ulPortCountLeadingZeros( UBaseType_t ulBitmap );
+
 /* If configUSE_TASK_FPU_SUPPORT is set to 1 (or left undefined) then tasks are
  * created without an FPU context and must call vPortTaskUsesFPU() to give
  * themselves an FPU context before using any FPU instructions.  If
@@ -159,7 +168,7 @@ void FreeRTOS_Tick_Handler( void );
     /* Store, clear and get the ready priorities in a bit map. */
     #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
     #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
-    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )  uxTopPriority = ( 31UL - ( uint32_t ) __builtin_clz( uxReadyPriorities ) )
+    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )  uxTopPriority = ( 31UL - ulPortCountLeadingZeros( ( uxTopReadyPriority ) ) )
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 

--- a/portable/GCC/ARM_CRx_No_GIC/portmacro.h
+++ b/portable/GCC/ARM_CRx_No_GIC/portmacro.h
@@ -105,9 +105,6 @@ extern void vPortEnableInterrupts( void );
 extern void vPortDisableInterrupts( void );
 extern uint32_t ulPortSetInterruptMaskFromISR( void );
 
-/* The I bit within the CPSR. */
-#define portINTERRUPT_ENABLE_BIT    ( 1 << 7 )
-
 /* In the absence of a priority mask register, these functions and macros
  * globally enable and disable interrupts. */
 #define portENTER_CRITICAL()                    vPortEnterCritical();
@@ -135,9 +132,18 @@ extern uint32_t ulPortSetInterruptMaskFromISR( void );
  * handler for whichever peripheral is used to generate the RTOS tick. */
 void FreeRTOS_Tick_Handler( void );
 
-/* Any task that uses the floating point unit MUST call vPortTaskUsesFPU()
- * before any floating point instructions are executed. */
-void vPortTaskUsesFPU( void );
+/* If configUSE_TASK_FPU_SUPPORT is set to 1 (or left undefined) then tasks are
+ * created without an FPU context and must call vPortTaskUsesFPU() to give
+ * themselves an FPU context before using any FPU instructions.  If
+ * configUSE_TASK_FPU_SUPPORT is set to 2 then all tasks will have an FPU
+ * context by default. */
+#if ( configUSE_TASK_FPU_SUPPORT != 2 )
+    void vPortTaskUsesFPU( void );
+#else
+    /* Each task has an FPU context already, so define this function away to
+     * nothing to prevent it from being called accidentally. */
+    #define vPortTaskUsesFPU()
+#endif
 #define portTASK_USES_FLOATING_POINT()    vPortTaskUsesFPU()
 
 #define portLOWEST_INTERRUPT_PRIORITY           ( ( ( uint32_t ) configUNIQUE_INTERRUPT_PRIORITIES ) - 1UL )

--- a/portable/GCC/ARM_CRx_No_GIC/portmacro.h
+++ b/portable/GCC/ARM_CRx_No_GIC/portmacro.h
@@ -150,7 +150,7 @@ UBaseType_t ulPortCountLeadingZeros( UBaseType_t ulBitmap );
     void vPortTaskUsesFPU( void );
 #else
     /* Each task has an FPU context already, so define this function as a
-     *no-op. */
+     * no-op. */
     #define vPortTaskUsesFPU()
 #endif
 #define portTASK_USES_FLOATING_POINT()    vPortTaskUsesFPU()


### PR DESCRIPTION
Description
-----------
This PR makes the following improvements to the ARM_CRx_No_GIC port-
1. Remove inline assembly and move all the assembly code to the `portASM.S` file.
2. Add support for `configUSE_TASK_FPU_SUPPORT` - 
    * When `configUSE_TASK_FPU_SUPPORT` is defined to 1, tasks are created without floating point context. Tasks that want to use floating point, need to call `portTASK_USES_FLOATING_POINT()`. This is the current behavior.
    * When `configUSE_TASK_FPU_SUPPORT` is defined to 2, each task is created with a floating point context.
   
    If left undefined, `configUSE_TASK_FPU_SUPPORT` defaults to 1 for backward compatibility. 
3. The application writer can now implement `vApplicationSVCHandler` to handle the `SVC` calls raised within the application. `SVC 0` is used for the yield kernel operation and the application can use all the `SVC` calls other than 0.

Test Steps
-----------
Tested using register tests and standard full demo tests on the TI RM57 board.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
