### PR TITLE
Fix POSIX port to respect configUSE_TIME_SLICING

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -264,7 +264,7 @@ BaseType_t xPortStartScheduler( void )
     #else /* Linux PTHREAD library*/
         hSigSetupThread = PTHREAD_ONCE_INIT;
     #endif /* __APPLE__*/
-    
+
     /* Restore original signal mask. */
     ( void ) pthread_sigmask( SIG_SETMASK, &xSchedulerOriginalSignalMask, NULL );
 
@@ -382,7 +382,7 @@ static uint64_t prvGetTimeNs( void )
 static void * prvTimerTickHandler( void * arg )
 {
     ( void ) arg;
-    
+
     prvPortSetCurrentThreadName("Scheduler timer");
 
     while( xTimerTickThreadShouldRun )
@@ -420,36 +420,19 @@ static void vPortSystemTickHandler( int sig )
 
     ( void ) sig;
 
-/* uint64_t xExpectedTicks; */
-
     uxCriticalNesting++; /* Signals are blocked in this signal handler. */
 
-    #if ( configUSE_PREEMPTION == 1 )
-        pxThreadToSuspend = prvGetThreadFromTask( xTaskGetCurrentTaskHandle() );
-    #endif
+    pxThreadToSuspend = prvGetThreadFromTask( xTaskGetCurrentTaskHandle() );
 
-    /* Tick Increment, accounting for any lost signals or drift in
-     * the timer. */
-
-/*
- *      Comment code to adjust timing according to full demo requirements
- *      xExpectedTicks = (prvGetTimeNs() - prvStartTimeNs)
- *        / (portTICK_RATE_MICROSECONDS * 1000);
- * do { */
-    xTaskIncrementTick();
-
-/*        prvTickCount++;
- *    } while (prvTickCount < xExpectedTicks);
- */
-
-    #if ( configUSE_PREEMPTION == 1 )
+    if( xTaskIncrementTick() != pdFALSE )
+    {
         /* Select Next Task. */
         vTaskSwitchContext();
 
         pxThreadToResume = prvGetThreadFromTask( xTaskGetCurrentTaskHandle() );
 
         prvSwitchThread( pxThreadToResume, pxThreadToSuspend );
-    #endif
+    }
 
     uxCriticalNesting--;
 }


### PR DESCRIPTION
Description
-----------
Fix POSIX port to respect configUSE_TIME_SLICING.

Test Steps
-----------
```c
int main( void )
{
    BaseType_t xTaskCreationResult = pdFAIL;

    xTaskCreationResult = xTaskCreate( prvTask1Function,
                                       "Task1",
                                       configMINIMAL_STACK_SIZE,
                                       NULL,
                                       tskIDLE_PRIORITY,
                                       NULL );
    configASSERT( xTaskCreationResult == pdPASS );

    vTaskStartScheduler();

    for( ;; )
    {

    }

    return 0;
}
/*-----------------------------------------------------------*/

static void prvTask1Function( void * pvParams )
{
    uint64_t i;
    BaseType_t xTaskCreationResult = pdFAIL;

    /* Silence warning about unused parameters. */
    ( void ) pvParams;

    xTaskCreationResult = xTaskCreate( prvTask2Function,
                                       "Task2",
                                       configMINIMAL_STACK_SIZE,
                                       NULL,
                                       tskIDLE_PRIORITY,
                                       NULL );
    configASSERT( xTaskCreationResult == pdPASS );

    for( ;; )
    {
        configPRINTF( "Task 1 running...\r\n" );

        for( i = 0; i < 100000000; i++ )
        {
            /* This loop is just a very crude delay implementation. */
        }
    }
}
/*-----------------------------------------------------------*/

static void prvTask2Function( void * pvParams )
{
    uint64_t i;

    /* Silence warning about unused parameters. */
    ( void ) pvParams;

    for( ;; )
    {
        configPRINTF( "Task 2 running...\r\n" );

        for( i = 0; i < 100000000; i++ )
        {
            /* This loop is just a very crude delay implementation. */
        }
    }
}
/*-----------------------------------------------------------*/
```

When configUSE_TIME_SLICING is set to 0, without this change, the above test outputs the following - 
```
Task 1 running...
Task 2 running...
Task 1 running...
Task 2 running...
```

After the change, the above test outputs the following - 
```
Task 1 running...
Task 1 running...
Task 1 running...
Task 1 running...
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
