### PR TITLE
Add heap protector to allocted heap blocks

### DIFF
--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -308,7 +308,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     /* The block is being returned - it is allocated and owned
                      * by the application and has no "next" block. */
                     heapALLOCATE_BLOCK( pxBlock );
-                    pxBlock->pxNextFreeBlock = NULL;
+                    pxBlock->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( NULL );
                     xNumberOfSuccessfulAllocations++;
                 }
                 else
@@ -367,11 +367,11 @@ void vPortFree( void * pv )
 
         heapVALIDATE_BLOCK_POINTER( pxLink );
         configASSERT( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 );
-        configASSERT( pxLink->pxNextFreeBlock == NULL );
+        configASSERT( pxLink->pxNextFreeBlock == heapPROTECT_BLOCK_POINTER( NULL ) );
 
         if( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 )
         {
-            if( pxLink->pxNextFreeBlock == NULL )
+            if( pxLink->pxNextFreeBlock == heapPROTECT_BLOCK_POINTER( NULL ) )
             {
                 /* The block is being returned to the heap - it is no longer
                  * allocated. */

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -336,7 +336,7 @@ void * pvPortMalloc( size_t xWantedSize )
                     /* The block is being returned - it is allocated and owned
                      * by the application and has no "next" block. */
                     heapALLOCATE_BLOCK( pxBlock );
-                    pxBlock->pxNextFreeBlock = NULL;
+                    pxBlock->pxNextFreeBlock = heapPROTECT_BLOCK_POINTER( NULL );
                     xNumberOfSuccessfulAllocations++;
                 }
                 else
@@ -395,11 +395,11 @@ void vPortFree( void * pv )
 
         heapVALIDATE_BLOCK_POINTER( pxLink );
         configASSERT( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 );
-        configASSERT( pxLink->pxNextFreeBlock == NULL );
+        configASSERT( pxLink->pxNextFreeBlock == heapPROTECT_BLOCK_POINTER( NULL ) );
 
         if( heapBLOCK_IS_ALLOCATED( pxLink ) != 0 )
         {
-            if( pxLink->pxNextFreeBlock == NULL )
+            if( pxLink->pxNextFreeBlock == heapPROTECT_BLOCK_POINTER( NULL ) )
             {
                 /* The block is being returned to the heap - it is no longer
                  * allocated. */


### PR DESCRIPTION
Description
-----------
When a block was allocated to the user by `pvPortMalloc`, its `pxNextFreeBlock` was set to NULL and not XORed with the canary (when `configENABLE_HEAP_PROTECTOR` was set to 1). As a result, a memory corruption which sets `pxNextFreeBlock` to zero wont be detected. 

This PR XORs `pxNextFreeBlock`  with the canary before returning the block to the user. This would ensure that a memory corruption would get detected if  `pxNextFreeBlock`  is modified. The only time it won't be caught is when  `pxNextFreeBlock` is updated to the canary value. Since canary values changes on every run, it is unlikely that a memory corruption would set `pxNextFreeBlock` to the canary value on every run.

Test Steps
-----------
I have tested the FreeRTOS/Demo test on the RISCV platform for heap_4 and heap_5.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://forums.freertos.org/t/queuestion-about-configenable-heap-protector-in-heap-5/21229


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
