### PR TITLE
Make ARM_AARCH64 Port SMP ready

### DIFF
--- a/portable/GCC/ARM_AARCH64/portASM.S
+++ b/portable/GCC/ARM_AARCH64/portASM.S
@@ -1,6 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
- * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -25,17 +25,24 @@
  * https://github.com/FreeRTOS
  *
  */
+#include "FreeRTOSConfig.h"
 
-    .text
+.section .interrupt_handlers, "ax"
 
     /* Variables and functions. */
     .extern ullMaxAPIPriorityMask
-    .extern pxCurrentTCB
+#if configNUMBER_OF_CORES == 1
+	.extern pxCurrentTCB
+    .extern ullCriticalNesting
+    .extern ullPortInterruptNesting
+#else
+    .extern pxCurrentTCBs
+    .extern ullCriticalNestings
+    .extern ullPortInterruptNestings
+#endif
     .extern vTaskSwitchContext
     .extern vApplicationIRQHandler
-    .extern ullPortInterruptNesting
     .extern ullPortTaskHasFPUContext
-    .extern ullCriticalNesting
     .extern ullPortYieldRequired
     .extern ullICCEOIR
     .extern ullICCIAR
@@ -45,12 +52,7 @@
     .global FreeRTOS_SWI_Handler
     .global vPortRestoreTaskContext
 
