### PR TITLE
Add cast to xQueueGenericCreate to allow queue creation for 8-bit ports

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -513,7 +513,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
             /* Check for multiplication overflow. */
             ( ( SIZE_MAX / uxQueueLength ) >= uxItemSize ) &&
             /* Check for addition overflow. */
-            ( ( UBaseType_t ) ( SIZE_MAX - sizeof( Queue_t ) ) >= ( uxQueueLength * uxItemSize ) ) )
+            ( ( UBaseType_t ) ( SIZE_MAX - sizeof( Queue_t ) ) >= ( UBaseType_t ) ( uxQueueLength * uxItemSize ) ) )
         {
             /* Allocate enough space to hold the maximum number of items that
              * can be in the queue at any time.  It is valid for uxItemSize to be


### PR DESCRIPTION
Description
-----------
This PR addresses the bug which fails to create Queues with more element bytes than `UBaseType_t` for 8-bit ports. 
The fault is caused by the size of `UBaseType_t` on 8-bit ports which is `uint8_t`, meaning its maximum value is 255. This reduces the max "valid" size to a very small number.

Bigger CPUs like SAM/ARM which have UBaseType_t defined as uint16_t/uint32_t do not suffer this issue because such a large queues are not allocated in practice.

The fix is adding the case `UBaseType_t` to the RHS of this [check](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/queue.c#L516) 

Test Steps
-----------
Run the [Posix_GCC](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/Posix_GCC) demo with these changes:
`main_full.c`

```
int main_full( void )
{
    QueueHandle_t result1 = xQueueCreate(64, 4);
    if( result1 == NULL )
    {
        printf( "Queue 1 creation failed.\r\n" );
    }
    else
    {
        printf( "Queue 1 creation succeeded.\r\n" );
    }

    QueueHandle_t result2 = xQueueCreate(10, 2);
    if( result2 == NULL )
    {
        printf( "Queue 2 creation failed.\r\n" );
    }
    else
    {
        printf( "Queue 2 creation succeeded.\r\n" );
    }
}
```

O/p for Posix port
```
Queue 1 creation succeeded.
Queue 2 creation succeeded.
```

To simulate the 8-bit port behavior, this [line](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/queue.c#L516)  in `queue.c` is changed to :
```
( uint8_t ) ( SIZE_MAX - sizeof( Queue_t ) ) >= ( uxQueueLength * uxItemSize ) )
```
Output :
Queue Creation fails and [this configASSERT](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/queue.c#L554) is triggered. 

When this patch is applied :-
```
( uint8_t ) ( SIZE_MAX - sizeof( Queue_t ) ) >= ( uxQueueLength * uxItemSize ) )
```

Output:
```
Queue 1 creation succeeded.
Queue 2 creation succeeded.
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1151


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
