### PR TITLE
Enable Interrupts don't need NOP before portENABLE_INTERRUPTS

### DIFF
--- a/portable/IAR/MSP430X/portmacro.h
+++ b/portable/IAR/MSP430X/portmacro.h
@@ -73,7 +73,7 @@ typedef unsigned short   UBaseType_t;
 
 /* Interrupt control macros. */
 #define portDISABLE_INTERRUPTS()    __asm volatile ( "DINT\n" "NOP" )
-#define portENABLE_INTERRUPTS()     __asm volatile ( "NOP\n" "EINT\n" "NOP" )
+#define portENABLE_INTERRUPTS()     __asm volatile ( "EINT\n" "NOP" )
 /*-----------------------------------------------------------*/
 
 /* Critical section control macros. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
