### PR TITLE
Add configuration include to secure_heap.c

### DIFF
--- a/portable/ARMv8M/secure/heap/secure_heap.c
+++ b/portable/ARMv8M/secure/heap/secure_heap.c
@@ -29,7 +29,7 @@
 /* Standard includes. */
 #include <stdint.h>
 
-/* Configuration includes */
+/* Configuration includes. */
 #include "FreeRTOSConfig.h"
 
 /* Secure context heap includes. */

--- a/portable/ARMv8M/secure/heap/secure_heap.c
+++ b/portable/ARMv8M/secure/heap/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/GCC/ARM_CM23/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM23/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/GCC/ARM_CM33/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM33/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/GCC/ARM_CM35P/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM35P/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/GCC/ARM_CM55/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM55/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/GCC/ARM_CM85/secure/secure_heap.c
+++ b/portable/GCC/ARM_CM85/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/IAR/ARM_CM23/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM23/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/IAR/ARM_CM33/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM33/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/IAR/ARM_CM35P/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM35P/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/IAR/ARM_CM55/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM55/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 

--- a/portable/IAR/ARM_CM85/secure/secure_heap.c
+++ b/portable/IAR/ARM_CM85/secure/secure_heap.c
@@ -29,6 +29,9 @@
 /* Standard includes. */
 #include <stdint.h>
 
+/* Configuration includes. */
+#include "FreeRTOSConfig.h"
+
 /* Secure context heap includes. */
 #include "secure_heap.h"
 


### PR DESCRIPTION
Enables actually changing the size of the secure heap

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The secure heap is trying to use defines from FreeRTOSConfig.h but never actually included it. This patch changes this.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

1. Create a project with secure heap 
2. Increase the secure heap size in the config
3. Check real heap size via build analyzer

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
