### PR TITLE
refactor: remove uneccesary task{ENTER | EXIT}_CRITICAL()

### DIFF
--- a/.github/third_party_tools.md
+++ b/.github/third_party_tools.md
@@ -11,4 +11,4 @@ team.
 | Tool | Website | Getting Started |
 |------|---------|-----------------|
 | Code Sonar | [Link](https://codesecure.com/our-products/codesonar/) | [Link](https://github.com/CodeSecure-SE/FreeRTOS-Kernel/blob/main/examples/codesonar/README.md) |
-| Coverity | [Link](https://www.synopsys.com/software-integrity/security-testing/static-analysis-sast.html) | [Link](../examples/coverity/README.md) |
+| Coverity | [Link](https://www.blackduck.com/static-analysis-tools-sast/coverity.html) | [Link](../examples/coverity/README.md) |

--- a/examples/coverity/README.md
+++ b/examples/coverity/README.md
@@ -1,6 +1,6 @@
 # MISRA Compliance for FreeRTOS-Kernel
 FreeRTOS-Kernel is MISRA C:2012 compliant. This directory contains a project to
-run [Synopsys Coverity](https://www.synopsys.com/software-integrity/security-testing/static-analysis-sast.html)
+run [Synopsys Coverity](https://www.blackduck.com/static-analysis-tools-sast/coverity.html)
 for checking MISRA compliance.
 
 > **Note**

--- a/include/portable.h
+++ b/include/portable.h
@@ -85,6 +85,14 @@
     #define portARCH_NAME    NULL
 #endif
 
+#ifndef portBASE_TYPE_ENTER_CRITICAL
+	#define portBASE_TYPE_ENTER_CRITICAL() taskENTER_CRITICAL()
+#endif
+
+#ifndef portBASE_TYPE_EXIT_CRITICAL
+	#define portBASE_TYPE_EXIT_CRITICAL() taskEXIT_CRITICAL()
+#endif
+
 #ifndef configSTACK_DEPTH_TYPE
     #define configSTACK_DEPTH_TYPE    StackType_t
 #endif

--- a/include/portable.h
+++ b/include/portable.h
@@ -86,11 +86,11 @@
 #endif
 
 #ifndef portBASE_TYPE_ENTER_CRITICAL
-	#define portBASE_TYPE_ENTER_CRITICAL() taskENTER_CRITICAL()
+    #define portBASE_TYPE_ENTER_CRITICAL()    taskENTER_CRITICAL()
 #endif
 
 #ifndef portBASE_TYPE_EXIT_CRITICAL
-	#define portBASE_TYPE_EXIT_CRITICAL() taskEXIT_CRITICAL()
+    #define portBASE_TYPE_EXIT_CRITICAL()    taskEXIT_CRITICAL()
 #endif
 
 #ifndef configSTACK_DEPTH_TYPE

--- a/queue.c
+++ b/queue.c
@@ -2202,11 +2202,11 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
 
     configASSERT( xQueue );
 
-    taskENTER_CRITICAL();
+    portBASE_TYPE_ENTER_CRITICAL();
     {
         uxReturn = ( ( Queue_t * ) xQueue )->uxMessagesWaiting;
     }
-    taskEXIT_CRITICAL();
+    portBASE_TYPE_EXIT_CRITICAL();
 
     traceRETURN_uxQueueMessagesWaiting( uxReturn );
 
@@ -2223,11 +2223,11 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
 
     configASSERT( pxQueue );
 
-    taskENTER_CRITICAL();
+    portBASE_TYPE_ENTER_CRITICAL();
     {
         uxReturn = ( UBaseType_t ) ( pxQueue->uxLength - pxQueue->uxMessagesWaiting );
     }
-    taskEXIT_CRITICAL();
+    portBASE_TYPE_EXIT_CRITICAL();
 
     traceRETURN_uxQueueSpacesAvailable( uxReturn );
 

--- a/tasks.c
+++ b/tasks.c
@@ -2623,14 +2623,14 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskPriorityGet( xTask );
 
-        taskENTER_CRITICAL();
+        portBASE_TYPE_ENTER_CRITICAL();
         {
             /* If null is passed in here then it is the priority of the task
              * that called uxTaskPriorityGet() that is being queried. */
             pxTCB = prvGetTCBFromHandle( xTask );
             uxReturn = pxTCB->uxPriority;
         }
-        taskEXIT_CRITICAL();
+        portBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_uxTaskPriorityGet( uxReturn );
 
@@ -2697,14 +2697,14 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskBasePriorityGet( xTask );
 
-        taskENTER_CRITICAL();
+        portBASE_TYPE_ENTER_CRITICAL();
         {
             /* If null is passed in here then it is the base priority of the task
              * that called uxTaskBasePriorityGet() that is being queried. */
             pxTCB = prvGetTCBFromHandle( xTask );
             uxReturn = pxTCB->uxBasePriority;
         }
-        taskEXIT_CRITICAL();
+        portBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_uxTaskBasePriorityGet( uxReturn );
 
@@ -3040,12 +3040,12 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskCoreAffinityGet( xTask );
 
-        taskENTER_CRITICAL();
+        portBASE_TYPE_ENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             uxCoreAffinityMask = pxTCB->uxCoreAffinityMask;
         }
-        taskEXIT_CRITICAL();
+        portBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask );
 

--- a/timers.c
+++ b/timers.c
@@ -601,7 +601,7 @@
         traceENTER_xTimerGetReloadMode( xTimer );
 
         configASSERT( xTimer );
-        taskENTER_CRITICAL();
+        portBASE_TYPE_ENTER_CRITICAL();
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_AUTORELOAD ) == 0U )
             {
@@ -614,7 +614,7 @@
                 xReturn = pdTRUE;
             }
         }
