### PR TITLE
Event Groups: snapshot xEventGroupSetBits returning value while in vTaskSuspendAll

### DIFF
--- a/event_groups.c
+++ b/event_groups.c
@@ -636,7 +636,7 @@
              * bit was set in the control word. */
             pxEventBits->uxEventBits &= ~uxBitsToClear;
 
-            /* Snapshot resulting bits */
+            /* Snapshot resulting bits. */
             uxReturnBits = pxEventBits->uxEventBits;
         }
         ( void ) xTaskResumeAll();

--- a/event_groups.c
+++ b/event_groups.c
@@ -551,7 +551,7 @@
         ListItem_t * pxNext;
         ListItem_t const * pxListEnd;
         List_t const * pxList;
-        EventBits_t uxBitsToClear = 0, uxBitsWaitedFor, uxControlBits;
+        EventBits_t uxBitsToClear = 0, uxBitsWaitedFor, uxControlBits, uxReturnBits;
         EventGroup_t * pxEventBits = xEventGroup;
         BaseType_t xMatchFound = pdFALSE;
 
@@ -635,12 +635,15 @@
             /* Clear any bits that matched when the eventCLEAR_EVENTS_ON_EXIT_BIT
              * bit was set in the control word. */
             pxEventBits->uxEventBits &= ~uxBitsToClear;
+
+            /* Snapshot resulting bits */
+            uxReturnBits = pxEventBits->uxEventBits;
         }
         ( void ) xTaskResumeAll();
 
-        traceRETURN_xEventGroupSetBits( pxEventBits->uxEventBits );
+        traceRETURN_xEventGroupSetBits( uxReturnBits );
 
-        return pxEventBits->uxEventBits;
+        return uxReturnBits;
     }
 /*-----------------------------------------------------------*/
 

--- a/include/event_groups.h
+++ b/include/event_groups.h
@@ -483,14 +483,11 @@ EventBits_t xEventGroupClearBits( EventGroupHandle_t xEventGroup,
  * and bit 0 set uxBitsToSet to 0x09.
  *
  * @return The value of the event group at the time the call to
- * xEventGroupSetBits() returns.  There are two reasons why the returned value
- * might have the bits specified by the uxBitsToSet parameter cleared.  First,
- * if setting a bit results in a task that was waiting for the bit leaving the
- * blocked state then it is possible the bit will be cleared automatically
- * (see the xClearBitOnExit parameter of xEventGroupWaitBits()).  Second, any
- * unblocked (or otherwise Ready state) task that has a priority above that of
- * the task that called xEventGroupSetBits() will execute and may change the
- * event group value before the call to xEventGroupSetBits() returns.
+ * xEventGroupSetBits() returns.  Returned value might have the bits specified
+ * by the uxBitsToSet parameter cleared if setting a bit results in a task
+ * that was waiting for the bit leaving the blocked state then it is possible
+ * the bit will be cleared automatically (see the xClearBitOnExit parameter
+ * of xEventGroupWaitBits()).
  *
  * Example usage:
  * @code{c}


### PR DESCRIPTION
Event Groups: snapshot xEventGroupSetBits returning value while in vTaskSuspendAll

Description
-----------
Event Groups: snapshot xEventGroupSetBits returning value while in vTaskSuspendAll.
Fixes uxEventBits dereference after event group deleted by higher priority thread.

Test Steps
-----------
Code example that causes issues: https://github.com/flipperdevices/flipperzero-firmware/blob/78c5dd95d867941206e1be2fd3585c9c76132bd7/furi/core/timer.c#L43

General flow to reproduce issue:
- In High Priority Thread:
  - Place StaticEventGroup_t on stack and initialize
  - Call xTimerPendFunctionCall, pass reference to callback and event group handler
  - Call xEventGroupWaitBits
  - Delete Event Group 
- In callback(which will be executed in timer thread):
  - use xEventGroupSetBits
  - check returned result

Previously return results was not guaranteed because High Priority Thread deleted EventGroup before uxEventBits dereference.
In this PR result will be as described in documentation.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1142


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