-
-.macro portSAVE_CONTEXT
-
-    /* Switch to use the EL0 stack pointer. */
-    MSR     SPSEL, #0
-
+.macro saveallgpregisters
     /* Save the entire context. */
     STP     X0, X1, [SP, #-0x10]!
     STP     X2, X3, [SP, #-0x10]!
@@ -68,30 +70,56 @@
     STP     X26, X27, [SP, #-0x10]!
     STP     X28, X29, [SP, #-0x10]!
     STP     X30, XZR, [SP, #-0x10]!
+.endm
 
-    /* Save the SPSR. */
-#if defined( GUEST )
-    MRS     X3, SPSR_EL1
-    MRS     X2, ELR_EL1
-#else
-    MRS     X3, SPSR_EL3
-    /* Save the ELR. */
-    MRS     X2, ELR_EL3
-#endif
+.macro restoreallgpregisters
+    LDP     X30, XZR, [SP], #0x10
+    LDP     X28, X29, [SP], #0x10
+    LDP     X26, X27, [SP], #0x10
+    LDP     X24, X25, [SP], #0x10
+    LDP     X22, X23, [SP], #0x10
+    LDP     X20, X21, [SP], #0x10
+    LDP     X18, X19, [SP], #0x10
+    LDP     X16, X17, [SP], #0x10
+    LDP     X14, X15, [SP], #0x10
+    LDP     X12, X13, [SP], #0x10
+    LDP     X10, X11, [SP], #0x10
+    LDP     X8, X9, [SP], #0x10
+    LDP     X6, X7, [SP], #0x10
+    LDP     X4, X5, [SP], #0x10
+    LDP     X2, X3, [SP], #0x10
+    LDP     X0, X1, [SP], #0x10
+.endm
 
+.macro savefuncontextgpregs
+    STP     X0, X1, [SP, #-0x10]!
     STP     X2, X3, [SP, #-0x10]!
+    STP     X4, X5, [SP, #-0x10]!
+    STP     X6, X7, [SP, #-0x10]!
+    STP     X8, X9, [SP, #-0x10]!
+    STP     X10, X11, [SP, #-0x10]!
+    STP     X12, X13, [SP, #-0x10]!
+    STP     X14, X15, [SP, #-0x10]!
+    STP     X16, X17, [SP, #-0x10]!
+    STP     X18, X19, [SP, #-0x10]!
+    STP     X29, X30, [SP, #-0x10]!
+.endm
 
-    /* Save the critical section nesting depth. */
-    LDR     X0, ullCriticalNestingConst
-    LDR     X3, [X0]
+.macro restorefuncontextgpregs
+    LDP     X29, X30, [SP], #0x10
+    LDP     X18, X19, [SP], #0x10
+    LDP     X16, X17, [SP], #0x10
+    LDP     X14, X15, [SP], #0x10
+    LDP     X12, X13, [SP], #0x10
+    LDP     X10, X11, [SP], #0x10
+    LDP     X8, X9, [SP], #0x10
+    LDP     X6, X7, [SP], #0x10
+    LDP     X4, X5, [SP], #0x10
+    LDP     X2, X3, [SP], #0x10
+    LDP     X0, X1, [SP], #0x10
+.endm
 
-    /* Save the FPU context indicator. */
-    LDR     X0, ullPortTaskHasFPUContextConst
-    LDR     X2, [X0]
-
-    /* Save the FPU context, if any (32 128-bit registers). */
-    CMP     X2, #0
-    B.EQ    1f
+.macro savefloatregisters
     STP     Q0, Q1, [SP,#-0x20]!
     STP     Q2, Q3, [SP,#-0x20]!
     STP     Q4, Q5, [SP,#-0x20]!
@@ -108,12 +136,86 @@
     STP     Q26, Q27, [SP,#-0x20]!
     STP     Q28, Q29, [SP,#-0x20]!
     STP     Q30, Q31, [SP,#-0x20]!
+.endm
+
+.macro restorefloatregisters
+    LDP     Q30, Q31, [SP], #0x20
+    LDP     Q28, Q29, [SP], #0x20
+    LDP     Q26, Q27, [SP], #0x20
+    LDP     Q24, Q25, [SP], #0x20
+    LDP     Q22, Q23, [SP], #0x20
+    LDP     Q20, Q21, [SP], #0x20
+    LDP     Q18, Q19, [SP], #0x20
+    LDP     Q16, Q17, [SP], #0x20
+    LDP     Q14, Q15, [SP], #0x20
+    LDP     Q12, Q13, [SP], #0x20
+    LDP     Q10, Q11, [SP], #0x20
+    LDP     Q8, Q9, [SP], #0x20
+    LDP     Q6, Q7, [SP], #0x20
+    LDP     Q4, Q5, [SP], #0x20
+    LDP     Q2, Q3, [SP], #0x20
+    LDP     Q0, Q1, [SP], #0x20
+.endm
+
+.macro portSAVE_CONTEXT
+    /* Switch to use the EL0 stack pointer. */
+    MSR     SPSEL, #0
+    /* Save the entire context. */
+    saveallgpregisters
+
+    /* Save the SPSR. */
+#if defined( GUEST )
+    MRS     X3, SPSR_EL1
+    MRS     X2, ELR_EL1
+#else
+    MRS     X3, SPSR_EL3
+    /* Save the ELR. */
+    MRS     X2, ELR_EL3
+#endif
+
+    STP     X2, X3, [SP, #-0x10]!
+
+    /* Save the critical section nesting depth. */
+    LDR     X0, ullCriticalNestingsConst
+#if configNUMBER_OF_CORES > 1
+    /* Calculate the correct index for ullCriticalNestings array based on core ID. */
+    MRS     X1, MPIDR_EL1          // Read the Multiprocessor Affinity Register
+    AND     X1, X1, #0xff          // Extract Aff0 which contains the core ID
+
+    /* Calculate offset to the correct critical nesting value based on the core ID */
+    LSL     X1, X1, #3             // Multiply core ID by 8 (size of a pointer on ARM64)
+
+    ADD     X0, X0, X1             // Add to the base of the critical nesting array
+#endif
+    LDR     X3, [X0]
+
+    /* Save the FPU context indicator. */
+    LDR     X0, ullPortTaskHasFPUContextConst
+#if configNUMBER_OF_CORES > 1
+    ADD     X0, X0, X1             // Add to the base of the FPU array
+#endif
+    LDR     X2, [X0]
+
+    /* Save the FPU context, if any (32 128-bit registers). */
+    CMP     X2, #0
+    B.EQ    1f
+    savefloatregisters
 
 1:
     /* Store the critical nesting count and FPU context indicator. */
     STP     X2, X3, [SP, #-0x10]!
 
-    LDR     X0, pxCurrentTCBConst
+    LDR     X0, pxCurrentTCBsConst
+#if configNUMBER_OF_CORES > 1
+    MRS     X1, MPIDR_EL1          // Read the Multiprocessor Affinity Register
+    AND     X1, X1, #0xff          // Extract Aff0 which contains the core ID
+
+    /* Calculate offset to the correct TCB pointer based on the core ID */
+    LSL     X1, X1, #3             // Multiply core ID by 8 (size of a pointer on ARM64)
+    ADD     X0, X0, X1             // Add to the base of the TCB array
+#endif
+
+    /* Load the address of the TCB for the current core */
     LDR     X1, [X0]
     MOV     X0, SP   /* Move SP into X0 for saving. */
     STR     X0, [X1]
@@ -131,16 +233,33 @@
     MSR     SPSEL, #0
 
     /* Set the SP to point to the stack of the task being restored. */
-    LDR     X0, pxCurrentTCBConst
+    LDR     X0, pxCurrentTCBsConst
+#if configNUMBER_OF_CORES > 1
+    /* Get the core ID to index the TCB correctly. */
+    MRS     X2, MPIDR_EL1             // Read the Multiprocessor Affinity Register
+    AND     X2, X2, #0xff             // Extract Aff0 which contains the core ID
+    LSL     X2, X2, #3                // Scale the core ID to the size of a pointer (64-bit system)
+
+    ADD     X0, X0, X2                // Add the offset for the current core's TCB pointer
+#endif
     LDR     X1, [X0]
     LDR     X0, [X1]
     MOV     SP, X0
 
     LDP     X2, X3, [SP], #0x10  /* Critical nesting and FPU context. */
 
-    /* Set the PMR register to be correct for the current critical nesting
-    depth. */
-    LDR     X0, ullCriticalNestingConst /* X0 holds the address of ullCriticalNesting. */
+
+    /* Calculate offset for the current core's ullCriticalNesting and load its address. */
+    LDR     X0, ullCriticalNestingsConst    /* Load base address of the ullCriticalNesting array */
+#if configNUMBER_OF_CORES > 1
+    /* Existing code to get core ID and scale to pointer size is reused. */
+    MRS     X1, MPIDR_EL1             /* Read Multiprocessor Affinity Register */
+    AND     X1, X1, #0xff             /* Extract Aff0, which contains the core ID */
+    LSL     X1, X1, #3                /* Scale core ID to the size of a pointer (assuming 64-bit system) */
+    ADD     X0, X0, X1                      /* Add offset for the current core's ullCriticalNesting */
+    LDR     X0, [X0]                        /* Load the address of the ullCriticalNesting for the current core */
+#endif
+
     MOV     X1, #255                    /* X1 holds the unmask value. */
     LDR     X4, ullICCPMRConst          /* X4 holds the address of the ICCPMR constant. */
     CMP     X3, #0
@@ -154,29 +273,22 @@
     ISB     SY
     STR     X3, [X0]                    /* Restore the task's critical nesting count. */
 
-    /* Restore the FPU context indicator. */
     LDR     X0, ullPortTaskHasFPUContextConst
+
+#if configNUMBER_OF_CORES > 1
+	/* Existing code to get core ID and scale to pointer size is reused. */
+    MRS     X1, MPIDR_EL1             /* Read Multiprocessor Affinity Register */
+    AND     X1, X1, #0xff             /* Extract Aff0, which contains the core ID */
+    LSL     X1, X1, #3                /* Scale core ID to the size of a pointer (assuming 64-bit system) */
+    /* Restore the FPU context indicator. */
+    ADD     X0, X0, X1             // Add to the base of the FPU array
+#endif
     STR     X2, [X0]
 
     /* Restore the FPU context, if any. */
     CMP     X2, #0
     B.EQ    1f
-    LDP     Q30, Q31, [SP], #0x20
-    LDP     Q28, Q29, [SP], #0x20
-    LDP     Q26, Q27, [SP], #0x20
-    LDP     Q24, Q25, [SP], #0x20
-    LDP     Q22, Q23, [SP], #0x20
-    LDP     Q20, Q21, [SP], #0x20
-    LDP     Q18, Q19, [SP], #0x20
-    LDP     Q16, Q17, [SP], #0x20
-    LDP     Q14, Q15, [SP], #0x20
-    LDP     Q12, Q13, [SP], #0x20
-    LDP     Q10, Q11, [SP], #0x20
-    LDP     Q8, Q9, [SP], #0x20
-    LDP     Q6, Q7, [SP], #0x20
-    LDP     Q4, Q5, [SP], #0x20
-    LDP     Q2, Q3, [SP], #0x20
-    LDP     Q0, Q1, [SP], #0x20
+    restorefloatregisters
 1:
     LDP     X2, X3, [SP], #0x10  /* SPSR and ELR. */
 
@@ -192,22 +304,7 @@
     MSR     ELR_EL3, X2
 #endif
 
-    LDP     X30, XZR, [SP], #0x10
-    LDP     X28, X29, [SP], #0x10
-    LDP     X26, X27, [SP], #0x10
-    LDP     X24, X25, [SP], #0x10
-    LDP     X22, X23, [SP], #0x10
-    LDP     X20, X21, [SP], #0x10
-    LDP     X18, X19, [SP], #0x10
-    LDP     X16, X17, [SP], #0x10
-    LDP     X14, X15, [SP], #0x10
-    LDP     X12, X13, [SP], #0x10
-    LDP     X10, X11, [SP], #0x10
-    LDP     X8, X9, [SP], #0x10
-    LDP     X6, X7, [SP], #0x10
-    LDP     X4, X5, [SP], #0x10
-    LDP     X2, X3, [SP], #0x10
-    LDP     X0, X1, [SP], #0x10
+    restoreallgpregisters
 
     /* Switch to use the ELx stack pointer.  _RB_ Might not be required. */
     MSR     SPSEL, #1
@@ -239,6 +336,8 @@ FreeRTOS_SWI_Handler:
     CMP     X1, #0x17   /* 0x17 = SMC instruction. */
 #endif
     B.NE    FreeRTOS_Abort
+    MRS 	x0, mpidr_el1
+    AND     x0, x0, 255
     BL      vTaskSwitchContext
 
     portRESTORE_CONTEXT
@@ -276,17 +375,8 @@ vPortRestoreTaskContext:
 .type FreeRTOS_IRQ_Handler, %function
 FreeRTOS_IRQ_Handler:
     /* Save volatile registers. */
-    STP     X0, X1, [SP, #-0x10]!
-    STP     X2, X3, [SP, #-0x10]!
-    STP     X4, X5, [SP, #-0x10]!
-    STP     X6, X7, [SP, #-0x10]!
-    STP     X8, X9, [SP, #-0x10]!
-    STP     X10, X11, [SP, #-0x10]!
-    STP     X12, X13, [SP, #-0x10]!
-    STP     X14, X15, [SP, #-0x10]!
-    STP     X16, X17, [SP, #-0x10]!
-    STP     X18, X19, [SP, #-0x10]!
-    STP     X29, X30, [SP, #-0x10]!
+    savefuncontextgpregs
+    savefloatregisters
 
     /* Save the SPSR and ELR. */
 #if defined( GUEST )
@@ -299,7 +389,16 @@ FreeRTOS_IRQ_Handler:
     STP     X2, X3, [SP, #-0x10]!
 
     /* Increment the interrupt nesting counter. */
-    LDR     X5, ullPortInterruptNestingConst
+    LDR     X5, ullPortInterruptNestingsConst   /* Load base address of the ullPortYieldRequired array */
+#if configNUMBER_OF_CORES > 1
+    /* Existing code to get core ID and scale to pointer size is reused. */
+    MRS     X2, MPIDR_EL1             /* Read Multiprocessor Affinity Register */
+    AND     X2, X2, #0xff             /* Extract Aff0, which contains the core ID */
+    LSL     X2, X2, #3                /* Scale core ID to the size of a pointer (assuming 64-bit system) */
+
+    /* Calculate offset for the current core's ullPortYieldRequired and load its address. */
+    ADD     X5, X5, X2                      /* Add offset for the current core's ullPortYieldRequired */
+#endif
     LDR     X1, [X5]    /* Old nesting count in X1. */
     ADD     X6, X1, #1
     STR     X6, [X5]    /* Address of nesting count variable in X5. */
@@ -313,6 +412,7 @@ FreeRTOS_IRQ_Handler:
     LDR     X3, [X2]
     LDR     W0, [X3]    /* ICCIAR in W0 as parameter. */
 
+	/* ICCIAR in W0 as parameter. */
     /* Maintain the ICCIAR value across the function call. */
     STP     X0, X1, [SP, #-0x10]!
 
@@ -342,6 +442,16 @@ FreeRTOS_IRQ_Handler:
 
     /* Is a context switch required? */
     LDR     X0, ullPortYieldRequiredConst
+
+#if configNUMBER_OF_CORES > 1
+    /* Existing code to get core ID and scale to pointer size is reused. */
+    MRS     X2, MPIDR_EL1             /* Read Multiprocessor Affinity Register */
+    AND     X2, X2, #0xff             /* Extract Aff0, which contains the core ID */
+    LSL     X2, X2, #3                /* Scale core ID to the size of a pointer (assuming 64-bit system) */
+
+    /* Calculate offset for the current core's ullPortYieldRequired and load its address. */
+    ADD     X0, X0, X2                      /* Add offset for the current core's ullPortYieldRequired */
+#endif
     LDR     X1, [X0]
     CMP     X1, #0
     B.EQ    Exit_IRQ_No_Context_Switch
@@ -362,20 +472,13 @@ FreeRTOS_IRQ_Handler:
     DSB     SY
     ISB     SY
 
-    LDP     X29, X30, [SP], #0x10
-    LDP     X18, X19, [SP], #0x10
-    LDP     X16, X17, [SP], #0x10
-    LDP     X14, X15, [SP], #0x10
-    LDP     X12, X13, [SP], #0x10
-    LDP     X10, X11, [SP], #0x10
-    LDP     X8, X9, [SP], #0x10
-    LDP     X6, X7, [SP], #0x10
-    LDP     X4, X5, [SP], #0x10
-    LDP     X2, X3, [SP], #0x10
-    LDP     X0, X1, [SP], #0x10
+    restorefloatregisters
+    restorefuncontextgpregs
 
     /* Save the context of the current task and select a new task to run. */
     portSAVE_CONTEXT
+    MRS 	x0, mpidr_el1
+    AND     x0, x0, 255
     BL vTaskSwitchContext
     portRESTORE_CONTEXT
 
@@ -392,17 +495,8 @@ Exit_IRQ_No_Context_Switch:
     DSB     SY
     ISB     SY
 
-    LDP     X29, X30, [SP], #0x10
-    LDP     X18, X19, [SP], #0x10
-    LDP     X16, X17, [SP], #0x10
-    LDP     X14, X15, [SP], #0x10
-    LDP     X12, X13, [SP], #0x10
-    LDP     X10, X11, [SP], #0x10
-    LDP     X8, X9, [SP], #0x10
-    LDP     X6, X7, [SP], #0x10
-    LDP     X4, X5, [SP], #0x10
-    LDP     X2, X3, [SP], #0x10
-    LDP     X0, X1, [SP], #0x10
+    restorefloatregisters
+    restorefuncontextgpregs
 
     ERET
 
@@ -410,14 +504,22 @@ Exit_IRQ_No_Context_Switch:
 
 
 .align 8
-pxCurrentTCBConst: .dword pxCurrentTCB
-ullCriticalNestingConst: .dword ullCriticalNesting
-ullPortTaskHasFPUContextConst: .dword ullPortTaskHasFPUContext
+#if configNUMBER_OF_CORES == 1
+	pxCurrentTCBsConst: .dword pxCurrentTCB
+	ullCriticalNestingsConst: .dword ullCriticalNesting
+	ullPortInterruptNestingsConst: .dword ullPortInterruptNesting
+	ullPortYieldRequiredConst: .dword ullPortYieldRequired
+	ullPortTaskHasFPUContextConst: .dword ullPortTaskHasFPUContext
+#else
+	pxCurrentTCBsConst: .dword pxCurrentTCBs
+	ullCriticalNestingsConst: .dword ullCriticalNestings
+	ullPortInterruptNestingsConst: .dword ullPortInterruptNestings
+	ullPortYieldRequiredConst: .dword ullPortYieldRequired
+	ullPortTaskHasFPUContextConst: .dword ullPortTaskHasFPUContext
+#endif
 
 ullICCPMRConst: .dword ullICCPMR
 ullMaxAPIPriorityMaskConst: .dword ullMaxAPIPriorityMask
-ullPortInterruptNestingConst: .dword ullPortInterruptNesting
-ullPortYieldRequiredConst: .dword ullPortYieldRequired
 ullICCIARConst: .dword ullICCIAR
 ullICCEOIRConst: .dword ullICCEOIR
 vApplicationIRQHandlerConst: .word vApplicationIRQHandler


### PR DESCRIPTION
This change makes the ARM_AARCH64 Port ready for SMP use.

Description
-----------
As part of my master thesis I developed this Port. It was specifically developed for the Zynq Ultrascale Platform but only contains changes that are applicable to all AARCH64 Processors and therefor should work on all of them. I tested all of the code in Release and Debug build using the FullDemo of FreeRTOS. All Tests ran fine for over a week continuously.

Test Steps
-----------
Testing the code requires implementing the vPortStartCore function used in port.c in a file called hardware_setup.c . I can only provide a specific version for the Zynq Platform. Please let me know if I should provide them as part of the Community-Supported-Ports repository.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
