### PR TITLE
Add support for vApplicationFPUSafeIRQHandler

### DIFF
--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -39,6 +39,7 @@
     .extern pxCurrentTCB
     .extern vTaskSwitchContext
     .extern vApplicationIRQHandler
+    .extern vApplicationFPUSafeIRQHandler
     .extern ulPortInterruptNesting
     .extern ulPortTaskHasFPUContext
     .extern ulICCEOIR
@@ -234,6 +235,50 @@ ulPortSetInterruptMaskFromISR:
 .type vApplicationSVCHandler, %function
 vApplicationSVCHandler:
     B vApplicationSVCHandler
+
+/*-----------------------------------------------------------*/
+
+/* If the application provides an implementation of vApplicationIRQHandler(),
+ * then it will get called directly without saving the FPU registers on
+ * interrupt entry, and this weak implementation of vApplicationIRQHandler()
+ * will not get called.
+ *
+ * If the application provides its own implementation of
+ * vApplicationFPUSafeIRQHandler() then this implementation of
+ * vApplicationIRQHandler() will be called, save the FPU registers, and then
+ * call vApplicationFPUSafeIRQHandler().
+ *
+ * Therefore, if the application writer wants FPU registers to be saved on
+ * interrupt entry, their IRQ handler must be called
+ * vApplicationFPUSafeIRQHandler(), and if the application writer does not want
+ * FPU registers to be saved on interrupt entry their IRQ handler must be
+ * called vApplicationIRQHandler().
+ */
+.align 4
+.weak vApplicationIRQHandler
+.type vApplicationIRQHandler, %function
+vApplicationIRQHandler:
+    PUSH    {LR}
+
+    VMRS    R1, FPSCR
+    VPUSH   {D0-D7}
+    PUSH    {R1}
+
+    BLX     vApplicationFPUSafeIRQHandler
+
+    POP     {R0}
+    VPOP    {D0-D7}
+    VMSR    FPSCR, R0
+
+    POP     {PC}
+
+/*-----------------------------------------------------------*/
+
+.align 4
+.weak vApplicationFPUSafeIRQHandler
+.type vApplicationFPUSafeIRQHandler, %function
+vApplicationFPUSafeIRQHandler:
+    B       vApplicationFPUSafeIRQHandler
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
This PR adds support for `vApplicationFPUSafeIRQHandler`. The application writer needs to name their IRQ handler as:
1. `vApplicationIRQHandler` if the IRQ handler does not use FPU registers.
2.  `vApplicationFPUSafeIRQHandler` is the IRQ handler uses FPU registers.

When the application uses `vApplicationFPUSafeIRQHandler`, a default implementation of  `vApplicationIRQHandler` is used which stores FPU registers and then calls  `vApplicationFPUSafeIRQHandler`.

Test Steps
-----------
Tested on ARM_CRx_No_GIC [Demo ](https://github.com/FreeRTOS/FreeRTOS/pull/1236) with the code snippet
```
    __asm volatile ( "vmov d8, r0, r1       \n"
                     "vmov d9, r0, r1       \n"
                     "vmov d10, r0, r1      \n"
                     "vmov d11, r0, r1      \n"
                     "vmov d12, r0, r1      \n"
                     "vmov d13, r0, r1      \n"
                     "vmov d14, r0, r1      \n"
                     "vmov d15, r0, r1      \n"
                     ::: "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15" );

    __asm volatile ( "vmov d0, r0, r1       \n"
                     "vmov d1, r0, r1       \n"
                     "vmov d2, r0, r1       \n"
                     "vmov d3, r0, r1       \n"
                     "vmov d4, r0, r1       \n"
                     "vmov d5, r0, r1       \n"
                     "vmov d6, r0, r1       \n"
                     "vmov d7, r0, r1       \n"
                     ::: "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7" );
 ```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
