### PR TITLE
Add portMEMORY_BARRIER defination for Xtensa platform

### DIFF
--- a/portable/ThirdParty/XCC/Xtensa/portmacro.h
+++ b/portable/ThirdParty/XCC/Xtensa/portmacro.h
@@ -114,6 +114,7 @@ static inline unsigned portENTER_CRITICAL_NESTED() { unsigned state = XTOS_SET_I
 #define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
 #define portBYTE_ALIGNMENT          4
 #define portNOP()                   XT_NOP()
+#define portMEMORY_BARRIER()        XT_MEMW()
 /*-----------------------------------------------------------*/
 
 /* Fine resolution time */


### PR DESCRIPTION
Add portMEMORY_BARRIER defination for Xtensa platform.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The following code in xTaskResumeAll function may be over-optimized, the result is that the variable pxTCB does not change after the first loop.
```
pxTCB = listGET_OWNER_OF_HEAD_ENTRY( ( &xPendingReadyList ) );
listREMOVE_ITEM( &( pxTCB->xEventListItem ) );
portMEMORY_BARRIER();
listREMOVE_ITEM( &( pxTCB->xStateListItem ) );
prvAddTaskToReadyList( pxTCB );
```
The problem will be solved after define portMEMORY_BARRIER with a proper statement.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1114


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
