### PR TITLE
Fix ulStackSize overflow on Apple GCC port

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -169,7 +169,9 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         pxEndOfStack = ( StackType_t * ) mach_vm_round_page( pxEndOfStack );
     #endif
 
-    ulStackSize = ( size_t ) ( pxTopOfStack + 1 - pxEndOfStack ) * sizeof( *pxTopOfStack );
+    /* Ensure ulStackSize is not overflow */
+    ulStackSize = ( pxTopOfStack + 1 > pxEndOfStack ) ? ( pxTopOfStack + 1 - pxEndOfStack ) : ( pxEndOfStack - pxTopOfStack + 1);
+    ulStackSize = ( size_t ) ( ulStackSize ) * sizeof( *pxTopOfStack );
 
     #ifdef __APPLE__
         ulStackSize = mach_vm_trunc_page( ulStackSize );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
On Apple M1, `mach_vm_round_page()` round the address of `pxEndOfStack` up to the end of the page, causing overflow of `ulStackSize`.

<img width="1188" alt="Screenshot 2567-07-29 at 21 01 10" src="https://github.com/user-attachments/assets/e846d050-22c0-469a-834e-ec3ce2f03464">

Test Steps
-----------
<img width="1174" alt="Screenshot 2567-07-29 at 21 03 58" src="https://github.com/user-attachments/assets/e68ccf5c-553d-4f9f-af13-ca02cb94d025">

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