-        taskEXIT_CRITICAL();
+        portBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_xTimerGetReloadMode( xReturn );
 
@@ -1169,7 +1169,7 @@
         configASSERT( xTimer );
 
         /* Is the timer in the list of active timers? */
-        taskENTER_CRITICAL();
+        portBASE_TYPE_ENTER_CRITICAL();
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_ACTIVE ) == 0U )
             {
@@ -1180,7 +1180,7 @@
                 xReturn = pdTRUE;
             }
         }
-        taskEXIT_CRITICAL();
+        portBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_xTimerIsTimerActive( xReturn );
 


### PR DESCRIPTION
refactor: remove uneccesary task{ENTER | EXIT}_CRITICAL()

Description
-----------
The call to the task{ENTER|EXIT}_CRITICAL() function is being made unnecessarily. It was probably placed to control access to the UBaseType_t variable, which the kernel is only accessed in atomic contexts. Therefore, the MUTEX to access this variable is not necessary since tasks in the atomic context do not have concurrency problems in accessing certain data

I would like to thanks @n9wxu, @svenbieg, @richard-damon to help me with this task.

Test Steps
-----------
For test in ATMega328p:

First I create this FreeRTOSConfig.h
```C
#ifndef FREERTOS_CONFIG_H
#define FREERTOS_CONFIG_H

#define configUSE_PREEMPTION            1
#define configUSE_IDLE_HOOK             0
#define configUSE_TICK_HOOK             0
#define configCPU_CLOCK_HZ              ( 16000000UL )
#define configTICK_RATE_HZ              ( ( TickType_t ) 1000 )
#define configMAX_PRIORITIES            ( 4 )
#define configMINIMAL_STACK_SIZE        ( 85 )
#define configTOTAL_HEAP_SIZE           ( ( size_t ) ( 1024 ) )
#define configMAX_TASK_NAME_LEN         ( 8 )
#define configUSE_TRACE_FACILITY        0
#define configUSE_16_BIT_TICKS          1
#define configIDLE_SHOULD_YIELD         1
#define configUSE_MUTEXES               1
#define configQUEUE_REGISTRY_SIZE       0
#define configCHECK_FOR_STACK_OVERFLOW  0
#define configUSE_RECURSIVE_MUTEXES     1
#define configUSE_MALLOC_FAILED_HOOK    0
#define configUSE_APPLICATION_TASK_TAG  0
#define configUSE_COUNTING_SEMAPHORES   1
#define configSUPPORT_DYNAMIC_ALLOCATION 1
#define INCLUDE_uxTaskPriorityGet 1
#define configUSE_TIMERS 1
#define configTIMER_TASK_PRIORITY 1
#define configTIMER_QUEUE_LENGTH 1
#define configUSE_TIMERS 1
#define configTIMER_TASK_STACK_DEPTH 1

#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0

#define configASSERT( x ) if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }

#endif /* FREERTOS_CONFIG_H */
```

