### PR TITLE
Fix IA32 compilation with common IRQ entry disabled

### DIFF
--- a/portable/GCC/IA32_flat/port.c
+++ b/portable/GCC/IA32_flat/port.c
@@ -666,11 +666,13 @@ static BaseType_t prvCheckValidityOfVectorNumber( uint32_t ulVectorNumber )
         /* In use by FreeRTOS. */
         xReturn = pdFAIL;
     }
+#if ( configUSE_COMMON_INTERRUPT_ENTRY_POINT == 1 )
     else if( xInterruptHandlerTable[ ulVectorNumber ] != NULL )
     {
         /* Already in use by the application. */
         xReturn = pdFAIL;
     }
+#endif  /* configUSE_COMMON_INTERRUPT_ENTRY_POINT */
     else
     {
         xReturn = pdPASS;


### PR DESCRIPTION
Fix IA32 compilation with common IRQ entry disabled

Description
-----------
This change fixes compilation errors when using IA32 port when `configUSE_COMMON_INTERRUPT_ENTRY_POINT` is to to 0.
The follow compilation error is generated:

```
portable/GCC/IA32_flat/port.c:669:14: error: use of undeclared identifier 'xInterruptHandlerTable'
  669 |     else if( xInterruptHandlerTable[ ulVectorNumber ] != NULL )
 ```
Test Steps
-----------
* Modify `template_configuration/FreeRTOSConfig.h` as follows:
```diff
-#define configMAX_API_CALL_INTERRUPT_PRIORITY    0
+#define configMAX_API_CALL_INTERRUPT_PRIORITY    2  //Just to pass IA32 port.c checks
```
* Compiling with generate the above error.
```
gcc -m32 -march=pentium -c -o port.o portable/GCC/IA32_flat/port.c -DconfigISR_STACK_SIZE=256 -DconfigUSE_COMMON_INTERRUPT_ENTRY_POINT=0 -Iexamples/template_configuration -Iinclude -Iportable/GCC/IA32_flat
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
