### PR TITLE
Refine heap_5 heap protector

### DIFF
--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -129,12 +129,19 @@
  * heapVALIDATE_BLOCK_POINTER assert. */
     #define heapPROTECT_BLOCK_POINTER( pxBlock )    ( ( BlockLink_t * ) ( ( ( portPOINTER_SIZE_TYPE ) ( pxBlock ) ) ^ xHeapCanary ) )
 
-/* Assert that a heap block pointer is within the heap bounds. */
-    #define heapVALIDATE_BLOCK_POINTER( pxBlock )                       \
-    configASSERT( ( pucHeapHighAddress != NULL ) &&                     \
-                  ( pucHeapLowAddress != NULL ) &&                      \
-                  ( ( uint8_t * ) ( pxBlock ) >= pucHeapLowAddress ) && \
-                  ( ( uint8_t * ) ( pxBlock ) < pucHeapHighAddress ) )
+/* Assert that a heap block pointer is within the heap bounds.
+ * Setting configVALIDATE_HEAP_BLOCK_POINTER to 1 enables customized heap block pointers
+ * protection on heap_5. */
+    #ifndef configVALIDATE_HEAP_BLOCK_POINTER
+        #define heapVALIDATE_BLOCK_POINTER( pxBlock )                       \
+        configASSERT( ( pucHeapHighAddress != NULL ) &&                     \
+                    ( pucHeapLowAddress != NULL ) &&                        \
+                    ( ( uint8_t * ) ( pxBlock ) >= pucHeapLowAddress ) &&   \
+                    ( ( uint8_t * ) ( pxBlock ) < pucHeapHighAddress ) )
+    #else /* ifndef configVALIDATE_HEAP_BLOCK_POINTER */
+        #define heapVALIDATE_BLOCK_POINTER( pxBlock )                       \
+            configVALIDATE_HEAP_BLOCK_POINTER( pxBlock )
+    #endif /* configVALIDATE_HEAP_BLOCK_POINTER */
 
 #else /* if ( configENABLE_HEAP_PROTECTOR == 1 ) */
 

--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -133,13 +133,13 @@
  * Setting configVALIDATE_HEAP_BLOCK_POINTER to 1 enables customized heap block pointers
  * protection on heap_5. */
     #ifndef configVALIDATE_HEAP_BLOCK_POINTER
-        #define heapVALIDATE_BLOCK_POINTER( pxBlock )                       \
-        configASSERT( ( pucHeapHighAddress != NULL ) &&                     \
-                    ( pucHeapLowAddress != NULL ) &&                        \
-                    ( ( uint8_t * ) ( pxBlock ) >= pucHeapLowAddress ) &&   \
-                    ( ( uint8_t * ) ( pxBlock ) < pucHeapHighAddress ) )
+        #define heapVALIDATE_BLOCK_POINTER( pxBlock )                           \
+            configASSERT( ( pucHeapHighAddress != NULL ) &&                     \
+                          ( pucHeapLowAddress != NULL ) &&                      \
+                          ( ( uint8_t * ) ( pxBlock ) >= pucHeapLowAddress ) && \
+                          ( ( uint8_t * ) ( pxBlock ) < pucHeapHighAddress ) )
     #else /* ifndef configVALIDATE_HEAP_BLOCK_POINTER */
-        #define heapVALIDATE_BLOCK_POINTER( pxBlock )                       \
+        #define heapVALIDATE_BLOCK_POINTER( pxBlock )                           \
             configVALIDATE_HEAP_BLOCK_POINTER( pxBlock )
     #endif /* configVALIDATE_HEAP_BLOCK_POINTER */
 


### PR DESCRIPTION
heap_5 is used for multiple separated memory spaces. In the previous implementation, it only verifies the highest and lowest addresses. A pointer may not be within heap regions, but is still located between the highest and lowest addressed.

<!--- Title -->

Description
heap_5 is used for multiple separated memory spaces. In the previous implementation, it only verifies the highest and lowest addresses. A pointer may not be within heap regions, but is still located between the highest and lowest addressed.

This PR will use a buffer to record the boundary of each heap region so the pointer detection can be made more accurate . This buffter is dynamically allocated at the end of vPortDefineHeapRegions().  At this time, the multi heap regions have been defined and there is only a free block and "pxFakeEnd" (the heap structure points to the next heap region) and pxEnd (At the last heap region).

![Heap_range_diagram](https://github.com/user-attachments/assets/f3addc76-c8f1-43af-91fe-f99bbfa50236)

As shown in the diagram above, the white area represents the valid pointer range.


Test Steps
-----------
Test on [FreeRTO](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo) and runs correctly.
I have also manually corrupted a free list block and triggered assertion successfully.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