Then, I create this simple Makefile
```
MCU = atmega328p
F_CPU = 16000000UL
CC = avr-gcc
OBJCOPY = avr-objcopy
CFLAGS = -mmcu=$(MCU) -DF_CPU=$(F_CPU) -Wall -Os
LDFLAGS = -mmcu=$(MCU) -lm

SRC = main.c help.c FreeRTOS-Kernel/timers.c FreeRTOS-Kernel/portable/MemMang/heap_1.c FreeRTOS-Kernel/portable/GCC/ATMega323/port.c FreeRTOS-Kernel/list.c FreeRTOS-Kernel/queue.c FreeRTOS-Kernel/tasks.c

TARGET = main

all: $(TARGET).hex

$(TARGET).elf: $(SRC)
	$(CC) $(CFLAGS) -o $@ $(SRC)

%.hex: %.elf
	$(OBJCOPY) -O ihex -R .eeprom $< $@

clean:
	rm -f *.o *.elf *.hex
```

For help me with some things like print in serial port I create this help.c
```c
#include <avr/interrupt.h>

#include "help.h"
#include <stdlib.h>
#include <stdio.h>

void serial_init(unsigned int ubrr) {
    UBRR0H = (unsigned char)(ubrr >> 8);
    UBRR0L = (unsigned char)ubrr;
    UCSR0B = (1 << RXEN0) | (1 << TXEN0);
    UCSR0C = (1 << UCSZ01) | (1 << UCSZ00);
}

static void USART_Transmit(unsigned char data) {
    while (!(UCSR0A & (1 << UDRE0)));
    UDR0 = data;
}

void serial_print(const char *str) {
    while (*str) {
        USART_Transmit(*str++);
    }
}

void to_str(unsigned int from, char *to) {
	sprintf(to, "%u", (unsigned int) from);
}
```

and this help.h
```c
#ifndef __HELP_H__
#define __HELP_H__

void serial_init(unsigned int ubrr);
void serial_print(const char *str);

void to_str(unsigned int from, char *to);

#endif
```

for make a simple test about create a simple task, I create this main.c:
```C
#define __AVR_ATmega328P__
#define F_CPU 16000000UL

#include "FreeRTOS-Kernel/Arduino_FreeRTOS.h"
#include "FreeRTOS-Kernel/include/task.h"

#include "help.h"

#define MYUBRR F_CPU/16/9599

void vTask1(void *pvParameters);

int main(void) {
    serial_init(MYUBRR);

	/// test a simple task create
	xTaskCreate(vTask1, "task1", 128, NULL, 1, NULL);

	vTaskStartScheduler();

	while(1); 
}

void vTask1(void *pvParameters) {
	serial_print("simple test about create a simple test...");
}
```

I compile: `make` and upload this for my Arduino:
```bash
avrdude -c arduino -P /dev/ttyUSB0 -b 115200 -p m328p -U flash:w:main.hex
```

I use the picocom for monitoring of serial port:
```bash
picocom -b 9600 /dev/ttyUSB0
```

main.c for test uxQueueMessagesWaiting() and uxQueueSpacesAvailable():
```c
#define __AVR_ATmega328P__
#define F_CPU 16000000UL

#include <avr/io.h>
#include <util/delay.h>
#include <stdlib.h>

#include "FreeRTOS-Kernel/Arduino_FreeRTOS.h"
#include "FreeRTOS-Kernel/include/queue.h"

#include "help.h"

#define MYUBRR F_CPU/16/9599

QueueHandle_t xQueue;

int main(void) {
    serial_init(MYUBRR);

	char *str = (char*) malloc(sizeof(char));

  	xQueue = xQueueCreate(10, sizeof(int));

  	if (xQueue == NULL) {
  	  serial_print("fail\n");
  	  return 1;
  	}

  	serial_print("queue created\n");

  	serial_print("messages in the queue (expected 0): ");
	to_str(uxQueueMessagesWaiting(xQueue), str);
  	serial_print(str);  // should print 0
	serial_print("\n");

  	int valor = 42;
  	for (int i = 0; i < 3; i++) {
  	  xQueueSend(xQueue, &valor, 0);
  	}

  	serial_print("messeges in the queue after added 3 elements (expected 3): ");
	to_str(uxQueueMessagesWaiting(xQueue), str);
  	serial_print(str);  // sould print 3
	serial_print("\n");

  	int recebido;
  	xQueueReceive(xQueue, &recebido, 0);

  	serial_print("messages in the queue after remove 1 element (expected 2): ");
	to_str(uxQueueMessagesWaiting(xQueue), str);
  	serial_print(str);  // should print 2
	serial_print("\n");

	serial_print("uxQueueSpacesAvailable (expected 8): ");
	to_str(uxQueueSpacesAvailable(xQueue), str);
	serial_print(str);
	serial_print("\n");

	while(1); 
}
```

