### PR TITLE
Fix getting stats on the current running task running time.

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -6171,6 +6171,16 @@ static void prvCheckTasksWaitingTermination( void )
         #if ( configGENERATE_RUN_TIME_STATS == 1 )
         {
             pxTaskStatus->ulRunTimeCounter = pxTCB->ulRunTimeCounter;
+            if( pxTCB == pxCurrentTCB )
+            {
+                  uint32_t ulCurrentTotalRunTime;
+#ifdef portALT_GET_RUN_TIME_COUNTER_VALUE
+                  portALT_GET_RUN_TIME_COUNTER_VALUE( ulCurrentTotalRunTime );
+#else
+                  ulCurrentTotalRunTime = portGET_RUN_TIME_COUNTER_VALUE();
+#endif
+                  pxTaskStatus->ulRunTimeCounter += ( ulCurrentTotalRunTime - ulTaskSwitchedInTime );
+            }
         }
         #else
         {


### PR DESCRIPTION

<!--- Title -->
Fix getting stats on the current running task running time via vTaskGetInfo.
 This is especially important if the current task is stuck
Description
-----------
<!--- Describe your changes in detail. -->

I caused a task to stuck with while (true){} and when my watchdog catches it display the correct running time after my change.
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
