### PR TITLE
Remove error for 16 MPU resgion from IAR ports

### DIFF
--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -54,11 +54,6 @@
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /* ARMv8-M common port configurations. */
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -58,16 +58,11 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
 #elif( configENABLE_MVE != 0 )
     #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
-
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
@@ -58,10 +58,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
 #elif( configENABLE_MVE != 0 )

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
@@ -63,11 +63,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Critical section management.
  */

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
@@ -63,11 +63,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Critical section management.
  */

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -54,11 +54,6 @@
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /* ARMv8-M common port configurations. */
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -58,16 +58,11 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
 #elif( configENABLE_MVE != 0 )
     #error configENABLE_MVE must be left undefined, or defined to 0 for the Cortex-M33.
 #endif
-
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacro.h
@@ -58,10 +58,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
 #elif( configENABLE_MVE != 0 )

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -58,10 +58,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-
 #ifndef configENABLE_MVE
     #define configENABLE_MVE    0
 #elif( configENABLE_MVE != 0 )

--- a/portable/IAR/ARM_CM55/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacro.h
@@ -63,11 +63,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Critical section management.
  */

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -63,11 +63,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Critical section management.
  */

--- a/portable/IAR/ARM_CM85/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacro.h
@@ -63,11 +63,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Critical section management.
  */

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -63,11 +63,6 @@
 #include "portmacrocommon.h"
 /*-----------------------------------------------------------*/
 
-#if ( configTOTAL_MPU_REGIONS == 16 )
-    #error 16 MPU regions are not yet supported for this port.
-#endif
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Critical section management.
  */


### PR DESCRIPTION
Description
-----------
Support for 16 MPU regions was added to Cortex-M33, M35P, M55 and M85 ports was added in [this PR](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/705) but the compile time error check was not removed. This results in compilation error when 16 MPU regions are used. This PR removes the not needed compile time error check.

Test Steps
-----------
Build IAR demo with `configTOTAL_MPU_REGIONS` set to 16.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://forums.freertos.org/t/cortex-m55-and-16-region-mpu-support/21470


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