for test uxTaskPriorityGet() ans uxTaskBasePriorityGet();
```c
#define __AVR_ATmega328P__
#define F_CPU 16000000UL

#include <stdlib.h>

#include "FreeRTOS-Kernel/Arduino_FreeRTOS.h"
#include "FreeRTOS-Kernel/include/task.h"

#include "help.h"

#define MYUBRR F_CPU/16/9599

void vTask1(void *pvParameters);

int main(void) {
    serial_init(MYUBRR);

	TaskHandle_t xHandle = NULL;

	/// test a simple task create
	xTaskCreate(vTask1, "task1", 128, NULL, 1, &xHandle);

	serial_print("task priority (expected 1): ");
	UBaseType_t res = uxTaskPriorityGet(xHandle);
	char *str = (char*) malloc(sizeof(char));
	to_str(res, str);
	serial_print(str);
	serial_print("\n");

	serial_print("task base priority (expected 1): ");
	UBaseType_t res_base = uxTaskBasePriorityGet(xHandle);
	to_str(res_base, str);
	serial_print(str);
	serial_print("\n");

	vTaskStartScheduler();
}

void vTask1(void *pvParameters) {
	serial_print("simple test about create a simple test...");
}

```

for test xTimerGetReloadMode() and xTimerIsTimerActive() 
```c
#define __AVR_ATmega328P__
#define F_CPU 16000000UL

#include <stdlib.h>

#include "FreeRTOS-Kernel/Arduino_FreeRTOS.h"
#include "FreeRTOS-Kernel/include/timers.h"

#include "help.h"

#define MYUBRR F_CPU/16/9599

TimerHandle_t periodicTimer;
TimerHandle_t oneShotTimer;

void vPeriodicTimerCallback(TimerHandle_t xTimer) {
  serial_print("temp added\n");
}

void vOneShotTimerCallback(TimerHandle_t xTimer) {
  serial_print("temp no periodic added\n");
}

int main(void) {
    serial_init(MYUBRR);

	periodicTimer = xTimerCreate("PeriodicTimer", pdMS_TO_TICKS(1000), pdTRUE, 0, vPeriodicTimerCallback);

  	if (periodicTimer == NULL) {
  	  serial_print("fail\n");
  	  return 1;
  	}

  	oneShotTimer = xTimerCreate("OneShotTimer", pdMS_TO_TICKS(1000), pdFALSE, 0, vOneShotTimerCallback);

  	if (oneShotTimer == NULL) {
  	  serial_print("fail\n");
  	  return 1;
  	}

  	xTimerStart(periodicTimer, 0);
  	xTimerStart(oneShotTimer, 0);

  	serial_print("Periodic timer recharge mode (expect - periodical): ");
	BaseType_t periodic = xTimerGetReloadMode(periodicTimer);
	char *str  = periodic == pdTRUE ? "periodical" : "not periodical";
  	serial_print(str);
  	serial_print("\n");

  	serial_print("Non-periodic timer recharge mode (expect - not periodical): ");
	BaseType_t nperiodic = xTimerGetReloadMode(oneShotTimer);
	char *nstr = periodic == pdFALSE ? "periodical" : "not periodical";
  	serial_print(nstr);
	serial_print("\n");


	char* astr = (char*) malloc(sizeof(char));

	serial_print("The timer is active? (expected 0): ");
	BaseType_t act = xTimerIsTimerActive(oneShotTimer);
	to_str(act, astr);
	serial_print(astr);
	serial_print("\n");
}
```

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[1059](https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1059)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

