### PR TITLE
Task: fix compiler warning for architectures that does not define portARMV8M_MINOR_VERSION

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -65,7 +65,7 @@
 #define tskMPU_REGION_EXECUTE_NEVER                   ( 1U << 2U )
 #define tskMPU_REGION_NORMAL_MEMORY                   ( 1U << 3U )
 #define tskMPU_REGION_DEVICE_MEMORY                   ( 1U << 4U )
-#if ( portARMV8M_MINOR_VERSION >= 1 )
+#if defined( portARMV8M_MINOR_VERSION ) && ( portARMV8M_MINOR_VERSION >= 1 )
     #define tskMPU_REGION_PRIVILEGED_EXECUTE_NEVER    ( 1U << 5U )
 #endif /* portARMV8M_MINOR_VERSION >= 1 */
 


### PR DESCRIPTION
Task: fix compiler warning for architectures that does not define portARMV8M_MINOR_VERSION

Description
-----------
task.h was using `#if` on macros that was not used in some architectures.
This fix explicitly checks if macros defined and only then compares it with value.

Test Steps
-----------
Compile with -Werror=undef 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
