### PR TITLE
Feature - SMP Granular Locks

### DIFF
--- a/event_groups.c
+++ b/event_groups.c
@@ -621,13 +621,6 @@
         {
             traceEVENT_GROUP_SET_BITS( xEventGroup, uxBitsToSet );
 
-            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-
-                /* We are about to access the kernel data group non-deterministically,
-                 * thus we suspend the kernel data group.*/
-                vTaskSuspendAll();
-            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-
             pxListItem = listGET_HEAD_ENTRY( pxList );
 
             /* Set the bits. */
@@ -698,10 +691,6 @@
 
             /* Snapshot resulting bits. */
             uxReturnBits = pxEventBits->uxEventBits;
-
-            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-                ( void ) xTaskResumeAll();
-            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         }
         ( void ) event_groupsUNLOCK( pxEventBits );
 
@@ -726,13 +715,6 @@
         {
             traceEVENT_GROUP_DELETE( xEventGroup );
 
-            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-
-                /* We are about to access the kernel data group non-deterministically,
-                 * thus we suspend the kernel data group.*/
-                vTaskSuspendAll();
-            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-
             while( listCURRENT_LIST_LENGTH( pxTasksWaitingForBits ) > ( UBaseType_t ) 0 )
             {
                 /* Unblock the task, returning 0 as the event list is being deleted
@@ -740,10 +722,6 @@
                 configASSERT( pxTasksWaitingForBits->xListEnd.pxNext != ( const ListItem_t * ) &( pxTasksWaitingForBits->xListEnd ) );
                 vTaskRemoveFromUnorderedEventList( pxTasksWaitingForBits->xListEnd.pxNext, eventUNBLOCKED_DUE_TO_BIT_SET );
             }
-
-            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-                ( void ) xTaskResumeAll();
-            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         }
         ( void ) event_groupsUNLOCK( pxEventBits );
 

--- a/event_groups.c
+++ b/event_groups.c
@@ -112,21 +112,7 @@
  */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         #define event_groupsLOCK( pxEventBits )      taskDATA_GROUP_LOCK( &( ( pxEventBits )->xTaskSpinlock ) )
-        #define event_groupsUNLOCK( pxEventBits )                     \
-    ( {                                                               \
-        taskDATA_GROUP_UNLOCK( &( ( pxEventBits )->xTaskSpinlock ) ); \
-        BaseType_t xAlreadyYielded;                                   \
-        if( xTaskUnlockCanYield() == pdTRUE )                         \
-        {                                                             \
-            taskYIELD_WITHIN_API();                                   \
-            xAlreadyYielded = pdTRUE;                                 \
-        }                                                             \
-        else                                                          \
-        {                                                             \
-            xAlreadyYielded = pdFALSE;                                \
-        }                                                             \
-        xAlreadyYielded;                                              \
-    } )
+        #define event_groupsUNLOCK( pxEventBits )    taskDATA_GROUP_UNLOCK( &( ( pxEventBits )->xTaskSpinlock ) )
     #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         #define event_groupsLOCK( pxEventBits )      vTaskSuspendAll()
         #define event_groupsUNLOCK( pxEventBits )    xTaskResumeAll()

--- a/event_groups.c
+++ b/event_groups.c
@@ -883,14 +883,29 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         static BaseType_t prvUnlockEventGroupForTasks( EventGroup_t * pxEventBits )
         {
+            BaseType_t xReturn = pdFALSE;
+
             /* Release the previously held task spinlock */
             portRELEASE_SPINLOCK( portGET_CORE_ID(), &( pxEventBits->xTaskSpinlock ) );
 
             /* Re-enable preemption */
             vTaskPreemptionEnable( NULL );
 
-            /* We assume that the task was preempted when preemption was enabled */
-            return pdTRUE;
+            /* Yield if preemption was re-enabled*/
+            if( xTaskUnlockCanYield() == pdTRUE )
+            {
+                taskYIELD_WITHIN_API();
+
+                /* Return true as the task was preempted */
+                xReturn = pdTRUE;
+            }
+            else
+            {
+                /* Return false as the task was not preempted */
+                xReturn = pdFALSE;
+            }
+
+            return xReturn;
         }
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/

--- a/event_groups.c
+++ b/event_groups.c
@@ -113,9 +113,17 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         #define event_groupsLOCK( pxEventBits )      taskDATA_GROUP_LOCK( &( ( pxEventBits )->xTaskSpinlock ) )
         #define event_groupsUNLOCK( pxEventBits )    taskDATA_GROUP_UNLOCK( &( ( pxEventBits )->xTaskSpinlock ) )
+        #define event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, pxAlreadyYielded )         \
+    do {                                                                                      \
+        *( pxAlreadyYielded ) = taskDATA_GROUP_UNLOCK( &( ( pxEventBits )->xTaskSpinlock ) ); \
+    } while( 0 )
     #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         #define event_groupsLOCK( pxEventBits )      vTaskSuspendAll()
         #define event_groupsUNLOCK( pxEventBits )    xTaskResumeAll()
+        #define event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, pxAlreadyYielded ) \
+    do {                                                                              \
+        *( pxAlreadyYielded ) = xTaskResumeAll();                                     \
+    } while( 0 )
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
@@ -298,7 +306,7 @@
                 }
             }
         }
-        xAlreadyYielded = event_groupsUNLOCK( pxEventBits );
+        event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, &xAlreadyYielded );
 
         if( xTicksToWait != ( TickType_t ) 0 )
         {
@@ -454,7 +462,7 @@
                 traceEVENT_GROUP_WAIT_BITS_BLOCK( xEventGroup, uxBitsToWaitFor );
             }
         }
-        xAlreadyYielded = event_groupsUNLOCK( pxEventBits );
+        event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, &xAlreadyYielded );
 
         if( xTicksToWait != ( TickType_t ) 0 )
         {
@@ -621,6 +629,13 @@
         {
             traceEVENT_GROUP_SET_BITS( xEventGroup, uxBitsToSet );
 
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+                /* We are about to access the kernel data group non-deterministically,
+                 * thus we suspend the kernel data group.*/
+                vTaskSuspendAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
             pxListItem = listGET_HEAD_ENTRY( pxList );
 
             /* Set the bits. */
@@ -691,8 +706,12 @@
 
             /* Snapshot resulting bits. */
             uxReturnBits = pxEventBits->uxEventBits;
+
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+                ( void ) xTaskResumeAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         }
-        ( void ) event_groupsUNLOCK( pxEventBits );
+        event_groupsUNLOCK( pxEventBits );
 
         traceRETURN_xEventGroupSetBits( uxReturnBits );
 
@@ -715,6 +734,13 @@
         {
             traceEVENT_GROUP_DELETE( xEventGroup );
 
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+                /* We are about to access the kernel data group non-deterministically,
+                 * thus we suspend the kernel data group.*/
+                vTaskSuspendAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
             while( listCURRENT_LIST_LENGTH( pxTasksWaitingForBits ) > ( UBaseType_t ) 0 )
             {
                 /* Unblock the task, returning 0 as the event list is being deleted
@@ -722,8 +748,12 @@
                 configASSERT( pxTasksWaitingForBits->xListEnd.pxNext != ( const ListItem_t * ) &( pxTasksWaitingForBits->xListEnd ) );
                 vTaskRemoveFromUnorderedEventList( pxTasksWaitingForBits->xListEnd.pxNext, eventUNBLOCKED_DUE_TO_BIT_SET );
             }
+
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+                ( void ) xTaskResumeAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         }
-        ( void ) event_groupsUNLOCK( pxEventBits );
+        event_groupsUNLOCK( pxEventBits );
 
         #if ( ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 0 ) )
         {

--- a/event_groups.c
+++ b/event_groups.c
@@ -81,6 +81,34 @@
 
 /*-----------------------------------------------------------*/
 
+/*
+ * Macros used to lock and unlock an event group. When a task locks an,
+ * event group, the task will have thread safe non-deterministic access to
+ * the event group.
+ * - Concurrent access from other tasks will be blocked by the xTaskSpinlock
+ * - Concurrent access from ISRs will be pended
+ *
+ * When the task unlocks the event group, all pended access attempts are handled.
+ */
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #define event_groupsLOCK( pxEventBits )      taskDATA_GROUP_LOCK( &( ( pxEventBits )->xTaskSpinlock ) )
+        #define event_groupsUNLOCK( pxEventBits )    taskDATA_GROUP_UNLOCK( &( ( pxEventBits )->xTaskSpinlock ) )
+        #define event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, pxAlreadyYielded )         \
+    do {                                                                                      \
+        *( pxAlreadyYielded ) = taskDATA_GROUP_UNLOCK( &( ( pxEventBits )->xTaskSpinlock ) ); \
+    } while( 0 )
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+        #define event_groupsLOCK( pxEventBits )      vTaskSuspendAll()
+        #define event_groupsUNLOCK( pxEventBits )    xTaskResumeAll()
+        #define event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, pxAlreadyYielded ) \
+    do {                                                                              \
+        *( pxAlreadyYielded ) = xTaskResumeAll();                                     \
+    } while( 0 )
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+/*-----------------------------------------------------------*/
+
+
     #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
 
         EventGroupHandle_t xEventGroupCreateStatic( StaticEventGroup_t * pxEventGroupBuffer )
@@ -245,7 +273,7 @@
                 }
             }
         }
-        xAlreadyYielded = xTaskResumeAll();
+        event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, &xAlreadyYielded );
 
         if( xTicksToWait != ( TickType_t ) 0 )
         {
@@ -401,7 +429,7 @@
                 traceEVENT_GROUP_WAIT_BITS_BLOCK( xEventGroup, uxBitsToWaitFor );
             }
         }
-        xAlreadyYielded = xTaskResumeAll();
+        event_groupsUNLOCK_WITH_YIELD_STATUS( pxEventBits, &xAlreadyYielded );
 
         if( xTicksToWait != ( TickType_t ) 0 )
         {
@@ -568,6 +596,13 @@
         {
             traceEVENT_GROUP_SET_BITS( xEventGroup, uxBitsToSet );
 
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+                /* We are about to access the kernel data group non-deterministically,
+                 * thus we suspend the kernel data group.*/
+                vTaskSuspendAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
             pxListItem = listGET_HEAD_ENTRY( pxList );
 
             /* Set the bits. */
@@ -638,8 +673,12 @@
 
             /* Snapshot resulting bits. */
             uxReturnBits = pxEventBits->uxEventBits;
+
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+                ( void ) xTaskResumeAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         }
-        ( void ) xTaskResumeAll();
+        event_groupsUNLOCK( pxEventBits );
 
         traceRETURN_xEventGroupSetBits( uxReturnBits );
 
@@ -662,6 +701,13 @@
         {
             traceEVENT_GROUP_DELETE( xEventGroup );
 
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+                /* We are about to access the kernel data group non-deterministically,
+                 * thus we suspend the kernel data group.*/
+                vTaskSuspendAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
             while( listCURRENT_LIST_LENGTH( pxTasksWaitingForBits ) > ( UBaseType_t ) 0 )
             {
                 /* Unblock the task, returning 0 as the event list is being deleted
@@ -669,8 +715,12 @@
                 configASSERT( pxTasksWaitingForBits->xListEnd.pxNext != ( const ListItem_t * ) &( pxTasksWaitingForBits->xListEnd ) );
                 vTaskRemoveFromUnorderedEventList( pxTasksWaitingForBits->xListEnd.pxNext, eventUNBLOCKED_DUE_TO_BIT_SET );
             }
+
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+                ( void ) xTaskResumeAll();
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         }
-        ( void ) xTaskResumeAll();
+        event_groupsUNLOCK( pxEventBits );
 
         #if ( ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 0 ) )
         {

--- a/event_groups.c
+++ b/event_groups.c
@@ -63,9 +63,29 @@
         #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
             uint8_t ucStaticallyAllocated; /**< Set to pdTRUE if the event group is statically allocated to ensure no attempt is made to free the memory. */
         #endif
+
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            portSPINLOCK_TYPE xTaskSpinlock;
+            portSPINLOCK_TYPE xISRSpinlock;
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     } EventGroup_t;
 
 /*-----------------------------------------------------------*/
+
+/*
+ * Macros to mark the start and end of a critical code region.
+ */
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        #define event_groupsENTER_CRITICAL( pxEventBits )                                      taskDATA_GROUP_ENTER_CRITICAL( &pxEventBits->xTaskSpinlock, &pxEventBits->xISRSpinlock )
+        #define event_groupsENTER_CRITICAL_FROM_ISR( pxEventBits, puxSavedInterruptStatus )    taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( &pxEventBits->xISRSpinlock, puxSavedInterruptStatus )
+        #define event_groupsEXIT_CRITICAL( pxEventBits )                                       taskDATA_GROUP_EXIT_CRITICAL( &pxEventBits->xTaskSpinlock, &pxEventBits->xISRSpinlock )
+        #define event_groupsEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxEventBits )      taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, &pxEventBits->xISRSpinlock )
+    #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+        #define event_groupsENTER_CRITICAL( pxEventBits )                                      taskENTER_CRITICAL();
+        #define event_groupsENTER_CRITICAL_FROM_ISR( pxEventBits, puxSavedInterruptStatus )    do { *( puxSavedInterruptStatus ) = taskENTER_CRITICAL_FROM_ISR(); } while( 0 )
+        #define event_groupsEXIT_CRITICAL( pxEventBits )                                       taskEXIT_CRITICAL();
+        #define event_groupsEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxEventBits )      taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
 /*
  * Test the bits set in uxCurrentEventBits to see if the wait condition is met.
@@ -108,7 +128,6 @@
 
 /*-----------------------------------------------------------*/
 
-
     #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
 
         EventGroupHandle_t xEventGroupCreateStatic( StaticEventGroup_t * pxEventGroupBuffer )
@@ -149,6 +168,13 @@
                     pxEventBits->ucStaticallyAllocated = pdTRUE;
                 }
                 #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
+
+                #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+                {
+                    portINIT_SPINLOCK( &( pxEventBits->xTaskSpinlock ) );
+                    portINIT_SPINLOCK( &( pxEventBits->xISRSpinlock ) );
+                }
+                #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
                 traceEVENT_GROUP_CREATE( pxEventBits );
             }
@@ -195,6 +221,13 @@
                 }
                 #endif /* configSUPPORT_STATIC_ALLOCATION */
 
+                #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+                {
+                    portINIT_SPINLOCK( &( pxEventBits->xTaskSpinlock ) );
+                    portINIT_SPINLOCK( &( pxEventBits->xISRSpinlock ) );
+                }
+                #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
                 traceEVENT_GROUP_CREATE( pxEventBits );
             }
             else
@@ -230,7 +263,7 @@
         }
         #endif
 
-        vTaskSuspendAll();
+        event_groupsLOCK( pxEventBits );
         {
             uxOriginalBitValue = pxEventBits->uxEventBits;
 
@@ -295,7 +328,7 @@
             if( ( uxReturn & eventUNBLOCKED_DUE_TO_BIT_SET ) == ( EventBits_t ) 0 )
             {
                 /* The task timed out, just return the current event bit value. */
-                taskENTER_CRITICAL();
+                event_groupsENTER_CRITICAL( pxEventBits );
                 {
                     uxReturn = pxEventBits->uxEventBits;
 
@@ -312,7 +345,7 @@
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                taskEXIT_CRITICAL();
+                event_groupsEXIT_CRITICAL( pxEventBits );
 
                 xTimeoutOccurred = pdTRUE;
             }
@@ -361,7 +394,7 @@
         }
         #endif
 
-        vTaskSuspendAll();
+        event_groupsLOCK( pxEventBits );
         {
             const EventBits_t uxCurrentEventBits = pxEventBits->uxEventBits;
 
@@ -450,7 +483,7 @@
 
             if( ( uxReturn & eventUNBLOCKED_DUE_TO_BIT_SET ) == ( EventBits_t ) 0 )
             {
-                taskENTER_CRITICAL();
+                event_groupsENTER_CRITICAL( pxEventBits );
                 {
                     /* The task timed out, just return the current event bit value. */
                     uxReturn = pxEventBits->uxEventBits;
@@ -475,7 +508,7 @@
 
                     xTimeoutOccurred = pdTRUE;
                 }
-                taskEXIT_CRITICAL();
+                event_groupsEXIT_CRITICAL( pxEventBits );
             }
             else
             {
@@ -510,7 +543,7 @@
         configASSERT( xEventGroup );
         configASSERT( ( uxBitsToClear & eventEVENT_BITS_CONTROL_BYTES ) == 0 );
 
-        taskENTER_CRITICAL();
+        event_groupsENTER_CRITICAL( pxEventBits );
         {
             traceEVENT_GROUP_CLEAR_BITS( xEventGroup, uxBitsToClear );
 
@@ -521,7 +554,7 @@
             /* Clear the bits. */
             pxEventBits->uxEventBits &= ~uxBitsToClear;
         }
-        taskEXIT_CRITICAL();
+        event_groupsEXIT_CRITICAL( pxEventBits );
 
         traceRETURN_xEventGroupClearBits( uxReturn );
 
@@ -552,7 +585,7 @@
     EventBits_t xEventGroupGetBitsFromISR( EventGroupHandle_t xEventGroup )
     {
         UBaseType_t uxSavedInterruptStatus;
-        EventGroup_t const * const pxEventBits = xEventGroup;
+        EventGroup_t * const pxEventBits = xEventGroup;
         EventBits_t uxReturn;
 
         traceENTER_xEventGroupGetBitsFromISR( xEventGroup );
@@ -560,11 +593,11 @@
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
+        event_groupsENTER_CRITICAL_FROM_ISR( pxEventBits, &uxSavedInterruptStatus );
         {
             uxReturn = pxEventBits->uxEventBits;
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        event_groupsEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxEventBits );
 
         traceRETURN_xEventGroupGetBitsFromISR( uxReturn );
 
@@ -592,7 +625,7 @@
 
         pxList = &( pxEventBits->xTasksWaitingForBits );
         pxListEnd = listGET_END_MARKER( pxList );
-        vTaskSuspendAll();
+        event_groupsLOCK( pxEventBits );
         {
             traceEVENT_GROUP_SET_BITS( xEventGroup, uxBitsToSet );
 
@@ -697,7 +730,7 @@
 
         pxTasksWaitingForBits = &( pxEventBits->xTasksWaitingForBits );
 
-        vTaskSuspendAll();
+        event_groupsLOCK( pxEventBits );
         {
             traceEVENT_GROUP_DELETE( xEventGroup );
 
@@ -824,6 +857,7 @@
         traceRETURN_vEventGroupClearBitsCallback();
     }
 /*-----------------------------------------------------------*/
+
 
     static BaseType_t prvTestWaitCondition( const EventBits_t uxCurrentEventBits,
                                             const EventBits_t uxBitsToWaitFor,

--- a/freertos_smp_granular_locks_design.md
+++ b/freertos_smp_granular_locks_design.md
@@ -1,0 +1,442 @@
+# FreeRTOS SMP Granular Locks — Design
+
+## Introduction
+
+Historically, the SMP FreeRTOS kernel has implemented critical sections using a "Global Locking" approach, where all kernel data is protected by a single pair of spinlocks (the Task Lock and ISR Lock). Every critical section contests for this pair of spinlocks, even when the sections protect unrelated data.
+
+This document describes the **"Dual Spinlock With Data Group Locking"** scheme that replaces global locking with per-data-group locks. The goal is to reduce contention between concurrent operations on independent kernel objects (queues, event groups, stream buffers, etc.) so that the SMP kernel scales better with the number of cores.
+
+Granular locking is opt-in via the new port-layer configuration `portUSING_GRANULAR_LOCKS`. With it disabled the kernel behaves exactly as before; with it enabled the per-data-group locks described below are used.
+
+Source-code changes are layered on the V11.1.0 release of the upstream FreeRTOS kernel.
+
+### Status (as of this branch)
+
+- Implemented in the kernel against `configNUMBER_OF_CORES > 1` builds.
+- Verified on the Espressif ESP32 (Xtensa, dual-core) target via the ESP-IDF FreeRTOS unit-test suite.
+- Other ports remain to be updated; reference port macros and the porting checklist are listed in the *Porting Interface* section.
+
+# Data Groups
+
+To make the spinlocks granular, FreeRTOS data will be organized into the following data groups, where each data group is protected by their own set of spinlocks.
+
+- Kernel Data Group
+  - All data in `tasks.c` and all event lists (e.g., `xTasksWaitingToSend` and `xTasksWaitingToReceive` in the queue objects)
+- Queue Data Group
+  - Each queue object (`Queue_t`) is its own data group (excluding the task lists)
+- Event Group Data Group
+  - Each event group object (`EventGroup_t`) is its own data group (excluding the task lists)
+- Stream Buffer Data Group
+  - Each stream buffer object (`StreamBuffer_t`) is its own data group (excluding the task lists)
+- Timers
+  - All data in `timers.c` and timer objects,  belong to the same Timer Data Group
+- User/Port Data Groups
+  - The user and ports are free to organize their own data in to data groups of their choosing
+
+# Dual Spinlock With Data Group Locking
+
+The **"Dual Spinlock With Data Group Locking"** uses a pair of spinlocks to protect each data group (namely the `xTaskSpinlock` and `xISRSpinlock` spinlocks).
+
+```c
+typedef struct
+{
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+} xSomeDataGroup_t;
+```
+
+However, each data group must also allow for non-deterministic access with interrupts **enabled** by providing a pair of lock/unlock functions. These functions must block access to other tasks trying to access members of a data group and must pend access to ISRs trying to access members of the data group.
+
+```c
+static void prvLockSomeDataGroupForTasks( xSomeDataGroup_t * const pxSomDataGroup );
+static void prvUnlockSomeDataGroupForTasks( xSomeDataGroup_t * const pxSomDataGroup );
+```
+
+In simple terms, the "Dual Spinlock With Data Group Locking" is an extension is the existing dual spinlock (i.e., Task and ISR spinlock) approach used in the SMP FreeRTOS kernel, but replicated across different data groups.
+
+## Data Group Critical Sections (Granular Locks)
+
+A critical section for a data group can be achieved as follows:
+
+- When entering a data group critical section from a task
+  1. Disable interrupts
+  2. Take `xTaskSpinlock` of data group
+  3. Take `xISRSpinlock` of data group
+  4. Increment nesting count
+- When entering data group critical section from an ISR
+  1. Disable interrupts
+  2. Take `xISRSpinlock` of data group
+  3. Increment nesting count
+
+When exiting a data group critical section, the procedure is reversed. Furthermore, since yield requests are pended when inside a critical section, exiting a task critical section will also need to handle any pended yields.
+
+- When exiting a data group critical section from a task
+  1. Release `xISRSpinlock` of data group
+  2. Release `xTaskSpinlock` of data group
+  3. Decrement nesting count
+  4. Reenable interrupts if nesting count is 0
+  5. Trigger yield if there is a yield pending
+- When exiting data group critical section form an ISR
+  1. Release `xISRSpinlock` of data group
+  2. Decrement nesting count
+  3. Reenable interrupts if nesting count is 0
+
+Entering multiple data group critical sections in a nested manner is permitted. This means, if a code path has already entered a critical section in data group A, it can then enter a critical section in data group B. This is analogous to nested critical sections. However, care must be taken to avoid deadlocks. This can be achieved by organizing data groups into a hierarchy, where a higher layer data group cannot nest into a lower one.
+
+```
+                                           +-------------------+
+                                           | Kernel Data Group |
+                                           +-------------------+
+
+  +-------------------+  +---------------------------+ +--------------------------+ +------------------+
+  | Queue Data Groups |  | Stream Buffer Data Groups | | Event Groups Data Groups | | Timer Data Group |
+  +-------------------+  +---------------------------+ +--------------------------+ +------------------+
+
++------------------------------------------------------------------------------------------------------+
+|                                            User Data Groups                                          |
++------------------------------------------------------------------------------------------------------+
+```
+
+If nested locking only occurs from bottom up (e.g., User data group can nested into a Queue data group which in turn can nested into Kernel data group), then deadlocking will never occur.
+
+## Data Group Locking
+
+FreeRTOS does not permit walking linked lists while interrupts are disabled to ensure deterministic ISR latency. Therefore, each data group must provide a method of locking so that non-deterministic operations can be executed for a data group. While a data group is locked:
+
+- Preemption is disabled for the current task
+- Interrupts remained enabled
+- The data group's `xTaskSpinlock` is taken to prevent tasks running on other cores from accessing the data group
+- Any ISR that attempts to update the data group will have their access pended. These pended accesses will be handled on resumption
+
+The logic of suspending a data group is analogous to the logic of `vTaskSuspendAll()`/`xTaskResumeAll()` and `prvLockQueue()`/`prvUnlockQueue()` in the existing SMP kernel.
+
+The details of how ISR accesses are pended during suspension will be specific to each data group type, thus the implementation of the suspend/resumption functions also be specified to each data group type. However, the procedure for data group suspension and resumption will typically be as follows:
+
+- Suspension
+  1. Disable preemption
+  2. Lock the data group
+  3. Set a suspension flag that indicates the data group is suspended
+  4. Unlock the data group, but keep holding `xTaskSpinlock`
+- Resumption
+  1. Lock the data group
+  2. Clear the suspension flag
+  3. Handle all pended accesses from ISRs
+  4. Unlock the data group, thus releasing `xTaskSpinlock`
+
+Locking multiple data groups in a nested manner is permitted, meaning if a code path has already locked data group A, it can then lock data group B. This is analogous to nested `vTaskSuspendAll()` calls. Similar to data group locking, deadlocks can be avoided by organizing data groups into a hierarchy.
+
+## Thread Safety Check
+
+Under SMP, there are four sources of concurrent access for a particular data group:
+
+- Preempting task on the same core
+- Preempting ISR on the same core
+- Concurrent task on another core
+- Concurrent ISR on another core
+
+This section checks that the data group critical section and locking mechanisms mentioned, ensure thread safety from each concurrent source of access.
+
+- Data Group Critical Section from tasks: Interrupts are disabled, `xTaskSpinlock` and `xISRSpinlock` are taken
+  - Task (same core): Context switch cannot occur because interrupts are disabled
+  - Task (other cores): The task will spin on `xTaskSpinlock`
+  - ISR (same core): Interrupts on the current core are disabled
+  - ISR (other cores): ISR will spin on `xISRSpinlock`
+
+- Data Group Critical Sections from ISRs: Interrupts are disabled, `xISRSpinlock` is taken
+  - Task (same core): Context switch cannot occur because we are in an ISR
+  - Task (other cores): The task will spin on `xISRSpinlock`
+  - ISR (same core): Interrupts on the current core are disabled
+  - ISR (other cores): ISR will spin on `xISRSpinlock`
+
+- Data Group Locking from tasks: Preemption is disabled, `xTaskSpinlock` is taken
+  - Task (same core): Context switch cannot occur because preemption is disabled
+  - Task (other cores): The task will spin on `xTaskSpinlock`
+  - ISR (same core): Critical section is entered because `xISRSpinlock` is not held, but access is pended
+  - ISR (other cores): Critical section is entered because `xISRSpinlock` is not held, but access is pended
+
+# Public API Changes
+
+To support **"Dual Spinlock With Data Group Locking"**, the following changes have been made to the public facing API. These changes are non-breaking, meaning that applications that can build against the existing SMP FreeRTOS kernel will still be able to build even with granular locking enabled (albeit less performant).
+
+The following APIs have been added to enter/exit a critical section in a data group. This are called by FreeRTOS source code to mark critical sections in data groups. However, users can also create their own data groups and enter/exit critical sections in the same manner.
+
+If granular locking is disabled, these macros simply revert to being the standard task enter/exit critical macros.
+
+```c
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define data_groupENTER_CRITICAL()                                    portENTER_CRITICAL_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_DATA_GROUP_FROM_ISR( ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupEXIT_CRITICAL()                                     portEXIT_CRITICAL_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( uxSavedInterruptStatus, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define data_groupENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define data_groupENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define data_groupEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define data_groupEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+```
+
+In case of the kernel data group (tasks.c), the granular locking macros make use of the existing `vTaskEnter/ExitCritical<FromISR>()` functions to establish critical sections.
+
+
+```c
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define kernelENTER_CRITICAL()                                    vTaskEnterCritical()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           vTaskEnterCriticalFromISR()
+    #define kernelEXIT_CRITICAL()                                     vTaskExitCritical()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define kernelENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define kernelEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+```
+
+The previous critical section macros, viz., `taskENTER/EXIT_CRITICAL()` are still provided and can be called by users. However, FreeRTOS source code will no longer call them. If called by the users, the port should implement a "user" data group. As a result, if an application previously relied on `taskENTER/EXIT_CRITICAL()` for thread safe access to some user data, the same code is still thread safe with granular locking enabled.
+
+```c
+#define taskENTER_CRITICAL()                portENTER_CRITICAL()
+#define taskEXIT_CRITICAL()                 portEXIT_CRITICAL()
+#define taskENTER_CRITICAL_FROM_ISR()       portENTER_CRITICAL_FROM_ISR()
+#define taskEXIT_CRITICAL_FROM_ISR( x )     portEXIT_CRITICAL_FROM_ISR( x )
+```
+
+# Porting Interface
+
+To support **"Dual Spinlock With Data Group Locking"**, ports will need to provide the following macro definitions
+
+## Port Config
+
+The ports will need to provide the following port configuration macros
+
+```c
+#define portUSING_GRANULAR_LOCKS        1   // Enables usage of granular locks
+#define portCRITICAL_NESTING_IN_TCB     0   // Disable critical nesting in TCB. Ports will need to track their own critical nesting
+```
+
+## Spinlocks
+
+Ports will need to provide the following spinlock related macros macros
+
+```c
+/*
+Data type for the port's implementation of a spinlock
+*/
+#define portSPINLOCK_TYPE               port_spinlock_t
+```
+
+Macros are provided for the spinlocks for initializing them either statically or dynamically. This is reflected in the macros API pattern.
+
+```c
+#define portINIT_SPINLOCK( pxSpinlock )    _port_spinlock_init( pxSpinlock )
+#define portINIT__SPINLOCK_STATIC          PORT_SPINLOCK_STATIC_INIT
+```
+
+## Critical Section Macros
+
+The port will need to provide implementations for macros to enter/exit a data group critical section according the procedures described above. Typical implementations of each macro is demonstrated below:
+
+```c
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define portENTER_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )     vPortEnterCriticalDataGroup( pxTaskSpinlock, pxISRSpinlock )
+    #define portENTER_CRITICAL_DATA_GROUP_FROM_ISR( pxISRSpinlock )            uxPortEnterCriticalDataGroupFromISR( pxISRSpinlock )
+    #define portEXIT_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )      vPortExitCriticalDataGroup( pxTaskSpinlock, pxISRSpinlock )
+    #define portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )          vPortExitCriticalDataGroupFromISR( x, pxISRSpinlock )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+```
+
+Example implementation of `portENTER_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )` and `portEXIT_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )`. Note that:
+
+- `pxTaskSpinlock` is made optional in case users want to create their own data groups that are protected only be a single lock.
+- The kernel implements the `xTaskUnlockCanYield()` function to indicate whether an yield should occur when a critical section exits. This function takes into account whether there are any pending yields and whether preemption is currently disabled.
+
+```c
+void vPortEnterCriticalDataGroup( port_spinlock_t *pxTaskSpinlock, port_spinlock_t *pxISRSpinlock )
+{
+    portDISABLE_INTERRUPTS();
+
+    BaseType_t xCoreID = xPortGetCoreID();
+
+    /* Task spinlock is optional and is always taken first */
+    if( pxTaskSpinlock != NULL )
+    {
+        vPortSpinlockTake( pxTaskSpinlock, portMUX_NO_TIMEOUT );
+        uxCriticalNesting[ xCoreID ]++;
+    }
+
+    /* ISR spinlock must always be provided */
+    vPortSpinlockTake( pxISRSpinlock, portMUX_NO_TIMEOUT );
+    uxCriticalNesting[ xCoreID ]++;
+}
+
+void vPortExitCriticalDataGroup( port_spinlock_t *pxTaskSpinlock, port_spinlock_t *pxISRSpinlock )
+{
+    BaseType_t xCoreID = xPortGetCoreID();
+    BaseType_t xYieldCurrentTask;
+
+    configASSERT( uxCriticalNesting[ xCoreID ] > 0U );
+
+    /* Get the xYieldPending stats inside the critical section. */
+    xYieldCurrentTask = xTaskUnlockCanYield();
+
+    /* ISR spinlock must always be provided */
+    vPortSpinlockRelease( pxISRSpinlock );
+    uxCriticalNesting[ xCoreID ]--;
+
+    /* Task spinlock is optional and is always taken first */
+    if( pxTaskSpinlock != NULL )
+    {
+        vPortSpinlockRelease( pxTaskSpinlock);
+        uxCriticalNesting[ xCoreID ]--;
+    }
+
+    assert(uxCriticalNesting[ xCoreID ] >= 0);
+
+    if( uxCriticalNesting[ xCoreID ] == 0 )
+    {
+        portENABLE_INTERRUPTS();
+
+        /* When a task yields in a critical section it just sets xYieldPending to
+         * true. So now that we have exited the critical section check if xYieldPending
+         * is true, and if so yield. */
+        if( xYieldCurrentTask != pdFALSE )
+        {
+            portYIELD();
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+    }
+}
+```
+
+Example implementation of `portENTER_CRITICAL_DATA_GROUP_FROM_ISR( pxISRSpinlock )` and `portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )`. Note that only `pxISRSpinlock` needs to be provided since ISR critical sections take a single lock.
+
+```c
+UBaseType_t uxPortLockDataGroupFromISR( port_spinlock_t *pxISRSpinlock )
+{
+    UBaseType_t uxSavedInterruptStatus = 0;
+
+    uxSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
+
+    vPortSpinlockTake( pxISRSpinlock, portMUX_NO_TIMEOUT );
+    uxCriticalNesting[xPortGetCoreID()]++;
+
+    return uxSavedInterruptStatus;
+}
+
+```c
+void vPortUnlockDataGroupFromISR( UBaseType_t uxSavedInterruptStatus, port_spinlock_t *pxISRSpinlock )
+{
+    BaseType_t xCoreID = xPortGetCoreID();
+
+    vPortSpinlockRelease( pxISRSpinlock );
+    uxCriticalNesting[ xCoreID ]--;
+
+    assert(uxCriticalNesting[ xCoreID ] >= 0);
+
+    if( uxCriticalNesting[ xCoreID ] == 0 )
+    {
+        portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+    }
+}
+```
+
+# Source Specific Changes
+
+- Added a `xTaskSpinlock` and `xISRSpinlock` to the data structures of each data group
+- All calls to `taskENTER/EXIT_CRITICAL[_FROM_ISR]()` have been replaced with `data_groupENTER/EXIT_CRITICAL[_FROM_ISR]()`.
+- Added `xTaskUnlockCanYield()` which indicates whether a yield should occur when exiting a critical (i.e., unlocking a data group). Yields should not occur if preemption is disabled (such as when exiting a critical section inside a suspension block).
+
+## Tasks (Kernel Data Group)
+
+- Some functions are called from nested critical sections of other data groups, thus an extra critical section call needs to be added to lock/unlock the kernel data group:
+  - `vTaskInternalSetTimeOutState()`
+  - `xTaskIncrementTick()`
+  - `vTaskSwitchContext()`
+  - `xTaskRemoveFromEventList()`
+  - `vTaskInternalSetTimeOutState()`
+  - `eTaskConfirmSleepModeStatus()`
+  - `xTaskPriorityDisinherit()`
+  - `pvTaskIncrementMutexHeldCount()`
+- Some functions are called from nested suspension blocks of other data gropus, thus an extra suspend/resume call need to be added:
+  - `vTaskPlaceOnEventList()`
+  - `vTaskPlaceOnUnorderedEventList()`
+  - `vTaskPlaceOnEventListRestricted()`
+- `prvCheckForRunStateChange()` has been removed
+- Updated `vTaskSuspendAll()` and `xTaskResumeAll()`
+    - Now holds the `xTaskSpinlock` during kernel suspension
+    - Also increments/decrements `xPreemptionDisable` to prevent yield from occuring when exiting a critical section from inside a kernel suspension block.
+
+## Queue
+
+- Added `queueLOCK()` and `queueUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `prvLockQueue()` and `prvUnlockQueue()`
+  - If granular locks are enabled, will lock/unlock the queue data group for tasks
+
+## Event Groups
+
+- Added `eventLOCK()` and `eventUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `vTaskSuspendAll()` and `xTaskResumeAll()` calls
+  - If granular locks are enabled, will lock/unlock the event groups data group for tasks
+- `xEventGroupSetBits()` and `vEventGroupDelete()` will manually walk the task lists (which belong to the kernel data group). Thus, an extra `vTaskSuspendAll()`/`xTaskResumeAll()` is added to ensure that the kernel data group is suspended while walking those tasks lists.
+
+## Stream Buffer
+
+- Added `sbLOCK()` and `sbUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `vTaskSuspendAll()` and `xTaskResumeAll()` calls
+  - If granular locks are enabled, will lock/unlock the stream buffer data group for tasks
+
+## Timers
+
+- Timers don't have a lock/unlock function. The existing `vTaskSuspendAll()`/`xTaskResumeAll()` calls are valid as they rely on freezing the tick count which is part of the kernel data group.
+
+# Prerequisite Refactoring
+
+A number of refactoring commits have been added to make the addition of granular locking changes simpler:
+
+1. Move critical sections inside `xTaskPriorityInherit()`
+
+Currently, `xTaskPriorityInherit()` is called with wrapping critical sections. The critical sections have now be moved inside the function so that they have access to the kernel data group's spinlocks.
+
+2. Move critical section into `vTaskPriorityDisinheritAfterTimeout()`
+
+Currently, `vTaskPriorityDisinheritAfterTimeout()` is called wrapping critical sections, where the highest priority waiting task is separately obtained via `prvGetDisinheritPriorityAfterTimeout()`. The critical section and checking of the highest priority have been all been moved into `vTaskPriorityDisinheritAfterTimeout()` as all of these operations access the kernel data group.
+
+3. Allow `vTaskPreemptionEnable()` to be nested
+
+Currently, nested calls of `vTaskPreemptionEnable()` is not supported. However, nested calls are required for granular locking due the occurrence of nested suspension across multiple data groups.
+
+Thus, `vTaskPreemptionEnable()` has been updated to support nested calls. This is done by changing `xPreemptionDisable` to a count, where a non-zero count means that the current task cannot be preempted.
+
+# TCB Locks
+
+When `portUSING_GRANULAR_LOCKS == 1` and `configNUMBER_OF_CORES > 1`, each TCB carries an additional spinlock (`xTCBSpinlock`) that guards TCB-specific fields touched by preemption-disable / preemption-enable paths (`uxPreemptionDisable`, `uxDeferredStateChange`). The TCB lock is acquired via `vTaskTCBEnterCritical()` / `vTaskTCBExitCritical()` and lives below the kernel data group in the lock hierarchy. Using a per-TCB lock here avoids contention on the kernel data-group lock for the common case where a task only needs to inspect or update its own preemption-disable state.
+
+# Deferred State Changes
+
+Calls that change a task's run state (`vTaskDelete()`, `vTaskSuspend()`) cannot run their full effect while the target task has preemption disabled, because doing so would yield from a TCB whose owner asked not to be preempted. Granular locks introduce `uxDeferredStateChange` on the TCB to record the requested transition (`tskDEFERRED_DELETION`, `tskDEFERRED_SUSPENSION`). The deferred work is then performed at the next `xTaskPreemptionEnableWithYieldStatus()` once the preemption-disable count drops to zero, outside the TCB critical section so that any context switch and the post-state-change ready-list manipulation happen in a regular kernel critical section.
+
+# ISR-Only Kernel Critical Section Helpers
+
+`prvKernelEnterISROnlyCritical()` / `prvKernelExitISROnlyCritical()` are internal helpers used to enter the kernel data group from a context that is already inside a surrounding data-group critical section (and therefore already has interrupts disabled and holds the surrounding data group's ISR spinlock). Unlike `kernelENTER_CRITICAL_FROM_ISR()` / `kernelEXIT_CRITICAL_FROM_ISR()`, they do not touch the interrupt state — the outer section owns that — and they only acquire/release the kernel ISR spinlock and adjust the per-core kernel critical-nesting count. `xTaskRemoveFromEventList()` and `xTaskRemoveFromEventListFromISR()` use these helpers so that callers walking an event list while holding e.g. a queue's spinlock do not need to know whether they are in task or ISR context.
+
+# Event-List TOCTOU Considerations
+
+Under granular locks, an event list (`xTasksWaitingToSend`, `xTasksWaitingToReceive`, queue-set container waiting list) is protected by the kernel ISR spinlock, while the surrounding queue / event-group critical section only holds that data group's own spinlocks. The kernel API `xTaskRemoveFromEventList()` re-checks list emptiness under the kernel ISR lock before removing an entry, so callers must call it directly rather than gating it on an outer `listLIST_IS_EMPTY()` check. The outer check can race with a concurrent removal from the tick ISR on another core; the inner re-check is authoritative.
+
+The only places where an outer empty-check is retained on purpose are the `prvUnlockQueue()` drain loops, where the surrounding queue ISR spinlock prevents concurrent additions to the wait list and the outer check exists for early loop termination, not for race avoidance.
+
+# Known Limitations
+
+- Under `configRUN_MULTIPLE_PRIORITIES == 1`, the relaxed lock hierarchy means that an unblock triggered by a tick on one core may take effect on the unblocking core a little later than under global locking. The single-highest-priority invariant continues to hold under `configRUN_MULTIPLE_PRIORITIES == 0`.
+- The design has been exercised on the Xtensa SMP port (ESP32). Other ports — including the upstream POSIX, ARMv7-M and ARMv8-M SMP ports — need to provide the spinlock, critical-nesting, and yield primitives listed in *Porting Interface* before they can opt in.
+
+# Performance Metrics
+
+Performance numbers will be added once the upstream port reference has the porting checklist completed. Initial measurements on ESP32 (Xtensa, dual-core, 240 MHz) show reduced contention on multi-queue workloads where unrelated tasks send to / receive from distinct queues concurrently; full benchmark methodology and numbers will be published with this PR's review pass.
+

--- a/granular_locks_v4.md
+++ b/granular_locks_v4.md
@@ -1,0 +1,411 @@
+# Introduction
+
+Currently, the SMP FreeRTOS kernel implements critical section using a "Global locking" approach, where all data is protected by a pair of spinlocks (namely the Task Lock and ISR Lock). This means that every critical section contests for this pair of spinlocks, even if those critical sections access unrelated/orthogonal data.
+
+The goal of this proposal is to use granular or localized spinlocks so that concurrent access to different data groups do no contest for the same spinlocks. This will reduce lock contention and hopefully increase performance of the SMP FreeRTOS kernel.
+
+This proposal describes a **"Dual Spinlock With Data Group Locking"** approach to granular locking.
+
+Source code changes are based off release V11.1.0 of the FreeRTOS kernel.
+
+# Data Groups
+
+To make the spinlocks granular, FreeRTOS data will be organized into the following data groups, where each data group is protected by their own set of spinlocks.
+
+- Kernel Data Group
+  - All data in `tasks.c` and all event lists (e.g., `xTasksWaitingToSend` and `xTasksWaitingToReceive` in the queue objects)
+- Queue Data Group
+  - Each queue object (`Queue_t`) is its own data group (excluding the task lists)
+- Event Group Data Group
+  - Each event group object (`EventGroup_t`) is its own data group (excluding the task lists)
+- Stream Buffer Data Group
+  - Each stream buffer object (`StreamBuffer_t`) is its own data group (excluding the task lists)
+- Timers
+  - All data in `timers.c` and timer objects,  belong to the same Timer Data Group
+- User/Port Data Groups
+  - The user and ports are free to organize their own data in to data groups of their choosing
+
+# Dual Spinlock With Data Group Locking
+
+The **"Dual Spinlock With Data Group Locking"** uses a pair of spinlocks to protect each data group (namely the `xTaskSpinlock` and `xISRSpinlock` spinlocks).
+
+```c
+typedef struct
+{
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+} xSomeDataGroup_t;
+```
+
+However, each data group must also allow for non-deterministic access with interrupts **enabled** by providing a pair of lock/unlock functions. These functions must block access to other tasks trying to access members of a data group and must pend access to ISRs trying to access members of the data group.
+
+```c
+static void prvLockSomeDataGroupForTasks( xSomeDataGroup_t * const pxSomDataGroup );
+static void prvUnlockSomeDataGroupForTasks( xSomeDataGroup_t * const pxSomDataGroup );
+```
+
+In simple terms, the "Dual Spinlock With Data Group Locking" is an extension is the existing dual spinlock (i.e., Task and ISR spinlock) approach used in the SMP FreeRTOS kernel, but replicated across different data groups.
+
+## Data Group Critical Sections (Granular Locks)
+
+A critical section for a data group can be achieved as follows:
+
+- When entering a data group critical section from a task
+  1. Disable interrupts
+  2. Take `xTaskSpinlock` of data group
+  3. Take `xISRSpinlock` of data group
+  4. Increment nesting count
+- When entering data group critical section from an ISR
+  1. Disable interrupts
+  2. Take `xISRSpinlock` of data group
+  3. Increment nesting count
+
+When exiting a data group critical section, the procedure is reversed. Furthermore, since yield requests are pended when inside a critical section, exiting a task critical section will also need to handle any pended yields.
+
+- When exiting a data group critical section from a task
+  1. Release `xISRSpinlock` of data group
+  2. Release `xTaskSpinlock` of data group
+  3. Decrement nesting count
+  4. Reenable interrupts if nesting count is 0
+  5. Trigger yield if there is a yield pending
+- When exiting data group critical section form an ISR
+  1. Release `xISRSpinlock` of data group
+  2. Decrement nesting count
+  3. Reenable interrupts if nesting count is 0
+
+Entering multiple data group critical sections in a nested manner is permitted. This means, if a code path has already entered a critical section in data group A, it can then enter a critical section in data group B. This is analogous to nested critical sections. However, care must be taken to avoid deadlocks. This can be achieved by organizing data groups into a hierarchy, where a higher layer data group cannot nest into a lower one.
+
+```
+                                           +-------------------+
+                                           | Kernel Data Group |
+                                           +-------------------+
+
+  +-------------------+  +---------------------------+ +--------------------------+ +------------------+
+  | Queue Data Groups |  | Stream Buffer Data Groups | | Event Groups Data Groups | | Timer Data Group |
+  +-------------------+  +---------------------------+ +--------------------------+ +------------------+
+
++------------------------------------------------------------------------------------------------------+
+|                                            User Data Groups                                          |
++------------------------------------------------------------------------------------------------------+
+```
+
+If nested locking only occurs from bottom up (e.g., User data group can nested into a Queue data group which in turn can nested into Kernel data group), then deadlocking will never occur.
+
+## Data Group Locking
+
+FreeRTOS does not permit walking linked lists while interrupts are disabled to ensure deterministic ISR latency. Therefore, each data group must provide a method of locking so that non-deterministic operations can be executed for a data group. While a data group is locked:
+
+- Preemption is disabled for the current task
+- Interrupts remained enabled
+- The data group's `xTaskSpinlock` is taken to prevent tasks running on other cores from accessing the data group
+- Any ISR that attempts to update the data group will have their access pended. These pended accesses will be handled on resumption
+
+The logic of suspending a data group is analogous to the logic of `vTaskSuspendAll()`/`xTaskResumeAll()` and `prvLockQueue()`/`prvUnlockQueue()` in the existing SMP kernel.
+
+The details of how ISR accesses are pended during suspension will be specific to each data group type, thus the implementation of the suspend/resumption functions also be specified to each data group type. However, the procedure for data group suspension and resumption will typically be as follows:
+
+- Suspension
+  1. Disable preemption
+  2. Lock the data group
+  3. Set a suspension flag that indicates the data group is suspended
+  4. Unlock the data group, but keep holding `xTaskSpinlock`
+- Resumption
+  1. Lock the data group
+  2. Clear the suspension flag
+  3. Handle all pended accesses from ISRs
+  4. Unlock the data group, thus releasing `xTaskSpinlock`
+
+Locking multiple data groups in a nested manner is permitted, meaning if a code path has already locked data group A, it can then lock data group B. This is analogous to nested `vTaskSuspendAll()` calls. Similar to data group locking, deadlocks can be avoided by organizing data groups into a hierarchy.
+
+## Thread Safety Check
+
+Under SMP, there are four sources of concurrent access for a particular data group:
+
+- Preempting task on the same core
+- Preempting ISR on the same core
+- Concurrent task on another core
+- Concurrent ISR on another core
+
+This section checks that the data group critical section and locking mechanisms mentioned, ensure thread safety from each concurrent source of access.
+
+- Data Group Critical Section from tasks: Interrupts are disabled, `xTaskSpinlock` and `xISRSpinlock` are taken
+  - Task (same core): Context switch cannot occur because interrupts are disabled
+  - Task (other cores): The task will spin on `xTaskSpinlock`
+  - ISR (same core): Interrupts on the current core are disabled
+  - ISR (other cores): ISR will spin on `xISRSpinlock`
+
+- Data Group Critical Sections from ISRs: Interrupts are disabled, `xISRSpinlock` is taken
+  - Task (same core): Context switch cannot occur because we are in an ISR
+  - Task (other cores): The task will spin on `xISRSpinlock`
+  - ISR (same core): Interrupts on the current core are disabled
+  - ISR (other cores): ISR will spin on `xISRSpinlock`
+
+- Data Group Locking from tasks: Preemption is disabled, `xTaskSpinlock` is taken
+  - Task (same core): Context switch cannot occur because preemption is disabled
+  - Task (other cores): The task will spin on `xTaskSpinlock`
+  - ISR (same core): Critical section is entered because `xISRSpinlock` is not held, but access is pended
+  - ISR (other cores): Critical section is entered because `xISRSpinlock` is not held, but access is pended
+
+# Public API Changes
+
+To support **"Dual Spinlock With Data Group Locking"**, the following changes have been made to the public facing API. These changes are non-breaking, meaning that applications that can build against the existing SMP FreeRTOS kernel will still be able to build even with granular locking enabled (albeit less performant).
+
+The following APIs have been added to enter/exit a critical section in a data group. This are called by FreeRTOS source code to mark critical sections in data groups. However, users can also create their own data groups and enter/exit critical sections in the same manner.
+
+If granular locking is disabled, these macros simply revert to being the standard task enter/exit critical macros.
+
+```c
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define data_groupENTER_CRITICAL()                                    portENTER_CRITICAL_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_DATA_GROUP_FROM_ISR( ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupEXIT_CRITICAL()                                     portEXIT_CRITICAL_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define data_groupEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( uxSavedInterruptStatus, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define data_groupENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define data_groupENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define data_groupEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define data_groupEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+```
+
+In case of the kernel data group (tasks.c), the granular locking macros make use of the existing `vTaskEnter/ExitCritical<FromISR>()` functions to establish critical sections.
+
+
+```c
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define kernelENTER_CRITICAL()                                    vTaskEnterCritical()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           vTaskEnterCriticalFromISR()
+    #define kernelEXIT_CRITICAL()                                     vTaskExitCritical()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define kernelENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define kernelEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+```
+
+The previous critical section macros, viz., `taskENTER/EXIT_CRITICAL()` are still provided and can be called by users. However, FreeRTOS source code will no longer call them. If called by the users, the port should implement a "user" data group. As a result, if an application previously relied on `taskENTER/EXIT_CRITICAL()` for thread safe access to some user data, the same code is still thread safe with granular locking enabled.
+
+```c
+#define taskENTER_CRITICAL()                portENTER_CRITICAL()
+#define taskEXIT_CRITICAL()                 portEXIT_CRITICAL()
+#define taskENTER_CRITICAL_FROM_ISR()       portENTER_CRITICAL_FROM_ISR()
+#define taskEXIT_CRITICAL_FROM_ISR( x )     portEXIT_CRITICAL_FROM_ISR( x )
+```
+
+# Porting Interface
+
+To support **"Dual Spinlock With Data Group Locking"**, ports will need to provide the following macro definitions
+
+## Port Config
+
+The ports will need to provide the following port configuration macros
+
+```c
+#define portUSING_GRANULAR_LOCKS        1   // Enables usage of granular locks
+#define portCRITICAL_NESTING_IN_TCB     0   // Disable critical nesting in TCB. Ports will need to track their own critical nesting
+```
+
+## Spinlocks
+
+Ports will need to provide the following spinlock related macros macros
+
+```c
+/*
+Data type for the port's implementation of a spinlock
+*/
+#define portSPINLOCK_TYPE               port_spinlock_t
+```
+
+Macros are provided for the spinlocks for initializing them either statically or dynamically. This is reflected in the macros API pattern.
+
+```c
+#define portINIT_SPINLOCK( pxSpinlock )    _port_spinlock_init( pxSpinlock )
+#define portINIT__SPINLOCK_STATIC          PORT_SPINLOCK_STATIC_INIT
+```
+
+## Critical Section Macros
+
+The port will need to provide implementations for macros to enter/exit a data group critical section according the procedures described above. Typical implementations of each macro is demonstrated below:
+
+```c
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define portENTER_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )     vPortEnterCriticalDataGroup( pxTaskSpinlock, pxISRSpinlock )
+    #define portENTER_CRITICAL_DATA_GROUP_FROM_ISR( pxISRSpinlock )            uxPortEnterCriticalDataGroupFromISR( pxISRSpinlock )
+    #define portEXIT_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )      vPortExitCriticalDataGroup( pxTaskSpinlock, pxISRSpinlock )
+    #define portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )          vPortExitCriticalDataGroupFromISR( x, pxISRSpinlock )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+```
+
+Example implementation of `portENTER_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )` and `portEXIT_CRITICAL_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )`. Note that:
+
+- `pxTaskSpinlock` is made optional in case users want to create their own data groups that are protected only be a single lock.
+- The kernel implements the `xTaskUnlockCanYield()` function to indicate whether an yield should occur when a critical section exits. This function takes into account whether there are any pending yields and whether preemption is currently disabled.
+
+```c
+void vPortEnterCriticalDataGroup( port_spinlock_t *pxTaskSpinlock, port_spinlock_t *pxISRSpinlock )
+{
+    portDISABLE_INTERRUPTS();
+
+    BaseType_t xCoreID = xPortGetCoreID();
+
+    /* Task spinlock is optional and is always taken first */
+    if( pxTaskSpinlock != NULL )
+    {
+        vPortSpinlockTake( pxTaskSpinlock, portMUX_NO_TIMEOUT );
+        uxCriticalNesting[ xCoreID ]++;
+    }
+
+    /* ISR spinlock must always be provided */
+    vPortSpinlockTake( pxISRSpinlock, portMUX_NO_TIMEOUT );
+    uxCriticalNesting[ xCoreID ]++;
+}
+
+void vPortExitCriticalDataGroup( port_spinlock_t *pxTaskSpinlock, port_spinlock_t *pxISRSpinlock )
+{
+    BaseType_t xCoreID = xPortGetCoreID();
+    BaseType_t xYieldCurrentTask;
+
+    configASSERT( uxCriticalNesting[ xCoreID ] > 0U );
+
+    /* Get the xYieldPending stats inside the critical section. */
+    xYieldCurrentTask = xTaskUnlockCanYield();
+
+    /* ISR spinlock must always be provided */
+    vPortSpinlockRelease( pxISRSpinlock );
+    uxCriticalNesting[ xCoreID ]--;
+
+    /* Task spinlock is optional and is always taken first */
+    if( pxTaskSpinlock != NULL )
+    {
+        vPortSpinlockRelease( pxTaskSpinlock);
+        uxCriticalNesting[ xCoreID ]--;
+    }
+
+    assert(uxCriticalNesting[ xCoreID ] >= 0);
+
+    if( uxCriticalNesting[ xCoreID ] == 0 )
+    {
+        portENABLE_INTERRUPTS();
+
+        /* When a task yields in a critical section it just sets xYieldPending to
+         * true. So now that we have exited the critical section check if xYieldPending
+         * is true, and if so yield. */
+        if( xYieldCurrentTask != pdFALSE )
+        {
+            portYIELD();
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+    }
+}
+```
+
+Example implementation of `portENTER_CRITICAL_DATA_GROUP_FROM_ISR( pxISRSpinlock )` and `portEXIT_CRITICAL_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )`. Note that only `pxISRSpinlock` needs to be provided since ISR critical sections take a single lock.
+
+```c
+UBaseType_t uxPortLockDataGroupFromISR( port_spinlock_t *pxISRSpinlock )
+{
+    UBaseType_t uxSavedInterruptStatus = 0;
+
+    uxSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
+
+    vPortSpinlockTake( pxISRSpinlock, portMUX_NO_TIMEOUT );
+    uxCriticalNesting[xPortGetCoreID()]++;
+
+    return uxSavedInterruptStatus;
+}
+
+```c
+void vPortUnlockDataGroupFromISR( UBaseType_t uxSavedInterruptStatus, port_spinlock_t *pxISRSpinlock )
+{
+    BaseType_t xCoreID = xPortGetCoreID();
+
+    vPortSpinlockRelease( pxISRSpinlock );
+    uxCriticalNesting[ xCoreID ]--;
+
+    assert(uxCriticalNesting[ xCoreID ] >= 0);
+
+    if( uxCriticalNesting[ xCoreID ] == 0 )
+    {
+        portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+    }
+}
+```
+
+# Source Specific Changes
+
+- Added a `xTaskSpinlock` and `xISRSpinlock` to the data structures of each data group
+- All calls to `taskENTER/EXIT_CRITICAL[_FROM_ISR]()` have been replaced with `data_groupENTER/EXIT_CRITICAL[_FROM_ISR]()`.
+- Added `xTaskUnlockCanYield()` which indicates whether a yield should occur when exiting a critical (i.e., unlocking a data group). Yields should not occur if preemption is disabled (such as when exiting a critical section inside a suspension block).
+
+## Tasks (Kernel Data Group)
+
+- Some functions are called from nested critical sections of other data groups, thus an extra critical section call needs to be added to lock/unlock the kernel data group:
+  - `vTaskInternalSetTimeOutState()`
+  - `xTaskIncrementTick()`
+  - `vTaskSwitchContext()`
+  - `xTaskRemoveFromEventList()`
+  - `vTaskInternalSetTimeOutState()`
+  - `eTaskConfirmSleepModeStatus()`
+  - `xTaskPriorityDisinherit()`
+  - `pvTaskIncrementMutexHeldCount()`
+- Some functions are called from nested suspension blocks of other data gropus, thus an extra suspend/resume call need to be added:
+  - `vTaskPlaceOnEventList()`
+  - `vTaskPlaceOnUnorderedEventList()`
+  - `vTaskPlaceOnEventListRestricted()`
+- `prvCheckForRunStateChange()` has been removed
+- Updated `vTaskSuspendAll()` and `xTaskResumeAll()`
+    - Now holds the `xTaskSpinlock` during kernel suspension
+    - Also increments/decrements `xPreemptionDisable` to prevent yield from occuring when exiting a critical section from inside a kernel suspension block.
+
+## Queue
+
+- Added `queueLOCK()` and `queueUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `prvLockQueue()` and `prvUnlockQueue()`
+  - If granular locks are enabled, will lock/unlock the queue data group for tasks
+
+## Event Groups
+
+- Added `eventLOCK()` and `eventUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `vTaskSuspendAll()` and `xTaskResumeAll()` calls
+  - If granular locks are enabled, will lock/unlock the event groups data group for tasks
+- `xEventGroupSetBits()` and `vEventGroupDelete()` will manually walk the task lists (which belong to the kernel data group). Thus, an extra `vTaskSuspendAll()`/`xTaskResumeAll()` is added to ensure that the kernel data group is suspended while walking those tasks lists.
+
+## Stream Buffer
+
+- Added `sbLOCK()` and `sbUNLOCK()`
+  - If granular locks are disabled, reverts to the previous `vTaskSuspendAll()` and `xTaskResumeAll()` calls
+  - If granular locks are enabled, will lock/unlock the stream buffer data group for tasks
+
+## Timers
+
+- Timers don't have a lock/unlock function. The existing `vTaskSuspendAll()`/`xTaskResumeAll()` calls are valid as they rely on freezing the tick count which is part of the kernel data group.
+
+# Prerequisite Refactoring
+
+A number of refactoring commits have been added to make the addition of granular locking changes simpler:
+
+1. Move critical sections inside `xTaskPriorityInherit()`
+
+Currently, `xTaskPriorityInherit()` is called with wrapping critical sections. The critical sections have now be moved inside the function so that they have access to the kernel data group's spinlocks.
+
+2. Move critical section into `vTaskPriorityDisinheritAfterTimeout()`
+
+Currently, `vTaskPriorityDisinheritAfterTimeout()` is called wrapping critical sections, where the highest priority waiting task is separately obtained via `prvGetDisinheritPriorityAfterTimeout()`. The critical section and checking of the highest priority have been all been moved into `vTaskPriorityDisinheritAfterTimeout()` as all of these operations access the kernel data group.
+
+3. Allow `vTaskPreemptionEnable()` to be nested
+
+Currently, nested calls of `vTaskPreemptionEnable()` is not supported. However, nested calls are required for granular locking due the occurrence of nested suspension across multiple data groups.
+
+Thus, `vTaskPreemptionEnable()` has been updated to support nested calls. This is done by changing `xPreemptionDisable` to a count, where a non-zero count means that the current task cannot be preempted.
+
+# Performance Metrics
+
+Todo
+

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3179,7 +3179,7 @@ typedef struct xSTATIC_TCB
     #endif
     uint8_t ucDummy7[ configMAX_TASK_NAME_LEN ];
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        BaseType_t xDummy25;
+        UBaseType_t xDummy25;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3238,6 +3238,9 @@ typedef struct xSTATIC_TCB
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         UBaseType_t xDummy25;
     #endif
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        BaseType_t xDummy26;
+    #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;
     #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3321,6 +3321,10 @@ typedef struct xSTATIC_QUEUE
         UBaseType_t uxDummy8;
         uint8_t ucDummy9;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticQueue_t;
 typedef StaticQueue_t StaticSemaphore_t;
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3354,6 +3354,10 @@ typedef struct xSTATIC_EVENT_GROUP
     #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
         uint8_t ucDummy4;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticEventGroup_t;
 
 /*

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3413,6 +3413,9 @@ typedef struct xSTATIC_STREAM_BUFFER
         void * pvDummy5[ 2 ];
     #endif
     UBaseType_t uxDummy6;
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticStreamBuffer_t;
 
 /* Message buffers are built on stream buffers. */

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2146,8 +2146,16 @@
     #define traceENTER_xTaskRemoveFromEventList( pxEventList )
 #endif
 
+#ifndef traceENTER_xTaskRemoveFromEventListFromISR
+    #define traceENTER_xTaskRemoveFromEventListFromISR( pxEventList )
+#endif
+
 #ifndef traceRETURN_xTaskRemoveFromEventList
     #define traceRETURN_xTaskRemoveFromEventList( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskRemoveFromEventListFromISR
+    #define traceRETURN_xTaskRemoveFromEventListFromISR( xReturn )
 #endif
 
 #ifndef traceENTER_vTaskRemoveFromUnorderedEventList

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -369,6 +369,10 @@
     #define portCRITICAL_NESTING_IN_TCB    0
 #endif
 
+#ifndef portUSING_GRANULAR_LOCKS
+    #define portUSING_GRANULAR_LOCKS    0
+#endif
+
 #ifndef configMAX_TASK_NAME_LEN
     #define configMAX_TASK_NAME_LEN    16
 #endif
@@ -454,7 +458,7 @@
 
 #ifndef portRELEASE_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
         #error portRELEASE_TASK_LOCK is required in SMP
@@ -464,7 +468,7 @@
 
 #ifndef portGET_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
         #error portGET_TASK_LOCK is required in SMP
@@ -474,7 +478,7 @@
 
 #ifndef portRELEASE_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
         #error portRELEASE_ISR_LOCK is required in SMP
@@ -484,13 +488,37 @@
 
 #ifndef portGET_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
         #error portGET_ISR_LOCK is required in SMP
     #endif
 
 #endif /* portGET_ISR_LOCK */
+
+#ifndef portRELEASE_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portRELEASE_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portGET_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portGET_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portCHECK_IF_IN_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portCHECK_IF_IN_ISR is required for granular locking
+    #endif
+
+#endif
 
 #ifndef portENTER_CRITICAL_FROM_ISR
 
@@ -504,6 +532,126 @@
 
     #if ( configNUMBER_OF_CORES > 1 )
         #error portEXIT_CRITICAL_FROM_ISR is required in SMP
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portSPINLOCK_TYPE
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portSPINLOCK_TYPE is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
     #endif
 
 #endif
@@ -2915,8 +3063,13 @@
 /* Either variables of tick type cannot be read atomically, or
  * portTICK_TYPE_IS_ATOMIC was not set - map the critical sections used when
  * the tick count is returned to the standard critical section macros. */
-    #define portTICK_TYPE_ENTER_CRITICAL()                      portENTER_CRITICAL()
-    #define portTICK_TYPE_EXIT_CRITICAL()                       portEXIT_CRITICAL()
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL()
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL()
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
 #else

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2958,6 +2958,10 @@
     #error configUSE_PORT_OPTIMISED_TASK_SELECTION is not supported in SMP FreeRTOS
 #endif
 
+#ifndef configLIGHTWEIGHT_CRITICAL_SECTION
+    #define configLIGHTWEIGHT_CRITICAL_SECTION    0
+#endif
+
 #ifndef configINITIAL_TICK_COUNT
     #define configINITIAL_TICK_COUNT    0
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3337,6 +3337,11 @@ typedef struct xSTATIC_QUEUE
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         portSPINLOCK_TYPE xDummySpinlock[ 2 ];
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+    #if ( configQUEUE_DIRECT_TRANSFER == 1 )
+        void * pvDummyDirectTransferBuffer;
+        BaseType_t xDummyDirectTransferPosition;
+    #endif
 } StaticQueue_t;
 typedef StaticQueue_t StaticSemaphore_t;
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2958,10 +2958,6 @@
     #error configUSE_PORT_OPTIMISED_TASK_SELECTION is not supported in SMP FreeRTOS
 #endif
 
-#ifndef configLIGHTWEIGHT_CRITICAL_SECTION
-    #define configLIGHTWEIGHT_CRITICAL_SECTION    0
-#endif
-
 #ifndef configINITIAL_TICK_COUNT
     #define configINITIAL_TICK_COUNT    0
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2972,8 +2972,8 @@
  * portTICK_TYPE_IS_ATOMIC was not set - map the critical sections used when
  * the tick count is returned to the standard critical section macros. */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
-        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+        #define portTICK_TYPE_ENTER_CRITICAL()                  kernelENTER_CRITICAL()
+        #define portTICK_TYPE_EXIT_CRITICAL()                   kernelEXIT_CRITICAL()
     #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL()
         #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL()

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2966,6 +2966,10 @@
     #error configUSE_PORT_OPTIMISED_TASK_SELECTION is not supported in SMP FreeRTOS
 #endif
 
+#ifndef configLIGHTWEIGHT_CRITICAL_SECTION
+    #define configLIGHTWEIGHT_CRITICAL_SECTION    0
+#endif
+
 #ifndef configINITIAL_TICK_COUNT
     #define configINITIAL_TICK_COUNT    0
 #endif

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -461,7 +461,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
-        #error portRELEASE_TASK_LOCK is required in SMP
+        #error portRELEASE_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_TASK_LOCK */
@@ -471,7 +471,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
-        #error portGET_TASK_LOCK is required in SMP
+        #error portGET_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_TASK_LOCK */
@@ -481,7 +481,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
-        #error portRELEASE_ISR_LOCK is required in SMP
+        #error portRELEASE_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_ISR_LOCK */
@@ -491,7 +491,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
-        #error portGET_ISR_LOCK is required in SMP
+        #error portGET_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_ISR_LOCK */
@@ -499,7 +499,7 @@
 #ifndef portRELEASE_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portRELEASE_SPINLOCK is required for granular locking
+        #error portRELEASE_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -507,7 +507,7 @@
 #ifndef portGET_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portGET_SPINLOCK is required for granular locking
+        #error portGET_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -536,38 +536,6 @@
 
 #endif
 
-#ifndef portENTER_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
 #ifndef portSPINLOCK_TYPE
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
@@ -576,82 +544,18 @@
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+#ifndef portINIT_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+        #error portINIT_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+#ifndef portINIT_SPINLOCK_STATIC
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
+        #error portINIT_SPINLOCK_STATIC is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -3072,7 +2976,7 @@
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
-#else
+#else /* if ( portTICK_TYPE_IS_ATOMIC == 0 ) */
 
 /* The tick type can be read atomically, so critical sections used when the
  * tick count is returned can be defined away. */

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3291,6 +3291,11 @@ typedef struct xSTATIC_TCB
     #if ( configUSE_POSIX_ERRNO == 1 )
         int iDummy22;
     #endif
+
+    #if ( configQUEUE_DIRECT_TRANSFER == 1 )
+        void * pvDummyDirectTransferBuffer;
+        BaseType_t xDummyDirectTransferPosition;
+    #endif
 } StaticTask_t;
 
 /*
@@ -3337,11 +3342,6 @@ typedef struct xSTATIC_QUEUE
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         portSPINLOCK_TYPE xDummySpinlock[ 2 ];
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-
-    #if ( configQUEUE_DIRECT_TRANSFER == 1 )
-        void * pvDummyDirectTransferBuffer;
-        BaseType_t xDummyDirectTransferPosition;
-    #endif
 } StaticQueue_t;
 typedef StaticQueue_t StaticSemaphore_t;
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -373,25 +373,6 @@
     #define portUSING_GRANULAR_LOCKS    0
 #endif
 
-/* configUSE_TCB_DATA_GROUP_LOCK enables per-TCB spinlocks to protect TCB-specific
- * data such as uxPreemptionDisable. This reduces lock contention compared to using
- * the global kernel lock. When enabled:
- * - Each TCB has its own spinlock (xTCBSpinlock)
- * - vTaskPreemptionDisable/Enable use the TCB lock instead of kernel lock
- * - prvYieldCore acquires the target TCB's lock before checking uxPreemptionDisable
- * This feature requires portUSING_GRANULAR_LOCKS and multi-core. */
-#ifndef configUSE_TCB_DATA_GROUP_LOCK
-    #define configUSE_TCB_DATA_GROUP_LOCK    0
-#endif
-
-#if ( ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) && ( portUSING_GRANULAR_LOCKS != 1 ) )
-    #error configUSE_TCB_DATA_GROUP_LOCK requires portUSING_GRANULAR_LOCKS to be enabled
-#endif
-
-#if ( ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) && ( configNUMBER_OF_CORES == 1 ) )
-    #error configUSE_TCB_DATA_GROUP_LOCK is not supported in single core FreeRTOS
-#endif
-
 #ifndef configMAX_TASK_NAME_LEN
     #define configMAX_TASK_NAME_LEN    16
 #endif
@@ -2965,10 +2946,6 @@
     #error configUSE_MUTEXES must be set to 1 to use recursive mutexes
 #endif
 
-#if ( ( configRUN_MULTIPLE_PRIORITIES == 0 ) && ( configUSE_TASK_PREEMPTION_DISABLE != 0 ) )
-    #error configRUN_MULTIPLE_PRIORITIES must be set to 1 to use task preemption disable
-#endif
-
 #if ( ( configUSE_PREEMPTION == 0 ) && ( configUSE_TASK_PREEMPTION_DISABLE != 0 ) )
     #error configUSE_PREEMPTION must be set to 1 to use task preemption disable
 #endif
@@ -3272,6 +3249,9 @@ typedef struct xSTATIC_TCB
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         BaseType_t xDummy26;
     #endif
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        portSPINLOCK_TYPE xDummy27;
+    #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;
     #endif
@@ -3314,9 +3294,6 @@ typedef struct xSTATIC_TCB
     #if ( configQUEUE_DIRECT_TRANSFER == 1 )
         void * pvDummyDirectTransferBuffer;
         BaseType_t xDummyDirectTransferPosition;
-    #endif
-    #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
-        portSPINLOCK_TYPE xTCBDummySpinlock; /**< Spinlock protecting TCB-specific data (uxPreemptionDisable, uxDeferredStateChange). */
     #endif
 } StaticTask_t;
 

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3183,7 +3183,7 @@ typedef struct xSTATIC_TCB
     #endif
     uint8_t ucDummy7[ configMAX_TASK_NAME_LEN ];
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        BaseType_t xDummy25;
+        UBaseType_t xDummy25;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -465,7 +465,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
-        #error portRELEASE_TASK_LOCK is required in SMP
+        #error portRELEASE_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_TASK_LOCK */
@@ -475,7 +475,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
-        #error portGET_TASK_LOCK is required in SMP
+        #error portGET_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_TASK_LOCK */
@@ -485,7 +485,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
-        #error portRELEASE_ISR_LOCK is required in SMP
+        #error portRELEASE_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_ISR_LOCK */
@@ -495,7 +495,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
-        #error portGET_ISR_LOCK is required in SMP
+        #error portGET_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_ISR_LOCK */
@@ -503,7 +503,7 @@
 #ifndef portRELEASE_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portRELEASE_SPINLOCK is required for granular locking
+        #error portRELEASE_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -511,7 +511,7 @@
 #ifndef portGET_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portGET_SPINLOCK is required for granular locking
+        #error portGET_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -540,38 +540,6 @@
 
 #endif
 
-#ifndef portENTER_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
 #ifndef portSPINLOCK_TYPE
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
@@ -580,82 +548,18 @@
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+#ifndef portINIT_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+        #error portINIT_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+#ifndef portINIT_SPINLOCK_STATIC
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
+        #error portINIT_SPINLOCK_STATIC is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -3076,7 +2980,7 @@
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
-#else
+#else /* if ( portTICK_TYPE_IS_ATOMIC == 0 ) */
 
 /* The tick type can be read atomically, so critical sections used when the
  * tick count is returned can be defined away. */

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -369,6 +369,10 @@
     #define portCRITICAL_NESTING_IN_TCB    0
 #endif
 
+#ifndef portUSING_GRANULAR_LOCKS
+    #define portUSING_GRANULAR_LOCKS    0
+#endif
+
 #ifndef configMAX_TASK_NAME_LEN
     #define configMAX_TASK_NAME_LEN    16
 #endif
@@ -458,7 +462,7 @@
 
 #ifndef portRELEASE_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
         #error portRELEASE_TASK_LOCK is required in SMP
@@ -468,7 +472,7 @@
 
 #ifndef portGET_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
         #error portGET_TASK_LOCK is required in SMP
@@ -478,7 +482,7 @@
 
 #ifndef portRELEASE_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
         #error portRELEASE_ISR_LOCK is required in SMP
@@ -488,13 +492,37 @@
 
 #ifndef portGET_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
         #error portGET_ISR_LOCK is required in SMP
     #endif
 
 #endif /* portGET_ISR_LOCK */
+
+#ifndef portRELEASE_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portRELEASE_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portGET_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portGET_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portCHECK_IF_IN_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portCHECK_IF_IN_ISR is required for granular locking
+    #endif
+
+#endif
 
 #ifndef portENTER_CRITICAL_FROM_ISR
 
@@ -508,6 +536,126 @@
 
     #if ( configNUMBER_OF_CORES > 1 )
         #error portEXIT_CRITICAL_FROM_ISR is required in SMP
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portSPINLOCK_TYPE
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portSPINLOCK_TYPE is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
     #endif
 
 #endif
@@ -2919,8 +3067,13 @@
 /* Either variables of tick type cannot be read atomically, or
  * portTICK_TYPE_IS_ATOMIC was not set - map the critical sections used when
  * the tick count is returned to the standard critical section macros. */
-    #define portTICK_TYPE_ENTER_CRITICAL()                      portENTER_CRITICAL()
-    #define portTICK_TYPE_EXIT_CRITICAL()                       portEXIT_CRITICAL()
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL()
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL()
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
 #else

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2972,8 +2972,8 @@
  * portTICK_TYPE_IS_ATOMIC was not set - map the critical sections used when
  * the tick count is returned to the standard critical section macros. */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
-        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+        #define portTICK_TYPE_ENTER_CRITICAL()                  kernelENTER_CRITICAL()
+        #define portTICK_TYPE_EXIT_CRITICAL()                   kernelEXIT_CRITICAL()
     #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL()
         #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL()
@@ -3241,6 +3241,9 @@ typedef struct xSTATIC_TCB
     uint8_t ucDummy7[ configMAX_TASK_NAME_LEN ];
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         UBaseType_t xDummy25;
+    #endif
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        BaseType_t xDummy26;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -465,7 +465,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
-        #error portRELEASE_TASK_LOCK is required in SMP
+        #error portRELEASE_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_TASK_LOCK */
@@ -475,7 +475,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
-        #error portGET_TASK_LOCK is required in SMP
+        #error portGET_TASK_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_TASK_LOCK */
@@ -485,7 +485,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
-        #error portRELEASE_ISR_LOCK is required in SMP
+        #error portRELEASE_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portRELEASE_ISR_LOCK */
@@ -495,7 +495,7 @@
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
-        #error portGET_ISR_LOCK is required in SMP
+        #error portGET_ISR_LOCK is required in SMP without granular locking feature enabled
     #endif
 
 #endif /* portGET_ISR_LOCK */
@@ -503,7 +503,7 @@
 #ifndef portRELEASE_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portRELEASE_SPINLOCK is required for granular locking
+        #error portRELEASE_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -511,7 +511,7 @@
 #ifndef portGET_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portGET_SPINLOCK is required for granular locking
+        #error portGET_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -540,38 +540,6 @@
 
 #endif
 
-#ifndef portENTER_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
-#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
-    #endif
-
-#endif
-
 #ifndef portSPINLOCK_TYPE
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
@@ -580,82 +548,18 @@
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+#ifndef portINIT_SPINLOCK
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+        #error portINIT_SPINLOCK is required for SMP with granular locking feature enabled
     #endif
 
 #endif
 
-#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+#ifndef portINIT_SPINLOCK_STATIC
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_QUEUE_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
-    #endif
-
-#endif
-
-#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
+        #error portINIT_SPINLOCK_STATIC is required for SMP with granular locking feature enabled
     #endif
 
 #endif
@@ -3090,7 +2994,7 @@
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
-#else
+#else /* if ( portTICK_TYPE_IS_ATOMIC == 0 ) */
 
 /* The tick type can be read atomically, so critical sections used when the
  * tick count is returned can be defined away. */

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -369,6 +369,10 @@
     #define portCRITICAL_NESTING_IN_TCB    0
 #endif
 
+#ifndef portUSING_GRANULAR_LOCKS
+    #define portUSING_GRANULAR_LOCKS    0
+#endif
+
 #ifndef configMAX_TASK_NAME_LEN
     #define configMAX_TASK_NAME_LEN    16
 #endif
@@ -458,7 +462,7 @@
 
 #ifndef portRELEASE_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_TASK_LOCK( xCoreID )
     #else
         #error portRELEASE_TASK_LOCK is required in SMP
@@ -468,7 +472,7 @@
 
 #ifndef portGET_TASK_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_TASK_LOCK( xCoreID )
     #else
         #error portGET_TASK_LOCK is required in SMP
@@ -478,7 +482,7 @@
 
 #ifndef portRELEASE_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portRELEASE_ISR_LOCK( xCoreID )
     #else
         #error portRELEASE_ISR_LOCK is required in SMP
@@ -488,13 +492,37 @@
 
 #ifndef portGET_ISR_LOCK
 
-    #if ( configNUMBER_OF_CORES == 1 )
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) || ( configNUMBER_OF_CORES == 1 ) )
         #define portGET_ISR_LOCK( xCoreID )
     #else
         #error portGET_ISR_LOCK is required in SMP
     #endif
 
 #endif /* portGET_ISR_LOCK */
+
+#ifndef portRELEASE_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portRELEASE_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portGET_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portGET_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portCHECK_IF_IN_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portCHECK_IF_IN_ISR is required for granular locking
+    #endif
+
+#endif
 
 #ifndef portENTER_CRITICAL_FROM_ISR
 
@@ -508,6 +536,126 @@
 
     #if ( configNUMBER_OF_CORES > 1 )
         #error portEXIT_CRITICAL_FROM_ISR is required in SMP
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portENTER_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portENTER_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portEXIT_CRITICAL_DATA_GROUP_FROM_ISR
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portEXIT_CRITICAL_DATA_GROUP_FROM_ISR is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portSPINLOCK_TYPE
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portSPINLOCK_TYPE is required for SMP with granular locking feature enabled
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_EVENT_GROUP_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_EVENT_GROUP_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_QUEUE_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_QUEUE_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_TASK_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_TASK_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_STREAM_BUFFER_ISR_SPINLOCK
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_STREAM_BUFFER_ISR_SPINLOCK is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_KERNEL_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_KERNEL_ISR_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_TASK_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_TASK_SPINLOCK_STATIC is required for granular locking
+    #endif
+
+#endif
+
+#ifndef portINIT_TIMERS_ISR_SPINLOCK_STATIC
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #error portINIT_TIMERS_ISR_SPINLOCK_STATIC is required for granular locking
     #endif
 
 #endif
@@ -2914,6 +3062,12 @@
     #error configUSE_CORE_AFFINITY is not supported in single core FreeRTOS
 #endif
 
+/* Granular locking relies on the per-task preemption disable count to defer
+ * state changes and to decide whether a core can be requested to yield. */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) && ( configUSE_TASK_PREEMPTION_DISABLE != 1 ) )
+    #error configUSE_TASK_PREEMPTION_DISABLE must be set to 1 to use granular locks
+#endif
+
 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PORT_OPTIMISED_TASK_SELECTION != 0 ) )
     #error configUSE_PORT_OPTIMISED_TASK_SELECTION is not supported in SMP FreeRTOS
 #endif
@@ -2927,8 +3081,13 @@
 /* Either variables of tick type cannot be read atomically, or
  * portTICK_TYPE_IS_ATOMIC was not set - map the critical sections used when
  * the tick count is returned to the standard critical section macros. */
-    #define portTICK_TYPE_ENTER_CRITICAL()                      portENTER_CRITICAL()
-    #define portTICK_TYPE_EXIT_CRITICAL()                       portEXIT_CRITICAL()
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL()
+        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL()
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define portTICK_TYPE_SET_INTERRUPT_MASK_FROM_ISR()         portSET_INTERRUPT_MASK_FROM_ISR()
     #define portTICK_TYPE_CLEAR_INTERRUPT_MASK_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( ( x ) )
 #else

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3191,7 +3191,7 @@ typedef struct xSTATIC_TCB
     #endif
     uint8_t ucDummy7[ configMAX_TASK_NAME_LEN ];
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        BaseType_t xDummy25;
+        UBaseType_t xDummy25;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2986,8 +2986,8 @@
  * portTICK_TYPE_IS_ATOMIC was not set - map the critical sections used when
  * the tick count is returned to the standard critical section macros. */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
-        #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL_DATA_GROUP( &xTaskSpinlock, &xISRSpinlock )
+        #define portTICK_TYPE_ENTER_CRITICAL()                  kernelENTER_CRITICAL()
+        #define portTICK_TYPE_EXIT_CRITICAL()                   kernelEXIT_CRITICAL()
     #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
         #define portTICK_TYPE_ENTER_CRITICAL()                  portENTER_CRITICAL()
         #define portTICK_TYPE_EXIT_CRITICAL()                   portEXIT_CRITICAL()
@@ -3255,6 +3255,9 @@ typedef struct xSTATIC_TCB
     uint8_t ucDummy7[ configMAX_TASK_NAME_LEN ];
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         UBaseType_t xDummy25;
+    #endif
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        BaseType_t xDummy26;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2950,10 +2950,6 @@
     #error configUSE_MUTEXES must be set to 1 to use recursive mutexes
 #endif
 
-#if ( ( configRUN_MULTIPLE_PRIORITIES == 0 ) && ( configUSE_TASK_PREEMPTION_DISABLE != 0 ) )
-    #error configRUN_MULTIPLE_PRIORITIES must be set to 1 to use task preemption disable
-#endif
-
 #if ( ( configUSE_PREEMPTION == 0 ) && ( configUSE_TASK_PREEMPTION_DISABLE != 0 ) )
     #error configUSE_PREEMPTION must be set to 1 to use task preemption disable
 #endif
@@ -3258,6 +3254,9 @@ typedef struct xSTATIC_TCB
     #endif
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         BaseType_t xDummy26;
+    #endif
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        portSPINLOCK_TYPE xDummy27;
     #endif
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         void * pxDummy8;

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -2158,8 +2158,16 @@
     #define traceENTER_xTaskRemoveFromEventList( pxEventList )
 #endif
 
+#ifndef traceENTER_xTaskRemoveFromEventListFromISR
+    #define traceENTER_xTaskRemoveFromEventListFromISR( pxEventList )
+#endif
+
 #ifndef traceRETURN_xTaskRemoveFromEventList
     #define traceRETURN_xTaskRemoveFromEventList( xReturn )
+#endif
+
+#ifndef traceRETURN_xTaskRemoveFromEventListFromISR
+    #define traceRETURN_xTaskRemoveFromEventListFromISR( xReturn )
 #endif
 
 #ifndef traceENTER_vTaskRemoveFromUnorderedEventList
@@ -3338,6 +3346,10 @@ typedef struct xSTATIC_QUEUE
         UBaseType_t uxDummy8;
         uint8_t ucDummy9;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticQueue_t;
 typedef StaticQueue_t StaticSemaphore_t;
 
@@ -3367,6 +3379,10 @@ typedef struct xSTATIC_EVENT_GROUP
     #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
         uint8_t ucDummy4;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticEventGroup_t;
 
 /*
@@ -3422,6 +3438,9 @@ typedef struct xSTATIC_STREAM_BUFFER
         void * pvDummy5[ 2 ];
     #endif
     UBaseType_t uxDummy6;
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xDummySpinlock[ 2 ];
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StaticStreamBuffer_t;
 
 /* Message buffers are built on stream buffers. */

--- a/include/task.h
+++ b/include/task.h
@@ -213,7 +213,7 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                                                 portYIELD()
+#define taskYIELD()                          portYIELD()
 
 /**
  * task. h
@@ -227,19 +227,12 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()                                        portENTER_CRITICAL()
+#define taskENTER_CRITICAL()                 portENTER_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskENTER_CRITICAL_FROM_ISR()                           portSET_INTERRUPT_MASK_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portSET_INTERRUPT_MASK_FROM_ISR()
 #else
-    #define taskENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portENTER_CRITICAL_FROM_ISR()
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           portLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskENTER_CRITICAL()
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           taskENTER_CRITICAL_FROM_ISR()
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -253,19 +246,12 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                                           portEXIT_CRITICAL()
+#define taskEXIT_CRITICAL()                    portEXIT_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 #else
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portEXIT_CRITICAL_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portEXIT_CRITICAL_FROM_ISR( x )
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portUNLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        portUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskEXIT_CRITICAL()
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        taskEXIT_CRITICAL_FROM_ISR( x )
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -3837,7 +3823,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portENTER_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskEnterCritical( void );
 #endif
 
@@ -3849,7 +3835,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portEXIT_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCritical( void );
 #endif
 
@@ -3859,7 +3845,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portENTER_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     UBaseType_t vTaskEnterCriticalFromISR( void );
 #endif
 
@@ -3869,12 +3855,12 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portEXIT_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
 
 /*
- * Checks whether a yield is required after taskUNLOCK_DATA_GROUP() returns.
+ * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
  * To be called while data group is locked.
  */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )

--- a/include/task.h
+++ b/include/task.h
@@ -3720,6 +3720,8 @@ void vTaskPlaceOnEventListRestricted( List_t * const pxEventList,
  * Removes a task from both the specified event list and the list of blocked
  * tasks, and places it on a ready queue.
  *
+ * Do not call this function from an ISR context. Call xTaskRemoveFromEventListFromISR() instead.
+ *
  * xTaskRemoveFromEventList()/vTaskRemoveFromUnorderedEventList() will be called
  * if either an event occurs to unblock a task, or the block timeout period
  * expires.
@@ -3736,6 +3738,23 @@ void vTaskPlaceOnEventListRestricted( List_t * const pxEventList,
  * making the call, otherwise pdFALSE.
  */
 BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList ) PRIVILEGED_FUNCTION;
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS ONLY
+ * INTENDED FOR USE WHEN IMPLEMENTING A PORT OF THE SCHEDULER AND IS
+ * AN INTERFACE WHICH IS FOR THE EXCLUSIVE USE OF THE SCHEDULER.
+ *
+ * THIS FUNCTION MUST BE CALLED WITH INTERRUPTS DISABLED.
+ *
+ * Removes a task from both the specified event list and the list of blocked
+ * tasks, and places it on a ready queue. This function is the ISR-safe version
+ * of xTaskRemoveFromEventList().
+ *
+ * @return pdTRUE if the task being removed has a higher priority than the task
+ * making the call, otherwise pdFALSE.
+ */
+BaseType_t xTaskRemoveFromEventListFromISR( const List_t * const pxEventList ) PRIVILEGED_FUNCTION;
+
 void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
                                         const TickType_t xItemValue ) PRIVILEGED_FUNCTION;
 

--- a/include/task.h
+++ b/include/task.h
@@ -3930,14 +3930,6 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
     void vKernelLightWeightExitCritical( void );
 #endif
 
-/*
- * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
- * To be called while data group is locked.
- */
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    BaseType_t xTaskUnlockCanYield( void );
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-
 #if ( portUSING_MPU_WRAPPERS == 1 )
 
 /*

--- a/include/task.h
+++ b/include/task.h
@@ -3933,6 +3933,22 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
 
+/*
+ * This function is only intended for use when disabling or enabling preemption of a task.
+ * This function takes only the kernel ISR lock, not the task lock.
+ */
+#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+    void vKernelLightWeightEnterCritical( void );
+#endif
+
+/*
+ * This function is only intended for use when disabling or enabling preemption of a task.
+ * This function releases only the kernel ISR lock, not the task lock.
+ */
+#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+    void vKernelLightWeightExitCritical( void );
+#endif
+
 #if ( portUSING_MPU_WRAPPERS == 1 )
 
 /*

--- a/include/task.h
+++ b/include/task.h
@@ -3860,6 +3860,22 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
 #endif
 
 /*
+ * This function is only intended for use when disabling or enabling preemption of a task.
+ * This function takes only the kernel ISR lock, not the task lock.
+ */
+#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+    void vKernelLightWeightEnterCritical( void );
+#endif
+
+/*
+ * This function is only intended for use when disabling or enabling preemption of a task.
+ * This function releases only the kernel ISR lock, not the task lock.
+ */
+#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+    void vKernelLightWeightExitCritical( void );
+#endif
+
+/*
  * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
  * To be called while data group is locked.
  */

--- a/include/task.h
+++ b/include/task.h
@@ -3914,22 +3914,6 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
 
-/*
- * This function is only intended for use when disabling or enabling preemption of a task.
- * This function takes only the kernel ISR lock, not the task lock.
- */
-#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-    void vKernelLightWeightEnterCritical( void );
-#endif
-
-/*
- * This function is only intended for use when disabling or enabling preemption of a task.
- * This function releases only the kernel ISR lock, not the task lock.
- */
-#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-    void vKernelLightWeightExitCritical( void );
-#endif
-
 #if ( portUSING_MPU_WRAPPERS == 1 )
 
 /*

--- a/include/task.h
+++ b/include/task.h
@@ -3758,6 +3758,68 @@ BaseType_t xTaskRemoveFromEventListFromISR( const List_t * const pxEventList ) P
 void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
                                         const TickType_t xItemValue ) PRIVILEGED_FUNCTION;
 
+#if ( configQUEUE_DIRECT_TRANSFER == 1 )
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS AN
+ * INTERFACE FOR THE EXCLUSIVE USE OF THE QUEUE IMPLEMENTATION.
+ *
+ * Set the direct transfer buffer for the current task.
+ * Called when a task is about to block on a queue operation.
+ */
+    void vTaskSetDirectTransferBuffer( void * pvBuffer,
+                                       BaseType_t xPosition,
+                                       TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS AN
+ * INTERFACE FOR THE EXCLUSIVE USE OF THE QUEUE IMPLEMENTATION.
+ *
+ * Clear the direct transfer buffer for a task.
+ * @param xTask The task handle
+ */
+    void vTaskClearDirectTransferBuffer( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS AN
+ * INTERFACE FOR THE EXCLUSIVE USE OF THE QUEUE IMPLEMENTATION.
+ *
+ * Get the direct transfer buffer pointer from a task.
+ * @param xTask The task handle
+ * @return The buffer pointer, or NULL if not set
+ *
+ */
+    void * pvTaskGetDirectTransferBuffer( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS AN
+ * INTERFACE FOR THE EXCLUSIVE USE OF THE QUEUE IMPLEMENTATION.
+ *
+ * Get the direct transfer position from a task.
+ * @param xTask The task handle
+ * @return The position, or -1 if not set
+ *
+ */
+    BaseType_t xTaskGetDirectTransferPosition( TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS AN
+ * INTERFACE FOR THE EXCLUSIVE USE OF THE QUEUE IMPLEMENTATION.
+ *
+ * Get the highest priority task from an event list if it has armed direct transfer.
+ * Checks only the head of the event list (O(1) operation) for deterministic behavior.
+ *
+ * If the highest priority task hasn't armed direct transfer (e.g., using xQueuePeek()),
+ * returns NULL and direct transfer is skipped for this operation. This is acceptable since
+ * direct transfer is an optimization, not a requirement.
+ *
+ * @param pxEventList The event list to check
+ * @return Task handle of highest priority task if it has armed transfer, or NULL otherwise
+ */
+    TaskHandle_t xTaskGetHighestPriorityTaskWithDirectTransferArmed( const List_t * const pxEventList ) PRIVILEGED_FUNCTION;
+
+#endif /* configQUEUE_DIRECT_TRANSFER */
+
 /*
  * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS ONLY
  * INTENDED FOR USE WHEN IMPLEMENTING A PORT OF THE SCHEDULER AND IS

--- a/include/task.h
+++ b/include/task.h
@@ -292,22 +292,12 @@ typedef enum
  * \ingroup GranularLocks
  */
 #if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_ENTER_CRITICAL( pxTaskSpinlock, pxISRSpinlock )                \
-    do {                                                                                  \
-        /* Disable preemption to avoid task state changes during the critical section. */ \
-        vTaskPreemptionDisable( NULL );                                                   \
-        {                                                                                 \
-            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                  \
-            /* Task spinlock is always taken first */                                     \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) );      \
-            /* Disable interrupts */                                                      \
-            portDISABLE_INTERRUPTS();                                                     \
-            /* Take the ISR spinlock next */                                              \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );       \
-            /* Increment the critical nesting count */                                    \
-            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                              \
-        }                                                                                 \
-    } while( 0 )
+
+/* Using a function implementation now since the data group entering critical
+ * section needs to check for run state change. */
+    void taskDataGroupEnterCritical( portSPINLOCK_TYPE * pxTaskSpinlock,
+                                     portSPINLOCK_TYPE * pxISRSpinlock );
+    #define taskDATA_GROUP_ENTER_CRITICAL    taskDataGroupEnterCritical
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
 /**
@@ -361,7 +351,7 @@ typedef enum
             mtCOVERAGE_TEST_MARKER();                                                \
         }                                                                            \
         /* Re-enable preemption */                                                   \
-        prvTaskPreemptionEnable( NULL );                                             \
+        ( void ) xTaskPreemptionEnableWithYieldStatus( NULL );                       \
     } while( 0 )
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
@@ -421,7 +411,7 @@ typedef enum
     ( {                                                                                        \
         portRELEASE_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
         /* Re-enable preemption after releasing the task spinlock. */                          \
-        prvTaskPreemptionEnable( NULL );                                                       \
+        xTaskPreemptionEnableWithYieldStatus( NULL );                                          \
     } )
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
@@ -1639,7 +1629,7 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
  * switch, otherwise pdFALSE. This is used by the scheduler to determine if a
  * context switch may be required following the enable.
  */
-    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask );
+    BaseType_t xTaskPreemptionEnableWithYieldStatus( const TaskHandle_t xTask );
 #endif
 
 /*-----------------------------------------------------------
@@ -4010,6 +4000,14 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
 #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
     void vKernelLightWeightExitCritical( void );
 #endif
+
+/*
+ * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
+ * To be called while data group is locked.
+ */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    BaseType_t xTaskUnlockCanYield( void );
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 #if ( portUSING_MPU_WRAPPERS == 1 )
 

--- a/include/task.h
+++ b/include/task.h
@@ -217,7 +217,7 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                          portYIELD()
+#define taskYIELD()                                                 portYIELD()
 
 /**
  * task. h
@@ -231,12 +231,19 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()                 portENTER_CRITICAL()
+#define taskENTER_CRITICAL()                                        portENTER_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskENTER_CRITICAL_FROM_ISR()    portSET_INTERRUPT_MASK_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()                           portSET_INTERRUPT_MASK_FROM_ISR()
 #else
-    #define taskENTER_CRITICAL_FROM_ISR()    portENTER_CRITICAL_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_FROM_ISR()
 #endif
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           portLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )
+#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskENTER_CRITICAL()
+    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           taskENTER_CRITICAL_FROM_ISR()
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -250,12 +257,19 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                    portEXIT_CRITICAL()
+#define taskEXIT_CRITICAL()                                           portEXIT_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 #else
-    #define taskEXIT_CRITICAL_FROM_ISR( x )    portEXIT_CRITICAL_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portEXIT_CRITICAL_FROM_ISR( x )
 #endif
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portUNLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        portUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )
+#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskEXIT_CRITICAL()
+    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        taskEXIT_CRITICAL_FROM_ISR( x )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -286,6 +300,146 @@ typedef enum
 
 /* Checks if core ID is valid. */
 #define taskVALID_CORE_ID( xCoreID )    ( ( ( ( ( BaseType_t ) 0 <= ( xCoreID ) ) && ( ( xCoreID ) < ( BaseType_t ) configNUMBER_OF_CORES ) ) ) ? ( pdTRUE ) : ( pdFALSE ) )
+
+/**
+ * task. h
+ *
+ * Macro to enter a data group critical section.
+ *
+ * \defgroup taskDATA_GROUP_ENTER_CRITICAL taskDATA_GROUP_ENTER_CRITICAL
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_ENTER_CRITICAL( pxTaskSpinlock, pxISRSpinlock )                \
+    do {                                                                                  \
+        /* Disable preemption to avoid task state changes during the critical section. */ \
+        vTaskPreemptionDisable( NULL );                                                   \
+        {                                                                                 \
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                  \
+            /* Task spinlock is always taken first */                                     \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock );          \
+            /* Disable interrupts */                                                      \
+            portDISABLE_INTERRUPTS();                                                     \
+            /* Take the ISR spinlock next */                                              \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );           \
+            /* Increment the critical nesting count */                                    \
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                              \
+        }                                                                                 \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to enter a data group critical section from an interrupt.
+ *
+ * \defgroup taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( pxISRSpinlock, puxSavedInterruptStatus ) \
+    do {                                                                                     \
+        *( puxSavedInterruptStatus ) = portSET_INTERRUPT_MASK_FROM_ISR();                    \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                         \
+        /* Take the ISR spinlock */                                                          \
+        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );                  \
+        /* Increment the critical nesting count */                                           \
+        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                     \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to exit a data group critical section.
+ *
+ * \defgroup taskDATA_GROUP_EXIT_CRITICAL taskDATA_GROUP_EXIT_CRITICAL
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )        \
+    do {                                                                         \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();             \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );          \
+        /* Release the ISR spinlock */                                           \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );  \
+        /* Release the task spinlock */                                          \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock ); \
+        /* Decrement the critical nesting count */                               \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                         \
+        /* Enable interrupts only if the critical nesting count is 0 */          \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                     \
+        {                                                                        \
+            portENABLE_INTERRUPTS();                                             \
+        }                                                                        \
+        else                                                                     \
+        {                                                                        \
+            mtCOVERAGE_TEST_MARKER();                                            \
+        }                                                                        \
+        /* Re-enable preemption */                                               \
+        vTaskPreemptionEnable( NULL );                                           \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to exit a data group critical section from an interrupt.
+ *
+ * \defgroup taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxISRSpinlock ) \
+    do {                                                                                   \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                       \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );                    \
+        /* Decrement the critical nesting count */                                         \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                   \
+        /* Release the ISR spinlock */                                                     \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );            \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                               \
+        {                                                                                  \
+            portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );                   \
+        }                                                                                  \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macros to lock a data group (task-level lock only).
+ *
+ * \defgroup taskDATA_GROUP_LOCK taskDATA_GROUP_LOCK
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_LOCK( pxTaskSpinlock )                                              \
+    do {                                                                                       \
+        /* Disable preemption while holding the task spinlock. */                              \
+        vTaskPreemptionDisable( NULL );                                                        \
+        {                                                                                      \
+            portGET_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        }                                                                                      \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macros to unlock a data group (task-level lock only).
+ *
+ * \defgroup taskDATA_GROUP_UNLOCK taskDATA_GROUP_UNLOCK
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_UNLOCK( pxTaskSpinlock )                                            \
+    ( {                                                                                        \
+        portRELEASE_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        /* Re-enable preemption after releasing the task spinlock. */                          \
+        prvTaskPreemptionEnable( NULL );                                                       \
+    } )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
 /*-----------------------------------------------------------
 * TASK CREATION API
@@ -1486,6 +1640,23 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
  * }
  */
     void vTaskPreemptionEnable( const TaskHandle_t xTask );
+#endif
+
+#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS ONLY
+ * INTENDED FOR USE WHEN IMPLEMENTING A PORT OF THE SCHEDULER AND IS
+ * AN INTERFACE WHICH IS FOR THE EXCLUSIVE USE OF THE SCHEDULER.
+ *
+ * @param xTask The handle of the task to enable preemption. Passing NULL
+ * enables preemption for the calling task.
+ *
+ * @return pdTRUE if enabling preemption for the task resulted in a context
+ * switch, otherwise pdFALSE. This is used by the scheduler to determine if a
+ * context switch may be required following the enable.
+ */
+    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask );
 #endif
 
 /*-----------------------------------------------------------
@@ -3726,7 +3897,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portENTER_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     void vTaskEnterCritical( void );
 #endif
 
@@ -3738,7 +3909,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portEXIT_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCritical( void );
 #endif
 
@@ -3748,7 +3919,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portENTER_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if ( configNUMBER_OF_CORES > 1 )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     UBaseType_t vTaskEnterCriticalFromISR( void );
 #endif
 
@@ -3758,9 +3929,17 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portEXIT_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if ( configNUMBER_OF_CORES > 1 )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
+
+/*
+ * Checks whether a yield is required after taskUNLOCK_DATA_GROUP() returns.
+ * To be called while data group is locked.
+ */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    BaseType_t xTaskUnlockCanYield( void );
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 #if ( portUSING_MPU_WRAPPERS == 1 )
 

--- a/include/task.h
+++ b/include/task.h
@@ -217,7 +217,7 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                                                 portYIELD()
+#define taskYIELD()                          portYIELD()
 
 /**
  * task. h
@@ -231,19 +231,12 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()                                        portENTER_CRITICAL()
+#define taskENTER_CRITICAL()                 portENTER_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskENTER_CRITICAL_FROM_ISR()                           portSET_INTERRUPT_MASK_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portSET_INTERRUPT_MASK_FROM_ISR()
 #else
-    #define taskENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portENTER_CRITICAL_FROM_ISR()
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           portLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskENTER_CRITICAL()
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           taskENTER_CRITICAL_FROM_ISR()
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -257,19 +250,12 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                                           portEXIT_CRITICAL()
+#define taskEXIT_CRITICAL()                    portEXIT_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 #else
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portEXIT_CRITICAL_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portEXIT_CRITICAL_FROM_ISR( x )
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portUNLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        portUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskEXIT_CRITICAL()
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        taskEXIT_CRITICAL_FROM_ISR( x )
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -317,11 +303,11 @@ typedef enum
         {                                                                                 \
             const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                  \
             /* Task spinlock is always taken first */                                     \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock );          \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) );      \
             /* Disable interrupts */                                                      \
             portDISABLE_INTERRUPTS();                                                     \
             /* Take the ISR spinlock next */                                              \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );           \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );       \
             /* Increment the critical nesting count */                                    \
             portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                              \
         }                                                                                 \
@@ -340,11 +326,13 @@ typedef enum
     #define taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( pxISRSpinlock, puxSavedInterruptStatus ) \
     do {                                                                                     \
         *( puxSavedInterruptStatus ) = portSET_INTERRUPT_MASK_FROM_ISR();                    \
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                         \
-        /* Take the ISR spinlock */                                                          \
-        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );                  \
-        /* Increment the critical nesting count */                                           \
-        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                     \
+        {                                                                                    \
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                     \
+            /* Take the ISR spinlock */                                                      \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );          \
+            /* Increment the critical nesting count */                                       \
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                 \
+        }                                                                                    \
     } while( 0 )
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
@@ -357,27 +345,27 @@ typedef enum
  * \ingroup GranularLocks
  */
 #if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )        \
-    do {                                                                         \
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();             \
-        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );          \
-        /* Release the ISR spinlock */                                           \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );  \
-        /* Release the task spinlock */                                          \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock ); \
-        /* Decrement the critical nesting count */                               \
-        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                         \
-        /* Enable interrupts only if the critical nesting count is 0 */          \
-        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                     \
-        {                                                                        \
-            portENABLE_INTERRUPTS();                                             \
-        }                                                                        \
-        else                                                                     \
-        {                                                                        \
-            mtCOVERAGE_TEST_MARKER();                                            \
-        }                                                                        \
-        /* Re-enable preemption */                                               \
-        vTaskPreemptionEnable( NULL );                                           \
+    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )            \
+    do {                                                                             \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                 \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );              \
+        /* Release the ISR spinlock */                                               \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );  \
+        /* Release the task spinlock */                                              \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        /* Decrement the critical nesting count */                                   \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                             \
+        /* Enable interrupts only if the critical nesting count is 0 */              \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                         \
+        {                                                                            \
+            portENABLE_INTERRUPTS();                                                 \
+        }                                                                            \
+        else                                                                         \
+        {                                                                            \
+            mtCOVERAGE_TEST_MARKER();                                                \
+        }                                                                            \
+        /* Re-enable preemption */                                                   \
+        prvTaskPreemptionEnable( NULL );                                             \
     } while( 0 )
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
@@ -397,7 +385,7 @@ typedef enum
         /* Decrement the critical nesting count */                                         \
         portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                   \
         /* Release the ISR spinlock */                                                     \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );            \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );        \
         if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                               \
         {                                                                                  \
             portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );                   \
@@ -3897,7 +3885,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portENTER_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskEnterCritical( void );
 #endif
 
@@ -3909,7 +3897,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portEXIT_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCritical( void );
 #endif
 
@@ -3919,7 +3907,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portENTER_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     UBaseType_t vTaskEnterCriticalFromISR( void );
 #endif
 
@@ -3929,12 +3917,12 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portEXIT_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
 
 /*
- * Checks whether a yield is required after taskUNLOCK_DATA_GROUP() returns.
+ * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
  * To be called while data group is locked.
  */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )

--- a/include/task.h
+++ b/include/task.h
@@ -294,148 +294,6 @@ typedef enum
 /* Checks if core ID is valid. */
 #define taskVALID_CORE_ID( xCoreID )    ( ( ( ( ( BaseType_t ) 0 <= ( xCoreID ) ) && ( ( xCoreID ) < ( BaseType_t ) configNUMBER_OF_CORES ) ) ) ? ( pdTRUE ) : ( pdFALSE ) )
 
-/**
- * task. h
- *
- * Macro to enter a data group critical section.
- *
- * \defgroup taskDATA_GROUP_ENTER_CRITICAL taskDATA_GROUP_ENTER_CRITICAL
- * \ingroup GranularLocks
- */
-#if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_ENTER_CRITICAL( pxTaskSpinlock, pxISRSpinlock )                \
-    do {                                                                                  \
-        /* Disable preemption to avoid task state changes during the critical section. */ \
-        vTaskPreemptionDisable( NULL );                                                   \
-        {                                                                                 \
-            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                  \
-            /* Task spinlock is always taken first */                                     \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) );      \
-            /* Disable interrupts */                                                      \
-            portDISABLE_INTERRUPTS();                                                     \
-            /* Take the ISR spinlock next */                                              \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );       \
-            /* Increment the critical nesting count */                                    \
-            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                              \
-        }                                                                                 \
-    } while( 0 )
-#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
-
-/**
- * task. h
- *
- * Macro to enter a data group critical section from an interrupt.
- *
- * \defgroup taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR
- * \ingroup GranularLocks
- */
-#if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( pxISRSpinlock, puxSavedInterruptStatus ) \
-    do {                                                                                     \
-        *( puxSavedInterruptStatus ) = portSET_INTERRUPT_MASK_FROM_ISR();                    \
-        {                                                                                    \
-            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                     \
-            /* Take the ISR spinlock */                                                      \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );          \
-            /* Increment the critical nesting count */                                       \
-            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                 \
-        }                                                                                    \
-    } while( 0 )
-#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
-
-/**
- * task. h
- *
- * Macro to exit a data group critical section.
- *
- * \defgroup taskDATA_GROUP_EXIT_CRITICAL taskDATA_GROUP_EXIT_CRITICAL
- * \ingroup GranularLocks
- */
-#if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )            \
-    do {                                                                             \
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                 \
-        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );              \
-        /* Release the ISR spinlock */                                               \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );  \
-        /* Release the task spinlock */                                              \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
-        /* Decrement the critical nesting count */                                   \
-        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                             \
-        /* Enable interrupts only if the critical nesting count is 0 */              \
-        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                         \
-        {                                                                            \
-            portENABLE_INTERRUPTS();                                                 \
-        }                                                                            \
-        else                                                                         \
-        {                                                                            \
-            mtCOVERAGE_TEST_MARKER();                                                \
-        }                                                                            \
-        /* Re-enable preemption */                                                   \
-        prvTaskPreemptionEnable( NULL );                                             \
-    } while( 0 )
-#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
-
-/**
- * task. h
- *
- * Macro to exit a data group critical section from an interrupt.
- *
- * \defgroup taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR
- * \ingroup GranularLocks
- */
-#if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxISRSpinlock ) \
-    do {                                                                                   \
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                       \
-        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );                    \
-        /* Decrement the critical nesting count */                                         \
-        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                   \
-        /* Release the ISR spinlock */                                                     \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );        \
-        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                               \
-        {                                                                                  \
-            portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );                   \
-        }                                                                                  \
-    } while( 0 )
-#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
-
-/**
- * task. h
- *
- * Macros to lock a data group (task-level lock only).
- *
- * \defgroup taskDATA_GROUP_LOCK taskDATA_GROUP_LOCK
- * \ingroup GranularLocks
- */
-#if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_LOCK( pxTaskSpinlock )                                              \
-    do {                                                                                       \
-        /* Disable preemption while holding the task spinlock. */                              \
-        vTaskPreemptionDisable( NULL );                                                        \
-        {                                                                                      \
-            portGET_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
-        }                                                                                      \
-    } while( 0 )
-#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
-
-/**
- * task. h
- *
- * Macros to unlock a data group (task-level lock only).
- *
- * \defgroup taskDATA_GROUP_UNLOCK taskDATA_GROUP_UNLOCK
- * \ingroup GranularLocks
- */
-#if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_UNLOCK( pxTaskSpinlock )                                            \
-    ( {                                                                                        \
-        portRELEASE_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
-        /* Re-enable preemption after releasing the task spinlock. */                          \
-        prvTaskPreemptionEnable( NULL );                                                       \
-    } )
-#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
-
 /*-----------------------------------------------------------
 * TASK CREATION API
 *----------------------------------------------------------*/
@@ -1712,7 +1570,7 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
  * switch, otherwise pdFALSE. This is used by the scheduler to determine if a
  * context switch may be required following the enable.
  */
-    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask );
+    BaseType_t xTaskPreemptionEnableWithYieldStatus( const TaskHandle_t xTask );
 #endif
 
 /*-----------------------------------------------------------
@@ -3742,6 +3600,173 @@ void vTaskResetState( void ) PRIVILEGED_FUNCTION;
 * SCHEDULER INTERNALS AVAILABLE FOR PORTING PURPOSES
 *----------------------------------------------------------*/
 
+/**
+ * task. h
+ *
+ * Macro to enter a data group critical section.
+ *
+ * \defgroup taskDATA_GROUP_ENTER_CRITICAL taskDATA_GROUP_ENTER_CRITICAL
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+
+/* Using a function implementation now since the data group entering critical
+ * section needs to check for run state change. */
+    void vTaskDataGroupEnterCritical( portSPINLOCK_TYPE * pxTaskSpinlock,
+                                      portSPINLOCK_TYPE * pxISRSpinlock );
+    #define taskDATA_GROUP_ENTER_CRITICAL    vTaskDataGroupEnterCritical
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to enter a data group critical section from an interrupt.
+ *
+ * \defgroup taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( pxISRSpinlock, puxSavedInterruptStatus ) \
+    do {                                                                                     \
+        *( puxSavedInterruptStatus ) = portSET_INTERRUPT_MASK_FROM_ISR();                    \
+        {                                                                                    \
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                     \
+            /* Take the ISR spinlock */                                                      \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );          \
+            /* Increment the critical nesting count */                                       \
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                 \
+        }                                                                                    \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to exit a data group critical section.
+ *
+ * \defgroup taskDATA_GROUP_EXIT_CRITICAL taskDATA_GROUP_EXIT_CRITICAL
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )            \
+    do {                                                                             \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                 \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );              \
+        /* Release the ISR spinlock */                                               \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );  \
+        /* Release the task spinlock */                                              \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        /* Decrement the critical nesting count */                                   \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                             \
+        /* Enable interrupts only if the critical nesting count is 0 */              \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                         \
+        {                                                                            \
+            portENABLE_INTERRUPTS();                                                 \
+        }                                                                            \
+        else                                                                         \
+        {                                                                            \
+            mtCOVERAGE_TEST_MARKER();                                                \
+        }                                                                            \
+        /* Re-enable preemption */                                                   \
+        ( void ) xTaskPreemptionEnableWithYieldStatus( NULL );                       \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to exit a data group critical section from an interrupt.
+ *
+ * \defgroup taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxISRSpinlock ) \
+    do {                                                                                   \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                       \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );                    \
+        /* Decrement the critical nesting count */                                         \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                   \
+        /* Release the ISR spinlock */                                                     \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );        \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                               \
+        {                                                                                  \
+            portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );                   \
+        }                                                                                  \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macros to lock a data group (task-level lock only).
+ *
+ * \defgroup taskDATA_GROUP_LOCK taskDATA_GROUP_LOCK
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_LOCK( pxTaskSpinlock )                                              \
+    do {                                                                                       \
+        /* Disable preemption while holding the task spinlock. */                              \
+        vTaskPreemptionDisable( NULL );                                                        \
+        {                                                                                      \
+            portGET_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        }                                                                                      \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macros to unlock a data group (task-level lock only).
+ *
+ * \defgroup taskDATA_GROUP_UNLOCK taskDATA_GROUP_UNLOCK
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+
+/* Release the task spinlock and re-enable preemption.
+ * Returns the yield status reported by xTaskPreemptionEnableWithYieldStatus(). */
+    BaseType_t taskDataGroupUnlock( portSPINLOCK_TYPE * pxTaskSpinlock );
+    #define taskDATA_GROUP_UNLOCK    taskDataGroupUnlock
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macros to temporarily promote a held data group lock to a full data group
+ * critical section, and to demote it back again. A data group that is locked
+ * holds the task spinlock with preemption disabled, which keeps other tasks
+ * out but not interrupts. Promoting additionally masks interrupts and takes
+ * the ISR spinlock, so that data shared with an ISR can be updated. The
+ * critical nesting count records whether interrupts were already masked on
+ * entry, so no interrupt state has to be saved by the caller.
+ *
+ * \defgroup taskDATA_GROUP_PROMOTE_LOCK_TO_CRITICAL taskDATA_GROUP_PROMOTE_LOCK_TO_CRITICAL
+ * \ingroup GranularLocks
+ */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define taskDATA_GROUP_PROMOTE_LOCK_TO_CRITICAL( pxISRSpinlock )            \
+    do {                                                                        \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();            \
+        portDISABLE_INTERRUPTS();                                               \
+        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                        \
+        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) ); \
+    } while( 0 )
+
+    #define taskDATA_GROUP_DEMOTE_CRITICAL_TO_LOCK( pxISRSpinlock )                 \
+    do {                                                                            \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) ); \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                            \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )                       \
+        {                                                                           \
+            portENABLE_INTERRUPTS();                                                \
+        }                                                                           \
+    } while( 0 )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+
 #if ( configNUMBER_OF_CORES == 1 )
     #define taskYIELD_WITHIN_API()    portYIELD_WITHIN_API()
 #else /* #if ( configNUMBER_OF_CORES == 1 ) */
@@ -3826,6 +3851,8 @@ void vTaskPlaceOnEventListRestricted( List_t * const pxEventList,
  * Removes a task from both the specified event list and the list of blocked
  * tasks, and places it on a ready queue.
  *
+ * Do not call this function from an ISR context. Call xTaskRemoveFromEventListFromISR() instead.
+ *
  * xTaskRemoveFromEventList()/vTaskRemoveFromUnorderedEventList() will be called
  * if either an event occurs to unblock a task, or the block timeout period
  * expires.
@@ -3842,6 +3869,23 @@ void vTaskPlaceOnEventListRestricted( List_t * const pxEventList,
  * making the call, otherwise pdFALSE.
  */
 BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList ) PRIVILEGED_FUNCTION;
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS ONLY
+ * INTENDED FOR USE WHEN IMPLEMENTING A PORT OF THE SCHEDULER AND IS
+ * AN INTERFACE WHICH IS FOR THE EXCLUSIVE USE OF THE SCHEDULER.
+ *
+ * THIS FUNCTION MUST BE CALLED WITH INTERRUPTS DISABLED.
+ *
+ * Removes a task from both the specified event list and the list of blocked
+ * tasks, and places it on a ready queue. This function is the ISR-safe version
+ * of xTaskRemoveFromEventList().
+ *
+ * @return pdTRUE if the task being removed has a higher priority than the task
+ * making the call, otherwise pdFALSE.
+ */
+BaseType_t xTaskRemoveFromEventListFromISR( const List_t * const pxEventList ) PRIVILEGED_FUNCTION;
+
 void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
                                         const TickType_t xItemValue ) PRIVILEGED_FUNCTION;
 
@@ -4022,11 +4066,12 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
 
 /*
  * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
- * To be called while data group is locked.
+ * To be called while data group is locked or after an interrupt invokes
+ * a FreeRTOS API prior to returning to the task.
  */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     BaseType_t xTaskUnlockCanYield( void );
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif
 
 #if ( portUSING_MPU_WRAPPERS == 1 )
 

--- a/include/task.h
+++ b/include/task.h
@@ -224,7 +224,7 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                                                 portYIELD()
+#define taskYIELD()                          portYIELD()
 
 /**
  * task. h
@@ -238,19 +238,12 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()                                        portENTER_CRITICAL()
+#define taskENTER_CRITICAL()                 portENTER_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskENTER_CRITICAL_FROM_ISR()                           portSET_INTERRUPT_MASK_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portSET_INTERRUPT_MASK_FROM_ISR()
 #else
-    #define taskENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()    portENTER_CRITICAL_FROM_ISR()
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           portLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskENTER_CRITICAL()
-    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           taskENTER_CRITICAL_FROM_ISR()
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -264,19 +257,12 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                                           portEXIT_CRITICAL()
+#define taskEXIT_CRITICAL()                    portEXIT_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 #else
-    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portEXIT_CRITICAL_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )    portEXIT_CRITICAL_FROM_ISR( x )
 #endif
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portUNLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        portUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )
-#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskEXIT_CRITICAL()
-    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        taskEXIT_CRITICAL_FROM_ISR( x )
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -324,11 +310,11 @@ typedef enum
         {                                                                                 \
             const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                  \
             /* Task spinlock is always taken first */                                     \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock );          \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) );      \
             /* Disable interrupts */                                                      \
             portDISABLE_INTERRUPTS();                                                     \
             /* Take the ISR spinlock next */                                              \
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );           \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );       \
             /* Increment the critical nesting count */                                    \
             portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                              \
         }                                                                                 \
@@ -347,11 +333,13 @@ typedef enum
     #define taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( pxISRSpinlock, puxSavedInterruptStatus ) \
     do {                                                                                     \
         *( puxSavedInterruptStatus ) = portSET_INTERRUPT_MASK_FROM_ISR();                    \
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                         \
-        /* Take the ISR spinlock */                                                          \
-        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );                  \
-        /* Increment the critical nesting count */                                           \
-        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                     \
+        {                                                                                    \
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                     \
+            /* Take the ISR spinlock */                                                      \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );          \
+            /* Increment the critical nesting count */                                       \
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                 \
+        }                                                                                    \
     } while( 0 )
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
@@ -364,27 +352,27 @@ typedef enum
  * \ingroup GranularLocks
  */
 #if ( portUSING_GRANULAR_LOCKS == 1 )
-    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )        \
-    do {                                                                         \
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();             \
-        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );          \
-        /* Release the ISR spinlock */                                           \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );  \
-        /* Release the task spinlock */                                          \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock ); \
-        /* Decrement the critical nesting count */                               \
-        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                         \
-        /* Enable interrupts only if the critical nesting count is 0 */          \
-        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                     \
-        {                                                                        \
-            portENABLE_INTERRUPTS();                                             \
-        }                                                                        \
-        else                                                                     \
-        {                                                                        \
-            mtCOVERAGE_TEST_MARKER();                                            \
-        }                                                                        \
-        /* Re-enable preemption */                                               \
-        vTaskPreemptionEnable( NULL );                                           \
+    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )            \
+    do {                                                                             \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                 \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );              \
+        /* Release the ISR spinlock */                                               \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );  \
+        /* Release the task spinlock */                                              \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        /* Decrement the critical nesting count */                                   \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                             \
+        /* Enable interrupts only if the critical nesting count is 0 */              \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                         \
+        {                                                                            \
+            portENABLE_INTERRUPTS();                                                 \
+        }                                                                            \
+        else                                                                         \
+        {                                                                            \
+            mtCOVERAGE_TEST_MARKER();                                                \
+        }                                                                            \
+        /* Re-enable preemption */                                                   \
+        prvTaskPreemptionEnable( NULL );                                             \
     } while( 0 )
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
@@ -404,7 +392,7 @@ typedef enum
         /* Decrement the critical nesting count */                                         \
         portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                   \
         /* Release the ISR spinlock */                                                     \
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );            \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) ( pxISRSpinlock ) );        \
         if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                               \
         {                                                                                  \
             portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );                   \
@@ -3996,7 +3984,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portENTER_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskEnterCritical( void );
 #endif
 
@@ -4008,7 +3996,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portEXIT_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCritical( void );
 #endif
 
@@ -4018,7 +4006,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portENTER_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     UBaseType_t vTaskEnterCriticalFromISR( void );
 #endif
 
@@ -4028,12 +4016,12 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portEXIT_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
 
 /*
- * Checks whether a yield is required after taskUNLOCK_DATA_GROUP() returns.
+ * Checks whether a yield is required after portUNLOCK_DATA_GROUP() returns.
  * To be called while data group is locked.
  */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )

--- a/include/task.h
+++ b/include/task.h
@@ -224,7 +224,7 @@ typedef enum
  * \defgroup taskYIELD taskYIELD
  * \ingroup SchedulerControl
  */
-#define taskYIELD()                          portYIELD()
+#define taskYIELD()                                                 portYIELD()
 
 /**
  * task. h
@@ -238,12 +238,19 @@ typedef enum
  * \defgroup taskENTER_CRITICAL taskENTER_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskENTER_CRITICAL()                 portENTER_CRITICAL()
+#define taskENTER_CRITICAL()                                        portENTER_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskENTER_CRITICAL_FROM_ISR()    portSET_INTERRUPT_MASK_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()                           portSET_INTERRUPT_MASK_FROM_ISR()
 #else
-    #define taskENTER_CRITICAL_FROM_ISR()    portENTER_CRITICAL_FROM_ISR()
+    #define taskENTER_CRITICAL_FROM_ISR()                           portENTER_CRITICAL_FROM_ISR()
 #endif
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           portLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )
+#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    #define taskLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskENTER_CRITICAL()
+    #define taskLOCK_DATA_GROUP_FROM_ISR( pxISRSpinlock )           taskENTER_CRITICAL_FROM_ISR()
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -257,12 +264,19 @@ typedef enum
  * \defgroup taskEXIT_CRITICAL taskEXIT_CRITICAL
  * \ingroup SchedulerControl
  */
-#define taskEXIT_CRITICAL()                    portEXIT_CRITICAL()
+#define taskEXIT_CRITICAL()                                           portEXIT_CRITICAL()
 #if ( configNUMBER_OF_CORES == 1 )
-    #define taskEXIT_CRITICAL_FROM_ISR( x )    portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portCLEAR_INTERRUPT_MASK_FROM_ISR( x )
 #else
-    #define taskEXIT_CRITICAL_FROM_ISR( x )    portEXIT_CRITICAL_FROM_ISR( x )
+    #define taskEXIT_CRITICAL_FROM_ISR( x )                           portEXIT_CRITICAL_FROM_ISR( x )
 #endif
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    portUNLOCK_DATA_GROUP( ( portSPINLOCK_TYPE * ) pxTaskSpinlock, ( portSPINLOCK_TYPE * ) pxISRSpinlock )
+    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        portUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )
+#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    #define taskUNLOCK_DATA_GROUP( pxTaskSpinlock, pxISRSpinlock )    taskEXIT_CRITICAL()
+    #define taskUNLOCK_DATA_GROUP_FROM_ISR( x, pxISRSpinlock )        taskEXIT_CRITICAL_FROM_ISR( x )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /**
  * task. h
@@ -293,6 +307,146 @@ typedef enum
 
 /* Checks if core ID is valid. */
 #define taskVALID_CORE_ID( xCoreID )    ( ( ( ( ( BaseType_t ) 0 <= ( xCoreID ) ) && ( ( xCoreID ) < ( BaseType_t ) configNUMBER_OF_CORES ) ) ) ? ( pdTRUE ) : ( pdFALSE ) )
+
+/**
+ * task. h
+ *
+ * Macro to enter a data group critical section.
+ *
+ * \defgroup taskDATA_GROUP_ENTER_CRITICAL taskDATA_GROUP_ENTER_CRITICAL
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_ENTER_CRITICAL( pxTaskSpinlock, pxISRSpinlock )                \
+    do {                                                                                  \
+        /* Disable preemption to avoid task state changes during the critical section. */ \
+        vTaskPreemptionDisable( NULL );                                                   \
+        {                                                                                 \
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                  \
+            /* Task spinlock is always taken first */                                     \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock );          \
+            /* Disable interrupts */                                                      \
+            portDISABLE_INTERRUPTS();                                                     \
+            /* Take the ISR spinlock next */                                              \
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );           \
+            /* Increment the critical nesting count */                                    \
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                              \
+        }                                                                                 \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to enter a data group critical section from an interrupt.
+ *
+ * \defgroup taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( pxISRSpinlock, puxSavedInterruptStatus ) \
+    do {                                                                                     \
+        *( puxSavedInterruptStatus ) = portSET_INTERRUPT_MASK_FROM_ISR();                    \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                         \
+        /* Take the ISR spinlock */                                                          \
+        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );                  \
+        /* Increment the critical nesting count */                                           \
+        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                     \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to exit a data group critical section.
+ *
+ * \defgroup taskDATA_GROUP_EXIT_CRITICAL taskDATA_GROUP_EXIT_CRITICAL
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_EXIT_CRITICAL( pxTaskSpinlock, pxISRSpinlock )        \
+    do {                                                                         \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();             \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );          \
+        /* Release the ISR spinlock */                                           \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );  \
+        /* Release the task spinlock */                                          \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxTaskSpinlock ); \
+        /* Decrement the critical nesting count */                               \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                         \
+        /* Enable interrupts only if the critical nesting count is 0 */          \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                     \
+        {                                                                        \
+            portENABLE_INTERRUPTS();                                             \
+        }                                                                        \
+        else                                                                     \
+        {                                                                        \
+            mtCOVERAGE_TEST_MARKER();                                            \
+        }                                                                        \
+        /* Re-enable preemption */                                               \
+        vTaskPreemptionEnable( NULL );                                           \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macro to exit a data group critical section from an interrupt.
+ *
+ * \defgroup taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxISRSpinlock ) \
+    do {                                                                                   \
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();                       \
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );                    \
+        /* Decrement the critical nesting count */                                         \
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );                                   \
+        /* Release the ISR spinlock */                                                     \
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) pxISRSpinlock );            \
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )                               \
+        {                                                                                  \
+            portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );                   \
+        }                                                                                  \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macros to lock a data group (task-level lock only).
+ *
+ * \defgroup taskDATA_GROUP_LOCK taskDATA_GROUP_LOCK
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_LOCK( pxTaskSpinlock )                                              \
+    do {                                                                                       \
+        /* Disable preemption while holding the task spinlock. */                              \
+        vTaskPreemptionDisable( NULL );                                                        \
+        {                                                                                      \
+            portGET_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        }                                                                                      \
+    } while( 0 )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/**
+ * task. h
+ *
+ * Macros to unlock a data group (task-level lock only).
+ *
+ * \defgroup taskDATA_GROUP_UNLOCK taskDATA_GROUP_UNLOCK
+ * \ingroup GranularLocks
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define taskDATA_GROUP_UNLOCK( pxTaskSpinlock )                                            \
+    ( {                                                                                        \
+        portRELEASE_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) ( pxTaskSpinlock ) ); \
+        /* Re-enable preemption after releasing the task spinlock. */                          \
+        prvTaskPreemptionEnable( NULL );                                                       \
+    } )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
 /*-----------------------------------------------------------
 * TASK CREATION API
@@ -1554,6 +1708,23 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
  * }
  */
     void vTaskPreemptionEnable( const TaskHandle_t xTask );
+#endif
+
+#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+
+/*
+ * THIS FUNCTION MUST NOT BE USED FROM APPLICATION CODE.  IT IS ONLY
+ * INTENDED FOR USE WHEN IMPLEMENTING A PORT OF THE SCHEDULER AND IS
+ * AN INTERFACE WHICH IS FOR THE EXCLUSIVE USE OF THE SCHEDULER.
+ *
+ * @param xTask The handle of the task to enable preemption. Passing NULL
+ * enables preemption for the calling task.
+ *
+ * @return pdTRUE if enabling preemption for the task resulted in a context
+ * switch, otherwise pdFALSE. This is used by the scheduler to determine if a
+ * context switch may be required following the enable.
+ */
+    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask );
 #endif
 
 /*-----------------------------------------------------------
@@ -3825,7 +3996,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portENTER_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     void vTaskEnterCritical( void );
 #endif
 
@@ -3837,7 +4008,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * It should be used in the implementation of portEXIT_CRITICAL if port is running a
  * multiple core FreeRTOS.
  */
-#if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) || ( configNUMBER_OF_CORES > 1 ) )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCritical( void );
 #endif
 
@@ -3847,7 +4018,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portENTER_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if ( configNUMBER_OF_CORES > 1 )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     UBaseType_t vTaskEnterCriticalFromISR( void );
 #endif
 
@@ -3857,9 +4028,17 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut ) PRIVILEGED_FUNC
  * should be used in the implementation of portEXIT_CRITICAL_FROM_ISR if port is
  * running a multiple core FreeRTOS.
  */
-#if ( configNUMBER_OF_CORES > 1 )
+#if !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 #endif
+
+/*
+ * Checks whether a yield is required after taskUNLOCK_DATA_GROUP() returns.
+ * To be called while data group is locked.
+ */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    BaseType_t xTaskUnlockCanYield( void );
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 #if ( portUSING_MPU_WRAPPERS == 1 )
 

--- a/queue.c
+++ b/queue.c
@@ -328,25 +328,23 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
  * When the tasks unlocks the queue, all pended access attempts are handled.
  */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    #define queueLOCK( pxQueue )                                            \
-    do {                                                                    \
-        vTaskPreemptionDisable( NULL );                                     \
-        prvLockQueue( ( pxQueue ) );                                        \
-        portGET_SPINLOCK( portGET_CORE_ID(), &( pxQueue->xTaskSpinlock ) ); \
+    #define queueLOCK( pxQueue )                                \
+    do {                                                        \
+        taskDATA_GROUP_LOCK( &( ( pxQueue )->xTaskSpinlock ) ); \
+        prvLockQueue( ( pxQueue ) );                            \
     } while( 0 )
-    #define queueUNLOCK( pxQueue, xYieldAPI )                                   \
-    do {                                                                        \
-        prvUnlockQueue( ( pxQueue ) );                                          \
-        portRELEASE_SPINLOCK( portGET_CORE_ID(), &( pxQueue->xTaskSpinlock ) ); \
-        vTaskPreemptionEnable( NULL );                                          \
-        if( ( xYieldAPI ) == pdTRUE )                                           \
-        {                                                                       \
-            taskYIELD_WITHIN_API();                                             \
-        }                                                                       \
-        else                                                                    \
-        {                                                                       \
-            mtCOVERAGE_TEST_MARKER();                                           \
-        }                                                                       \
+    #define queueUNLOCK( pxQueue, xYieldAPI )                     \
+    do {                                                          \
+        prvUnlockQueue( ( pxQueue ) );                            \
+        taskDATA_GROUP_UNLOCK( &( ( pxQueue )->xTaskSpinlock ) ); \
+        if( ( xYieldAPI ) == pdTRUE )                             \
+        {                                                         \
+            taskYIELD_WITHIN_API();                               \
+        }                                                         \
+        else                                                      \
+        {                                                         \
+            mtCOVERAGE_TEST_MARKER();                             \
+        }                                                         \
     } while( 0 )
 #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define queueLOCK( pxQueue )     \

--- a/queue.c
+++ b/queue.c
@@ -346,18 +346,19 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         taskDATA_GROUP_LOCK( &( ( pxQueue )->xTaskSpinlock ) ); \
         prvLockQueue( ( pxQueue ) );                            \
     } while( 0 )
-    #define queueUNLOCK( pxQueue, xYieldAPI )                     \
-    do {                                                          \
-        prvUnlockQueue( ( pxQueue ) );                            \
-        taskDATA_GROUP_UNLOCK( &( ( pxQueue )->xTaskSpinlock ) ); \
-        if( ( xYieldAPI ) == pdTRUE )                             \
-        {                                                         \
-            taskYIELD_WITHIN_API();                               \
-        }                                                         \
-        else                                                      \
-        {                                                         \
-            mtCOVERAGE_TEST_MARKER();                             \
-        }                                                         \
+    #define queueUNLOCK( pxQueue, xYieldAPI )                                       \
+    do {                                                                            \
+        BaseType_t xAlreadyYielded;                                                 \
+        prvUnlockQueue( ( pxQueue ) );                                              \
+        xAlreadyYielded = taskDATA_GROUP_UNLOCK( &( ( pxQueue )->xTaskSpinlock ) ); \
+        if( ( xAlreadyYielded == pdFALSE ) && ( ( xYieldAPI ) == pdTRUE ) )         \
+        {                                                                           \
+            taskYIELD_WITHIN_API();                                                 \
+        }                                                                           \
+        else                                                                        \
+        {                                                                           \
+            mtCOVERAGE_TEST_MARKER();                                               \
+        }                                                                           \
     } while( 0 )
 #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
     #define queueLOCK( pxQueue )     \

--- a/queue.c
+++ b/queue.c
@@ -1790,11 +1790,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 {
                     if( pxQueue->uxQueueType == queueQUEUE_IS_MUTEX )
                     {
-                        taskENTER_CRITICAL();
-                        {
-                            xInheritanceOccurred = xTaskPriorityInherit( pxQueue->u.xSemaphore.xMutexHolder );
-                        }
-                        taskEXIT_CRITICAL();
+                        xInheritanceOccurred = xTaskPriorityInherit( pxQueue->u.xSemaphore.xMutexHolder );
                     }
                     else
                     {

--- a/queue.c
+++ b/queue.c
@@ -2806,8 +2806,9 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
      * locked items can be added or removed, but the event lists cannot be
      * updated. */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        const BaseType_t xCoreID = portGET_CORE_ID();
+
         portDISABLE_INTERRUPTS();
-        BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
         portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
         portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
     #else
@@ -2891,10 +2892,10 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
         pxQueue->cTxLock = queueUNLOCKED;
     }
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        portRELEASE_SPINLOCK( portGET_CORE_ID(), ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
         portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
 
-        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 )
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
         {
             portENABLE_INTERRUPTS();
         }
@@ -2905,7 +2906,6 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
     /* Do the same for the Rx lock. */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         portDISABLE_INTERRUPTS();
-        xCoreID = ( BaseType_t ) portGET_CORE_ID();
         portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
         portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
     #else
@@ -3667,17 +3667,60 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_QUEUE_SETS == 1 )
-
     static BaseType_t prvNotifyQueueSetContainer( const Queue_t * const pxQueue )
     {
+        BaseType_t xReturn;
+
         /* Call the generic version with xIsISR = pdFALSE to indicate task context */
-        return prvNotifyQueueSetContainerGeneric( pxQueue, pdFALSE );
+
+        #if ( portUSING_GRANULAR_LOCKS == 0 )
+        {
+            xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdFALSE );
+        }
+        #else
+        {
+            const BaseType_t xCoreID = portGET_CORE_ID();
+
+            /* This API must be called in a critical section which already has preemption
+             * and interrupt disabled. */
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xTaskSpinlock ) );
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+            {
+                xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdFALSE );
+            }
+            portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+            portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xTaskSpinlock ) );
+        }
+        #endif /* if ( portUSING_GRANULAR_LOCKS == 0 ) */
+
+        return xReturn;
     }
 
     static BaseType_t prvNotifyQueueSetContainerFromISR( const Queue_t * const pxQueue )
     {
+        BaseType_t xReturn;
+
         /* Call the generic version with xIsISR = pdTRUE to indicate ISR context */
-        return prvNotifyQueueSetContainerGeneric( pxQueue, pdTRUE );
+
+        #if ( portUSING_GRANULAR_LOCKS == 0 )
+        {
+            xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdTRUE );
+        }
+        #else
+        {
+            UBaseType_t uxSavedInterruptStatus;
+            const BaseType_t xCoreID = portGET_CORE_ID();
+
+            /* This API must be called in a critical section which already has interrupt disabled. */
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+            {
+                xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdTRUE );
+            }
+            portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+        }
+        #endif /* if ( portUSING_GRANULAR_LOCKS == 0 ) */
+
+        return xReturn;
     }
 
     static BaseType_t prvNotifyQueueSetContainerGeneric( const Queue_t * const pxQueue,

--- a/queue.c
+++ b/queue.c
@@ -133,6 +133,11 @@ typedef struct QueueDefinition /* The old naming convention is used to prevent b
         UBaseType_t uxQueueNumber;
         uint8_t ucQueueType;
     #endif
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } xQUEUE;
 
 /* The old xQUEUE name is maintained above then typedefed to the new Queue_t
@@ -172,6 +177,15 @@ typedef xQUEUE Queue_t;
 
 #endif /* configQUEUE_REGISTRY_SIZE */
 
+/* Queue accessors that only read the queue still have to acquire the queue's
+ * spinlocks when granular locking is used, so the queue cannot be const
+ * qualified in that case. Every other configuration keeps the qualifier. */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define queueQUEUE_CONST
+#else
+    #define queueQUEUE_CONST    const
+#endif
+
 /*
  * Unlocks a queue locked by a call to prvLockQueue.  Locking a queue does not
  * prevent an ISR from adding or removing items to the queue, but does prevent
@@ -187,14 +201,14 @@ static void prvUnlockQueue( Queue_t * const pxQueue ) PRIVILEGED_FUNCTION;
  *
  * @return pdTRUE if the queue contains no items, otherwise pdFALSE.
  */
-static BaseType_t prvIsQueueEmpty( const Queue_t * pxQueue ) PRIVILEGED_FUNCTION;
+static BaseType_t prvIsQueueEmpty( queueQUEUE_CONST Queue_t * pxQueue ) PRIVILEGED_FUNCTION;
 
 /*
  * Uses a critical section to determine if there is any space in a queue.
  *
  * @return pdTRUE if there is no space, otherwise pdFALSE;
  */
-static BaseType_t prvIsQueueFull( const Queue_t * pxQueue ) PRIVILEGED_FUNCTION;
+static BaseType_t prvIsQueueFull( queueQUEUE_CONST Queue_t * pxQueue ) PRIVILEGED_FUNCTION;
 
 /*
  * Copies an item into the queue, either at the front of the queue or the
@@ -217,7 +231,20 @@ static void prvCopyDataFromQueue( Queue_t * const pxQueue,
  * the queue set that the queue contains data.
  */
     static BaseType_t prvNotifyQueueSetContainer( const Queue_t * const pxQueue ) PRIVILEGED_FUNCTION;
-#endif
+
+/*
+ * A version of prvNotifyQueueSetContainer() that can be called from an
+ * interrupt service routine (ISR).
+ */
+    static BaseType_t prvNotifyQueueSetContainerFromISR( const Queue_t * const pxQueue ) PRIVILEGED_FUNCTION;
+
+/*
+ * This function serves as a generic implementation for prvNotifyQueueSetContainer()
+ * and prvNotifyQueueSetContainerFromISR().
+ */
+    static BaseType_t prvNotifyQueueSetContainerGeneric( const Queue_t * const pxQueue,
+                                                         const BaseType_t xIsISR ) PRIVILEGED_FUNCTION;
+#endif /* if ( configUSE_QUEUE_SETS == 1 ) */
 
 /*
  * Called after a Queue_t structure has been allocated either statically or
@@ -252,11 +279,64 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
 /*-----------------------------------------------------------*/
 
 /*
+ * Macros to mark the start and end of a critical code region.
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define queueENTER_CRITICAL( pxQueue )                                      taskDATA_GROUP_ENTER_CRITICAL( ( portSPINLOCK_TYPE * ) &( pxQueue )->xTaskSpinlock, ( portSPINLOCK_TYPE * ) &( pxQueue )->xISRSpinlock )
+    #define queueENTER_CRITICAL_FROM_ISR( pxQueue, puxSavedInterruptStatus )    taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( ( portSPINLOCK_TYPE * ) &( pxQueue )->xISRSpinlock, puxSavedInterruptStatus )
+    #define queueEXIT_CRITICAL( pxQueue )                                       taskDATA_GROUP_EXIT_CRITICAL( ( portSPINLOCK_TYPE * ) &( pxQueue )->xTaskSpinlock, ( portSPINLOCK_TYPE * ) &( pxQueue )->xISRSpinlock )
+    #define queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue )      taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, ( portSPINLOCK_TYPE * ) &( pxQueue )->xISRSpinlock )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define queueENTER_CRITICAL( pxQueue )                                      taskENTER_CRITICAL()
+    #define queueENTER_CRITICAL_FROM_ISR( pxQueue, puxSavedInterruptStatus )    do { *( puxSavedInterruptStatus ) = taskENTER_CRITICAL_FROM_ISR(); } while( 0 )
+    #define queueEXIT_CRITICAL( pxQueue )                                       taskEXIT_CRITICAL()
+    #define queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue )      taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/*
+ * Macros to mark the start and end of a critical code region that only reads a
+ * single BaseType_t sized queue member. Ports that can read such a member
+ * atomically define portBASE_TYPE_ENTER_CRITICAL() away, so that path must be
+ * preserved wherever a data group critical section is not required.
+ */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define queueBASE_TYPE_ENTER_CRITICAL( pxQueue )    queueENTER_CRITICAL( pxQueue )
+    #define queueBASE_TYPE_EXIT_CRITICAL( pxQueue )     queueEXIT_CRITICAL( pxQueue )
+#else
+    #define queueBASE_TYPE_ENTER_CRITICAL( pxQueue )    portBASE_TYPE_ENTER_CRITICAL()
+    #define queueBASE_TYPE_EXIT_CRITICAL( pxQueue )     portBASE_TYPE_EXIT_CRITICAL()
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+/*
  * Macro to mark a queue as locked.  Locking a queue prevents an ISR from
  * accessing the queue event lists.
+ *
+ * Under granular locks, queueLOCK()/queueUNLOCK() already surround this with
+ * task-level spinlock + preemption-disabled region. To avoid redundant
+ * data-group enter/exit (which would re-disable preemption and re-acquire the
+ * same task spinlock), we minimize to interrupt masking only for the small
+ * metadata updates here. For the non-granular path, retain the full
+ * queueENTER_CRITICAL/queueEXIT_CRITICAL.
  */
-#define prvLockQueue( pxQueue )                            \
-    taskENTER_CRITICAL();                                  \
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define prvLockQueue( pxQueue )                                                \
+    do {                                                                           \
+        taskDATA_GROUP_PROMOTE_LOCK_TO_CRITICAL( &( ( pxQueue )->xISRSpinlock ) ); \
+        {                                                                          \
+            if( ( pxQueue )->cRxLock == queueUNLOCKED )                            \
+            {                                                                      \
+                ( pxQueue )->cRxLock = queueLOCKED_UNMODIFIED;                     \
+            }                                                                      \
+            if( ( pxQueue )->cTxLock == queueUNLOCKED )                            \
+            {                                                                      \
+                ( pxQueue )->cTxLock = queueLOCKED_UNMODIFIED;                     \
+            }                                                                      \
+        }                                                                          \
+        taskDATA_GROUP_DEMOTE_CRITICAL_TO_LOCK( &( ( pxQueue )->xISRSpinlock ) );  \
+    } while( 0 )
+#else /* if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    #define prvLockQueue( pxQueue )                        \
+    queueENTER_CRITICAL( pxQueue );                        \
     {                                                      \
         if( ( pxQueue )->cRxLock == queueUNLOCKED )        \
         {                                                  \
@@ -267,7 +347,8 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             ( pxQueue )->cTxLock = queueLOCKED_UNMODIFIED; \
         }                                                  \
     }                                                      \
-    taskEXIT_CRITICAL()
+    queueEXIT_CRITICAL( pxQueue )
+#endif /* if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*
  * Macro to increment cTxLock member of the queue data structure. It is
@@ -298,6 +379,56 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             ( pxQueue )->cRxLock = ( int8_t ) ( ( cRxLock ) + ( int8_t ) 1 ); \
         }                                                                     \
     } while( 0 )
+
+/*
+ * Macro used to lock and unlock a queue. When a task locks a queue, the
+ * task will have thread safe non-deterministic access to the queue.
+ * - Concurrent access from other tasks will be blocked by the xTaskSpinlock
+ * - Concurrent access from ISRs will be pended
+ *
+ * When the tasks unlocks the queue, all pended access attempts are handled.
+ */
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    #define queueLOCK( pxQueue )                                \
+    do {                                                        \
+        taskDATA_GROUP_LOCK( &( ( pxQueue )->xTaskSpinlock ) ); \
+        prvLockQueue( ( pxQueue ) );                            \
+    } while( 0 )
+    #define queueUNLOCK( pxQueue, xYieldAPI )                                       \
+    do {                                                                            \
+        BaseType_t xAlreadyYielded;                                                 \
+        prvUnlockQueue( ( pxQueue ) );                                              \
+        xAlreadyYielded = taskDATA_GROUP_UNLOCK( &( ( pxQueue )->xTaskSpinlock ) ); \
+        if( ( xAlreadyYielded == pdFALSE ) && ( ( xYieldAPI ) == pdTRUE ) )         \
+        {                                                                           \
+            taskYIELD_WITHIN_API();                                                 \
+        }                                                                           \
+        else                                                                        \
+        {                                                                           \
+            mtCOVERAGE_TEST_MARKER();                                               \
+        }                                                                           \
+    } while( 0 )
+#else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    #define queueLOCK( pxQueue )     \
+    do {                             \
+        vTaskSuspendAll();           \
+        prvLockQueue( ( pxQueue ) ); \
+    } while( 0 )
+    #define queueUNLOCK( pxQueue, xYieldAPI )                               \
+    do {                                                                    \
+        BaseType_t xAlreadyYielded;                                         \
+        prvUnlockQueue( ( pxQueue ) );                                      \
+        xAlreadyYielded = xTaskResumeAll();                                 \
+        if( ( xAlreadyYielded == pdFALSE ) && ( ( xYieldAPI ) == pdTRUE ) ) \
+        {                                                                   \
+            taskYIELD_WITHIN_API();                                         \
+        }                                                                   \
+        else                                                                \
+        {                                                                   \
+            mtCOVERAGE_TEST_MARKER();                                       \
+        }                                                                   \
+    } while( 0 )
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
 BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
@@ -310,12 +441,22 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
 
     configASSERT( pxQueue );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    {
+        if( xNewQueue == pdTRUE )
+        {
+            portINIT_SPINLOCK( &( pxQueue->xTaskSpinlock ) );
+            portINIT_SPINLOCK( &( pxQueue->xISRSpinlock ) );
+        }
+    }
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     if( ( pxQueue != NULL ) &&
         ( pxQueue->uxLength >= 1U ) &&
         /* Check for multiplication overflow. */
         ( ( SIZE_MAX / pxQueue->uxLength ) >= pxQueue->uxItemSize ) )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             pxQueue->u.xQueue.pcTail = pxQueue->pcHead + ( pxQueue->uxLength * pxQueue->uxItemSize );
             pxQueue->uxMessagesWaiting = ( UBaseType_t ) 0U;
@@ -331,16 +472,9 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
                  * will still be empty.  If there are tasks blocked waiting to write to
                  * the queue, then one should be unblocked as after this function exits
                  * it will be possible to write to it. */
-                if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToSend ) ) == pdFALSE )
+                if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
                 {
-                    if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
-                    {
-                        queueYIELD_IF_USING_PREEMPTION();
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                    queueYIELD_IF_USING_PREEMPTION();
                 }
                 else
                 {
@@ -354,7 +488,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
                 vListInitialise( &( pxQueue->xTasksWaitingToReceive ) );
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
     }
     else
     {
@@ -703,7 +837,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
          * calling task is the mutex holder, but not a good way of determining the
          * identity of the mutex holder, as the holder may change between the
          * following critical section exiting and the function returning. */
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxSemaphore );
         {
             if( pxSemaphore->uxQueueType == queueQUEUE_IS_MUTEX )
             {
@@ -714,7 +848,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
                 pxReturn = NULL;
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxSemaphore );
 
         traceRETURN_xQueueGetMutexHolder( pxReturn );
 
@@ -968,7 +1102,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             /* Is there room on the queue now?  The running task must be the
              * highest priority task wanting to access the queue.  If the head item
@@ -1009,20 +1143,13 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                     {
                         /* If there was a task waiting for data to arrive on the
                          * queue then unblock it now. */
-                        if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
+                        if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                         {
-                            if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
-                            {
-                                /* The unblocked task has a priority higher than
-                                 * our own so yield immediately.  Yes it is ok to
-                                 * do this from within the critical section - the
-                                 * kernel takes care of that. */
-                                queueYIELD_IF_USING_PREEMPTION();
-                            }
-                            else
-                            {
-                                mtCOVERAGE_TEST_MARKER();
-                            }
+                            /* The unblocked task has a priority higher than
+                             * our own so yield immediately.  Yes it is ok to
+                             * do this from within the critical section - the
+                             * kernel takes care of that. */
+                            queueYIELD_IF_USING_PREEMPTION();
                         }
                         else if( xYieldRequired != pdFALSE )
                         {
@@ -1044,20 +1171,13 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
 
                     /* If there was a task waiting for data to arrive on the
                      * queue then unblock it now. */
-                    if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
+                    if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                     {
-                        if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
-                        {
-                            /* The unblocked task has a priority higher than
-                             * our own so yield immediately.  Yes it is ok to do
-                             * this from within the critical section - the kernel
-                             * takes care of that. */
-                            queueYIELD_IF_USING_PREEMPTION();
-                        }
-                        else
-                        {
-                            mtCOVERAGE_TEST_MARKER();
-                        }
+                        /* The unblocked task has a priority higher than
+                         * our own so yield immediately.  Yes it is ok to do
+                         * this from within the critical section - the kernel
+                         * takes care of that. */
+                        queueYIELD_IF_USING_PREEMPTION();
                     }
                     else if( xYieldRequired != pdFALSE )
                     {
@@ -1074,7 +1194,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 }
                 #endif /* configUSE_QUEUE_SETS */
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueueGenericSend( pdPASS );
 
@@ -1086,7 +1206,7 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 {
                     /* The queue was full and no block time is specified (or
                      * the block time has expired) so leave now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     /* Return to the original privilege level before exiting
                      * the function. */
@@ -1109,13 +1229,12 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can send to and receive from the queue
          * now the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1125,35 +1244,18 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
                 traceBLOCKING_ON_QUEUE_SEND( pxQueue );
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToSend ), xTicksToWait );
 
-                /* Unlocking the queue means queue events can effect the
-                 * event list. It is possible that interrupts occurring now
-                 * remove this task from the event list again - but as the
-                 * scheduler is suspended the task will go onto the pending
-                 * ready list instead of the actual ready list. */
-                prvUnlockQueue( pxQueue );
-
-                /* Resuming the scheduler will move tasks from the pending
-                 * ready list into the ready list - so it is feasible that this
-                 * task is already in the ready list before it yields - in which
-                 * case the yield will not cause a context switch unless there
-                 * is also a higher priority task in the pending ready list. */
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* Try again. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* The timeout has expired. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             traceQUEUE_SEND_FAILED( pxQueue );
             traceRETURN_xQueueGenericSend( errQUEUE_FULL );
@@ -1202,7 +1304,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         if( ( pxQueue->uxMessagesWaiting < pxQueue->uxLength ) || ( xCopyPosition == queueOVERWRITE ) )
         {
@@ -1233,7 +1335,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
                              * in the queue has not changed. */
                             mtCOVERAGE_TEST_MARKER();
                         }
-                        else if( prvNotifyQueueSetContainer( pxQueue ) != pdFALSE )
+                        else if( prvNotifyQueueSetContainerFromISR( pxQueue ) != pdFALSE )
                         {
                             /* The queue is a member of a queue set, and posting
                              * to the queue set caused a higher priority task to
@@ -1254,20 +1356,13 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
                     }
                     else
                     {
-                        if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
+                        if( xTaskRemoveFromEventListFromISR( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                         {
-                            if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
+                            /* The task waiting has a higher priority so
+                             *  record that a context switch is required. */
+                            if( pxHigherPriorityTaskWoken != NULL )
                             {
-                                /* The task waiting has a higher priority so
-                                 *  record that a context switch is required. */
-                                if( pxHigherPriorityTaskWoken != NULL )
-                                {
-                                    *pxHigherPriorityTaskWoken = pdTRUE;
-                                }
-                                else
-                                {
-                                    mtCOVERAGE_TEST_MARKER();
-                                }
+                                *pxHigherPriorityTaskWoken = pdTRUE;
                             }
                             else
                             {
@@ -1282,20 +1377,13 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
                 }
                 #else /* configUSE_QUEUE_SETS */
                 {
-                    if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
+                    if( xTaskRemoveFromEventListFromISR( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                     {
-                        if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
+                        /* The task waiting has a higher priority so record that a
+                         * context switch is required. */
+                        if( pxHigherPriorityTaskWoken != NULL )
                         {
-                            /* The task waiting has a higher priority so record that a
-                             * context switch is required. */
-                            if( pxHigherPriorityTaskWoken != NULL )
-                            {
-                                *pxHigherPriorityTaskWoken = pdTRUE;
-                            }
-                            else
-                            {
-                                mtCOVERAGE_TEST_MARKER();
-                            }
+                            *pxHigherPriorityTaskWoken = pdTRUE;
                         }
                         else
                         {
@@ -1327,7 +1415,7 @@ BaseType_t xQueueGenericSendFromISR( QueueHandle_t xQueue,
             xReturn = errQUEUE_FULL;
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueueGenericSendFromISR( xReturn );
 
@@ -1378,7 +1466,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -1407,7 +1495,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
                 {
                     if( pxQueue->pxQueueSetContainer != NULL )
                     {
-                        if( prvNotifyQueueSetContainer( pxQueue ) != pdFALSE )
+                        if( prvNotifyQueueSetContainerFromISR( pxQueue ) != pdFALSE )
                         {
                             /* The semaphore is a member of a queue set, and
                              * posting to the queue set caused a higher priority
@@ -1428,20 +1516,13 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
                     }
                     else
                     {
-                        if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
+                        if( xTaskRemoveFromEventListFromISR( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                         {
-                            if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
+                            /* The task waiting has a higher priority so
+                             *  record that a context switch is required. */
+                            if( pxHigherPriorityTaskWoken != NULL )
                             {
-                                /* The task waiting has a higher priority so
-                                 *  record that a context switch is required. */
-                                if( pxHigherPriorityTaskWoken != NULL )
-                                {
-                                    *pxHigherPriorityTaskWoken = pdTRUE;
-                                }
-                                else
-                                {
-                                    mtCOVERAGE_TEST_MARKER();
-                                }
+                                *pxHigherPriorityTaskWoken = pdTRUE;
                             }
                             else
                             {
@@ -1456,20 +1537,13 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
                 }
                 #else /* configUSE_QUEUE_SETS */
                 {
-                    if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
+                    if( xTaskRemoveFromEventListFromISR( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                     {
-                        if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
+                        /* The task waiting has a higher priority so record that a
+                         * context switch is required. */
+                        if( pxHigherPriorityTaskWoken != NULL )
                         {
-                            /* The task waiting has a higher priority so record that a
-                             * context switch is required. */
-                            if( pxHigherPriorityTaskWoken != NULL )
-                            {
-                                *pxHigherPriorityTaskWoken = pdTRUE;
-                            }
-                            else
-                            {
-                                mtCOVERAGE_TEST_MARKER();
-                            }
+                            *pxHigherPriorityTaskWoken = pdTRUE;
                         }
                         else
                         {
@@ -1498,7 +1572,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
             xReturn = errQUEUE_FULL;
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueueGiveFromISR( xReturn );
 
@@ -1532,7 +1606,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -1548,23 +1622,16 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 /* There is now space in the queue, were any tasks waiting to
                  * post to the queue?  If so, unblock the highest priority waiting
                  * task. */
-                if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToSend ) ) == pdFALSE )
+                if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
                 {
-                    if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
-                    {
-                        queueYIELD_IF_USING_PREEMPTION();
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                    queueYIELD_IF_USING_PREEMPTION();
                 }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueueReceive( pdPASS );
 
@@ -1576,7 +1643,7 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 {
                     /* The queue was empty and no block time is specified (or
                      * the block time has expired) so leave now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
                     traceRETURN_xQueueReceive( errQUEUE_EMPTY );
@@ -1597,13 +1664,12 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can send to and receive from the queue
          * now the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1614,31 +1680,20 @@ BaseType_t xQueueReceive( QueueHandle_t xQueue,
             {
                 traceBLOCKING_ON_QUEUE_RECEIVE( pxQueue );
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToReceive ), xTicksToWait );
-                prvUnlockQueue( pxQueue );
-
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* The queue contains data again.  Loop back to try and read the
                  * data. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* Timed out.  If there is no data in the queue exit, otherwise loop
              * back and attempt to read the data. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             if( prvIsQueueEmpty( pxQueue ) != pdFALSE )
             {
@@ -1685,7 +1740,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             /* Semaphores are queues with an item size of 0, and where the
              * number of messages in the queue is the semaphore's count value. */
@@ -1718,23 +1773,16 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
 
                 /* Check to see if other tasks are blocked waiting to give the
                  * semaphore, and if so, unblock the highest priority such task. */
-                if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToSend ) ) == pdFALSE )
+                if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
                 {
-                    if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
-                    {
-                        queueYIELD_IF_USING_PREEMPTION();
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                    queueYIELD_IF_USING_PREEMPTION();
                 }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueueSemaphoreTake( pdPASS );
 
@@ -1746,7 +1794,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 {
                     /* The semaphore count was 0 and no block time is specified
                      * (or the block time has expired) so exit now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     traceQUEUE_RECEIVE_FAILED( pxQueue );
                     traceRETURN_xQueueSemaphoreTake( errQUEUE_EMPTY );
@@ -1767,13 +1815,12 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can give to and take from the semaphore
          * now the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1800,30 +1847,19 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                 #endif /* if ( configUSE_MUTEXES == 1 ) */
 
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToReceive ), xTicksToWait );
-                prvUnlockQueue( pxQueue );
-
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* There was no timeout and the semaphore count was not 0, so
                  * attempt to take the semaphore again. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* Timed out. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             /* If the semaphore count is 0 exit now as the timeout has
              * expired.  Otherwise return to attempt to take the semaphore that is
@@ -1838,7 +1874,7 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                      * test the mutex type again to check it is actually a mutex. */
                     if( xInheritanceOccurred != pdFALSE )
                     {
-                        taskENTER_CRITICAL();
+                        queueENTER_CRITICAL( pxQueue );
                         {
                             UBaseType_t uxHighestWaitingPriority;
 
@@ -1847,6 +1883,18 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                              * has timed out the priority should be disinherited
                              * again, but only as low as the next highest priority
                              * task that is waiting for the same mutex. */
+
+                            #if ( portUSING_GRANULAR_LOCKS == 1 )
+
+                                /* Acquire the kernel lock so that reading the highest priority
+                                 * of the waiting tasks and the subsequent priority disinheritance
+                                 * are performed atomically. The waiting tasks' event list item
+                                 * values encode their priorities and are maintained under the
+                                 * kernel lock, so the queue data group lock alone is not sufficient
+                                 * to read them consistently. */
+                                vTaskEnterCritical();
+                            #endif
+
                             uxHighestWaitingPriority = prvGetHighestPriorityOfWaitToReceiveList( pxQueue );
 
                             /* vTaskPriorityDisinheritAfterTimeout uses the uxHighestWaitingPriority
@@ -1857,8 +1905,12 @@ BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                              * is capped at ( configMAX_PRIORITIES - 1 ). */
                             /* coverity[overrun] */
                             vTaskPriorityDisinheritAfterTimeout( pxQueue->u.xSemaphore.xMutexHolder, uxHighestWaitingPriority );
+
+                            #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                vTaskExitCritical();
+                            #endif
                         }
-                        taskEXIT_CRITICAL();
+                        queueEXIT_CRITICAL( pxQueue );
                     }
                 }
                 #endif /* configUSE_MUTEXES */
@@ -1901,7 +1953,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
 
     for( ; ; )
     {
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -1922,24 +1974,17 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
 
                 /* The data is being left in the queue, so see if there are
                  * any other tasks waiting for the data. */
-                if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
+                if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                 {
-                    if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
-                    {
-                        /* The task waiting has a higher priority than this task. */
-                        queueYIELD_IF_USING_PREEMPTION();
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                    /* The task waiting has a higher priority than this task. */
+                    queueYIELD_IF_USING_PREEMPTION();
                 }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
 
-                taskEXIT_CRITICAL();
+                queueEXIT_CRITICAL( pxQueue );
 
                 traceRETURN_xQueuePeek( pdPASS );
 
@@ -1951,7 +1996,7 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                 {
                     /* The queue was empty and no block time is specified (or
                      * the block time has expired) so leave now. */
-                    taskEXIT_CRITICAL();
+                    queueEXIT_CRITICAL( pxQueue );
 
                     traceQUEUE_PEEK_FAILED( pxQueue );
                     traceRETURN_xQueuePeek( errQUEUE_EMPTY );
@@ -1973,13 +2018,12 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         /* Interrupts and other tasks can send to and receive from the queue
          * now that the critical section has been exited. */
 
-        vTaskSuspendAll();
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         /* Update the timeout state to see if it has expired yet. */
         if( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE )
@@ -1990,31 +2034,20 @@ BaseType_t xQueuePeek( QueueHandle_t xQueue,
             {
                 traceBLOCKING_ON_QUEUE_PEEK( pxQueue );
                 vTaskPlaceOnEventList( &( pxQueue->xTasksWaitingToReceive ), xTicksToWait );
-                prvUnlockQueue( pxQueue );
-
-                if( xTaskResumeAll() == pdFALSE )
-                {
-                    taskYIELD_WITHIN_API();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
+                queueUNLOCK( pxQueue, pdTRUE );
             }
             else
             {
                 /* There is data in the queue now, so don't enter the blocked
                  * state, instead return to try and obtain the data. */
-                prvUnlockQueue( pxQueue );
-                ( void ) xTaskResumeAll();
+                queueUNLOCK( pxQueue, pdFALSE );
             }
         }
         else
         {
             /* The timeout has expired.  If there is still no data in the queue
              * exit, otherwise go back and try to read the data again. */
-            prvUnlockQueue( pxQueue );
-            ( void ) xTaskResumeAll();
+            queueUNLOCK( pxQueue, pdFALSE );
 
             if( prvIsQueueEmpty( pxQueue ) != pdFALSE )
             {
@@ -2064,7 +2097,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         const UBaseType_t uxMessagesWaiting = pxQueue->uxMessagesWaiting;
 
@@ -2084,20 +2117,13 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
              * locked. */
             if( cRxLock == queueUNLOCKED )
             {
-                if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToSend ) ) == pdFALSE )
+                if( xTaskRemoveFromEventListFromISR( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
                 {
-                    if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
+                    /* The task waiting has a higher priority than us so
+                     * force a context switch. */
+                    if( pxHigherPriorityTaskWoken != NULL )
                     {
-                        /* The task waiting has a higher priority than us so
-                         * force a context switch. */
-                        if( pxHigherPriorityTaskWoken != NULL )
-                        {
-                            *pxHigherPriorityTaskWoken = pdTRUE;
-                        }
-                        else
-                        {
-                            mtCOVERAGE_TEST_MARKER();
-                        }
+                        *pxHigherPriorityTaskWoken = pdTRUE;
                     }
                     else
                     {
@@ -2124,7 +2150,7 @@ BaseType_t xQueueReceiveFromISR( QueueHandle_t xQueue,
             traceQUEUE_RECEIVE_FROM_ISR_FAILED( pxQueue );
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueueReceiveFromISR( xReturn );
 
@@ -2164,7 +2190,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+    queueENTER_CRITICAL_FROM_ISR( pxQueue, &uxSavedInterruptStatus );
     {
         /* Cannot block in an ISR, so check there is data available. */
         if( pxQueue->uxMessagesWaiting > ( UBaseType_t ) 0 )
@@ -2185,7 +2211,7 @@ BaseType_t xQueuePeekFromISR( QueueHandle_t xQueue,
             traceQUEUE_PEEK_FROM_ISR_FAILED( pxQueue );
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    queueEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxQueue );
 
     traceRETURN_xQueuePeekFromISR( xReturn );
 
@@ -2201,11 +2227,11 @@ UBaseType_t uxQueueMessagesWaiting( const QueueHandle_t xQueue )
 
     configASSERT( xQueue );
 
-    portBASE_TYPE_ENTER_CRITICAL();
+    queueBASE_TYPE_ENTER_CRITICAL( xQueue );
     {
         uxReturn = ( ( Queue_t * ) xQueue )->uxMessagesWaiting;
     }
-    portBASE_TYPE_EXIT_CRITICAL();
+    queueBASE_TYPE_EXIT_CRITICAL( xQueue );
 
     traceRETURN_uxQueueMessagesWaiting( uxReturn );
 
@@ -2222,11 +2248,11 @@ UBaseType_t uxQueueSpacesAvailable( const QueueHandle_t xQueue )
 
     configASSERT( pxQueue );
 
-    portBASE_TYPE_ENTER_CRITICAL();
+    queueBASE_TYPE_ENTER_CRITICAL( pxQueue );
     {
         uxReturn = ( UBaseType_t ) ( pxQueue->uxLength - pxQueue->uxMessagesWaiting );
     }
-    portBASE_TYPE_EXIT_CRITICAL();
+    queueBASE_TYPE_EXIT_CRITICAL( pxQueue );
 
     traceRETURN_uxQueueSpacesAvailable( uxReturn );
 
@@ -2494,18 +2520,15 @@ static void prvCopyDataFromQueue( Queue_t * const pxQueue,
 
 static void prvUnlockQueue( Queue_t * const pxQueue )
 {
-    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED. */
+    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED WHEN portUSING_GRANULAR_LOCKS IS 0.
+     * IT MUST BE CALLED WITH TASK PREEMTION DISABLED WHEN portUSING_GRANULAR_LOCKS IS 1. */
 
     /* The lock counts contains the number of extra data items placed or
      * removed from the queue while the queue was locked.  When a queue is
      * locked items can be added or removed, but the event lists cannot be
      * updated. */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        const BaseType_t xCoreID = portGET_CORE_ID();
-
-        portDISABLE_INTERRUPTS();
-        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
-        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
+        taskDATA_GROUP_PROMOTE_LOCK_TO_CRITICAL( &( pxQueue->xISRSpinlock ) );
     #else
         queueENTER_CRITICAL( pxQueue );
     #endif
@@ -2538,35 +2561,10 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
                     /* Tasks that are removed from the event list will get
                      * added to the pending ready list as the scheduler is still
                      * suspended. */
-                    if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
-                    {
-                        if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
-                        {
-                            /* The task waiting has a higher priority so record that a
-                             * context switch is required. */
-                            vTaskMissedYield();
-                        }
-                        else
-                        {
-                            mtCOVERAGE_TEST_MARKER();
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-            #else /* configUSE_QUEUE_SETS */
-            {
-                /* Tasks that are removed from the event list will get added to
-                 * the pending ready list as the scheduler is still suspended. */
-                if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
-                {
                     if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
                     {
-                        /* The task waiting has a higher priority so record that
-                         * a context switch is required. */
+                        /* The task waiting has a higher priority so record that a
+                         * context switch is required. */
                         vTaskMissedYield();
                     }
                     else
@@ -2574,9 +2572,20 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
+            }
+            #else /* configUSE_QUEUE_SETS */
+            {
+                /* Tasks that are removed from the event list will get added to
+                 * the pending ready list as the scheduler is still suspended. */
+                if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
+                {
+                    /* The task waiting has a higher priority so record that
+                     * a context switch is required. */
+                    vTaskMissedYield();
+                }
                 else
                 {
-                    break;
+                    mtCOVERAGE_TEST_MARKER();
                 }
             }
             #endif /* configUSE_QUEUE_SETS */
@@ -2587,22 +2596,14 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
         pxQueue->cTxLock = queueUNLOCKED;
     }
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
-        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
-
-        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
-        {
-            portENABLE_INTERRUPTS();
-        }
+        taskDATA_GROUP_DEMOTE_CRITICAL_TO_LOCK( &( pxQueue->xISRSpinlock ) );
     #else
         queueEXIT_CRITICAL( pxQueue );
     #endif
 
     /* Do the same for the Rx lock. */
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        portDISABLE_INTERRUPTS();
-        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
-        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
+        taskDATA_GROUP_PROMOTE_LOCK_TO_CRITICAL( &( pxQueue->xISRSpinlock ) );
     #else
         queueENTER_CRITICAL( pxQueue );
     #endif
@@ -2611,36 +2612,33 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
 
         while( cRxLock > queueLOCKED_UNMODIFIED )
         {
-            if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToSend ) ) == pdFALSE )
+            if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
             {
-                if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToSend ) ) != pdFALSE )
-                {
-                    vTaskMissedYield();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
-
-                --cRxLock;
+                vTaskMissedYield();
             }
             else
             {
-                break;
+                mtCOVERAGE_TEST_MARKER();
             }
+
+            --cRxLock;
         }
 
         pxQueue->cRxLock = queueUNLOCKED;
     }
-    taskEXIT_CRITICAL();
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        taskDATA_GROUP_DEMOTE_CRITICAL_TO_LOCK( &( pxQueue->xISRSpinlock ) );
+    #else
+        queueEXIT_CRITICAL( pxQueue );
+    #endif
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvIsQueueEmpty( const Queue_t * pxQueue )
+static BaseType_t prvIsQueueEmpty( queueQUEUE_CONST Queue_t * pxQueue )
 {
     BaseType_t xReturn;
 
-    taskENTER_CRITICAL();
+    queueENTER_CRITICAL( pxQueue );
     {
         if( pxQueue->uxMessagesWaiting == ( UBaseType_t ) 0 )
         {
@@ -2651,7 +2649,7 @@ static BaseType_t prvIsQueueEmpty( const Queue_t * pxQueue )
             xReturn = pdFALSE;
         }
     }
-    taskEXIT_CRITICAL();
+    queueEXIT_CRITICAL( pxQueue );
 
     return xReturn;
 }
@@ -2681,11 +2679,11 @@ BaseType_t xQueueIsQueueEmptyFromISR( const QueueHandle_t xQueue )
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvIsQueueFull( const Queue_t * pxQueue )
+static BaseType_t prvIsQueueFull( queueQUEUE_CONST Queue_t * pxQueue )
 {
     BaseType_t xReturn;
 
-    taskENTER_CRITICAL();
+    queueENTER_CRITICAL( pxQueue );
     {
         if( pxQueue->uxMessagesWaiting == pxQueue->uxLength )
         {
@@ -2696,7 +2694,7 @@ static BaseType_t prvIsQueueFull( const Queue_t * pxQueue )
             xReturn = pdFALSE;
         }
     }
-    taskEXIT_CRITICAL();
+    queueEXIT_CRITICAL( pxQueue );
 
     return xReturn;
 }
@@ -3176,7 +3174,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
          *  time a yield will be performed.  If an item is added to the queue while
          *  the queue is locked, and the calling task blocks on the queue, then the
          *  calling task will be immediately unblocked when the queue is unlocked. */
-        prvLockQueue( pxQueue );
+        queueLOCK( pxQueue );
 
         if( pxQueue->uxMessagesWaiting == ( UBaseType_t ) 0U )
         {
@@ -3188,7 +3186,7 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             mtCOVERAGE_TEST_MARKER();
         }
 
-        prvUnlockQueue( pxQueue );
+        queueUNLOCK( pxQueue, pdFALSE );
 
         traceRETURN_vQueueWaitForMessageRestricted();
     }
@@ -3240,10 +3238,11 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                                QueueSetHandle_t xQueueSet )
     {
         BaseType_t xReturn;
+        Queue_t * const pxQueue = xQueueOrSemaphore;
 
         traceENTER_xQueueAddToSet( xQueueOrSemaphore, xQueueSet );
 
-        taskENTER_CRITICAL();
+        queueENTER_CRITICAL( pxQueue );
         {
             if( ( ( Queue_t * ) xQueueSet )->uxItemSize != ( UBaseType_t ) sizeof( Queue_t * ) )
             {
@@ -3254,12 +3253,12 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
                  * from a single pointer on the stack. */
                 xReturn = pdFAIL;
             }
-            else if( ( ( Queue_t * ) xQueueOrSemaphore )->pxQueueSetContainer != NULL )
+            else if( pxQueue->pxQueueSetContainer != NULL )
             {
                 /* Cannot add a queue/semaphore to more than one queue set. */
                 xReturn = pdFAIL;
             }
-            else if( ( ( Queue_t * ) xQueueOrSemaphore )->uxMessagesWaiting != ( UBaseType_t ) 0 )
+            else if( pxQueue->uxMessagesWaiting != ( UBaseType_t ) 0 )
             {
                 /* Cannot add a queue/semaphore to a queue set if there are already
                  * items in the queue/semaphore. */
@@ -3267,11 +3266,11 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
             }
             else
             {
-                ( ( Queue_t * ) xQueueOrSemaphore )->pxQueueSetContainer = xQueueSet;
+                pxQueue->pxQueueSetContainer = xQueueSet;
                 xReturn = pdPASS;
             }
         }
-        taskEXIT_CRITICAL();
+        queueEXIT_CRITICAL( pxQueue );
 
         traceRETURN_xQueueAddToSet( xReturn );
 
@@ -3305,12 +3304,12 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         }
         else
         {
-            taskENTER_CRITICAL();
+            queueENTER_CRITICAL( pxQueueOrSemaphore );
             {
                 /* The queue is no longer contained in the set. */
                 pxQueueOrSemaphore->pxQueueSetContainer = NULL;
             }
-            taskEXIT_CRITICAL();
+            queueEXIT_CRITICAL( pxQueueOrSemaphore );
             xReturn = pdPASS;
         }
 
@@ -3374,15 +3373,15 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
         {
             const BaseType_t xCoreID = portGET_CORE_ID();
 
-            /* This API must be called in a critical section which already has preemption
-             * and interrupt disabled. */
-            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xTaskSpinlock ) );
+            /* This API is called within the queue critical section (which
+             * already holds the source queue's task spinlock and disables
+             * interrupts), so only the queue-set container's ISR spinlock
+             * needs to be acquired here. */
             portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
             {
                 xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdFALSE );
             }
             portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
-            portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xTaskSpinlock ) );
         }
         #endif /* if ( portUSING_GRANULAR_LOCKS == 0 ) */
 
@@ -3442,17 +3441,21 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 
             if( cTxLock == queueUNLOCKED )
             {
-                if( listLIST_IS_EMPTY( &( pxQueueSetContainer->xTasksWaitingToReceive ) ) == pdFALSE )
+                BaseType_t xHigherPriorityTaskWoken;
+
+                if( xIsISR == pdTRUE )
                 {
-                    if( xTaskRemoveFromEventList( &( pxQueueSetContainer->xTasksWaitingToReceive ) ) != pdFALSE )
-                    {
-                        /* The task waiting has a higher priority. */
-                        xReturn = pdTRUE;
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                    xHigherPriorityTaskWoken = xTaskRemoveFromEventListFromISR( &( pxQueueSetContainer->xTasksWaitingToReceive ) );
+                }
+                else
+                {
+                    xHigherPriorityTaskWoken = xTaskRemoveFromEventList( &( pxQueueSetContainer->xTasksWaitingToReceive ) );
+                }
+
+                if( xHigherPriorityTaskWoken != pdFALSE )
+                {
+                    /* The task waiting has a higher priority. */
+                    xReturn = pdTRUE;
                 }
                 else
                 {

--- a/queue.c
+++ b/queue.c
@@ -2500,7 +2500,15 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
      * removed from the queue while the queue was locked.  When a queue is
      * locked items can be added or removed, but the event lists cannot be
      * updated. */
-    taskENTER_CRITICAL();
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        const BaseType_t xCoreID = portGET_CORE_ID();
+
+        portDISABLE_INTERRUPTS();
+        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
+    #else
+        queueENTER_CRITICAL( pxQueue );
+    #endif
     {
         int8_t cTxLock = pxQueue->cTxLock;
 
@@ -2578,10 +2586,26 @@ static void prvUnlockQueue( Queue_t * const pxQueue )
 
         pxQueue->cTxLock = queueUNLOCKED;
     }
-    taskEXIT_CRITICAL();
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+        if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+        {
+            portENABLE_INTERRUPTS();
+        }
+    #else
+        queueEXIT_CRITICAL( pxQueue );
+    #endif
 
     /* Do the same for the Rx lock. */
-    taskENTER_CRITICAL();
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portDISABLE_INTERRUPTS();
+        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+        portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->xISRSpinlock ) );
+    #else
+        queueENTER_CRITICAL( pxQueue );
+    #endif
     {
         int8_t cRxLock = pxQueue->cRxLock;
 
@@ -3336,8 +3360,63 @@ BaseType_t xQueueIsQueueFullFromISR( const QueueHandle_t xQueue )
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_QUEUE_SETS == 1 )
-
     static BaseType_t prvNotifyQueueSetContainer( const Queue_t * const pxQueue )
+    {
+        BaseType_t xReturn;
+
+        /* Call the generic version with xIsISR = pdFALSE to indicate task context */
+
+        #if ( portUSING_GRANULAR_LOCKS == 0 )
+        {
+            xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdFALSE );
+        }
+        #else
+        {
+            const BaseType_t xCoreID = portGET_CORE_ID();
+
+            /* This API must be called in a critical section which already has preemption
+             * and interrupt disabled. */
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xTaskSpinlock ) );
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+            {
+                xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdFALSE );
+            }
+            portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+            portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xTaskSpinlock ) );
+        }
+        #endif /* if ( portUSING_GRANULAR_LOCKS == 0 ) */
+
+        return xReturn;
+    }
+
+    static BaseType_t prvNotifyQueueSetContainerFromISR( const Queue_t * const pxQueue )
+    {
+        BaseType_t xReturn;
+
+        /* Call the generic version with xIsISR = pdTRUE to indicate ISR context */
+
+        #if ( portUSING_GRANULAR_LOCKS == 0 )
+        {
+            xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdTRUE );
+        }
+        #else
+        {
+            const BaseType_t xCoreID = portGET_CORE_ID();
+
+            /* This API must be called in a critical section which already has interrupt disabled. */
+            portGET_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+            {
+                xReturn = prvNotifyQueueSetContainerGeneric( pxQueue, pdTRUE );
+            }
+            portRELEASE_SPINLOCK( xCoreID, ( portSPINLOCK_TYPE * ) &( pxQueue->pxQueueSetContainer->xISRSpinlock ) );
+        }
+        #endif /* if ( portUSING_GRANULAR_LOCKS == 0 ) */
+
+        return xReturn;
+    }
+
+    static BaseType_t prvNotifyQueueSetContainerGeneric( const Queue_t * const pxQueue,
+                                                         const BaseType_t xIsISR )
     {
         Queue_t * pxQueueSetContainer = pxQueue->pxQueueSetContainer;
         BaseType_t xReturn = pdFALSE;

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -947,7 +947,11 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
 
             traceBLOCKING_ON_STREAM_BUFFER_SEND( xStreamBuffer );
             ( void ) xTaskNotifyWaitIndexed( pxStreamBuffer->uxNotificationIndex, ( uint32_t ) 0, ( uint32_t ) 0, NULL, xTicksToWait );
-            pxStreamBuffer->xTaskWaitingToSend = NULL;
+            sbENTER_CRITICAL( pxStreamBuffer );
+            {
+                pxStreamBuffer->xTaskWaitingToSend = NULL;
+            }
+            sbEXIT_CRITICAL( pxStreamBuffer );
         } while( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE );
     }
     else
@@ -1171,7 +1175,11 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
             /* Wait for data to be available. */
             traceBLOCKING_ON_STREAM_BUFFER_RECEIVE( xStreamBuffer );
             ( void ) xTaskNotifyWaitIndexed( pxStreamBuffer->uxNotificationIndex, ( uint32_t ) 0, ( uint32_t ) 0, NULL, xTicksToWait );
-            pxStreamBuffer->xTaskWaitingToReceive = NULL;
+            sbENTER_CRITICAL( pxStreamBuffer );
+            {
+                pxStreamBuffer->xTaskWaitingToReceive = NULL;
+            }
+            sbEXIT_CRITICAL( pxStreamBuffer );
 
             /* Recheck the data available after blocking. */
             xBytesAvailable = prvBytesInBuffer( pxStreamBuffer );

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -58,6 +58,39 @@
         #error INCLUDE_xTaskGetCurrentTaskHandle must be set to 1 to build stream_buffer.c
     #endif
 
+
+/*
+ * Macros to mark the start and end of a critical code region.
+ */
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        #define sbENTER_CRITICAL( pxStreamBuffer )                                      taskDATA_GROUP_ENTER_CRITICAL( &( ( pxStreamBuffer )->xTaskSpinlock ), &( ( pxStreamBuffer )->xISRSpinlock ) )
+        #define sbENTER_CRITICAL_FROM_ISR( pxStreamBuffer, puxSavedInterruptStatus )    taskDATA_GROUP_ENTER_CRITICAL_FROM_ISR( &( ( pxStreamBuffer )->xISRSpinlock ), puxSavedInterruptStatus )
+        #define sbEXIT_CRITICAL( pxStreamBuffer )                                       taskDATA_GROUP_EXIT_CRITICAL( &( ( pxStreamBuffer )->xTaskSpinlock ), &( ( pxStreamBuffer )->xISRSpinlock ) )
+        #define sbEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxStreamBuffer )      taskDATA_GROUP_EXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, &( ( pxStreamBuffer )->xISRSpinlock ) )
+    #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+        #define sbENTER_CRITICAL( pxStreamBuffer )                                      taskENTER_CRITICAL()
+        #define sbENTER_CRITICAL_FROM_ISR( pxStreamBuffer, puxSavedInterruptStatus )    do { *( puxSavedInterruptStatus ) = taskENTER_CRITICAL_FROM_ISR(); } while( 0 )
+        #define sbEXIT_CRITICAL( pxStreamBuffer )                                       taskEXIT_CRITICAL()
+        #define sbEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxStreamBuffer )      taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+    #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/*
+ * Macro used to lock and unlock a stream buffer. When a task locks a stream
+ * buffer, the task will have thread safe non-deterministic access to the stream
+ * buffer.
+ * - Concurrent access from other tasks will be blocked by the xTaskSpinlock
+ * - Concurrent access from ISRs will be pended
+ *
+ * When the task unlocks the stream buffer, all pended access attempts are handled.
+ */
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #define sbLOCK( pxStreamBuffer )      taskDATA_GROUP_LOCK( &( ( pxStreamBuffer )->xTaskSpinlock ) )
+        #define sbUNLOCK( pxStreamBuffer )    taskDATA_GROUP_UNLOCK( &( ( pxStreamBuffer )->xTaskSpinlock ) )
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+        #define sbLOCK( pxStreamBuffer )      vTaskSuspendAll()
+        #define sbUNLOCK( pxStreamBuffer )    ( void ) xTaskResumeAll()
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
 /* If the user has not provided application specific Rx notification macros,
  * or #defined the notification macros away, then provide default implementations
  * that uses task notifications. */
@@ -65,7 +98,7 @@
         #define sbRECEIVE_COMPLETED( pxStreamBuffer )                                 \
     do                                                                                \
     {                                                                                 \
-        vTaskSuspendAll();                                                            \
+        sbLOCK( pxStreamBuffer );                                                     \
         {                                                                             \
             if( ( pxStreamBuffer )->xTaskWaitingToSend != NULL )                      \
             {                                                                         \
@@ -76,7 +109,7 @@
                 ( pxStreamBuffer )->xTaskWaitingToSend = NULL;                        \
             }                                                                         \
         }                                                                             \
-        ( void ) xTaskResumeAll();                                                    \
+        sbUNLOCK( pxStreamBuffer );                                                   \
     } while( 0 )
     #endif /* sbRECEIVE_COMPLETED */
 
@@ -105,7 +138,7 @@
     do {                                                                                     \
         UBaseType_t uxSavedInterruptStatus;                                                  \
                                                                                              \
-        uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();                              \
+        sbENTER_CRITICAL_FROM_ISR( pxStreamBuffer, &uxSavedInterruptStatus );                \
         {                                                                                    \
             if( ( pxStreamBuffer )->xTaskWaitingToSend != NULL )                             \
             {                                                                                \
@@ -117,7 +150,7 @@
                 ( pxStreamBuffer )->xTaskWaitingToSend = NULL;                               \
             }                                                                                \
         }                                                                                    \
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );                                \
+        sbEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxStreamBuffer );                  \
     } while( 0 )
     #endif /* sbRECEIVE_COMPLETED_FROM_ISR */
 
@@ -145,7 +178,7 @@
  */
     #ifndef sbSEND_COMPLETED
         #define sbSEND_COMPLETED( pxStreamBuffer )                                  \
-    vTaskSuspendAll();                                                              \
+    sbLOCK( pxStreamBuffer );                                                       \
     {                                                                               \
         if( ( pxStreamBuffer )->xTaskWaitingToReceive != NULL )                     \
         {                                                                           \
@@ -156,7 +189,7 @@
             ( pxStreamBuffer )->xTaskWaitingToReceive = NULL;                       \
         }                                                                           \
     }                                                                               \
-    ( void ) xTaskResumeAll()
+    sbUNLOCK( pxStreamBuffer )
     #endif /* sbSEND_COMPLETED */
 
 /* If user has provided a per-instance send completed callback, then
@@ -184,7 +217,7 @@
     do {                                                                                       \
         UBaseType_t uxSavedInterruptStatus;                                                    \
                                                                                                \
-        uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();                                \
+        sbENTER_CRITICAL_FROM_ISR( pxStreamBuffer, &uxSavedInterruptStatus );                  \
         {                                                                                      \
             if( ( pxStreamBuffer )->xTaskWaitingToReceive != NULL )                            \
             {                                                                                  \
@@ -196,7 +229,7 @@
                 ( pxStreamBuffer )->xTaskWaitingToReceive = NULL;                              \
             }                                                                                  \
         }                                                                                      \
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );                                  \
+        sbEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxStreamBuffer );                    \
     } while( 0 )
     #endif /* sbSEND_COMPLETE_FROM_ISR */
 
@@ -249,6 +282,10 @@ typedef struct StreamBufferDef_t
         StreamBufferCallbackFunction_t pxReceiveCompletedCallback; /* Optional callback called on receive complete.  sbRECEIVE_COMPLETED is called if this is NULL. */
     #endif
     UBaseType_t uxNotificationIndex;                               /* The index we are using for notification, by default tskDEFAULT_INDEX_TO_NOTIFY. */
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 } StreamBuffer_t;
 
 /*
@@ -336,6 +373,7 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
                                           StreamBufferCallbackFunction_t pxReceiveCompletedCallback ) PRIVILEGED_FUNCTION;
 
 /*-----------------------------------------------------------*/
+
     #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
     StreamBufferHandle_t xStreamBufferGenericCreate( size_t xBufferSizeBytes,
                                                      size_t xTriggerLevelBytes,
@@ -413,6 +451,13 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
                                           ucFlags,
                                           pxSendCompletedCallback,
                                           pxReceiveCompletedCallback );
+
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            {
+                portINIT_SPINLOCK( &( ( ( StreamBuffer_t * ) pvAllocatedMemory )->xTaskSpinlock ) );
+                portINIT_SPINLOCK( &( ( ( StreamBuffer_t * ) pvAllocatedMemory )->xISRSpinlock ) );
+            }
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
             traceSTREAM_BUFFER_CREATE( ( ( StreamBuffer_t * ) pvAllocatedMemory ), xStreamBufferType );
         }
@@ -507,6 +552,13 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             /* Remember this was statically allocated in case it is ever deleted
              * again. */
             pxStreamBuffer->ucFlags |= sbFLAGS_IS_STATICALLY_ALLOCATED;
+
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            {
+                portINIT_SPINLOCK( &( pxStreamBuffer->xTaskSpinlock ) );
+                portINIT_SPINLOCK( &( pxStreamBuffer->xISRSpinlock ) );
+            }
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
             traceSTREAM_BUFFER_CREATE( pxStreamBuffer, xStreamBufferType );
 
@@ -623,7 +675,7 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
     #endif
 
     /* Can only reset a message buffer if there are no tasks blocked on it. */
-    taskENTER_CRITICAL();
+    sbENTER_CRITICAL( pxStreamBuffer );
     {
         if( ( pxStreamBuffer->xTaskWaitingToReceive == NULL ) && ( pxStreamBuffer->xTaskWaitingToSend == NULL ) )
         {
@@ -653,7 +705,7 @@ BaseType_t xStreamBufferReset( StreamBufferHandle_t xStreamBuffer )
             xReturn = pdPASS;
         }
     }
-    taskEXIT_CRITICAL();
+    sbEXIT_CRITICAL( pxStreamBuffer );
 
     traceRETURN_xStreamBufferReset( xReturn );
 
@@ -881,7 +933,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
         {
             /* Wait until the required number of bytes are free in the message
              * buffer. */
-            taskENTER_CRITICAL();
+            sbENTER_CRITICAL( pxStreamBuffer );
             {
                 xSpace = xStreamBufferSpacesAvailable( pxStreamBuffer );
 
@@ -896,15 +948,19 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
                 }
                 else
                 {
-                    taskEXIT_CRITICAL();
+                    sbEXIT_CRITICAL( pxStreamBuffer );
                     break;
                 }
             }
-            taskEXIT_CRITICAL();
+            sbEXIT_CRITICAL( pxStreamBuffer );
 
             traceBLOCKING_ON_STREAM_BUFFER_SEND( xStreamBuffer );
             ( void ) xTaskNotifyWaitIndexed( pxStreamBuffer->uxNotificationIndex, ( uint32_t ) 0, ( uint32_t ) 0, NULL, xTicksToWait );
-            pxStreamBuffer->xTaskWaitingToSend = NULL;
+            sbENTER_CRITICAL( pxStreamBuffer );
+            {
+                pxStreamBuffer->xTaskWaitingToSend = NULL;
+            }
+            sbEXIT_CRITICAL( pxStreamBuffer );
         } while( xTaskCheckForTimeOut( &xTimeOut, &xTicksToWait ) == pdFALSE );
     }
     else
@@ -1099,7 +1155,7 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
     {
         /* Checking if there is data and clearing the notification state must be
          * performed atomically. */
-        taskENTER_CRITICAL();
+        sbENTER_CRITICAL( pxStreamBuffer );
         {
             xBytesAvailable = prvBytesInBuffer( pxStreamBuffer );
 
@@ -1124,14 +1180,18 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        sbEXIT_CRITICAL( pxStreamBuffer );
 
         if( xBytesAvailable <= xBytesToStoreMessageLength )
         {
             /* Wait for data to be available. */
             traceBLOCKING_ON_STREAM_BUFFER_RECEIVE( xStreamBuffer );
             ( void ) xTaskNotifyWaitIndexed( pxStreamBuffer->uxNotificationIndex, ( uint32_t ) 0, ( uint32_t ) 0, NULL, xTicksToWait );
-            pxStreamBuffer->xTaskWaitingToReceive = NULL;
+            sbENTER_CRITICAL( pxStreamBuffer );
+            {
+                pxStreamBuffer->xTaskWaitingToReceive = NULL;
+            }
+            sbEXIT_CRITICAL( pxStreamBuffer );
 
             /* Recheck the data available after blocking. */
             xBytesAvailable = prvBytesInBuffer( pxStreamBuffer );
@@ -1421,7 +1481,7 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
+    sbENTER_CRITICAL_FROM_ISR( pxStreamBuffer, &uxSavedInterruptStatus );
     {
         if( ( pxStreamBuffer )->xTaskWaitingToReceive != NULL )
         {
@@ -1438,7 +1498,7 @@ BaseType_t xStreamBufferSendCompletedFromISR( StreamBufferHandle_t xStreamBuffer
             xReturn = pdFALSE;
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    sbEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxStreamBuffer );
 
     traceRETURN_xStreamBufferSendCompletedFromISR( xReturn );
 
@@ -1460,7 +1520,7 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
     /* MISRA Ref 4.7.1 [Return value shall be checked] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
     /* coverity[misra_c_2012_directive_4_7_violation] */
-    uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
+    sbENTER_CRITICAL_FROM_ISR( pxStreamBuffer, &uxSavedInterruptStatus );
     {
         if( ( pxStreamBuffer )->xTaskWaitingToSend != NULL )
         {
@@ -1477,7 +1537,7 @@ BaseType_t xStreamBufferReceiveCompletedFromISR( StreamBufferHandle_t xStreamBuf
             xReturn = pdFALSE;
         }
     }
-    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    sbEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus, pxStreamBuffer );
 
     traceRETURN_xStreamBufferReceiveCompletedFromISR( xReturn );
 
@@ -1633,6 +1693,13 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
                                           StreamBufferCallbackFunction_t pxSendCompletedCallback,
                                           StreamBufferCallbackFunction_t pxReceiveCompletedCallback )
 {
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* Preserve the embedded spinlocks across the memset; the reset
+         * path runs with xTaskSpinlock held by the caller. */
+        portSPINLOCK_TYPE xTaskSpinlock = pxStreamBuffer->xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock = pxStreamBuffer->xISRSpinlock;
+    #endif
+
     /* Assert here is deliberately writing to the entire buffer to ensure it can
      * be written to without generating exceptions, and is setting the buffer to a
      * known value to assist in development/debugging. */
@@ -1652,6 +1719,11 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
     pxStreamBuffer->xTriggerLevelBytes = xTriggerLevelBytes;
     pxStreamBuffer->ucFlags = ucFlags;
     pxStreamBuffer->uxNotificationIndex = tskDEFAULT_INDEX_TO_NOTIFY;
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        pxStreamBuffer->xTaskSpinlock = xTaskSpinlock;
+        pxStreamBuffer->xISRSpinlock = xISRSpinlock;
+    #endif
     #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
     {
         pxStreamBuffer->pxSendCompletedCallback = pxSendCompletedCallback;

--- a/tasks.c
+++ b/tasks.c
@@ -3286,7 +3286,11 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskPreemptionDisable( xTask );
 
-        kernelENTER_CRITICAL();
+        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+            vKernelLightWeightEnterCritical();
+        #else
+            kernelENTER_CRITICAL();
+        #endif
         {
             if( xSchedulerRunning != pdFALSE )
             {
@@ -3300,7 +3304,11 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        kernelEXIT_CRITICAL();
+        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+            vKernelLightWeightExitCritical();
+        #else
+            kernelEXIT_CRITICAL();
+        #endif
 
         traceRETURN_vTaskPreemptionDisable();
     }
@@ -3316,7 +3324,11 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         UBaseType_t uxDeferredAction = 0U;
         BaseType_t xAlreadyYielded = pdFALSE;
 
-        kernelENTER_CRITICAL();
+        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+            vKernelLightWeightEnterCritical();
+        #else
+            kernelENTER_CRITICAL();
+        #endif
         {
             if( xSchedulerRunning != pdFALSE )
             {
@@ -3355,7 +3367,11 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        kernelEXIT_CRITICAL();
+        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
+            vKernelLightWeightExitCritical();
+        #else
+            kernelEXIT_CRITICAL();
+        #endif
 
         if( uxDeferredAction != 0U )
         {

--- a/tasks.c
+++ b/tasks.c
@@ -1085,12 +1085,23 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             #endif
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                                {
                                     if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
-                                #endif
+                                    {
+                                        xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
+                                        xLowestPriorityCore = xCoreID;
+                                    }
+                                    else
+                                    {
+                                        xYieldPendings[ xCoreID ] = pdTRUE;
+                                    }
+                                }
+                                #else
                                 {
                                     xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
                                     xLowestPriorityCore = xCoreID;
                                 }
+                                #endif
                             }
                         }
                         else
@@ -1391,12 +1402,23 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 ( xYieldPendings[ uxCore ] == pdFALSE ) )
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                                {
                                     if( pxCurrentTCBs[ uxCore ]->uxPreemptionDisable == 0U )
-                                #endif
+                                    {
+                                        xLowestPriority = xTaskPriority;
+                                        xLowestPriorityCore = ( BaseType_t ) uxCore;
+                                    }
+                                    else
+                                    {
+                                        xYieldPendings[ uxCore ] = pdTRUE;
+                                    }
+                                }
+                                #else
                                 {
                                     xLowestPriority = xTaskPriority;
                                     xLowestPriorityCore = ( BaseType_t ) uxCore;
                                 }
+                                #endif
                             }
                         }
                     }
@@ -3053,12 +3075,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     /* Setting the priority of a running task down means
                      * there may now be another task of higher priority that
                      * is ready to execute. */
-                    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxTCB->uxPreemptionDisable == 0U )
-                    #endif
-                    {
-                        xYieldRequired = pdTRUE;
-                    }
+                    xYieldRequired = pdTRUE;
                 }
                 else
                 {

--- a/tasks.c
+++ b/tasks.c
@@ -7850,12 +7850,7 @@ static void prvResetNextTaskUnblockTime( void )
 
                 portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
 
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U
-                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                    /* Check for the run state change of the task only if a deferred state change is not pending */
-                    && pxCurrentTCB->uxDeferredStateChange == 0U
-                #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
-                )
+                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U )
                 {
                     prvLightWeightCheckForRunStateChange();
                 }
@@ -7890,12 +7885,7 @@ static void prvResetNextTaskUnblockTime( void )
                 {
                     portENABLE_INTERRUPTS();
 
-                    if( xYieldCurrentTask != pdFALSE
-                        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                            /* Yield only if no deferred state change is pending */
-                            && pxCurrentTCB->uxDeferredStateChange == 0U
-                        #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
-                        )
+                    if( xYieldCurrentTask != pdFALSE )
                     {
                         portYIELD();
                     }
@@ -7917,6 +7907,7 @@ static void prvResetNextTaskUnblockTime( void )
         if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE )
             #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                 && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+                && ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
             #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
             )
         {

--- a/tasks.c
+++ b/tasks.c
@@ -3334,7 +3334,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     }
                     else
                     {
-                        if( ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) )
+                        if( xYieldPendings[ pxTCB->xTaskRunState ] != pdFALSE && ( taskTASK_IS_RUNNING( pxTCB ) != pdFALSE ) )
                         {
                             prvYieldCore( pxTCB->xTaskRunState );
                         }

--- a/tasks.c
+++ b/tasks.c
@@ -629,15 +629,6 @@ static BaseType_t prvCreateIdleTasks( void );
     static void prvCheckForRunStateChange( void );
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
-#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-
-/*
- * Checks to see if another task moved the current task out of the ready
- * list while it was waiting to enter a lightweight critical section and yields, if so.
- */
-    static void prvLightWeightCheckForRunStateChange( void );
-#endif /* #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 ) */
-
 #if ( configNUMBER_OF_CORES > 1 )
 
 /*
@@ -973,67 +964,6 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
         }
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
-
-/*-----------------------------------------------------------*/
-
-#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-    static void prvLightWeightCheckForRunStateChange( void )
-    {
-        const TCB_t * pxThisTCB;
-        BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-
-        /* This must only be called from within a task. */
-        portASSERT_IF_IN_ISR();
-
-        /* This function is always called with interrupts disabled
-         * so this is safe. */
-        pxThisTCB = pxCurrentTCBs[ xCoreID ];
-
-        while( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD )
-        {
-            UBaseType_t uxPrevCriticalNesting;
-
-            /* We are only here if we just entered a critical section
-            * or if we just suspended the scheduler, and another task
-            * has requested that we yield.
-            *
-            * This is slightly complicated since we need to save and restore
-            * the suspension and critical nesting counts, as well as release
-            * and reacquire the correct locks. And then, do it all over again
-            * if our state changed again during the reacquisition. */
-            uxPrevCriticalNesting = portGET_CRITICAL_NESTING_COUNT( xCoreID );
-
-            if( uxPrevCriticalNesting > 0U )
-            {
-                portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
-                kernelRELEASE_ISR_LOCK( xCoreID );
-            }
-            else
-            {
-                /* The scheduler is suspended. uxSchedulerSuspended is updated
-                 * only when the task is not requested to yield. */
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            portMEMORY_BARRIER();
-
-            portENABLE_INTERRUPTS();
-
-            /* Enabling interrupts should cause this core to immediately service
-             * the pending interrupt and yield. After servicing the pending interrupt,
-             * the task needs to re-evaluate its run state within this loop, as
-             * other cores may have requested this task to yield, potentially altering
-             * its run state. */
-
-            portDISABLE_INTERRUPTS();
-
-            xCoreID = ( BaseType_t ) portGET_CORE_ID();
-            kernelGET_ISR_LOCK( xCoreID );
-
-            portSET_CRITICAL_NESTING_COUNT( xCoreID, uxPrevCriticalNesting );
-        }
-    }
-#endif /* #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 ) */
 
 /*-----------------------------------------------------------*/
 
@@ -3342,11 +3272,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskPreemptionDisable( xTask );
 
-        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-            vKernelLightWeightEnterCritical();
-        #else
-            kernelENTER_CRITICAL();
-        #endif
+        kernelENTER_CRITICAL();
         {
             if( xSchedulerRunning != pdFALSE )
             {
@@ -3360,11 +3286,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-            vKernelLightWeightExitCritical();
-        #else
-            kernelEXIT_CRITICAL();
-        #endif
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskPreemptionDisable();
     }
@@ -3380,11 +3302,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         UBaseType_t uxDeferredAction = 0U;
         BaseType_t xAlreadyYielded = pdFALSE;
 
-        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-            vKernelLightWeightEnterCritical();
-        #else
-            kernelENTER_CRITICAL();
-        #endif
+        kernelENTER_CRITICAL();
         {
             if( xSchedulerRunning != pdFALSE )
             {
@@ -3423,11 +3341,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-            vKernelLightWeightExitCritical();
-        #else
-            kernelEXIT_CRITICAL();
-        #endif
+        kernelEXIT_CRITICAL();
 
         if( uxDeferredAction != 0U )
         {
@@ -7846,80 +7760,6 @@ static void prvResetNextTaskUnblockTime( void )
     }
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
-/*-----------------------------------------------------------*/
-
-#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-
-    void vKernelLightWeightEnterCritical( void )
-    {
-        if( xSchedulerRunning != pdFALSE )
-        {
-            portDISABLE_INTERRUPTS();
-            {
-                const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-
-                /* Get only the ISR lock, not the task lock */
-                kernelGET_ISR_LOCK( xCoreID );
-
-                portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
-
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U )
-                {
-                    prvLightWeightCheckForRunStateChange();
-                }
-            }
-        }
-    }
-
-#endif /* #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 ) */
-/*-----------------------------------------------------------*/
-
-#if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 )
-
-    void vKernelLightWeightExitCritical( void )
-    {
-        if( xSchedulerRunning != pdFALSE )
-        {
-            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-
-            if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U )
-            {
-                BaseType_t xYieldCurrentTask;
-
-                if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE )
-                    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
-                        ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
-                    #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
-                    )
-                {
-                    xYieldCurrentTask = pdTRUE;
-                }
-                else
-                {
-                    xYieldCurrentTask = pdFALSE;
-                }
-
-                /* Release the ISR lock */
-                kernelRELEASE_ISR_LOCK( xCoreID );
-
-                portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
-
-                /* If the critical nesting count is 0, enable interrupts */
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
-                {
-                    portENABLE_INTERRUPTS();
-
-                    if( xYieldCurrentTask != pdFALSE )
-                    {
-                        portYIELD();
-                    }
-                }
-            }
-        }
-    }
-
-#endif /* #if ( configLIGHTWEIGHT_CRITICAL_SECTION == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )

--- a/tasks.c
+++ b/tasks.c
@@ -5977,9 +5977,12 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
 
     traceENTER_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue );
 
-    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
-     * the event flags implementation. */
-    configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #if ( !( portUSING_GRANULAR_LOCKS == 1 ) )
+
+        /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
+         * the event flags implementation. */
+        configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #endif /* #if ( ! ( portUSING_GRANULAR_LOCKS == 1 ) ) */
 
     /* Store the new item value in the event list. */
     listSET_LIST_ITEM_VALUE( pxEventListItem, xItemValue | taskEVENT_LIST_ITEM_VALUE_IN_USE );

--- a/tasks.c
+++ b/tasks.c
@@ -350,28 +350,45 @@
 /* Yields the given core. This must be called from a critical section and xCoreID
  * must be valid. This macro is not required in single core since there is only
  * one core to yield. */
-    #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
 
-/* When TCB data group lock is enabled, we need to acquire the target core's
- * TCB spinlock before checking uxPreemptionDisable to prevent a race condition
- * where the target core could disable preemption between our check and the
- * cross-core interrupt arriving. */
-        #define prvYieldCore( xCoreID )                                                               \
+/* xYieldPending indicates that a yield was requested but could not be
+ * processed immediately.
+ *
+ * This occurs in situations such as:
+ * 1. Task preemption is disabled.
+ * 2. A task requests itself to yield while inside a critical section.
+ *
+ * In these cases, xYieldPending is set to pdTRUE to indicate that the
+ * yield request should be serviced after exiting the critical section.
+ *
+ * With granular locking, the task disables preemption first before acquiring
+ * data group locks. A check for run state change is required before acquiring
+ * the data group locks to preserve priority ordering, for example, in queue
+ * operations. However, setting xYieldPending alone is not sufficient. Without
+ * setting the task run state to taskTASK_SCHEDULED_TO_YIELD, the task would
+ * not be able to relinquish the critical section for higher priority tasks.
+ *
+ * Key distinction:
+ * - xYieldPending: yield is serviced when leaving the critical section.
+ * - taskTASK_SCHEDULED_TO_YIELD: yield is serviced before entering the
+ *   critical section. */
+            #define prvYieldCore( xCoreID )                                                           \
     do {                                                                                              \
-        BaseType_t xCurrentCoreID = ( BaseType_t ) portGET_CORE_ID();                                 \
-        BaseType_t xCoreToYield = ( xCoreID );                                                        \
-        if( xCoreToYield == xCurrentCoreID )                                                          \
+        const BaseType_t xCoreToYield = ( xCoreID );                                                  \
+        BaseType_t xCurrentCoreID = portGET_CORE_ID();                                                \
+        if( ( xCoreID ) == xCurrentCoreID )                                                           \
         {                                                                                             \
             /* Pending a yield for this core since it is in the critical section. */                  \
             xYieldPendings[ xCoreToYield ] = pdTRUE;                                                  \
+            pxCurrentTCBs[ xCoreToYield ]->xTaskRunState = taskTASK_SCHEDULED_TO_YIELD;               \
         }                                                                                             \
         else                                                                                          \
         {                                                                                             \
-            /* Acquire the target core's TCB spinlock to prevent race with vTaskPreemptionDisable. */ \
             portGET_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreToYield ]->xTCBSpinlock ) );     \
             {                                                                                         \
-                if( ( pxCurrentTCBs[ xCoreToYield ]->uxPreemptionDisable == 0U ) &&                   \
-                    ( pxCurrentTCBs[ xCoreToYield ]->uxDeferredStateChange == 0U ) )                  \
+                if( pxCurrentTCBs[ xCoreToYield ]->uxPreemptionDisable == 0U )                        \
                 {                                                                                     \
                     /* Request other core to yield if it is not requested before. */                  \
                     if( pxCurrentTCBs[ xCoreToYield ]->xTaskRunState != taskTASK_SCHEDULED_TO_YIELD ) \
@@ -383,13 +400,15 @@
                 else                                                                                  \
                 {                                                                                     \
                     xYieldPendings[ xCoreToYield ] = pdTRUE;                                          \
+                    pxCurrentTCBs[ xCoreToYield ]->xTaskRunState = taskTASK_SCHEDULED_TO_YIELD;       \
                 }                                                                                     \
             }                                                                                         \
             portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreToYield ]->xTCBSpinlock ) ); \
         }                                                                                             \
     } while( 0 )
-    #elif ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        #define prvYieldCore( xCoreID )                                                          \
+
+        #else /* if ( portUSING_GRANULAR_LOCKS == 1 ) */
+            #define prvYieldCore( xCoreID )                                                      \
     do {                                                                                         \
         if( ( xCoreID ) == ( BaseType_t ) portGET_CORE_ID() )                                    \
         {                                                                                        \
@@ -398,8 +417,7 @@
         }                                                                                        \
         else                                                                                     \
         {                                                                                        \
-            if( ( pxCurrentTCBs[ ( xCoreID ) ]->uxPreemptionDisable == 0U ) &&                   \
-                ( pxCurrentTCBs[ ( xCoreID ) ]->uxDeferredStateChange == 0U ) )                  \
+            if( pxCurrentTCBs[ ( xCoreID ) ]->uxPreemptionDisable == 0U )                        \
             {                                                                                    \
                 /* Request other core to yield if it is not requested before. */                 \
                 if( pxCurrentTCBs[ ( xCoreID ) ]->xTaskRunState != taskTASK_SCHEDULED_TO_YIELD ) \
@@ -414,7 +432,8 @@
             }                                                                                    \
         }                                                                                        \
     } while( 0 )
-    #else /* if ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) */
+        #endif /* if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
         #define prvYieldCore( xCoreID )                                                      \
     do {                                                                                     \
         if( ( xCoreID ) == ( BaseType_t ) portGET_CORE_ID() )                                \
@@ -432,7 +451,7 @@
             }                                                                                \
         }                                                                                    \
     } while( 0 )
-    #endif /* #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) */
+    #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
@@ -503,6 +522,10 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
         UBaseType_t uxDeferredStateChange; /**< Used to indicate if the task's state change is deferred. */
     #endif
 
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        portSPINLOCK_TYPE xTCBSpinlock;
+    #endif
+
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
         StackType_t * pxEndOfStack; /**< Points to the highest valid address for the stack. */
     #endif
@@ -562,10 +585,6 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
                                              * - When waiting to SEND: points to this task's send data
                                              * NULL when not using direct transfer */
         BaseType_t xDirectTransferPosition; /**< Position for direct transfer (queueSEND_TO_BACK, queueSEND_TO_FRONT, queueOVERWRITE) */
-    #endif
-
-    #if ( ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        portSPINLOCK_TYPE xTCBSpinlock; /**< Spinlock protecting TCB-specific data (uxPreemptionDisable, uxDeferredStateChange). */
     #endif
 } tskTCB;
 
@@ -939,10 +958,10 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif
 
 /*
- * Helper function to enable preemption for a task.
+ * Helper function to enable preemption for a task and return yield status.
  */
 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+    BaseType_t xTaskPreemptionEnableWithYieldStatus( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
 
 /*
@@ -986,6 +1005,11 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                                         size_t n );
 
 #endif /* #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
+
+static void prvKernelEnterISROnlyCritical( void );
+
+static void prvKernelExitISROnlyCritical( void );
+
 /*-----------------------------------------------------------*/
 
 #if ( configNUMBER_OF_CORES > 1 )
@@ -1014,20 +1038,11 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             * and reacquire the correct locks. And then, do it all over again
             * if our state changed again during the reacquisition. */
             uxPrevCriticalNesting = portGET_CRITICAL_NESTING_COUNT( xCoreID );
+            portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
 
-            if( uxPrevCriticalNesting > 0U )
-            {
-                portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
-                kernelRELEASE_ISR_LOCK( xCoreID );
-            }
-            else
-            {
-                /* The scheduler is suspended. uxSchedulerSuspended is updated
-                 * only when the task is not requested to yield. */
-                mtCOVERAGE_TEST_MARKER();
-            }
-
+            kernelRELEASE_ISR_LOCK( xCoreID );
             kernelRELEASE_TASK_LOCK( xCoreID );
+
             portMEMORY_BARRIER();
             configASSERT( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD );
 
@@ -1042,15 +1057,11 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             portDISABLE_INTERRUPTS();
 
             xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
             kernelGET_TASK_LOCK( xCoreID );
             kernelGET_ISR_LOCK( xCoreID );
 
             portSET_CRITICAL_NESTING_COUNT( xCoreID, uxPrevCriticalNesting );
-
-            if( uxPrevCriticalNesting == 0U )
-            {
-                kernelRELEASE_ISR_LOCK( xCoreID );
-            }
         }
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -1113,14 +1124,30 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                                 {
+                                    /* Acquire the preemption lock to prevent the task changes
+                                     * it's preemption state. */
+                                    #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                        portGET_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreID ]->xTCBSpinlock ) );
+                                    #endif
+
                                     if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
                                     {
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            if( xLowestPriorityCore != -1 )
+                                            {
+                                                /* Release previous preemption lock. */
+                                                portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                                            }
+                                        #endif
                                         xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
                                         xLowestPriorityCore = xCoreID;
                                     }
                                     else
                                     {
                                         xYieldPendings[ xCoreID ] = pdTRUE;
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreID ]->xTCBSpinlock ) );
+                                        #endif
                                     }
                                 }
                                 #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
@@ -1168,6 +1195,18 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             {
                 prvYieldCore( xLowestPriorityCore );
             }
+
+            /* After request the core to yield, preemption lock can be released.
+             * The task tries to set the preemption disable count will check it's
+             * run state first. If it is already requested to yield, it will serve
+             * the yield request first then retring to set the preemption disable
+             * count. */
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
+                if( xLowestPriorityCore >= 0 )
+                {
+                    portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                }
+            #endif
 
             #if ( configRUN_MULTIPLE_PRIORITIES == 0 )
                 /* Verify that the calling core always yields to higher priority tasks. */
@@ -1349,9 +1388,13 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
                     for( x = ( BaseType_t ) 0; x < ( BaseType_t ) configNUMBER_OF_CORES; x++ )
                     {
-                        if( ( pxCurrentTCBs[ x ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U )
+                        /* Core xCoreID already selects the task to run. */
+                        if( x != xCoreID )
                         {
-                            prvYieldCore( x );
+                            if( ( pxCurrentTCBs[ x ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U )
+                            {
+                                prvYieldCore( x );
+                            }
                         }
                     }
                 }
@@ -1429,17 +1472,28 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 ( xYieldPendings[ uxCore ] == pdFALSE ) )
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                {
+                                    #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                        portGET_SPINLOCK( xCoreID, &( pxCurrentTCBs[ uxCore ]->xTCBSpinlock ) );
+                                    #endif
+
                                     if( pxCurrentTCBs[ uxCore ]->uxPreemptionDisable == 0U )
                                     {
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            if( xLowestPriorityCore != -1 )
+                                            {
+                                                portRELEASE_SPINLOCK( xCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                                            }
+                                        #endif
                                         xLowestPriority = xTaskPriority;
                                         xLowestPriorityCore = ( BaseType_t ) uxCore;
                                     }
                                     else
                                     {
                                         xYieldPendings[ uxCore ] = pdTRUE;
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            portRELEASE_SPINLOCK( xCoreID, &( pxCurrentTCBs[ uxCore ]->xTCBSpinlock ) );
+                                        #endif
                                     }
-                                }
                                 #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                                 {
                                     xLowestPriority = xTaskPriority;
@@ -1453,6 +1507,10 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                     if( xLowestPriorityCore >= 0 )
                     {
                         prvYieldCore( xLowestPriorityCore );
+
+                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                            portRELEASE_SPINLOCK( xCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                        #endif
                     }
                 }
             }
@@ -2151,6 +2209,12 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     }
     #endif
 
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+    {
+        portINIT_SPINLOCK( &pxNewTCB->xTCBSpinlock );
+    }
+    #endif
+
     /* Initialize the TCB stack to look as if the task was already running,
      * but had been interrupted by the scheduler.  The return address is set
      * to the start of the task function. Once the stack has been initialised
@@ -2215,12 +2279,6 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
     }
     #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
-
-    #if ( ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    {
-        portINIT_SPINLOCK( &( pxNewTCB->xTCBSpinlock ) );
-    }
-    #endif
 
     if( pxCreatedTask != NULL )
     {
@@ -2423,46 +2481,34 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         kernelENTER_CRITICAL();
         {
+            const BaseType_t xCoreID = portGET_CORE_ID();
+
             /* If null is passed in here then it is the calling task that is
              * being deleted. */
             pxTCB = prvGetTCBFromHandle( xTaskToDelete );
             configASSERT( pxTCB != NULL );
 
             #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-
-                /* When TCB data group lock is enabled, we must acquire the target TCB's spinlock
-                 * to prevent a race condition with prvTaskPreemptionEnable(). */
-            #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
+            {
+                /* FIXME : Acquire the TCB lock before reading the preemptions
+                 * disable count. */
+                portGET_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
                 {
-                    const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-                    portGET_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                    /* If the task has disabled preemption, we need to defer the deletion until the
+                     * task enables preemption. The deletion will be performed in vTaskPreemptionEnable(). */
+                    if( pxTCB->uxPreemptionDisable > 0U )
+                    {
+                        pxTCB->uxDeferredStateChange |= tskDEFERRED_DELETION;
+                        xDeferredDeletion = pdTRUE;
+                        portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                    }
+                    else
+                    {
+                        /* Reset the deferred state change flags */
+                        pxTCB->uxDeferredStateChange &= ~tskDEFERRED_DELETION;
+                    }
                 }
-                #endif /* configUSE_TCB_DATA_GROUP_LOCK */
-
-                /* If the task has disabled preemption, we need to defer the deletion until the
-                 * task enables preemption. The deletion will be performed in prvTaskPreemptionEnable(). */
-                if( pxTCB->uxPreemptionDisable > 0U )
-                {
-                    /* Deletion takes priority over suspension. Clear any pending suspension
-                     * and set only the deletion flag. */
-                    pxTCB->uxDeferredStateChange = tskDEFERRED_DELETION;
-                    xDeferredDeletion = pdTRUE;
-                }
-                else
-                {
-                    /* Reset all deferred state change flags since the task is being
-                     * deleted. Any pending suspension is now irrelevant. Clearing all
-                     * flags is necessary to allow the yield to happen in vTaskExitCritical
-                     * which checks uxDeferredStateChange == 0. */
-                    pxTCB->uxDeferredStateChange = 0U;
-                }
-
-            #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
-                {
-                    const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
-                }
-                #endif /* configUSE_TCB_DATA_GROUP_LOCK */
+            }
             #endif /* configUSE_TASK_PREEMPTION_DISABLE */
 
             #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
@@ -2569,6 +2615,10 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                      * the task that has just been deleted. */
                     prvResetNextTaskUnblockTime();
                 }
+
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
+                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                #endif
             }
         }
         kernelEXIT_CRITICAL();
@@ -3381,7 +3431,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 /*-----------------------------------------------------------*/
 
-#if ( ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( portUSING_GRANULAR_LOCKS == 1 )
 
     static void prvTaskTCBLockCheckForRunStateChange( void )
     {
@@ -3472,8 +3522,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 BaseType_t xYieldCurrentTask = pdFALSE;
 
                 /* Get the xYieldPending stats inside the critical section. */
-                if( ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
-                    ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U ) )
+                if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
                 {
                     xYieldCurrentTask = xYieldPendings[ xCoreID ];
                 }
@@ -3496,18 +3545,112 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         }
     }
 
-#endif /* #if ( ( configUSE_TCB_DATA_GROUP_LOCK == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    static void prvTaskDataGroupCheckForRunStateChange( portSPINLOCK_TYPE * pxTaskSpinlock,
+                                                        portSPINLOCK_TYPE * pxISRSpinlock )
+    {
+        const TCB_t * pxThisTCB;
+        BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+        /* This must only be called from within a task. */
+        portASSERT_IF_IN_ISR();
+
+        /* This function is always called with interrupts disabled
+         * so this is safe. */
+        pxThisTCB = pxCurrentTCBs[ xCoreID ];
+
+        while( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD )
+        {
+            UBaseType_t uxPrevCriticalNesting;
+
+            /* We are only here if we just entered a critical section
+            * or if we just suspended the scheduler, and another task
+            * has requested that we yield.
+            *
+            * This is slightly complicated since we need to save and restore
+            * the suspension and critical nesting counts, as well as release
+            * and reacquire the correct locks. And then, do it all over again
+            * if our state changed again during the reacquisition. */
+            uxPrevCriticalNesting = portGET_CRITICAL_NESTING_COUNT( xCoreID );
+
+            /* Data group lock. */
+            if( uxPrevCriticalNesting > 0U )
+            {
+                portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
+                portRELEASE_SPINLOCK( xCoreID, pxISRSpinlock );
+            }
+            else
+            {
+                /* The scheduler is suspended. uxSchedulerSuspended is updated
+                 * only when the task is not requested to yield. */
+                mtCOVERAGE_TEST_MARKER();
+            }
+
+            portENABLE_INTERRUPTS();
+
+            portRELEASE_SPINLOCK( xCoreID, pxTaskSpinlock );
+
+            portMEMORY_BARRIER();
+
+            xTaskPreemptionEnableWithYieldStatus( NULL );
+
+
+
+            /* Enabling interrupts should cause this core to immediately service
+             * the pending interrupt and yield. After servicing the pending interrupt,
+             * the task needs to re-evaluate its run state within this loop, as
+             * other cores may have requested this task to yield, potentially altering
+             * its run state. */
+
+            vTaskPreemptionDisable( NULL );
+
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
+            portGET_SPINLOCK( xCoreID, pxTaskSpinlock );
+            /* Disable interrupts */
+            portDISABLE_INTERRUPTS();
+            /* Take the ISR spinlock next */
+            portGET_SPINLOCK( xCoreID, pxISRSpinlock );
+            /* Increment the critical nesting count */
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+        }
+    }
+
+    void taskDataGroupEnterCritical( portSPINLOCK_TYPE * pxTaskSpinlock,
+                                     portSPINLOCK_TYPE * pxISRSpinlock )
+    {
+        /* Disable preemption to avoid task state changes during the critical section. */
+        vTaskPreemptionDisable( NULL );
+        {
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+            /* Task spinlock is always taken first */
+            portGET_SPINLOCK( xCoreID, pxTaskSpinlock );
+            /* Disable interrupts */
+            portDISABLE_INTERRUPTS();
+            /* Take the ISR spinlock next */
+            portGET_SPINLOCK( xCoreID, pxISRSpinlock );
+            /* Increment the critical nesting count */
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+            if( xSchedulerRunning == pdTRUE )
+            {
+                if( ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U ) &&
+                    ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 1U ) )
+                {
+                    prvTaskDataGroupCheckForRunStateChange( pxTaskSpinlock, pxISRSpinlock );
+                }
+            }
+        }
+    }
+#endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-
     void vTaskPreemptionDisable( const TaskHandle_t xTask )
     {
         TCB_t * pxTCB;
 
         traceENTER_vTaskPreemptionDisable( xTask );
 
-        #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
             vTaskTCBEnterCritical();
         #else
             kernelENTER_CRITICAL();
@@ -3525,7 +3668,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
             vTaskTCBExitCritical();
         #else
             kernelEXIT_CRITICAL();
@@ -3539,19 +3682,21 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask )
+    BaseType_t xTaskPreemptionEnableWithYieldStatus( const TaskHandle_t xTask )
     {
         TCB_t * pxTCB;
-        BaseType_t xHasDeferredAction = pdFALSE;
+        UBaseType_t uxDeferredAction = 0U;
         BaseType_t xAlreadyYielded = pdFALSE;
         BaseType_t xTaskRequestedToYield = pdFALSE;
 
-        #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
             vTaskTCBEnterCritical();
         #else
             kernelENTER_CRITICAL();
         #endif
         {
+            const BaseType_t xCoreID = portGET_CORE_ID();
+
             if( xSchedulerRunning != pdFALSE )
             {
                 /* Current task running on the core can not be changed by other core.
@@ -3566,17 +3711,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 {
                     if( pxTCB->uxDeferredStateChange != 0U )
                     {
-                        /* A deferred state change is pending. Leave uxDeferredStateChange
-                         * non-zero — it acts as a yield-suppression flag. All yield paths
-                         * (vTaskTCBExitCritical, vTaskSwitchContext, prvYieldCore,
-                         * xTaskIncrementTick, vTaskExitCritical) check this flag and
-                         * suppress context switches when it is set.
-                         *
-                         * After exiting this critical section, we will call the
-                         * appropriate deferred action function (vTaskDelete/vTaskSuspend)
-                         * which will enter the kernel critical section, clear the flag,
-                         * and execute the action atomically. */
-                        xHasDeferredAction = pdTRUE;
+                        uxDeferredAction = pxTCB->uxDeferredStateChange;
                     }
                     else
                     {
@@ -3600,56 +3735,50 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
             vTaskTCBExitCritical();
         #else
             kernelEXIT_CRITICAL();
         #endif
 
-        if( xHasDeferredAction != pdFALSE )
+        if( uxDeferredAction != 0U )
         {
-            /* At this point:
-             * - uxPreemptionDisable == 0 (preemption re-enabled)
-             * - uxDeferredStateChange != 0 (suppresses all yield paths)
-             * - Interrupts are enabled but no context switch can occur
-             *
-             * vTaskDelete/vTaskSuspend will:
-             * 1. Enter kernel critical section (recursive spinlocks allow nesting)
-             * 2. Acquire TCB spinlock
-             * 3. See uxPreemptionDisable == 0 -> take immediate path
-             * 4. Clear uxDeferredStateChange
-             * 5. Execute the action (remove from lists, add to termination/suspended)
-             * 6. Call taskYIELD_WITHIN_API (pends yield since critical nesting > 0)
-             * 7. Exit kernel critical section -> yield occurs */
-            if( pxTCB->uxDeferredStateChange & tskDEFERRED_DELETION )
+            if( uxDeferredAction & tskDEFERRED_DELETION )
             {
                 vTaskDelete( xTask );
             }
-            else if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
+            else if( uxDeferredAction & tskDEFERRED_SUSPENSION )
             {
                 vTaskSuspend( xTask );
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
             }
 
             /* Any deferred action on the task would result in a context switch. */
             xAlreadyYielded = pdTRUE;
         }
-        else if( xTaskRequestedToYield != pdFALSE )
+        else
         {
-            /* prvYieldCore must be called in critical section. */
-            kernelENTER_CRITICAL();
+            if( xTaskRequestedToYield != pdFALSE )
             {
-                pxTCB = prvGetTCBFromHandle( xTask );
-
-                /* There is gap between TCB critical section and kernel critical section.
-                 * Checking the yield pending again to prevent that the current task
-                 * already handle the yield request. */
-                if( ( xYieldPendings[ pxTCB->xTaskRunState ] != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) != pdFALSE ) )
+                /* prvYieldCore must be called in critical section. */
+                kernelENTER_CRITICAL();
                 {
-                    prvYieldCore( pxTCB->xTaskRunState );
+                    pxTCB = prvGetTCBFromHandle( xTask );
+
+                    /* There is gap between TCB critical section and kernel critical section.
+                     * Checking the yield pending again to prevent that the current task
+                     * already handle the yield request. */
+                    if( ( xYieldPendings[ pxTCB->xTaskRunState ] != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) != pdFALSE ) )
+                    {
+                        prvYieldCore( pxTCB->xTaskRunState );
+                    }
                 }
+                kernelEXIT_CRITICAL();
+                xAlreadyYielded = pdTRUE;
             }
-            kernelEXIT_CRITICAL();
-            xAlreadyYielded = pdTRUE;
         }
 
         return xAlreadyYielded;
@@ -3663,7 +3792,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         traceENTER_vTaskPreemptionEnable( xTask );
 
-        ( void ) prvTaskPreemptionEnable( xTask );
+        ( void ) xTaskPreemptionEnableWithYieldStatus( xTask );
 
         traceRETURN_vTaskPreemptionEnable();
     }
@@ -3685,48 +3814,33 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         kernelENTER_CRITICAL();
         {
+            const BaseType_t xCoreID = portGET_CORE_ID();
+
             /* If null is passed in here then it is the running task that is
              * being suspended. */
             pxTCB = prvGetTCBFromHandle( xTaskToSuspend );
             configASSERT( pxTCB != NULL );
 
             #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-
-                /* When TCB data group lock is enabled, we must acquire the target TCB's spinlock
-                 * to prevent a race condition with prvTaskPreemptionEnable(). */
-            #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
-                {
-                    const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-                    portGET_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
-                }
-                #endif /* configUSE_TCB_DATA_GROUP_LOCK */
+            {
+                /* FIXME : Acquire the TCB lock before reading the preemptions
+                 * disable count. */
+                portGET_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
 
                 /* If the task has disabled preemption, we need to defer the suspension until the
-                 * task enables preemption. The suspension will be performed in prvTaskPreemptionEnable(). */
+                 * task enables preemption. The suspension will be performed in vTaskPreemptionEnable(). */
                 if( pxTCB->uxPreemptionDisable > 0U )
                 {
-                    /* Only set deferred suspension if deletion is not already deferred.
-                     * Deletion takes priority over suspension - if both are requested,
-                     * only deletion will be processed. */
-                    if( ( pxTCB->uxDeferredStateChange & tskDEFERRED_DELETION ) == 0U )
-                    {
-                        pxTCB->uxDeferredStateChange |= tskDEFERRED_SUSPENSION;
-                    }
-
+                    pxTCB->uxDeferredStateChange |= tskDEFERRED_SUSPENSION;
                     xDeferredSuspension = pdTRUE;
+                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
                 }
                 else
                 {
                     /* Reset the deferred state change flags */
                     pxTCB->uxDeferredStateChange &= ~tskDEFERRED_SUSPENSION;
                 }
-
-            #if ( configUSE_TCB_DATA_GROUP_LOCK == 1 )
-                {
-                    const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
-                }
-                #endif /* configUSE_TCB_DATA_GROUP_LOCK */
+            }
             #endif /* configUSE_TASK_PREEMPTION_DISABLE */
 
             #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
@@ -3813,6 +3927,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     }
                 }
                 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                #endif
             }
         }
         kernelEXIT_CRITICAL();
@@ -3990,7 +4107,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             kernelENTER_CRITICAL();
             {
                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-
+                {
                     /* If the task being resumed is in a deferred suspension state,
                      * we simply clear the deferred suspension state and return. */
                     if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
@@ -4002,6 +4119,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     {
                         mtCOVERAGE_TEST_MARKER();
                     }
+                }
                 #endif /* configUSE_TASK_PREEMPTION_DISABLE */
 
                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
@@ -4050,6 +4168,10 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t * const pxTCB = xTaskToResume;
         UBaseType_t uxSavedInterruptStatus;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xTaskResumed = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_xTaskResumeFromISR( xTaskToResume );
 
         configASSERT( xTaskToResume );
@@ -4077,58 +4199,82 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
         {
-            if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
             {
-                traceTASK_RESUME_FROM_ISR( pxTCB );
+                /* FIXME : Acquire the TCB lock before reading the preemptions
+                 * disable count. */
 
-                /* Check the ready lists can be accessed. */
-                if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
+                /* If the task being resumed is in a deferred suspension state,
+                 * we simply clear the deferred suspension state and return. */
+                if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
                 {
-                    #if ( configNUMBER_OF_CORES == 1 )
-                    {
-                        /* Ready lists can be accessed so move the task from the
-                         * suspended list to the ready list directly. */
-                        if( pxTCB->uxPriority > pxCurrentTCB->uxPriority )
-                        {
-                            xYieldRequired = pdTRUE;
-
-                            /* Mark that a yield is pending in case the user is not
-                             * using the return value to initiate a context switch
-                             * from the ISR using the port specific portYIELD_FROM_ISR(). */
-                            xYieldPendings[ 0 ] = pdTRUE;
-                        }
-                        else
-                        {
-                            mtCOVERAGE_TEST_MARKER();
-                        }
-                    }
-                    #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
-
-                    ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
-                    prvAddTaskToReadyList( pxTCB );
+                    pxTCB->uxDeferredStateChange &= ~tskDEFERRED_SUSPENSION;
+                    xTaskResumed = pdTRUE;
                 }
                 else
                 {
-                    /* The delayed or ready lists cannot be accessed so the task
-                     * is held in the pending ready list until the scheduler is
-                     * unsuspended. */
-                    vListInsertEnd( &( xPendingReadyList ), &( pxTCB->xEventListItem ) );
+                    mtCOVERAGE_TEST_MARKER();
                 }
-
-                #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
-                {
-                    prvYieldForTask( pxTCB );
-
-                    if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
-                    {
-                        xYieldRequired = pdTRUE;
-                    }
-                }
-                #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) ) */
             }
-            else
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                if( xTaskResumed == pdFALSE )
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
             {
-                mtCOVERAGE_TEST_MARKER();
+                if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
+                {
+                    traceTASK_RESUME_FROM_ISR( pxTCB );
+
+                    /* Check the ready lists can be accessed. */
+                    if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
+                    {
+                        #if ( configNUMBER_OF_CORES == 1 )
+                        {
+                            /* Ready lists can be accessed so move the task from the
+                             * suspended list to the ready list directly. */
+                            if( pxTCB->uxPriority > pxCurrentTCB->uxPriority )
+                            {
+                                xYieldRequired = pdTRUE;
+
+                                /* Mark that a yield is pending in case the user is not
+                                 * using the return value to initiate a context switch
+                                 * from the ISR using the port specific portYIELD_FROM_ISR(). */
+                                xYieldPendings[ 0 ] = pdTRUE;
+                            }
+                            else
+                            {
+                                mtCOVERAGE_TEST_MARKER();
+                            }
+                        }
+                        #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+                        ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
+                        prvAddTaskToReadyList( pxTCB );
+                    }
+                    else
+                    {
+                        /* The delayed or ready lists cannot be accessed so the task
+                         * is held in the pending ready list until the scheduler is
+                         * unsuspended. */
+                        vListInsertEnd( &( xPendingReadyList ), &( pxTCB->xEventListItem ) );
+                    }
+
+                    #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
+                    {
+                        prvYieldForTask( pxTCB );
+
+                        if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+                        {
+                            xYieldRequired = pdTRUE;
+                        }
+                    }
+                    #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) ) */
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
             }
         }
         kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
@@ -4510,6 +4656,13 @@ void vTaskSuspendAll( void )
 
             kernelGET_TASK_LOCK( xCoreID );
 
+            /* Task lock is acquired here to increase the scheduler suspended count.
+             * In granular lock, it is possible that prvYieldCore is called with only
+             * ISR spinlock is acquired in ISR. To remove the gap, the logic is updated
+             * to acquire the ISR spinlock before check for run state. The logic in
+             * prvCheckForRunStateChange() is updated accordingly. */
+            kernelGET_ISR_LOCK( xCoreID );
+
             /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
              * purpose is to prevent altering the variable when fromISR APIs are readying
              * it. */
@@ -4518,9 +4671,14 @@ void vTaskSuspendAll( void )
                 /* If the scheduler is being suspended after taking a granular lock (in any data group)
                  * then we do not check for the run state of a task and we let it run through until
                  * the granular lock is released. */
+
+                /* Task may acquire kernel lock in data group critical section.
+                * In this case, check for run state change is not required since
+                * we can't yield for other task when preemption is disabled. */
                 #if ( portUSING_GRANULAR_LOCKS == 1 )
                     && ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
                 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+                && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
                 )
             {
                 prvCheckForRunStateChange();
@@ -4534,8 +4692,6 @@ void vTaskSuspendAll( void )
              * caused the task to get scheduled on a different core. The correct
              * task lock for the core is acquired in prvCheckForRunStateChange. */
             xCoreID = ( BaseType_t ) portGET_CORE_ID();
-
-            kernelGET_ISR_LOCK( xCoreID );
 
             /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
              * is used to allow calls to vTaskSuspendAll() to nest. */
@@ -4681,9 +4837,9 @@ BaseType_t xTaskResumeAll( void )
                         }
                         #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                         {
-                            /* All appropriate tasks yield at the moment a task is added to xPendingReadyList.
-                             * If the current core yielded then vTaskSwitchContext() has already been called
-                             * which sets xYieldPendings for the current core to pdTRUE. */
+                            /* Yield for the task when removing out from pending
+                             * ready list. */
+                            prvYieldForTask( pxTCB );
                         }
                         #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
                     }
@@ -5346,6 +5502,10 @@ BaseType_t xTaskIncrementTick( void )
         UBaseType_t uxSavedInterruptStatus;
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configUSE_TICK_HOOK == 1 ) )
+        BaseType_t xApplicationTickRequired = pdFALSE;
+    #endif
+
     traceENTER_xTaskIncrementTick();
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
@@ -5520,7 +5680,15 @@ BaseType_t xTaskIncrementTick( void )
              * count is being unwound (when the scheduler is being unlocked). */
             if( xPendedTicks == ( TickType_t ) 0 )
             {
-                vApplicationTickHook();
+                #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configUSE_TICK_HOOK == 1 ) )
+                {
+                    xApplicationTickRequired = pdTRUE;
+                }
+                #else
+                {
+                    vApplicationTickHook();
+                }
+                #endif
             }
             else
             {
@@ -5551,8 +5719,7 @@ BaseType_t xTaskIncrementTick( void )
                 for( xCoreID = 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
                 {
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
-                            ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U ) )
+                        if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
                     #endif
                     {
                         if( xYieldPendings[ xCoreID ] != pdFALSE )
@@ -5583,7 +5750,11 @@ BaseType_t xTaskIncrementTick( void )
 
         /* The tick hook gets called at regular intervals, even if the
          * scheduler is locked. */
-        #if ( configUSE_TICK_HOOK == 1 )
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configUSE_TICK_HOOK == 1 ) )
+        {
+            xApplicationTickRequired = pdTRUE;
+        }
+        #else
         {
             vApplicationTickHook();
         }
@@ -5593,6 +5764,17 @@ BaseType_t xTaskIncrementTick( void )
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configUSE_TICK_HOOK == 1 ) )
+    {
+        /* In order not to voilate granular lock critical section hierarchy, calling
+         * the vApplicationTickHook when leaving the kernel critical section. */
+        if( xApplicationTickRequired == pdTRUE )
+        {
+            vApplicationTickHook();
+        }
+    }
+    #endif
 
     traceRETURN_xTaskIncrementTick( xSwitchRequired );
 
@@ -5852,17 +6034,6 @@ BaseType_t xTaskIncrementTick( void )
                  * a context switch. */
                 xYieldPendings[ xCoreID ] = pdTRUE;
             }
-
-            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                else if( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange != 0U )
-                {
-                    /* A deferred state change (deletion or suspension) is pending
-                     * for the current task. The task must execute this deferred
-                     * action before being switched out. Pend the yield so it will
-                     * be processed after the deferred action completes. */
-                    xYieldPendings[ xCoreID ] = pdTRUE;
-                }
-            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
             else
             {
                 xYieldPendings[ xCoreID ] = pdFALSE;
@@ -6080,11 +6251,11 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         /* Lock the kernel data group as we are about to access its members */
-        kernelENTER_CRITICAL();
+        prvKernelEnterISROnlyCritical();
         {
             xReturn = prvTaskRemoveFromEventList( pxEventList );
         }
-        kernelEXIT_CRITICAL();
+        prvKernelExitISROnlyCritical();
     #else
         xReturn = prvTaskRemoveFromEventList( pxEventList );
     #endif
@@ -6317,7 +6488,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         /* Lock the kernel data group as we are about to access its members */
-        kernelENTER_CRITICAL();
+        prvKernelEnterISROnlyCritical();
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* For internal use only as it does not use a critical section. */
@@ -6326,7 +6497,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         /* We are done accessing the kernel data group. Unlock it. */
-        kernelEXIT_CRITICAL();
+        prvKernelExitISROnlyCritical();
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     traceRETURN_vTaskInternalSetTimeOutState();
@@ -7748,7 +7919,16 @@ static void prvResetNextTaskUnblockTime( void )
         {
             const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
-            if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+            if( ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+
+                    /* Task yield can be called in a data group critilcal section.
+                     * Adding a preemption disable check to prevent invalid context
+                     * switch. */
+                    && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
+                    ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
+                #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+                )
             {
                 portYIELD();
             }
@@ -7976,7 +8156,7 @@ static void prvResetNextTaskUnblockTime( void )
                     BaseType_t xYieldCurrentTask;
 
                     /* Get the xYieldPending status inside the critical section. */
-                    if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE )
+                    if( ( xYieldPendings[ xCoreID ] == pdTRUE )
                         #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                             && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
                             ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
@@ -8189,7 +8369,7 @@ static void prvResetNextTaskUnblockTime( void )
             {
                 BaseType_t xYieldCurrentTask;
 
-                if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE )
+                if( ( xYieldPendings[ xCoreID ] == pdTRUE )
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                         && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
                         ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
@@ -8220,8 +8400,42 @@ static void prvResetNextTaskUnblockTime( void )
             }
         }
     }
-
 #endif /* configLIGHTWEIGHT_CRITICAL_SECTION == 1 */
+/*-----------------------------------------------------------*/
+
+/* ISR only critical can only be used when multi-critical section is used.
+ * Therefore, run state change is not valid due to task can't be requested to yield. */
+static void prvKernelEnterISROnlyCritical( void )
+{
+    if( xSchedulerRunning != pdFALSE )
+    {
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );
+
+        /* Take only the ISR lock, not the task lock. */
+        kernelGET_ISR_LOCK( xCoreID );
+
+        portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+    }
+}
+/*-----------------------------------------------------------*/
+
+static void prvKernelExitISROnlyCritical( void )
+{
+    if( xSchedulerRunning != pdFALSE )
+    {
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+        configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );
+
+        /* Release only the ISR lock. */
+        kernelRELEASE_ISR_LOCK( xCoreID );
+
+        portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+    }
+}
+
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )
@@ -9154,6 +9368,9 @@ TickType_t uxTaskResetEventItemValue( void )
                 #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                 {
                     #if ( configUSE_PREEMPTION == 1 )
+
+                    /* Yield for the unblocked task is required even when scheduler
+                     * is suspended. */
                     {
                         prvYieldForTask( pxTCB );
 
@@ -9288,6 +9505,9 @@ TickType_t uxTaskResetEventItemValue( void )
                 #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                 {
                     #if ( configUSE_PREEMPTION == 1 )
+
+                    /* Yield for the unblocked task is required even when scheduler
+                     * is suspended. */
                     {
                         prvYieldForTask( pxTCB );
 
@@ -9961,4 +10181,33 @@ void vTaskResetState( void )
     }
     #endif /* #if ( configGENERATE_RUN_TIME_STATS == 1 ) */
 }
+/*-----------------------------------------------------------*/
+
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+    BaseType_t xTaskUnlockCanYield( void )
+    {
+        BaseType_t xReturn;
+        BaseType_t xCoreID = portGET_CORE_ID();
+
+        /* Current core to call this function should handle the yield request when
+         * the scheduler is suspended. In vTaskSwitchContext, the core will be blocking
+         * on TASK spinlocks until scheduler is resumed. */
+        if( ( xYieldPendings[ xCoreID ] == pdTRUE )
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+            #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+            )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+
+        return xReturn;
+    }
+
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -6665,91 +6665,95 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
         traceENTER_xTaskPriorityInherit( pxMutexHolder );
 
-        /* If the mutex is taken by an interrupt, the mutex holder is NULL. Priority
-         * inheritance is not applied in this scenario. */
-        if( pxMutexHolder != NULL )
+        taskENTER_CRITICAL();
         {
-            /* If the holder of the mutex has a priority below the priority of
-             * the task attempting to obtain the mutex then it will temporarily
-             * inherit the priority of the task attempting to obtain the mutex. */
-            if( pxMutexHolderTCB->uxPriority < pxCurrentTCB->uxPriority )
+            /* If the mutex is taken by an interrupt, the mutex holder is NULL. Priority
+             * inheritance is not applied in this scenario. */
+            if( pxMutexHolder != NULL )
             {
-                /* Adjust the mutex holder state to account for its new
-                 * priority.  Only reset the event list item value if the value is
-                 * not being used for anything else. */
-                if( ( listGET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
+                /* If the holder of the mutex has a priority below the priority of
+                 * the task attempting to obtain the mutex then it will temporarily
+                 * inherit the priority of the task attempting to obtain the mutex. */
+                if( pxMutexHolderTCB->uxPriority < pxCurrentTCB->uxPriority )
                 {
-                    listSET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxCurrentTCB->uxPriority );
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
-
-                /* If the task being modified is in the ready state it will need
-                 * to be moved into a new list. */
-                if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ pxMutexHolderTCB->uxPriority ] ), &( pxMutexHolderTCB->xStateListItem ) ) != pdFALSE )
-                {
-                    if( uxListRemove( &( pxMutexHolderTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                    /* Adjust the mutex holder state to account for its new
+                     * priority.  Only reset the event list item value if the value is
+                     * not being used for anything else. */
+                    if( ( listGET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
                     {
-                        /* It is known that the task is in its ready list so
-                         * there is no need to check again and the port level
-                         * reset macro can be called directly. */
-                        portRESET_READY_PRIORITY( pxMutexHolderTCB->uxPriority, uxTopReadyPriority );
+                        listSET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxCurrentTCB->uxPriority );
                     }
                     else
                     {
                         mtCOVERAGE_TEST_MARKER();
                     }
 
-                    /* Inherit the priority before being moved into the new list. */
-                    pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
-                    prvAddTaskToReadyList( pxMutexHolderTCB );
-                    #if ( configNUMBER_OF_CORES > 1 )
+                    /* If the task being modified is in the ready state it will need
+                     * to be moved into a new list. */
+                    if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ pxMutexHolderTCB->uxPriority ] ), &( pxMutexHolderTCB->xStateListItem ) ) != pdFALSE )
                     {
-                        /* The priority of the task is raised. Yield for this task
-                         * if it is not running. */
-                        if( taskTASK_IS_RUNNING( pxMutexHolderTCB ) != pdTRUE )
+                        if( uxListRemove( &( pxMutexHolderTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
                         {
-                            prvYieldForTask( pxMutexHolderTCB );
+                            /* It is known that the task is in its ready list so
+                             * there is no need to check again and the port level
+                             * reset macro can be called directly. */
+                            portRESET_READY_PRIORITY( pxMutexHolderTCB->uxPriority, uxTopReadyPriority );
                         }
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
+
+                        /* Inherit the priority before being moved into the new list. */
+                        pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
+                        prvAddTaskToReadyList( pxMutexHolderTCB );
+                        #if ( configNUMBER_OF_CORES > 1 )
+                        {
+                            /* The priority of the task is raised. Yield for this task
+                             * if it is not running. */
+                            if( taskTASK_IS_RUNNING( pxMutexHolderTCB ) != pdTRUE )
+                            {
+                                prvYieldForTask( pxMutexHolderTCB );
+                            }
+                        }
+                        #endif /* if ( configNUMBER_OF_CORES > 1 ) */
                     }
-                    #endif /* if ( configNUMBER_OF_CORES > 1 ) */
-                }
-                else
-                {
-                    /* Just inherit the priority. */
-                    pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
-                }
+                    else
+                    {
+                        /* Just inherit the priority. */
+                        pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
+                    }
 
-                traceTASK_PRIORITY_INHERIT( pxMutexHolderTCB, pxCurrentTCB->uxPriority );
+                    traceTASK_PRIORITY_INHERIT( pxMutexHolderTCB, pxCurrentTCB->uxPriority );
 
-                /* Inheritance occurred. */
-                xReturn = pdTRUE;
-            }
-            else
-            {
-                if( pxMutexHolderTCB->uxBasePriority < pxCurrentTCB->uxPriority )
-                {
-                    /* The base priority of the mutex holder is lower than the
-                     * priority of the task attempting to take the mutex, but the
-                     * current priority of the mutex holder is not lower than the
-                     * priority of the task attempting to take the mutex.
-                     * Therefore the mutex holder must have already inherited a
-                     * priority, but inheritance would have occurred if that had
-                     * not been the case. */
+                    /* Inheritance occurred. */
                     xReturn = pdTRUE;
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    if( pxMutexHolderTCB->uxBasePriority < pxCurrentTCB->uxPriority )
+                    {
+                        /* The base priority of the mutex holder is lower than the
+                         * priority of the task attempting to take the mutex, but the
+                         * current priority of the mutex holder is not lower than the
+                         * priority of the task attempting to take the mutex.
+                         * Therefore the mutex holder must have already inherited a
+                         * priority, but inheritance would have occurred if that had
+                         * not been the case. */
+                        xReturn = pdTRUE;
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
                 }
             }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
         }
-        else
-        {
-            mtCOVERAGE_TEST_MARKER();
-        }
+        taskEXIT_CRITICAL();
 
         traceRETURN_xTaskPriorityInherit( xReturn );
 

--- a/tasks.c
+++ b/tasks.c
@@ -137,11 +137,15 @@
 /*
  * Macros used by vListTask to indicate which state a task is in.
  */
-#define tskRUNNING_CHAR      ( 'X' )
-#define tskBLOCKED_CHAR      ( 'B' )
-#define tskREADY_CHAR        ( 'R' )
-#define tskDELETED_CHAR      ( 'D' )
-#define tskSUSPENDED_CHAR    ( 'S' )
+#define tskRUNNING_CHAR           ( 'X' )
+#define tskBLOCKED_CHAR           ( 'B' )
+#define tskREADY_CHAR             ( 'R' )
+#define tskDELETED_CHAR           ( 'D' )
+#define tskSUSPENDED_CHAR         ( 'S' )
+
+/* Bits used to record a deferred state change of a task. */
+#define tskDEFERRED_DELETION      ( UBaseType_t ) ( 1U << 0U )
+#define tskDEFERRED_SUSPENSION    ( UBaseType_t ) ( 1U << 1U )
 
 /*
  * Some kernel aware debuggers require the data the debugger needs access to be
@@ -349,7 +353,33 @@
 /* Yields the given core. This must be called from a critical section and xCoreID
  * must be valid. This macro is not required in single core since there is only
  * one core to yield. */
-    #define prvYieldCore( xCoreID )                                                          \
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        #define prvYieldCore( xCoreID )                                                          \
+    do {                                                                                         \
+        if( ( xCoreID ) == ( BaseType_t ) portGET_CORE_ID() )                                    \
+        {                                                                                        \
+            /* Pending a yield for this core since it is in the critical section. */             \
+            xYieldPendings[ ( xCoreID ) ] = pdTRUE;                                              \
+        }                                                                                        \
+        else                                                                                     \
+        {                                                                                        \
+            if( pxCurrentTCBs[ ( xCoreID ) ]->uxPreemptionDisable == 0U )                        \
+            {                                                                                    \
+                /* Request other core to yield if it is not requested before. */                 \
+                if( pxCurrentTCBs[ ( xCoreID ) ]->xTaskRunState != taskTASK_SCHEDULED_TO_YIELD ) \
+                {                                                                                \
+                    portYIELD_CORE( xCoreID );                                                   \
+                    pxCurrentTCBs[ ( xCoreID ) ]->xTaskRunState = taskTASK_SCHEDULED_TO_YIELD;   \
+                }                                                                                \
+            }                                                                                    \
+            else                                                                                 \
+            {                                                                                    \
+                xYieldPendings[ ( xCoreID ) ] = pdTRUE;                                          \
+            }                                                                                    \
+        }                                                                                        \
+    } while( 0 )
+    #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+        #define prvYieldCore( xCoreID )                                                      \
     do {                                                                                     \
         if( ( xCoreID ) == ( BaseType_t ) portGET_CORE_ID() )                                \
         {                                                                                    \
@@ -366,7 +396,40 @@
             }                                                                                \
         }                                                                                    \
     } while( 0 )
+    #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+/*-----------------------------------------------------------*/
+
+/* Macros to take and release kernel spinlocks */
+#if ( configNUMBER_OF_CORES > 1 )
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        #define kernelGET_TASK_LOCK( xCoreID )        portGET_SPINLOCK( xCoreID, &xTaskSpinlock )
+        #define kernelRELEASE_TASK_LOCK( xCoreID )    portRELEASE_SPINLOCK( xCoreID, &xTaskSpinlock )
+        #define kernelGET_ISR_LOCK( xCoreID )         portGET_SPINLOCK( xCoreID, &xISRSpinlock )
+        #define kernelRELEASE_ISR_LOCK( xCoreID )     portRELEASE_SPINLOCK( xCoreID, &xISRSpinlock )
+    #else
+        #define kernelGET_TASK_LOCK( xCoreID )        portGET_TASK_LOCK( xCoreID )
+        #define kernelRELEASE_TASK_LOCK( xCoreID )    portRELEASE_TASK_LOCK( xCoreID )
+        #define kernelGET_ISR_LOCK( xCoreID )         portGET_ISR_LOCK( xCoreID )
+        #define kernelRELEASE_ISR_LOCK( xCoreID )     portRELEASE_ISR_LOCK( xCoreID )
+    #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/*
+ * Macros to mark the start and end of a critical code region.
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define kernelENTER_CRITICAL()                                    vTaskEnterCritical()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           vTaskEnterCriticalFromISR()
+    #define kernelEXIT_CRITICAL()                                     vTaskExitCritical()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define kernelENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define kernelEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
 /*-----------------------------------------------------------*/
 
 /*
@@ -397,7 +460,11 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
     char pcTaskName[ configMAX_TASK_NAME_LEN ]; /**< Descriptive name given to the task when created.  Facilitates debugging only. */
 
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        UBaseType_t xPreemptionDisable; /**< Used to prevent the task from being preempted. */
+        UBaseType_t uxPreemptionDisable; /**< Used to prevent the task from being preempted. */
+    #endif
+
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        UBaseType_t uxDeferredStateChange; /**< Used to indicate if the task's state change is deferred. */
     #endif
 
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
@@ -541,9 +608,10 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
 
 #endif
 
+/* Kernel spinlock variables when using granular locking */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_KERNEL_TASK_SPINLOCK_STATIC;
-    PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_KERNEL_ISR_SPINLOCK_STATIC;
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_SPINLOCK_STATIC;
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_SPINLOCK_STATIC;
 #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
@@ -555,14 +623,14 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
  */
 STATIC BaseType_t prvCreateIdleTasks( void );
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
 /*
  * Checks to see if another task moved the current task out of the ready
  * list while it was waiting to enter a critical section and yields, if so.
  */
     STATIC void prvCheckForRunStateChange( void );
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 #if ( configNUMBER_OF_CORES > 1 )
 
@@ -786,6 +854,13 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) */
 
 /*
+ * Helper function to enable preemption for a task.
+ */
+#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+#endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
+/*
  * freertos_tasks_c_additions_init() should only be called if the user definable
  * macro FREERTOS_TASKS_C_ADDITIONS_INIT() is defined, as that is the only macro
  * called by the function.
@@ -828,10 +903,9 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     STATIC void prvCheckForRunStateChange( void )
     {
-        UBaseType_t uxPrevCriticalNesting;
         const TCB_t * pxThisTCB;
         BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
@@ -844,6 +918,8 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         while( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD )
         {
+            UBaseType_t uxPrevCriticalNesting;
+
             /* We are only here if we just entered a critical section
             * or if we just suspended the scheduler, and another task
             * has requested that we yield.
@@ -857,7 +933,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             if( uxPrevCriticalNesting > 0U )
             {
                 portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
-                portRELEASE_ISR_LOCK( xCoreID );
+                kernelRELEASE_ISR_LOCK( xCoreID );
             }
             else
             {
@@ -866,7 +942,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                 mtCOVERAGE_TEST_MARKER();
             }
 
-            portRELEASE_TASK_LOCK( xCoreID );
+            kernelRELEASE_TASK_LOCK( xCoreID );
             portMEMORY_BARRIER();
             configASSERT( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD );
 
@@ -881,18 +957,18 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             portDISABLE_INTERRUPTS();
 
             xCoreID = ( BaseType_t ) portGET_CORE_ID();
-            portGET_TASK_LOCK( xCoreID );
-            portGET_ISR_LOCK( xCoreID );
+            kernelGET_TASK_LOCK( xCoreID );
+            kernelGET_ISR_LOCK( xCoreID );
 
             portSET_CRITICAL_NESTING_COUNT( xCoreID, uxPrevCriticalNesting );
 
             if( uxPrevCriticalNesting == 0U )
             {
-                portRELEASE_ISR_LOCK( xCoreID );
+                kernelRELEASE_ISR_LOCK( xCoreID );
             }
         }
     }
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 /*-----------------------------------------------------------*/
 
@@ -951,12 +1027,23 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             #endif
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
-                                #endif
+                                {
+                                    if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+                                    {
+                                        xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
+                                        xLowestPriorityCore = xCoreID;
+                                    }
+                                    else
+                                    {
+                                        xYieldPendings[ xCoreID ] = pdTRUE;
+                                    }
+                                }
+                                #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                                 {
                                     xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
                                     xLowestPriorityCore = xCoreID;
                                 }
+                                #endif /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                             }
                         }
                         else
@@ -1257,12 +1344,23 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 ( xYieldPendings[ uxCore ] == pdFALSE ) )
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == 0U )
-                                #endif
+                                {
+                                    if( pxCurrentTCBs[ uxCore ]->uxPreemptionDisable == 0U )
+                                    {
+                                        xLowestPriority = xTaskPriority;
+                                        xLowestPriorityCore = ( BaseType_t ) uxCore;
+                                    }
+                                    else
+                                    {
+                                        xYieldPendings[ uxCore ] = pdTRUE;
+                                    }
+                                }
+                                #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                                 {
                                     xLowestPriority = xTaskPriority;
                                     xLowestPriorityCore = ( BaseType_t ) uxCore;
                                 }
+                                #endif /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                             }
                         }
                     }
@@ -2062,7 +2160,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         /* Ensure interrupts don't access the task lists while the lists are being
          * updated. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             uxCurrentNumberOfTasks = ( UBaseType_t ) ( uxCurrentNumberOfTasks + 1U );
 
@@ -2120,7 +2218,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             portSETUP_TCB( pxNewTCB );
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -2140,7 +2238,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         /* Ensure interrupts don't access the task lists while the lists are being
          * updated. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             uxCurrentNumberOfTasks++;
 
@@ -2189,7 +2287,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
     }
 
 #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
@@ -2236,144 +2334,173 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         BaseType_t xDeleteTCBInIdleTask = pdFALSE;
         BaseType_t xTaskIsRunningOrYielding;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xDeferredDeletion = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_vTaskDelete( xTaskToDelete );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If null is passed in here then it is the calling task that is
              * being deleted. */
             pxTCB = prvGetTCBFromHandle( xTaskToDelete );
             configASSERT( pxTCB != NULL );
 
-            /* Remove task from the ready/delayed list. */
-            if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
-            {
-                taskRESET_READY_PRIORITY( pxTCB->uxPriority );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-            /* Is the task waiting on an event also? */
-            if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
-            {
-                ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            /* Increment the uxTaskNumber also so kernel aware debuggers can
-             * detect that the task lists need re-generating.  This is done before
-             * portPRE_TASK_DELETE_HOOK() as in the Windows port that macro will
-             * not return. */
-            uxTaskNumber++;
-
-            /* Use temp variable as distinct sequence points for reading volatile
-             * variables prior to a logical operator to ensure compliance with
-             * MISRA C 2012 Rule 13.5. */
-            xTaskIsRunningOrYielding = taskTASK_IS_RUNNING_OR_SCHEDULED_TO_YIELD( pxTCB );
-
-            /* If the task is running (or yielding), we must add it to the
-             * termination list so that an idle task can delete it when it is
-             * no longer running. */
-            if( ( xSchedulerRunning != pdFALSE ) && ( xTaskIsRunningOrYielding != pdFALSE ) )
-            {
-                /* A running task or a task which is scheduled to yield is being
-                 * deleted. This cannot complete when the task is still running
-                 * on a core, as a context switch to another task is required.
-                 * Place the task in the termination list. The idle task will check
-                 * the termination list and free up any memory allocated by the
-                 * scheduler for the TCB and stack of the deleted task. */
-                vListInsertEnd( &xTasksWaitingTermination, &( pxTCB->xStateListItem ) );
-
-                /* Increment the ucTasksDeleted variable so the idle task knows
-                 * there is a task that has been deleted and that it should therefore
-                 * check the xTasksWaitingTermination list. */
-                ++uxDeletedTasksWaitingCleanUp;
-
-                /* Call the delete hook before portPRE_TASK_DELETE_HOOK() as
-                 * portPRE_TASK_DELETE_HOOK() does not return in the Win32 port. */
-                traceTASK_DELETE( pxTCB );
-
-                /* Delete the task TCB in idle task. */
-                xDeleteTCBInIdleTask = pdTRUE;
-
-                /* The pre-delete hook is primarily for the Windows simulator,
-                 * in which Windows specific clean up operations are performed,
-                 * after which it is not possible to yield away from this task -
-                 * hence xYieldPending is used to latch that a context switch is
-                 * required. */
-                #if ( configNUMBER_OF_CORES == 1 )
-                    portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ 0 ] ) );
-                #else
-                    portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ pxTCB->xTaskRunState ] ) );
-                #endif
-
-                /* In the case of SMP, it is possible that the task being deleted
-                 * is running on another core. We must evict the task before
-                 * exiting the critical section to ensure that the task cannot
-                 * take an action which puts it back on ready/state/event list,
-                 * thereby nullifying the delete operation. Once evicted, the
-                 * task won't be scheduled ever as it will no longer be on the
-                 * ready list. */
-                #if ( configNUMBER_OF_CORES > 1 )
+                /* If the task has disabled preemption, we need to defer the deletion until the
+                 * task enables preemption. The deletion will be performed in vTaskPreemptionEnable(). */
+                if( pxTCB->uxPreemptionDisable > 0U )
                 {
-                    if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
-                    {
-                        if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
-                        {
-                            configASSERT( uxSchedulerSuspended == 0 );
-                            taskYIELD_WITHIN_API();
-                        }
-                        else
-                        {
-                            prvYieldCore( pxTCB->xTaskRunState );
-                        }
-                    }
-                }
-                #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
-            }
-            else
-            {
-                --uxCurrentNumberOfTasks;
-                traceTASK_DELETE( pxTCB );
-
-                /* Reset the next expected unblock time in case it referred to
-                 * the task that has just been deleted. */
-                prvResetNextTaskUnblockTime();
-            }
-        }
-        taskEXIT_CRITICAL();
-
-        /* If the task is not deleting itself, call prvDeleteTCB from outside of
-         * critical section. If a task deletes itself, prvDeleteTCB is called
-         * from prvCheckTasksWaitingTermination which is called from Idle task. */
-        if( xDeleteTCBInIdleTask != pdTRUE )
-        {
-            prvDeleteTCB( pxTCB );
-        }
-
-        /* Force a reschedule if it is the currently running task that has just
-         * been deleted. */
-        #if ( configNUMBER_OF_CORES == 1 )
-        {
-            if( xSchedulerRunning != pdFALSE )
-            {
-                if( pxTCB == pxCurrentTCB )
-                {
-                    configASSERT( uxSchedulerSuspended == 0 );
-                    taskYIELD_WITHIN_API();
+                    pxTCB->uxDeferredStateChange |= tskDEFERRED_DELETION;
+                    xDeferredDeletion = pdTRUE;
                 }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                if( xDeferredDeletion == pdFALSE )
+            #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+            {
+                /* Remove task from the ready/delayed list. */
+                if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                {
+                    taskRESET_READY_PRIORITY( pxTCB->uxPriority );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                /* Is the task waiting on an event also? */
+                if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
+                {
+                    ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                /* Increment the uxTaskNumber also so kernel aware debuggers can
+                 * detect that the task lists need re-generating.  This is done before
+                 * portPRE_TASK_DELETE_HOOK() as in the Windows port that macro will
+                 * not return. */
+                uxTaskNumber++;
+
+                /* Use temp variable as distinct sequence points for reading volatile
+                 * variables prior to a logical operator to ensure compliance with
+                 * MISRA C 2012 Rule 13.5. */
+                xTaskIsRunningOrYielding = taskTASK_IS_RUNNING_OR_SCHEDULED_TO_YIELD( pxTCB );
+
+                /* If the task is running (or yielding), we must add it to the
+                 * termination list so that an idle task can delete it when it is
+                 * no longer running. */
+                if( ( xSchedulerRunning != pdFALSE ) && ( xTaskIsRunningOrYielding != pdFALSE ) )
+                {
+                    /* A running task or a task which is scheduled to yield is being
+                     * deleted. This cannot complete when the task is still running
+                     * on a core, as a context switch to another task is required.
+                     * Place the task in the termination list. The idle task will check
+                     * the termination list and free up any memory allocated by the
+                     * scheduler for the TCB and stack of the deleted task. */
+                    vListInsertEnd( &xTasksWaitingTermination, &( pxTCB->xStateListItem ) );
+
+                    /* Increment the ucTasksDeleted variable so the idle task knows
+                     * there is a task that has been deleted and that it should therefore
+                     * check the xTasksWaitingTermination list. */
+                    ++uxDeletedTasksWaitingCleanUp;
+
+                    /* Call the delete hook before portPRE_TASK_DELETE_HOOK() as
+                     * portPRE_TASK_DELETE_HOOK() does not return in the Win32 port. */
+                    traceTASK_DELETE( pxTCB );
+
+                    /* Delete the task TCB in idle task. */
+                    xDeleteTCBInIdleTask = pdTRUE;
+
+                    /* The pre-delete hook is primarily for the Windows simulator,
+                     * in which Windows specific clean up operations are performed,
+                     * after which it is not possible to yield away from this task -
+                     * hence xYieldPending is used to latch that a context switch is
+                     * required. */
+                    #if ( configNUMBER_OF_CORES == 1 )
+                        portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ 0 ] ) );
+                    #else
+                        portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ pxTCB->xTaskRunState ] ) );
+                    #endif
+
+                    /* In the case of SMP, it is possible that the task being deleted
+                     * is running on another core. We must evict the task before
+                     * exiting the critical section to ensure that the task cannot
+                     * take an action which puts it back on ready/state/event list,
+                     * thereby nullifying the delete operation. Once evicted, the
+                     * task won't be scheduled ever as it will no longer be on the
+                     * ready list. */
+                    #if ( configNUMBER_OF_CORES > 1 )
+                    {
+                        if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                        {
+                            if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+                            {
+                                configASSERT( uxSchedulerSuspended == 0 );
+                                taskYIELD_WITHIN_API();
+                            }
+                            else
+                            {
+                                prvYieldCore( pxTCB->xTaskRunState );
+                            }
+                        }
+                    }
+                    #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+                }
+                else
+                {
+                    --uxCurrentNumberOfTasks;
+                    traceTASK_DELETE( pxTCB );
+
+                    /* Reset the next expected unblock time in case it referred to
+                     * the task that has just been deleted. */
+                    prvResetNextTaskUnblockTime();
+                }
             }
         }
-        #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+        kernelEXIT_CRITICAL();
+
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            if( xDeferredDeletion == pdFALSE )
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+        {
+            /* If the task is not deleting itself, call prvDeleteTCB from outside of
+             * critical section. If a task deletes itself, prvDeleteTCB is called
+             * from prvCheckTasksWaitingTermination which is called from Idle task. */
+            if( xDeleteTCBInIdleTask != pdTRUE )
+            {
+                prvDeleteTCB( pxTCB );
+            }
+
+            /* Force a reschedule if it is the currently running task that has just
+             * been deleted. */
+            #if ( configNUMBER_OF_CORES == 1 )
+            {
+                if( xSchedulerRunning != pdFALSE )
+                {
+                    if( pxTCB == pxCurrentTCB )
+                    {
+                        configASSERT( uxSchedulerSuspended == 0 );
+                        taskYIELD_WITHIN_API();
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
+                }
+            }
+            #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+        }
 
         traceRETURN_vTaskDelete();
     }
@@ -2547,14 +2674,14 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             else
         #endif
         {
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
                 pxStateList = listLIST_ITEM_CONTAINER( &( pxTCB->xStateListItem ) );
                 pxEventList = listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) );
                 pxDelayedList = pxDelayedTaskList;
                 pxOverflowedDelayedList = pxOverflowDelayedTaskList;
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
 
             if( pxEventList == &xPendingReadyList )
             {
@@ -2664,7 +2791,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskPriorityGet( xTask );
 
-        portBASE_TYPE_ENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             /* If null is passed in here then it is the priority of the task
              * that called uxTaskPriorityGet() that is being queried. */
@@ -2673,7 +2808,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxPriority;
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_uxTaskPriorityGet( uxReturn );
 
@@ -2714,7 +2857,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             /* If null is passed in here then it is the priority of the calling
              * task that is being queried. */
@@ -2723,7 +2866,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxPriority;
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_uxTaskPriorityGetFromISR( uxReturn );
 
@@ -2742,7 +2885,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskBasePriorityGet( xTask );
 
-        portBASE_TYPE_ENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             /* If null is passed in here then it is the base priority of the task
              * that called uxTaskBasePriorityGet() that is being queried. */
@@ -2751,7 +2902,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxBasePriority;
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_uxTaskBasePriorityGet( uxReturn );
 
@@ -2792,7 +2951,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             /* If null is passed in here then it is the base priority of the calling
              * task that is being queried. */
@@ -2801,7 +2960,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxBasePriority;
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_uxTaskBasePriorityGetFromISR( uxReturn );
 
@@ -2838,7 +2997,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             mtCOVERAGE_TEST_MARKER();
         }
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If null is passed in here then it is the priority of the calling
              * task that is being changed. */
@@ -2899,12 +3058,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     /* Setting the priority of a running task down means
                      * there may now be another task of higher priority that
                      * is ready to execute. */
-                    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxTCB->xPreemptionDisable == 0U )
-                    #endif
-                    {
-                        xYieldRequired = pdTRUE;
-                    }
+                    xYieldRequired = pdTRUE;
                 }
                 else
                 {
@@ -3018,7 +3172,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 ( void ) uxPriorityUsedOnEntry;
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskPrioritySet();
     }
@@ -3035,7 +3189,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
@@ -3076,7 +3230,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskCoreAffinitySet();
     }
@@ -3091,14 +3245,30 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskCoreAffinityGet( xTask );
 
-        portBASE_TYPE_ENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
 
             uxCoreAffinityMask = pxTCB->uxCoreAffinityMask;
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask );
 
@@ -3116,14 +3286,21 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskPreemptionDisable( xTask );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
-            pxTCB = prvGetTCBFromHandle( xTask );
-            configASSERT( pxTCB != NULL );
+            if( xSchedulerRunning != pdFALSE )
+            {
+                pxTCB = prvGetTCBFromHandle( xTask );
+                configASSERT( pxTCB != NULL );
 
-            pxTCB->xPreemptionDisable++;
+                pxTCB->uxPreemptionDisable++;
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskPreemptionDisable();
     }
@@ -3133,31 +3310,86 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-    void vTaskPreemptionEnable( const TaskHandle_t xTask )
+    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask )
     {
         TCB_t * pxTCB;
-        BaseType_t xCoreID;
+        UBaseType_t uxDeferredAction = 0U;
+        BaseType_t xAlreadyYielded = pdFALSE;
 
         traceENTER_vTaskPreemptionEnable( xTask );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
-            pxTCB = prvGetTCBFromHandle( xTask );
-            configASSERT( pxTCB != NULL );
-            configASSERT( pxTCB->xPreemptionDisable > 0U );
-
-            pxTCB->xPreemptionDisable--;
-
             if( xSchedulerRunning != pdFALSE )
             {
-                if( ( pxTCB->xPreemptionDisable == 0U ) && ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) )
+                pxTCB = prvGetTCBFromHandle( xTask );
+                configASSERT( pxTCB != NULL );
+                configASSERT( pxTCB->uxPreemptionDisable > 0U );
+
+                pxTCB->uxPreemptionDisable--;
+
+                if( pxTCB->uxPreemptionDisable == 0U )
                 {
-                    xCoreID = ( BaseType_t ) pxTCB->xTaskRunState;
-                    prvYieldCore( xCoreID );
+                    if( pxTCB->uxDeferredStateChange != 0U )
+                    {
+                        uxDeferredAction = pxTCB->uxDeferredStateChange;
+                    }
+                    else
+                    {
+                        if( ( xYieldPendings[ pxTCB->xTaskRunState ] != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) != pdFALSE ) )
+                        {
+                            prvYieldCore( pxTCB->xTaskRunState );
+                            xAlreadyYielded = pdTRUE;
+                        }
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
+                    }
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
                 }
             }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
+
+        if( uxDeferredAction != 0U )
+        {
+            if( uxDeferredAction & tskDEFERRED_DELETION )
+            {
+                vTaskDelete( xTask );
+            }
+            else if( uxDeferredAction & tskDEFERRED_SUSPENSION )
+            {
+                vTaskSuspend( xTask );
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+
+            /* Any deferred action on the task would result in a context switch. */
+            xAlreadyYielded = pdTRUE;
+        }
+
+        return xAlreadyYielded;
+    }
+#endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+
+    void vTaskPreemptionEnable( const TaskHandle_t xTask )
+    {
+        traceENTER_vTaskPreemptionEnable( xTask );
+
+        ( void ) prvTaskPreemptionEnable( xTask );
 
         traceRETURN_vTaskPreemptionEnable();
     }
@@ -3171,82 +3403,110 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * pxTCB;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xDeferredSuspension = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_vTaskSuspend( xTaskToSuspend );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If null is passed in here then it is the running task that is
              * being suspended. */
             pxTCB = prvGetTCBFromHandle( xTaskToSuspend );
             configASSERT( pxTCB != NULL );
 
-            traceTASK_SUSPEND( pxTCB );
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-            /* Remove task from the ready/delayed list and place in the
-             * suspended list. */
-            if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
-            {
-                taskRESET_READY_PRIORITY( pxTCB->uxPriority );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            /* Is the task waiting on an event also? */
-            if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
-            {
-                ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            vListInsertEnd( &xSuspendedTaskList, &( pxTCB->xStateListItem ) );
-
-            #if ( configUSE_TASK_NOTIFICATIONS == 1 )
-            {
-                BaseType_t x;
-
-                for( x = ( BaseType_t ) 0; x < ( BaseType_t ) configTASK_NOTIFICATION_ARRAY_ENTRIES; x++ )
+                /* If the task has disabled preemption, we need to defer the suspension until the
+                 * task enables preemption. The suspension will be performed in vTaskPreemptionEnable(). */
+                if( pxTCB->uxPreemptionDisable > 0U )
                 {
-                    if( pxTCB->ucNotifyState[ x ] == taskWAITING_NOTIFICATION )
+                    pxTCB->uxDeferredStateChange |= tskDEFERRED_SUSPENSION;
+                    xDeferredSuspension = pdTRUE;
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                if( xDeferredSuspension == pdFALSE )
+            #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+            {
+                traceTASK_SUSPEND( pxTCB );
+
+                /* Remove task from the ready/delayed list and place in the
+                 * suspended list. */
+                if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                {
+                    taskRESET_READY_PRIORITY( pxTCB->uxPriority );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                /* Is the task waiting on an event also? */
+                if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
+                {
+                    ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                vListInsertEnd( &xSuspendedTaskList, &( pxTCB->xStateListItem ) );
+
+                #if ( configUSE_TASK_NOTIFICATIONS == 1 )
+                {
+                    BaseType_t x;
+
+                    for( x = ( BaseType_t ) 0; x < ( BaseType_t ) configTASK_NOTIFICATION_ARRAY_ENTRIES; x++ )
                     {
-                        /* The task was blocked to wait for a notification, but is
-                         * now suspended, so no notification was received. */
-                        pxTCB->ucNotifyState[ x ] = taskNOT_WAITING_NOTIFICATION;
+                        if( pxTCB->ucNotifyState[ x ] == taskWAITING_NOTIFICATION )
+                        {
+                            /* The task was blocked to wait for a notification, but is
+                             * now suspended, so no notification was received. */
+                            pxTCB->ucNotifyState[ x ] = taskNOT_WAITING_NOTIFICATION;
+                        }
                     }
                 }
-            }
-            #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
+                #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
 
-            /* In the case of SMP, it is possible that the task being suspended
-             * is running on another core. We must evict the task before
-             * exiting the critical section to ensure that the task cannot
-             * take an action which puts it back on ready/state/event list,
-             * thereby nullifying the suspend operation. Once evicted, the
-             * task won't be scheduled before it is resumed as it will no longer
-             * be on the ready list. */
-            #if ( configNUMBER_OF_CORES > 1 )
-            {
-                if( xSchedulerRunning != pdFALSE )
+                /* In the case of SMP, it is possible that the task being suspended
+                 * is running on another core. We must evict the task before
+                 * exiting the critical section to ensure that the task cannot
+                 * take an action which puts it back on ready/state/event list,
+                 * thereby nullifying the suspend operation. Once evicted, the
+                 * task won't be scheduled before it is resumed as it will no longer
+                 * be on the ready list. */
+                #if ( configNUMBER_OF_CORES > 1 )
                 {
-                    /* Reset the next expected unblock time in case it referred to the
-                     * task that is now in the Suspended state. */
-                    prvResetNextTaskUnblockTime();
-
-                    if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                    if( xSchedulerRunning != pdFALSE )
                     {
-                        if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+                        /* Reset the next expected unblock time in case it referred to the
+                         * task that is now in the Suspended state. */
+                        prvResetNextTaskUnblockTime();
+
+                        if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
                         {
-                            /* The current task has just been suspended. */
-                            configASSERT( uxSchedulerSuspended == 0 );
-                            vTaskYieldWithinAPI();
+                            if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+                            {
+                                /* The current task has just been suspended. */
+                                configASSERT( uxSchedulerSuspended == 0 );
+                                vTaskYieldWithinAPI();
+                            }
+                            else
+                            {
+                                prvYieldCore( pxTCB->xTaskRunState );
+                            }
                         }
                         else
                         {
-                            prvYieldCore( pxTCB->xTaskRunState );
+                            mtCOVERAGE_TEST_MARKER();
                         }
                     }
                     else
@@ -3254,73 +3514,74 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
+                #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+            }
+        }
+        kernelEXIT_CRITICAL();
+
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            if( xDeferredSuspension == pdFALSE )
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+        {
+            #if ( configNUMBER_OF_CORES == 1 )
+            {
+                UBaseType_t uxCurrentListLength;
+
+                if( xSchedulerRunning != pdFALSE )
+                {
+                    /* Reset the next expected unblock time in case it referred to the
+                     * task that is now in the Suspended state. */
+                    kernelENTER_CRITICAL();
+                    {
+                        prvResetNextTaskUnblockTime();
+                    }
+                    kernelEXIT_CRITICAL();
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                if( pxTCB == pxCurrentTCB )
+                {
+                    if( xSchedulerRunning != pdFALSE )
+                    {
+                        /* The current task has just been suspended. */
+                        configASSERT( uxSchedulerSuspended == 0 );
+                        portYIELD_WITHIN_API();
+                    }
+                    else
+                    {
+                        /* The scheduler is not running, but the task that was pointed
+                         * to by pxCurrentTCB has just been suspended and pxCurrentTCB
+                         * must be adjusted to point to a different task. */
+
+                        /* Use a temp variable as a distinct sequence point for reading
+                         * volatile variables prior to a comparison to ensure compliance
+                         * with MISRA C 2012 Rule 13.2. */
+                        uxCurrentListLength = listCURRENT_LIST_LENGTH( &xSuspendedTaskList );
+
+                        if( uxCurrentListLength == uxCurrentNumberOfTasks )
+                        {
+                            /* No other tasks are ready, so set pxCurrentTCB back to
+                             * NULL so when the next task is created pxCurrentTCB will
+                             * be set to point to it no matter what its relative priority
+                             * is. */
+                            pxCurrentTCB = NULL;
+                        }
+                        else
+                        {
+                            vTaskSwitchContext();
+                        }
+                    }
+                }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
             }
-            #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+            #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
         }
-        taskEXIT_CRITICAL();
-
-        #if ( configNUMBER_OF_CORES == 1 )
-        {
-            UBaseType_t uxCurrentListLength;
-
-            if( xSchedulerRunning != pdFALSE )
-            {
-                /* Reset the next expected unblock time in case it referred to the
-                 * task that is now in the Suspended state. */
-                taskENTER_CRITICAL();
-                {
-                    prvResetNextTaskUnblockTime();
-                }
-                taskEXIT_CRITICAL();
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            if( pxTCB == pxCurrentTCB )
-            {
-                if( xSchedulerRunning != pdFALSE )
-                {
-                    /* The current task has just been suspended. */
-                    configASSERT( uxSchedulerSuspended == 0 );
-                    portYIELD_WITHIN_API();
-                }
-                else
-                {
-                    /* The scheduler is not running, but the task that was pointed
-                     * to by pxCurrentTCB has just been suspended and pxCurrentTCB
-                     * must be adjusted to point to a different task. */
-
-                    /* Use a temp variable as a distinct sequence point for reading
-                     * volatile variables prior to a comparison to ensure compliance
-                     * with MISRA C 2012 Rule 13.2. */
-                    uxCurrentListLength = listCURRENT_LIST_LENGTH( &xSuspendedTaskList );
-
-                    if( uxCurrentListLength == uxCurrentNumberOfTasks )
-                    {
-                        /* No other tasks are ready, so set pxCurrentTCB back to
-                         * NULL so when the next task is created pxCurrentTCB will
-                         * be set to point to it no matter what its relative priority
-                         * is. */
-                        pxCurrentTCB = NULL;
-                    }
-                    else
-                    {
-                        vTaskSwitchContext();
-                    }
-                }
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-        }
-        #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
         traceRETURN_vTaskSuspend();
     }
@@ -3404,6 +3665,10 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * const pxTCB = xTaskToResume;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xTaskResumed = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_vTaskResume( xTaskToResume );
 
         /* It does not make sense to resume the calling task. */
@@ -3424,28 +3689,48 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             if( pxTCB != NULL )
         #endif
         {
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
-                if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
-                {
-                    traceTASK_RESUME( pxTCB );
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-                    /* The ready list can be accessed even if the scheduler is
-                     * suspended because this is inside a critical section. */
-                    ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
-                    prvAddTaskToReadyList( pxTCB );
+                    /* If the task being resumed is in a deferred suspension state,
+                     * we simply clear the deferred suspension state and return. */
+                    if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
+                    {
+                        pxTCB->uxDeferredStateChange &= ~tskDEFERRED_SUSPENSION;
+                        xTaskResumed = pdTRUE;
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
+                #endif /* configUSE_TASK_PREEMPTION_DISABLE */
 
-                    /* This yield may not cause the task just resumed to run,
-                     * but will leave the lists in the correct state for the
-                     * next yield. */
-                    taskYIELD_ANY_CORE_IF_USING_PREEMPTION( pxTCB );
-                }
-                else
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                    if( xTaskResumed == pdFALSE )
+                #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
+                    {
+                        traceTASK_RESUME( pxTCB );
+
+                        /* The ready list can be accessed even if the scheduler is
+                         * suspended because this is inside a critical section. */
+                        ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
+                        prvAddTaskToReadyList( pxTCB );
+
+                        /* This yield may not cause the task just resumed to run,
+                         * but will leave the lists in the correct state for the
+                         * next yield. */
+                        taskYIELD_ANY_CORE_IF_USING_PREEMPTION( pxTCB );
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
                 }
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
         }
         else
         {
@@ -3492,7 +3777,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
         {
             if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
             {
@@ -3548,7 +3833,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskResumeFromISR( xYieldRequired );
 
@@ -3930,45 +4215,39 @@ void vTaskSuspendAll( void )
              * do not otherwise exhibit real time behaviour. */
             portSOFTWARE_BARRIER();
 
-            #if ( portUSING_GRANULAR_LOCKS == 1 )
+            kernelGET_TASK_LOCK( xCoreID );
+
+            /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
+             * purpose is to prevent altering the variable when fromISR APIs are readying
+             * it. */
+            if( ( uxSchedulerSuspended == 0U )
+
+                /* If the scheduler is being suspended after taking a granular lock (in any data group)
+                 * then we do not check for the run state of a task and we let it run through until
+                 * the granular lock is released. */
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
+                    && ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+                )
             {
-                portGET_SPINLOCK( &xTaskSpinlock );
-                portGET_SPINLOCK( &xISRSpinlock );
-
-                /* Increment xPreemptionDisable to prevent preemption and also
-                 * track whether to yield in xTaskResumeAll(). */
-                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable++;
-
-                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
-                 * is used to allow calls to vTaskSuspendAll() to nest. */
-                ++uxSchedulerSuspended;
-
-                portRELEASE_SPINLOCK( &xISRSpinlock );
+                prvCheckForRunStateChange();
             }
-            #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+            else
             {
-                portGET_TASK_LOCK();
-
-                /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
-                 * purpose is to prevent altering the variable when fromISR APIs are readying
-                 * it. */
-                if( uxSchedulerSuspended == 0U )
-                {
-                    prvCheckForRunStateChange();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
-
-                portGET_ISR_LOCK();
-
-                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
-                 * is used to allow calls to vTaskSuspendAll() to nest. */
-                ++uxSchedulerSuspended;
-                portRELEASE_ISR_LOCK();
+                mtCOVERAGE_TEST_MARKER();
             }
-            #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+            /* Query the coreID again as prvCheckForRunStateChange may have
+             * caused the task to get scheduled on a different core. The correct
+             * task lock for the core is acquired in prvCheckForRunStateChange. */
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+            kernelGET_ISR_LOCK( xCoreID );
+
+            /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
+             * is used to allow calls to vTaskSuspendAll() to nest. */
+            ++uxSchedulerSuspended;
+            kernelRELEASE_ISR_LOCK( xCoreID );
 
             portCLEAR_INTERRUPT_MASK( ulState );
         }
@@ -4064,7 +4343,7 @@ BaseType_t xTaskResumeAll( void )
          * removed task will have been added to the xPendingReadyList.  Once the
          * scheduler has been resumed it is safe to move all the pending ready
          * tasks from this list into their appropriate ready list. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
@@ -4073,24 +4352,9 @@ BaseType_t xTaskResumeAll( void )
             configASSERT( uxSchedulerSuspended != 0U );
 
             uxSchedulerSuspended = ( UBaseType_t ) ( uxSchedulerSuspended - 1U );
-            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-            {
-                configASSERT( pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable > 0 );
-
-                /* Decrement xPreemptionDisable. If 0, it means this we are not
-                 * in a nested suspension scenario, thus this function and yield
-                 * if necessary. */
-                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable--;
-
-                /* Release the kernel's task spinlock that was held throughout
-                 * the kernel suspension. */
-                portRELEASE_SPINLOCK( &xTaskSpinlock );
-            }
-            #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-            {
-                portRELEASE_TASK_LOCK();
-            }
-            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+            #if ( configNUMBER_OF_CORES > 1 )
+                kernelRELEASE_TASK_LOCK( xCoreID );
+            #endif
 
             if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
             {
@@ -4205,7 +4469,7 @@ BaseType_t xTaskResumeAll( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
     }
 
     traceRETURN_xTaskResumeAll( xAlreadyYielded );
@@ -4634,11 +4898,11 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
             configASSERT( xTicksToJump != ( TickType_t ) 0 );
 
             /* Prevent the tick interrupt modifying xPendedTicks simultaneously. */
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
                 xPendedTicks++;
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
             xTicksToJump--;
         }
         else
@@ -4670,11 +4934,11 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
     vTaskSuspendAll();
 
     /* Prevent the tick interrupt modifying xPendedTicks simultaneously. */
-    taskENTER_CRITICAL();
+    kernelENTER_CRITICAL();
     {
         xPendedTicks += xTicksToCatchUp;
     }
-    taskEXIT_CRITICAL();
+    kernelEXIT_CRITICAL();
     xYieldOccurred = xTaskResumeAll();
 
     traceRETURN_xTaskCatchUpTicks( xYieldOccurred );
@@ -4711,7 +4975,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
                  * the event list too.  Interrupts can touch the event list item,
                  * even though the scheduler is suspended, so a critical section
                  * is used. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
                     {
@@ -4727,7 +4991,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 /* Place the unblocked task into the appropriate ready list. */
                 prvAddTaskToReadyList( pxTCB );
@@ -4754,11 +5018,11 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
                     }
                     #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                     {
-                        taskENTER_CRITICAL();
+                        kernelENTER_CRITICAL();
                         {
                             prvYieldForTask( pxTCB );
                         }
-                        taskEXIT_CRITICAL();
+                        kernelEXIT_CRITICAL();
                     }
                     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
                 }
@@ -4785,7 +5049,15 @@ BaseType_t xTaskIncrementTick( void )
     TickType_t xItemValue;
     BaseType_t xSwitchRequired = pdFALSE;
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        UBaseType_t uxSavedInterruptStatus;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceENTER_xTaskIncrementTick();
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* Called by the portable layer each time a tick interrupt occurs.
      * Increments the tick then checks to see if the new tick value will cause any
@@ -4887,7 +5159,8 @@ BaseType_t xTaskIncrementTick( void )
                             /* Preemption is on, but a context switch should
                              * only be performed if the unblocked task's
                              * priority is higher than the currently executing
-                             * task.
+                             * task and the currently executing task does not
+                             * have preemption disabled.
                              * The case of equal priority tasks sharing
                              * processing time (which happens when both
                              * preemption and time slicing are on) is
@@ -4985,7 +5258,7 @@ BaseType_t xTaskIncrementTick( void )
                 for( xCoreID = 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
                 {
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
+                        if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
                     #endif
                     {
                         if( xYieldPendings[ xCoreID ] != pdFALSE )
@@ -5023,6 +5296,10 @@ BaseType_t xTaskIncrementTick( void )
         #endif
     }
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_xTaskIncrementTick( xSwitchRequired );
 
     return xSwitchRequired;
@@ -5051,11 +5328,11 @@ BaseType_t xTaskIncrementTick( void )
 
         /* Save the hook function in the TCB.  A critical section is required as
          * the value can be accessed from an interrupt. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             xTCB->pxTaskTag = pxHookFunction;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskSetApplicationTaskTag();
     }
@@ -5078,11 +5355,11 @@ BaseType_t xTaskIncrementTick( void )
 
         /* Save the hook function in the TCB.  A critical section is required as
          * the value can be accessed from an interrupt. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             xReturn = pxTCB->pxTaskTag;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGetApplicationTaskTag( xReturn );
 
@@ -5111,11 +5388,11 @@ BaseType_t xTaskIncrementTick( void )
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
         {
             xReturn = pxTCB->pxTaskTag;
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn );
 
@@ -5260,18 +5537,25 @@ BaseType_t xTaskIncrementTick( void )
          *   and move on if another core suspended the scheduler. We should only
          *   do that if the current core has suspended the scheduler. */
 
-        portGET_TASK_LOCK( xCoreID ); /* Must always acquire the task lock first. */
-        portGET_ISR_LOCK( xCoreID );
+        kernelGET_TASK_LOCK( xCoreID ); /* Must always acquire the task lock first. */
+        kernelGET_ISR_LOCK( xCoreID );
         {
             /* vTaskSwitchContext() must never be called from within a critical section.
              * This is not necessarily true for single core FreeRTOS, but it is for this
              * SMP port. */
             configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 );
 
+            /* vTaskSwitchContext() must not be called with a task that has
+             * preemption disabled. */
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                configASSERT( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U );
+            #endif
+
             if( uxSchedulerSuspended != ( UBaseType_t ) 0U )
             {
-                /* The scheduler is currently suspended - do not allow a context
-                 * switch. */
+                /* The scheduler is currently suspended or the task
+                 * has requested to not be preempted - do not allow
+                 * a context switch. */
                 xYieldPendings[ xCoreID ] = pdTRUE;
             }
             else
@@ -5342,8 +5626,8 @@ BaseType_t xTaskIncrementTick( void )
                 #endif
             }
         }
-        portRELEASE_ISR_LOCK( xCoreID );
-        portRELEASE_TASK_LOCK( xCoreID );
+        kernelRELEASE_ISR_LOCK( xCoreID );
+        kernelRELEASE_TASK_LOCK( xCoreID );
 
         traceRETURN_vTaskSwitchContext();
     }
@@ -5357,8 +5641,15 @@ void vTaskPlaceOnEventList( List_t * const pxEventList,
 
     configASSERT( pxEventList );
 
-    /* THIS FUNCTION MUST BE CALLED WITH THE
-     * SCHEDULER SUSPENDED AND THE QUEUE BEING ACCESSED LOCKED. */
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* Suspend the kernel data group as we are about to access its members */
+        vTaskSuspendAll();
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+        /* THIS FUNCTION MUST BE CALLED WITH THE
+         * SCHEDULER SUSPENDED AND THE QUEUE BEING ACCESSED LOCKED. */
+        configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* Place the event list item of the TCB in the appropriate event list.
      * This is placed in the list in priority order so the highest priority task
@@ -5375,6 +5666,11 @@ void vTaskPlaceOnEventList( List_t * const pxEventList,
 
     prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* We are done accessing the kernel data group. Resume it. */
+        ( void ) xTaskResumeAll();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_vTaskPlaceOnEventList();
 }
 /*-----------------------------------------------------------*/
@@ -5387,9 +5683,16 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
     configASSERT( pxEventList );
 
-    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
-     * the event groups implementation. */
-    configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* Suspend the kernel data group as we are about to access its members */
+        vTaskSuspendAll();
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+        /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
+         * the event groups implementation. */
+        configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* Store the item value in the event list item.  It is safe to access the
      * event list item here as interrupts won't access the event list item of a
@@ -5405,6 +5708,11 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
     prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* We are done accessing the kernel data group. Resume it. */
+        ( void ) xTaskResumeAll();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_vTaskPlaceOnUnorderedEventList();
 }
 /*-----------------------------------------------------------*/
@@ -5419,11 +5727,17 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
         configASSERT( pxEventList );
 
-        /* This function should not be called by application code hence the
-         * 'Restricted' in its name.  It is not part of the public API.  It is
-         * designed for use by kernel code, and has special calling requirements -
-         * it should be called with the scheduler suspended. */
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Suspend the kernel data group as we are about to access its members */
+            vTaskSuspendAll();
+        #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
+            /* This function should not be called by application code hence the
+             * 'Restricted' in its name.  It is not part of the public API.  It is
+             * designed for use by kernel code, and has special calling requirements -
+             * it should be called with the scheduler suspended. */
+            configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         /* Place the event list item of the TCB in the appropriate event list.
          * In this case it is assume that this is the only task that is going to
@@ -5442,6 +5756,11 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
         traceTASK_DELAY_UNTIL( ( xTickCount + xTicksToWait ) );
         prvAddCurrentTaskToDelayedList( xTicksToWait, xWaitIndefinitely );
 
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Resume it. */
+            ( void ) xTaskResumeAll();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
         traceRETURN_vTaskPlaceOnEventListRestricted();
     }
 
@@ -5453,10 +5772,34 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
     TCB_t * pxUnblockedTCB;
     BaseType_t xReturn;
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        UBaseType_t uxSavedInterruptStatus;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceENTER_xTaskRemoveFromEventList( pxEventList );
 
-    /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
-     * called from a critical section within an ISR. */
+    #if ( !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) )
+
+        /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
+         * called from a critical section within an ISR. */
+    #else /* #if ( ! ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) ) */
+        /* Lock the kernel data group as we are about to access its members */
+        if( portCHECK_IF_IN_ISR() == pdTRUE )
+        {
+            uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
+        }
+        else
+        {
+            uxSavedInterruptStatus = 0;
+            kernelENTER_CRITICAL();
+        }
+
+        /* Before taking the kernel lock, another task/ISR could have already
+         * emptied the pxEventList. So we insert a check here to see if
+         * pxEventList is empty before attempting to remove an item from it. */
+        if( listLIST_IS_EMPTY( pxEventList ) == pdFALSE )
+        {
+    #endif /* #if ( ! ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) ) */
 
     /* The event list is sorted in priority order, so the first in the list can
      * be removed as it is known to be the highest priority.  Remove the TCB from
@@ -5536,6 +5879,26 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
     }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+}
+else
+{
+    /* The pxEventList was emptied before we entered the critical
+     * section, Nothing to do except return pdFALSE. */
+    xReturn = pdFALSE;
+}
+
+/* We are done accessing the kernel data group. Unlock it. */
+if( portCHECK_IF_IN_ISR() == pdTRUE )
+{
+    kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+}
+else
+{
+    kernelEXIT_CRITICAL();
+}
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_xTaskRemoveFromEventList( xReturn );
     return xReturn;
 }
@@ -5599,13 +5962,13 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
     {
         #if ( configUSE_PREEMPTION == 1 )
         {
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
                 prvYieldForTask( pxUnblockedTCB );
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
         }
-        #endif
+        #endif /* if ( configUSE_PREEMPTION == 1 ) */
     }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
@@ -5618,12 +5981,12 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
     traceENTER_vTaskSetTimeOutState( pxTimeOut );
 
     configASSERT( pxTimeOut );
-    taskENTER_CRITICAL();
+    kernelENTER_CRITICAL();
     {
         pxTimeOut->xOverflowCount = xNumOfOverflows;
         pxTimeOut->xTimeOnEntering = xTickCount;
     }
-    taskEXIT_CRITICAL();
+    kernelEXIT_CRITICAL();
 
     traceRETURN_vTaskSetTimeOutState();
 }
@@ -5633,9 +5996,19 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 {
     traceENTER_vTaskInternalSetTimeOutState( pxTimeOut );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* Lock the kernel data group as we are about to access its members */
+        kernelENTER_CRITICAL();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     /* For internal use only as it does not use a critical section. */
     pxTimeOut->xOverflowCount = xNumOfOverflows;
     pxTimeOut->xTimeOnEntering = xTickCount;
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* We are done accessing the kernel data group. Unlock it. */
+        kernelEXIT_CRITICAL();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     traceRETURN_vTaskInternalSetTimeOutState();
 }
@@ -5651,7 +6024,7 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
     configASSERT( pxTimeOut );
     configASSERT( pxTicksToWait );
 
-    taskENTER_CRITICAL();
+    kernelENTER_CRITICAL();
     {
         /* Minor optimisation.  The tick count cannot change in this block. */
         const TickType_t xConstTickCount = xTickCount;
@@ -5702,7 +6075,7 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
             xReturn = pdTRUE;
         }
     }
-    taskEXIT_CRITICAL();
+    kernelEXIT_CRITICAL();
 
     traceRETURN_xTaskCheckForTimeOut( xReturn );
 
@@ -6004,7 +6377,12 @@ STATIC portTASK_FUNCTION( prvIdleTask,
 
         traceENTER_eTaskConfirmSleepModeStatus();
 
-        /* This function must be called from a critical section. */
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Lock the kernel data group as we are about to access its members */
+            kernelENTER_CRITICAL();
+        #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+            /* This function must be called from a critical section. */
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         if( listCURRENT_LIST_LENGTH( &xPendingReadyList ) != 0U )
         {
@@ -6037,6 +6415,11 @@ STATIC portTASK_FUNCTION( prvIdleTask,
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Unlock it. */
+            kernelEXIT_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         traceRETURN_eTaskConfirmSleepModeStatus( eReturn );
 
@@ -6169,7 +6552,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
         {
             #if ( configNUMBER_OF_CORES == 1 )
             {
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     {
                         /* MISRA Ref 11.5.3 [Void pointer assignment] */
@@ -6181,7 +6564,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
                         --uxDeletedTasksWaitingCleanUp;
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 prvDeleteTCB( pxTCB );
             }
@@ -6189,7 +6572,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
             {
                 pxTCB = NULL;
 
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     /* For SMP, multiple idles can be running simultaneously
                      * and we need to check that other idles did not cleanup while we were
@@ -6212,12 +6595,12 @@ STATIC void prvCheckTasksWaitingTermination( void )
                             /* The TCB to be deleted still has not yet been switched out
                              * by the scheduler, so we will just exit this loop early and
                              * try again next time. */
-                            taskEXIT_CRITICAL();
+                            kernelEXIT_CRITICAL();
                             break;
                         }
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 if( pxTCB != NULL )
                 {
@@ -6339,14 +6722,14 @@ STATIC void prvCheckTasksWaitingTermination( void )
                 /* Tasks can be in pending ready list and other state list at the
                  * same time. These tasks are in ready state no matter what state
                  * list the task is in. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     if( listIS_CONTAINED_WITHIN( &xPendingReadyList, &( pxTCB->xEventListItem ) ) != pdFALSE )
                     {
                         pxTaskStatus->eCurrentState = eReady;
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
             }
         }
         else
@@ -6668,7 +7051,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         else
         {
             #if ( configNUMBER_OF_CORES > 1 )
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
             #endif
             {
                 if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
@@ -6681,7 +7064,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
                 }
             }
             #if ( configNUMBER_OF_CORES > 1 )
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
             #endif
         }
 
@@ -6702,7 +7085,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
         traceENTER_xTaskPriorityInherit( pxMutexHolder );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If the mutex is taken by an interrupt, the mutex holder is NULL. Priority
              * inheritance is not applied in this scenario. */
@@ -6790,7 +7173,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskPriorityInherit( xReturn );
 
@@ -6808,6 +7191,11 @@ STATIC void prvResetNextTaskUnblockTime( void )
         BaseType_t xReturn = pdFALSE;
 
         traceENTER_xTaskPriorityDisinherit( pxMutexHolder );
+
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Lock the kernel data group as we are about to access its members */
+            kernelENTER_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         if( pxMutexHolder != NULL )
         {
@@ -6886,6 +7274,11 @@ STATIC void prvResetNextTaskUnblockTime( void )
             mtCOVERAGE_TEST_MARKER();
         }
 
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Unlock it. */
+            kernelEXIT_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
         traceRETURN_xTaskPriorityDisinherit( xReturn );
 
         return xReturn;
@@ -6905,88 +7298,97 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
         traceENTER_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask );
 
-        if( pxMutexHolder != NULL )
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
+            kernelENTER_CRITICAL();
+        #endif
         {
-            /* If pxMutexHolder is not NULL then the holder must hold at least
-             * one mutex. */
-            configASSERT( pxTCB->uxMutexesHeld );
+            if( pxMutexHolder != NULL )
+            {
+                /* If pxMutexHolder is not NULL then the holder must hold at least
+                 * one mutex. */
+                configASSERT( pxTCB->uxMutexesHeld );
 
-            /* Determine the priority to which the priority of the task that
-             * holds the mutex should be set.  This will be the greater of the
-             * holding task's base priority and the priority of the highest
-             * priority task that is waiting to obtain the mutex. */
-            if( pxTCB->uxBasePriority < uxHighestPriorityWaitingTask )
-            {
-                uxPriorityToUse = uxHighestPriorityWaitingTask;
-            }
-            else
-            {
-                uxPriorityToUse = pxTCB->uxBasePriority;
-            }
-
-            /* Does the priority need to change? */
-            if( pxTCB->uxPriority != uxPriorityToUse )
-            {
-                /* Only disinherit if no other mutexes are held.  This is a
-                 * simplification in the priority inheritance implementation.  If
-                 * the task that holds the mutex is also holding other mutexes then
-                 * the other mutexes may have caused the priority inheritance. */
-                if( pxTCB->uxMutexesHeld == uxOnlyOneMutexHeld )
+                /* Determine the priority to which the priority of the task that
+                 * holds the mutex should be set.  This will be the greater of the
+                 * holding task's base priority and the priority of the highest
+                 * priority task that is waiting to obtain the mutex. */
+                if( pxTCB->uxBasePriority < uxHighestPriorityWaitingTask )
                 {
-                    /* If a task has timed out because it already holds the
-                     * mutex it was trying to obtain then it cannot of inherited
-                     * its own priority. */
-                    configASSERT( pxTCB != pxCurrentTCB );
+                    uxPriorityToUse = uxHighestPriorityWaitingTask;
+                }
+                else
+                {
+                    uxPriorityToUse = pxTCB->uxBasePriority;
+                }
 
-                    /* Disinherit the priority, remembering the previous
-                     * priority to facilitate determining the subject task's
-                     * state. */
-                    traceTASK_PRIORITY_DISINHERIT( pxTCB, uxPriorityToUse );
-                    uxPriorityUsedOnEntry = pxTCB->uxPriority;
-                    pxTCB->uxPriority = uxPriorityToUse;
+                /* Does the priority need to change? */
+                if( pxTCB->uxPriority != uxPriorityToUse )
+                {
+                    /* Only disinherit if no other mutexes are held.  This is a
+                     * simplification in the priority inheritance implementation.  If
+                     * the task that holds the mutex is also holding other mutexes then
+                     * the other mutexes may have caused the priority inheritance. */
+                    if( pxTCB->uxMutexesHeld == uxOnlyOneMutexHeld )
+                    {
+                        /* If a task has timed out because it already holds the
+                         * mutex it was trying to obtain then it cannot of inherited
+                         * its own priority. */
+                        configASSERT( pxTCB != pxCurrentTCB );
 
-                    /* Only reset the event list item value if the value is not
-                     * being used for anything else. */
-                    if( ( listGET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
-                    {
-                        listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) uxPriorityToUse );
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                        /* Disinherit the priority, remembering the previous
+                         * priority to facilitate determining the subject task's
+                         * state. */
+                        traceTASK_PRIORITY_DISINHERIT( pxTCB, uxPriorityToUse );
+                        uxPriorityUsedOnEntry = pxTCB->uxPriority;
+                        pxTCB->uxPriority = uxPriorityToUse;
 
-                    /* If the running task is not the task that holds the mutex
-                     * then the task that holds the mutex could be in either the
-                     * Ready, Blocked or Suspended states.  Only remove the task
-                     * from its current state list if it is in the Ready state as
-                     * the task's priority is going to change and there is one
-                     * Ready list per priority. */
-                    if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ uxPriorityUsedOnEntry ] ), &( pxTCB->xStateListItem ) ) != pdFALSE )
-                    {
-                        if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                        /* Only reset the event list item value if the value is not
+                         * being used for anything else. */
+                        if( ( listGET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
                         {
-                            /* It is known that the task is in its ready list so
-                             * there is no need to check again and the port level
-                             * reset macro can be called directly. */
-                            portRESET_READY_PRIORITY( uxPriorityUsedOnEntry, uxTopReadyPriority );
+                            listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) uxPriorityToUse );
                         }
                         else
                         {
                             mtCOVERAGE_TEST_MARKER();
                         }
 
-                        prvAddTaskToReadyList( pxTCB );
-                        #if ( configNUMBER_OF_CORES > 1 )
+                        /* If the running task is not the task that holds the mutex
+                         * then the task that holds the mutex could be in either the
+                         * Ready, Blocked or Suspended states.  Only remove the task
+                         * from its current state list if it is in the Ready state as
+                         * the task's priority is going to change and there is one
+                         * Ready list per priority. */
+                        if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ uxPriorityUsedOnEntry ] ), &( pxTCB->xStateListItem ) ) != pdFALSE )
                         {
-                            /* The priority of the task is dropped. Yield the core on
-                             * which the task is running. */
-                            if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                            if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
                             {
-                                prvYieldCore( pxTCB->xTaskRunState );
+                                /* It is known that the task is in its ready list so
+                                 * there is no need to check again and the port level
+                                 * reset macro can be called directly. */
+                                portRESET_READY_PRIORITY( uxPriorityUsedOnEntry, uxTopReadyPriority );
                             }
+                            else
+                            {
+                                mtCOVERAGE_TEST_MARKER();
+                            }
+
+                            prvAddTaskToReadyList( pxTCB );
+                            #if ( configNUMBER_OF_CORES > 1 )
+                            {
+                                /* The priority of the task is dropped. Yield the core on
+                                 * which the task is running. */
+                                if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                                {
+                                    prvYieldCore( pxTCB->xTaskRunState );
+                                }
+                            }
+                            #endif /* if ( configNUMBER_OF_CORES > 1 ) */
                         }
-                        #endif /* if ( configNUMBER_OF_CORES > 1 ) */
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
                     }
                     else
                     {
@@ -7003,10 +7405,9 @@ STATIC void prvResetNextTaskUnblockTime( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        else
-        {
-            mtCOVERAGE_TEST_MARKER();
-        }
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
+            kernelEXIT_CRITICAL();
+        #endif
 
         traceRETURN_vTaskPriorityDisinheritAfterTimeout();
     }
@@ -7081,7 +7482,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     void vTaskEnterCritical( void )
     {
@@ -7093,11 +7494,24 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
             if( xSchedulerRunning != pdFALSE )
             {
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                /* When using granular locks, the critical section nesting count
+                 * might have already been incremented if this call is a nested
+                 * call from a data group critical section. Hence, we have to
+                 * acquire the kernel task and ISR locks unconditionally. */
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
                 {
-                    portGET_TASK_LOCK( xCoreID );
-                    portGET_ISR_LOCK( xCoreID );
+                    kernelGET_TASK_LOCK( xCoreID );
+                    kernelGET_ISR_LOCK( xCoreID );
                 }
+                #else /* portUSING_GRANULAR_LOCKS */
+                {
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        kernelGET_TASK_LOCK( xCoreID );
+                        kernelGET_ISR_LOCK( xCoreID );
+                    }
+                }
+                #endif /* portUSING_GRANULAR_LOCKS */
 
                 portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
 
@@ -7130,10 +7544,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskEnterCritical();
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     UBaseType_t vTaskEnterCriticalFromISR( void )
     {
@@ -7146,10 +7560,18 @@ STATIC void prvResetNextTaskUnblockTime( void )
         {
             uxSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
 
-            if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
             {
-                portGET_ISR_LOCK( xCoreID );
+                kernelGET_ISR_LOCK( xCoreID );
             }
+            #else /* portUSING_GRANULAR_LOCKS */
+            {
+                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                {
+                    kernelGET_ISR_LOCK( xCoreID );
+                }
+            }
+            #endif /* portUSING_GRANULAR_LOCKS */
 
             portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
         }
@@ -7163,7 +7585,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         return uxSavedInterruptStatus;
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) )
@@ -7211,7 +7633,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     void vTaskExitCritical( void )
     {
@@ -7231,32 +7653,79 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
             if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U )
             {
-                portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
-
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
                 {
                     BaseType_t xYieldCurrentTask;
 
-                    /* Get the xYieldPending stats inside the critical section. */
-                    xYieldCurrentTask = xYieldPendings[ xCoreID ];
-
-                    portRELEASE_ISR_LOCK( xCoreID );
-                    portRELEASE_TASK_LOCK( xCoreID );
-                    portENABLE_INTERRUPTS();
-
-                    /* When a task yields in a critical section it just sets
-                     * xYieldPending to true. So now that we have exited the
-                     * critical section check if xYieldPending is true, and
-                     * if so yield. */
-                    if( xYieldCurrentTask != pdFALSE )
+                    /* Get the xYieldPending status inside the critical section. */
+                    if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE )
+                        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                            && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
+                            ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
+                        #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+                        )
                     {
-                        portYIELD();
+                        xYieldCurrentTask = pdTRUE;
+                    }
+                    else
+                    {
+                        xYieldCurrentTask = pdFALSE;
+                    }
+
+                    /* Release the ISR and task locks first when using granular locks. */
+                    kernelRELEASE_ISR_LOCK( xCoreID );
+                    kernelRELEASE_TASK_LOCK( xCoreID );
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        portENABLE_INTERRUPTS();
+
+                        /* When a task yields in a critical section it just sets
+                         * xYieldPending to true. So now that we have exited the
+                         * critical section check if xYieldPending is true, and
+                         * if so yield. */
+                        if( xYieldCurrentTask != pdFALSE )
+                        {
+                            portYIELD();
+                        }
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                else
+                #else /* portUSING_GRANULAR_LOCKS */
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    /* Decrement first; release locks and enable interrupts when count reaches zero. */
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        BaseType_t xYieldCurrentTask;
+
+                        /* Get the xYieldPending stats inside the critical section. */
+                        xYieldCurrentTask = xYieldPendings[ xCoreID ];
+
+                        kernelRELEASE_ISR_LOCK( xCoreID );
+                        kernelRELEASE_TASK_LOCK( xCoreID );
+                        portENABLE_INTERRUPTS();
+
+                        /* When a task yields in a critical section it just sets
+                         * xYieldPending to true. So now that we have exited the
+                         * critical section check if xYieldPending is true, and
+                         * if so yield. */
+                        if( xYieldCurrentTask != pdFALSE )
+                        {
+                            portYIELD();
+                        }
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
                 }
+                #endif /* portUSING_GRANULAR_LOCKS */
             }
             else
             {
@@ -7271,10 +7740,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCritical();
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
@@ -7292,17 +7761,28 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
             if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U )
             {
-                portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
+                {
+                    kernelRELEASE_ISR_LOCK( xCoreID );
 
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
-                {
-                    portRELEASE_ISR_LOCK( xCoreID );
-                    portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+                    }
                 }
-                else
+                #else /* portUSING_GRANULAR_LOCKS */
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        kernelRELEASE_ISR_LOCK( xCoreID );
+                        portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+                    }
                 }
+                #endif /* portUSING_GRANULAR_LOCKS */
             }
             else
             {
@@ -7317,29 +7797,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCriticalFromISR();
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-/*-----------------------------------------------------------*/
-
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-
-    BaseType_t xTaskUnlockCanYield( void )
-    {
-        BaseType_t xReturn;
-        BaseType_t xCoreID = portGET_CORE_ID();
-
-        if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE ) && ( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE ) )
-        {
-            xReturn = pdTRUE;
-        }
-        else
-        {
-            xReturn = pdFALSE;
-        }
-
-        return xReturn;
-    }
-
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )
@@ -7753,6 +8211,11 @@ TickType_t uxTaskResetEventItemValue( void )
 
         traceENTER_pvTaskIncrementMutexHeldCount();
 
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Lock the kernel data group as we are about to access its members */
+            kernelENTER_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
         pxTCB = pxCurrentTCB;
 
         /* If xSemaphoreCreateMutex() is called before any tasks have been created
@@ -7761,6 +8224,11 @@ TickType_t uxTaskResetEventItemValue( void )
         {
             ( pxTCB->uxMutexesHeld )++;
         }
+
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Unlock it. */
+            kernelEXIT_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         traceRETURN_pvTaskIncrementMutexHeldCount( pxTCB );
 
@@ -7795,7 +8263,7 @@ TickType_t uxTaskResetEventItemValue( void )
                  * has occurred and set the flag to indicate that we are waiting for
                  * a notification. If we do not do so, a notification sent from an ISR
                  * will get lost. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     /* Only block if the notification count is not already non-zero. */
                     if( pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] == 0U )
@@ -7811,7 +8279,7 @@ TickType_t uxTaskResetEventItemValue( void )
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 /* We are now out of the critical section but the scheduler is still
                  * suspended, so we are safe to do non-deterministic operations such
@@ -7839,7 +8307,7 @@ TickType_t uxTaskResetEventItemValue( void )
             }
         }
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             traceTASK_NOTIFY_TAKE( uxIndexToWaitOn );
             ulReturn = pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ];
@@ -7862,7 +8330,7 @@ TickType_t uxTaskResetEventItemValue( void )
 
             pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskNOT_WAITING_NOTIFICATION;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_ulTaskGenericNotifyTake( ulReturn );
 
@@ -7897,7 +8365,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 /* We MUST enter a critical section to atomically check and update the
                  * task notification value. If we do not do so, a notification from
                  * an ISR will get lost. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     /* Only block if a notification is not already pending. */
                     if( pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] != taskNOTIFICATION_RECEIVED )
@@ -7918,7 +8386,7 @@ TickType_t uxTaskResetEventItemValue( void )
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 /* We are now out of the critical section but the scheduler is still
                  * suspended, so we are safe to do non-deterministic operations such
@@ -7946,7 +8414,7 @@ TickType_t uxTaskResetEventItemValue( void )
             }
         }
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             traceTASK_NOTIFY_WAIT( uxIndexToWaitOn );
 
@@ -7976,7 +8444,7 @@ TickType_t uxTaskResetEventItemValue( void )
 
             pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskNOT_WAITING_NOTIFICATION;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotifyWait( xReturn );
 
@@ -8004,7 +8472,7 @@ TickType_t uxTaskResetEventItemValue( void )
         configASSERT( xTaskToNotify );
         pxTCB = xTaskToNotify;
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             if( pulPreviousNotificationValue != NULL )
             {
@@ -8096,7 +8564,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotify( xReturn );
 
@@ -8148,7 +8616,7 @@ TickType_t uxTaskResetEventItemValue( void )
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             if( pulPreviousNotificationValue != NULL )
             {
@@ -8278,7 +8746,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
             }
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskGenericNotifyFromISR( xReturn );
 
@@ -8326,7 +8794,7 @@ TickType_t uxTaskResetEventItemValue( void )
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             ucOriginalNotifyState = pxTCB->ucNotifyState[ uxIndexToNotify ];
             pxTCB->ucNotifyState[ uxIndexToNotify ] = taskNOTIFICATION_RECEIVED;
@@ -8412,7 +8880,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
             }
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_vTaskGenericNotifyGiveFromISR();
     }
@@ -8437,7 +8905,7 @@ TickType_t uxTaskResetEventItemValue( void )
         pxTCB = prvGetTCBFromHandle( xTask );
         configASSERT( pxTCB != NULL );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             if( pxTCB->ucNotifyState[ uxIndexToClear ] == taskNOTIFICATION_RECEIVED )
             {
@@ -8449,7 +8917,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 xReturn = pdFAIL;
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotifyStateClear( xReturn );
 
@@ -8477,14 +8945,14 @@ TickType_t uxTaskResetEventItemValue( void )
         pxTCB = prvGetTCBFromHandle( xTask );
         configASSERT( pxTCB != NULL );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* Return the notification as it was before the bits were cleared,
              * then clear the bit mask. */
             ulReturn = pxTCB->ulNotifiedValue[ uxIndexToClear ];
             pxTCB->ulNotifiedValue[ uxIndexToClear ] &= ~ulBitsToClear;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_ulTaskGenericNotifyValueClear( ulReturn );
 

--- a/tasks.c
+++ b/tasks.c
@@ -541,6 +541,11 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
 
 #endif
 
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_KERNEL_TASK_SPINLOCK_STATIC;
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_KERNEL_ISR_SPINLOCK_STATIC;
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
 /*-----------------------------------------------------------*/
 
 /* File private functions. --------------------------------*/
@@ -550,14 +555,14 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
  */
 STATIC BaseType_t prvCreateIdleTasks( void );
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
 /*
  * Checks to see if another task moved the current task out of the ready
  * list while it was waiting to enter a critical section and yields, if so.
  */
     STATIC void prvCheckForRunStateChange( void );
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 #if ( configNUMBER_OF_CORES > 1 )
 
@@ -823,7 +828,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
     STATIC void prvCheckForRunStateChange( void )
     {
         UBaseType_t uxPrevCriticalNesting;
@@ -887,7 +892,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             }
         }
     }
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
 
@@ -3925,31 +3930,45 @@ void vTaskSuspendAll( void )
              * do not otherwise exhibit real time behaviour. */
             portSOFTWARE_BARRIER();
 
-            portGET_TASK_LOCK( xCoreID );
-
-            /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
-             * purpose is to prevent altering the variable when fromISR APIs are readying
-             * it. */
-            if( uxSchedulerSuspended == 0U )
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
             {
-                prvCheckForRunStateChange();
+                portGET_SPINLOCK( &xTaskSpinlock );
+                portGET_SPINLOCK( &xISRSpinlock );
+
+                /* Increment xPreemptionDisable to prevent preemption and also
+                 * track whether to yield in xTaskResumeAll(). */
+                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable++;
+
+                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
+                 * is used to allow calls to vTaskSuspendAll() to nest. */
+                ++uxSchedulerSuspended;
+
+                portRELEASE_SPINLOCK( &xISRSpinlock );
             }
-            else
+            #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
             {
-                mtCOVERAGE_TEST_MARKER();
+                portGET_TASK_LOCK();
+
+                /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
+                 * purpose is to prevent altering the variable when fromISR APIs are readying
+                 * it. */
+                if( uxSchedulerSuspended == 0U )
+                {
+                    prvCheckForRunStateChange();
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                portGET_ISR_LOCK();
+
+                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
+                 * is used to allow calls to vTaskSuspendAll() to nest. */
+                ++uxSchedulerSuspended;
+                portRELEASE_ISR_LOCK();
             }
-
-            /* Query the coreID again as prvCheckForRunStateChange may have
-             * caused the task to get scheduled on a different core. The correct
-             * task lock for the core is acquired in prvCheckForRunStateChange. */
-            xCoreID = ( BaseType_t ) portGET_CORE_ID();
-
-            portGET_ISR_LOCK( xCoreID );
-
-            /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
-             * is used to allow calls to vTaskSuspendAll() to nest. */
-            ++uxSchedulerSuspended;
-            portRELEASE_ISR_LOCK( xCoreID );
+            #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
             portCLEAR_INTERRUPT_MASK( ulState );
         }
@@ -4054,7 +4073,24 @@ BaseType_t xTaskResumeAll( void )
             configASSERT( uxSchedulerSuspended != 0U );
 
             uxSchedulerSuspended = ( UBaseType_t ) ( uxSchedulerSuspended - 1U );
-            portRELEASE_TASK_LOCK( xCoreID );
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            {
+                configASSERT( pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable > 0 );
+
+                /* Decrement xPreemptionDisable. If 0, it means this we are not
+                 * in a nested suspension scenario, thus this function and yield
+                 * if necessary. */
+                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable--;
+
+                /* Release the kernel's task spinlock that was held throughout
+                 * the kernel suspension. */
+                portRELEASE_SPINLOCK( &xTaskSpinlock );
+            }
+            #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+            {
+                portRELEASE_TASK_LOCK();
+            }
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
             if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
             {
@@ -7045,7 +7081,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     void vTaskEnterCritical( void )
     {
@@ -7094,11 +7130,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskEnterCritical();
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
-
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     UBaseType_t vTaskEnterCriticalFromISR( void )
     {
@@ -7128,7 +7163,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         return uxSavedInterruptStatus;
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) )
@@ -7176,7 +7211,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     void vTaskExitCritical( void )
     {
@@ -7236,10 +7271,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCritical();
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
@@ -7282,7 +7317,29 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCriticalFromISR();
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+/*-----------------------------------------------------------*/
+
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+    BaseType_t xTaskUnlockCanYield( void )
+    {
+        BaseType_t xReturn;
+        BaseType_t xCoreID = portGET_CORE_ID();
+
+        if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE ) && ( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE ) )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+
+        return xReturn;
+    }
+
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )

--- a/tasks.c
+++ b/tasks.c
@@ -397,7 +397,7 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
     char pcTaskName[ configMAX_TASK_NAME_LEN ]; /**< Descriptive name given to the task when created.  Facilitates debugging only. */
 
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        BaseType_t xPreemptionDisable; /**< Used to prevent the task from being preempted. */
+        UBaseType_t xPreemptionDisable; /**< Used to prevent the task from being preempted. */
     #endif
 
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
@@ -946,7 +946,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             #endif
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE )
+                                    if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
                                 #endif
                                 {
                                     xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
@@ -1252,7 +1252,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 ( xYieldPendings[ uxCore ] == pdFALSE ) )
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == pdFALSE )
+                                    if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == 0U )
                                 #endif
                                 {
                                     xLowestPriority = xTaskPriority;
@@ -2895,7 +2895,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                      * there may now be another task of higher priority that
                      * is ready to execute. */
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxTCB->xPreemptionDisable == pdFALSE )
+                        if( pxTCB->xPreemptionDisable == 0U )
                     #endif
                     {
                         xYieldRequired = pdTRUE;
@@ -3116,7 +3116,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
 
-            pxTCB->xPreemptionDisable = pdTRUE;
+            pxTCB->xPreemptionDisable++;
         }
         taskEXIT_CRITICAL();
 
@@ -3139,12 +3139,13 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
+            configASSERT( pxTCB->xPreemptionDisable > 0U );
 
-            pxTCB->xPreemptionDisable = pdFALSE;
+            pxTCB->xPreemptionDisable--;
 
             if( xSchedulerRunning != pdFALSE )
             {
-                if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                if( ( pxTCB->xPreemptionDisable == 0U ) && ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) )
                 {
                     xCoreID = ( BaseType_t ) pxTCB->xTaskRunState;
                     prvYieldCore( xCoreID );
@@ -4948,7 +4949,7 @@ BaseType_t xTaskIncrementTick( void )
                 for( xCoreID = 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
                 {
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE )
+                        if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
                     #endif
                     {
                         if( xYieldPendings[ xCoreID ] != pdFALSE )

--- a/tasks.c
+++ b/tasks.c
@@ -137,11 +137,15 @@
 /*
  * Macros used by vListTask to indicate which state a task is in.
  */
-#define tskRUNNING_CHAR      ( 'X' )
-#define tskBLOCKED_CHAR      ( 'B' )
-#define tskREADY_CHAR        ( 'R' )
-#define tskDELETED_CHAR      ( 'D' )
-#define tskSUSPENDED_CHAR    ( 'S' )
+#define tskRUNNING_CHAR           ( 'X' )
+#define tskBLOCKED_CHAR           ( 'B' )
+#define tskREADY_CHAR             ( 'R' )
+#define tskDELETED_CHAR           ( 'D' )
+#define tskSUSPENDED_CHAR         ( 'S' )
+
+/* Bits used to record a deferred state change of a task. */
+#define tskDEFERRED_DELETION      ( UBaseType_t ) ( 1U << 0U )
+#define tskDEFERRED_SUSPENSION    ( UBaseType_t ) ( 1U << 1U )
 
 /*
  * Some kernel aware debuggers require the data the debugger needs access to be
@@ -349,7 +353,33 @@
 /* Yields the given core. This must be called from a critical section and xCoreID
  * must be valid. This macro is not required in single core since there is only
  * one core to yield. */
-    #define prvYieldCore( xCoreID )                                                          \
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        #define prvYieldCore( xCoreID )                                                          \
+    do {                                                                                         \
+        if( ( xCoreID ) == ( BaseType_t ) portGET_CORE_ID() )                                    \
+        {                                                                                        \
+            /* Pending a yield for this core since it is in the critical section. */             \
+            xYieldPendings[ ( xCoreID ) ] = pdTRUE;                                              \
+        }                                                                                        \
+        else                                                                                     \
+        {                                                                                        \
+            if( pxCurrentTCBs[ ( xCoreID ) ]->uxPreemptionDisable == 0U )                        \
+            {                                                                                    \
+                /* Request other core to yield if it is not requested before. */                 \
+                if( pxCurrentTCBs[ ( xCoreID ) ]->xTaskRunState != taskTASK_SCHEDULED_TO_YIELD ) \
+                {                                                                                \
+                    portYIELD_CORE( xCoreID );                                                   \
+                    pxCurrentTCBs[ ( xCoreID ) ]->xTaskRunState = taskTASK_SCHEDULED_TO_YIELD;   \
+                }                                                                                \
+            }                                                                                    \
+            else                                                                                 \
+            {                                                                                    \
+                xYieldPendings[ ( xCoreID ) ] = pdTRUE;                                          \
+            }                                                                                    \
+        }                                                                                        \
+    } while( 0 )
+    #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+        #define prvYieldCore( xCoreID )                                                      \
     do {                                                                                     \
         if( ( xCoreID ) == ( BaseType_t ) portGET_CORE_ID() )                                \
         {                                                                                    \
@@ -366,7 +396,40 @@
             }                                                                                \
         }                                                                                    \
     } while( 0 )
+    #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+/*-----------------------------------------------------------*/
+
+/* Macros to take and release kernel spinlocks */
+#if ( configNUMBER_OF_CORES > 1 )
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        #define kernelGET_TASK_LOCK( xCoreID )        portGET_SPINLOCK( xCoreID, &xTaskSpinlock )
+        #define kernelRELEASE_TASK_LOCK( xCoreID )    portRELEASE_SPINLOCK( xCoreID, &xTaskSpinlock )
+        #define kernelGET_ISR_LOCK( xCoreID )         portGET_SPINLOCK( xCoreID, &xISRSpinlock )
+        #define kernelRELEASE_ISR_LOCK( xCoreID )     portRELEASE_SPINLOCK( xCoreID, &xISRSpinlock )
+    #else
+        #define kernelGET_TASK_LOCK( xCoreID )        portGET_TASK_LOCK( xCoreID )
+        #define kernelRELEASE_TASK_LOCK( xCoreID )    portRELEASE_TASK_LOCK( xCoreID )
+        #define kernelGET_ISR_LOCK( xCoreID )         portGET_ISR_LOCK( xCoreID )
+        #define kernelRELEASE_ISR_LOCK( xCoreID )     portRELEASE_ISR_LOCK( xCoreID )
+    #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/*
+ * Macros to mark the start and end of a critical code region.
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define kernelENTER_CRITICAL()                                    vTaskEnterCritical()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           vTaskEnterCriticalFromISR()
+    #define kernelEXIT_CRITICAL()                                     vTaskExitCritical()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    vTaskExitCriticalFromISR( uxSavedInterruptStatus )
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define kernelENTER_CRITICAL()                                    taskENTER_CRITICAL()
+    #define kernelENTER_CRITICAL_FROM_ISR()                           taskENTER_CRITICAL_FROM_ISR()
+    #define kernelEXIT_CRITICAL()                                     taskEXIT_CRITICAL()
+    #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
 /*-----------------------------------------------------------*/
 
 /*
@@ -397,7 +460,11 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
     char pcTaskName[ configMAX_TASK_NAME_LEN ]; /**< Descriptive name given to the task when created.  Facilitates debugging only. */
 
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        UBaseType_t xPreemptionDisable; /**< Used to prevent the task from being preempted. */
+        UBaseType_t uxPreemptionDisable; /**< Used to prevent the task from being preempted. */
+    #endif
+
+    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+        UBaseType_t uxDeferredStateChange; /**< Used to indicate if the task's state change is deferred. */
     #endif
 
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
@@ -532,6 +599,15 @@ STATIC const volatile UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
  * from either an ISR or a task. */
 PRIVILEGED_DATA STATIC volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t ) 0U;
 
+#if ( configNUMBER_OF_CORES > 1 )
+
+/* Core that owns the scheduler suspension. It must never be requested to yield while
+ * it holds the suspension, as it cannot service the yield until it resumes the
+ * scheduler. Set/cleared under the same locks as uxSchedulerSuspended. */
+    PRIVILEGED_DATA STATIC volatile BaseType_t xSchedulerSuspendedFromCore = -1;
+
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
 #if ( configGENERATE_RUN_TIME_STATS == 1 )
 
 /* Do not move these variables to function scope as doing so prevents the
@@ -541,9 +617,10 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
 
 #endif
 
+/* Kernel spinlock variables when using granular locking */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_KERNEL_TASK_SPINLOCK_STATIC;
-    PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_KERNEL_ISR_SPINLOCK_STATIC;
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_SPINLOCK_STATIC;
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_SPINLOCK_STATIC;
 #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
@@ -555,14 +632,14 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
  */
 STATIC BaseType_t prvCreateIdleTasks( void );
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
 /*
  * Checks to see if another task moved the current task out of the ready
  * list while it was waiting to enter a critical section and yields, if so.
  */
     STATIC void prvCheckForRunStateChange( void );
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 #if ( configNUMBER_OF_CORES > 1 )
 
@@ -770,6 +847,13 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) */
 
 /*
+ * Helper function to enable preemption for a task.
+ */
+#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+#endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
+/*
  * freertos_tasks_c_additions_init() should only be called if the user definable
  * macro FREERTOS_TASKS_C_ADDITIONS_INIT() is defined, as that is the only macro
  * called by the function.
@@ -812,10 +896,9 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
     STATIC void prvCheckForRunStateChange( void )
     {
-        UBaseType_t uxPrevCriticalNesting;
         const TCB_t * pxThisTCB;
         BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
@@ -828,6 +911,8 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
         while( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD )
         {
+            UBaseType_t uxPrevCriticalNesting;
+
             /* We are only here if we just entered a critical section
             * or if we just suspended the scheduler, and another task
             * has requested that we yield.
@@ -841,7 +926,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             if( uxPrevCriticalNesting > 0U )
             {
                 portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
-                portRELEASE_ISR_LOCK( xCoreID );
+                kernelRELEASE_ISR_LOCK( xCoreID );
             }
             else
             {
@@ -850,7 +935,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                 mtCOVERAGE_TEST_MARKER();
             }
 
-            portRELEASE_TASK_LOCK( xCoreID );
+            kernelRELEASE_TASK_LOCK( xCoreID );
             portMEMORY_BARRIER();
             configASSERT( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD );
 
@@ -865,18 +950,18 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             portDISABLE_INTERRUPTS();
 
             xCoreID = ( BaseType_t ) portGET_CORE_ID();
-            portGET_TASK_LOCK( xCoreID );
-            portGET_ISR_LOCK( xCoreID );
+            kernelGET_TASK_LOCK( xCoreID );
+            kernelGET_ISR_LOCK( xCoreID );
 
             portSET_CRITICAL_NESTING_COUNT( xCoreID, uxPrevCriticalNesting );
 
             if( uxPrevCriticalNesting == 0U )
             {
-                portRELEASE_ISR_LOCK( xCoreID );
+                kernelRELEASE_ISR_LOCK( xCoreID );
             }
         }
     }
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 /*-----------------------------------------------------------*/
 
@@ -935,12 +1020,23 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             #endif
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
-                                #endif
+                                {
+                                    if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+                                    {
+                                        xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
+                                        xLowestPriorityCore = xCoreID;
+                                    }
+                                    else
+                                    {
+                                        xYieldPendings[ xCoreID ] = pdTRUE;
+                                    }
+                                }
+                                #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                                 {
                                     xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
                                     xLowestPriorityCore = xCoreID;
                                 }
+                                #endif /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                             }
                         }
                         else
@@ -1241,12 +1337,23 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 ( xYieldPendings[ uxCore ] == pdFALSE ) )
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == 0U )
-                                #endif
+                                {
+                                    if( pxCurrentTCBs[ uxCore ]->uxPreemptionDisable == 0U )
+                                    {
+                                        xLowestPriority = xTaskPriority;
+                                        xLowestPriorityCore = ( BaseType_t ) uxCore;
+                                    }
+                                    else
+                                    {
+                                        xYieldPendings[ uxCore ] = pdTRUE;
+                                    }
+                                }
+                                #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                                 {
                                     xLowestPriority = xTaskPriority;
                                     xLowestPriorityCore = ( BaseType_t ) uxCore;
                                 }
+                                #endif /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                             }
                         }
                     }
@@ -2046,7 +2153,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         /* Ensure interrupts don't access the task lists while the lists are being
          * updated. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             uxCurrentNumberOfTasks = ( UBaseType_t ) ( uxCurrentNumberOfTasks + 1U );
 
@@ -2104,7 +2211,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             portSETUP_TCB( pxNewTCB );
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -2124,7 +2231,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         /* Ensure interrupts don't access the task lists while the lists are being
          * updated. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             uxCurrentNumberOfTasks++;
 
@@ -2173,7 +2280,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
     }
 
 #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
@@ -2220,144 +2327,173 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         BaseType_t xDeleteTCBInIdleTask = pdFALSE;
         BaseType_t xTaskIsRunningOrYielding;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xDeferredDeletion = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_vTaskDelete( xTaskToDelete );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If null is passed in here then it is the calling task that is
              * being deleted. */
             pxTCB = prvGetTCBFromHandle( xTaskToDelete );
             configASSERT( pxTCB != NULL );
 
-            /* Remove task from the ready/delayed list. */
-            if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
-            {
-                taskRESET_READY_PRIORITY( pxTCB->uxPriority );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-            /* Is the task waiting on an event also? */
-            if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
-            {
-                ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            /* Increment the uxTaskNumber also so kernel aware debuggers can
-             * detect that the task lists need re-generating.  This is done before
-             * portPRE_TASK_DELETE_HOOK() as in the Windows port that macro will
-             * not return. */
-            uxTaskNumber++;
-
-            /* Use temp variable as distinct sequence points for reading volatile
-             * variables prior to a logical operator to ensure compliance with
-             * MISRA C 2012 Rule 13.5. */
-            xTaskIsRunningOrYielding = taskTASK_IS_RUNNING_OR_SCHEDULED_TO_YIELD( pxTCB );
-
-            /* If the task is running (or yielding), we must add it to the
-             * termination list so that an idle task can delete it when it is
-             * no longer running. */
-            if( ( xSchedulerRunning != pdFALSE ) && ( xTaskIsRunningOrYielding != pdFALSE ) )
-            {
-                /* A running task or a task which is scheduled to yield is being
-                 * deleted. This cannot complete when the task is still running
-                 * on a core, as a context switch to another task is required.
-                 * Place the task in the termination list. The idle task will check
-                 * the termination list and free up any memory allocated by the
-                 * scheduler for the TCB and stack of the deleted task. */
-                vListInsertEnd( &xTasksWaitingTermination, &( pxTCB->xStateListItem ) );
-
-                /* Increment the ucTasksDeleted variable so the idle task knows
-                 * there is a task that has been deleted and that it should therefore
-                 * check the xTasksWaitingTermination list. */
-                ++uxDeletedTasksWaitingCleanUp;
-
-                /* Call the delete hook before portPRE_TASK_DELETE_HOOK() as
-                 * portPRE_TASK_DELETE_HOOK() does not return in the Win32 port. */
-                traceTASK_DELETE( pxTCB );
-
-                /* Delete the task TCB in idle task. */
-                xDeleteTCBInIdleTask = pdTRUE;
-
-                /* The pre-delete hook is primarily for the Windows simulator,
-                 * in which Windows specific clean up operations are performed,
-                 * after which it is not possible to yield away from this task -
-                 * hence xYieldPending is used to latch that a context switch is
-                 * required. */
-                #if ( configNUMBER_OF_CORES == 1 )
-                    portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ 0 ] ) );
-                #else
-                    portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ pxTCB->xTaskRunState ] ) );
-                #endif
-
-                /* In the case of SMP, it is possible that the task being deleted
-                 * is running on another core. We must evict the task before
-                 * exiting the critical section to ensure that the task cannot
-                 * take an action which puts it back on ready/state/event list,
-                 * thereby nullifying the delete operation. Once evicted, the
-                 * task won't be scheduled ever as it will no longer be on the
-                 * ready list. */
-                #if ( configNUMBER_OF_CORES > 1 )
+                /* If the task has disabled preemption, we need to defer the deletion until the
+                 * task enables preemption. The deletion will be performed in vTaskPreemptionEnable(). */
+                if( pxTCB->uxPreemptionDisable > 0U )
                 {
-                    if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
-                    {
-                        if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
-                        {
-                            configASSERT( uxSchedulerSuspended == 0 );
-                            taskYIELD_WITHIN_API();
-                        }
-                        else
-                        {
-                            prvYieldCore( pxTCB->xTaskRunState );
-                        }
-                    }
-                }
-                #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
-            }
-            else
-            {
-                --uxCurrentNumberOfTasks;
-                traceTASK_DELETE( pxTCB );
-
-                /* Reset the next expected unblock time in case it referred to
-                 * the task that has just been deleted. */
-                prvResetNextTaskUnblockTime();
-            }
-        }
-        taskEXIT_CRITICAL();
-
-        /* If the task is not deleting itself, call prvDeleteTCB from outside of
-         * critical section. If a task deletes itself, prvDeleteTCB is called
-         * from prvCheckTasksWaitingTermination which is called from Idle task. */
-        if( xDeleteTCBInIdleTask != pdTRUE )
-        {
-            prvDeleteTCB( pxTCB );
-        }
-
-        /* Force a reschedule if it is the currently running task that has just
-         * been deleted. */
-        #if ( configNUMBER_OF_CORES == 1 )
-        {
-            if( xSchedulerRunning != pdFALSE )
-            {
-                if( pxTCB == pxCurrentTCB )
-                {
-                    configASSERT( uxSchedulerSuspended == 0 );
-                    taskYIELD_WITHIN_API();
+                    pxTCB->uxDeferredStateChange |= tskDEFERRED_DELETION;
+                    xDeferredDeletion = pdTRUE;
                 }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                if( xDeferredDeletion == pdFALSE )
+            #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+            {
+                /* Remove task from the ready/delayed list. */
+                if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                {
+                    taskRESET_READY_PRIORITY( pxTCB->uxPriority );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                /* Is the task waiting on an event also? */
+                if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
+                {
+                    ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                /* Increment the uxTaskNumber also so kernel aware debuggers can
+                 * detect that the task lists need re-generating.  This is done before
+                 * portPRE_TASK_DELETE_HOOK() as in the Windows port that macro will
+                 * not return. */
+                uxTaskNumber++;
+
+                /* Use temp variable as distinct sequence points for reading volatile
+                 * variables prior to a logical operator to ensure compliance with
+                 * MISRA C 2012 Rule 13.5. */
+                xTaskIsRunningOrYielding = taskTASK_IS_RUNNING_OR_SCHEDULED_TO_YIELD( pxTCB );
+
+                /* If the task is running (or yielding), we must add it to the
+                 * termination list so that an idle task can delete it when it is
+                 * no longer running. */
+                if( ( xSchedulerRunning != pdFALSE ) && ( xTaskIsRunningOrYielding != pdFALSE ) )
+                {
+                    /* A running task or a task which is scheduled to yield is being
+                     * deleted. This cannot complete when the task is still running
+                     * on a core, as a context switch to another task is required.
+                     * Place the task in the termination list. The idle task will check
+                     * the termination list and free up any memory allocated by the
+                     * scheduler for the TCB and stack of the deleted task. */
+                    vListInsertEnd( &xTasksWaitingTermination, &( pxTCB->xStateListItem ) );
+
+                    /* Increment the ucTasksDeleted variable so the idle task knows
+                     * there is a task that has been deleted and that it should therefore
+                     * check the xTasksWaitingTermination list. */
+                    ++uxDeletedTasksWaitingCleanUp;
+
+                    /* Call the delete hook before portPRE_TASK_DELETE_HOOK() as
+                     * portPRE_TASK_DELETE_HOOK() does not return in the Win32 port. */
+                    traceTASK_DELETE( pxTCB );
+
+                    /* Delete the task TCB in idle task. */
+                    xDeleteTCBInIdleTask = pdTRUE;
+
+                    /* The pre-delete hook is primarily for the Windows simulator,
+                     * in which Windows specific clean up operations are performed,
+                     * after which it is not possible to yield away from this task -
+                     * hence xYieldPending is used to latch that a context switch is
+                     * required. */
+                    #if ( configNUMBER_OF_CORES == 1 )
+                        portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ 0 ] ) );
+                    #else
+                        portPRE_TASK_DELETE_HOOK( pxTCB, &( xYieldPendings[ pxTCB->xTaskRunState ] ) );
+                    #endif
+
+                    /* In the case of SMP, it is possible that the task being deleted
+                     * is running on another core. We must evict the task before
+                     * exiting the critical section to ensure that the task cannot
+                     * take an action which puts it back on ready/state/event list,
+                     * thereby nullifying the delete operation. Once evicted, the
+                     * task won't be scheduled ever as it will no longer be on the
+                     * ready list. */
+                    #if ( configNUMBER_OF_CORES > 1 )
+                    {
+                        if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                        {
+                            if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+                            {
+                                configASSERT( uxSchedulerSuspended == 0 );
+                                taskYIELD_WITHIN_API();
+                            }
+                            else
+                            {
+                                prvYieldCore( pxTCB->xTaskRunState );
+                            }
+                        }
+                    }
+                    #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+                }
+                else
+                {
+                    --uxCurrentNumberOfTasks;
+                    traceTASK_DELETE( pxTCB );
+
+                    /* Reset the next expected unblock time in case it referred to
+                     * the task that has just been deleted. */
+                    prvResetNextTaskUnblockTime();
+                }
             }
         }
-        #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+        kernelEXIT_CRITICAL();
+
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            if( xDeferredDeletion == pdFALSE )
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+        {
+            /* If the task is not deleting itself, call prvDeleteTCB from outside of
+             * critical section. If a task deletes itself, prvDeleteTCB is called
+             * from prvCheckTasksWaitingTermination which is called from Idle task. */
+            if( xDeleteTCBInIdleTask != pdTRUE )
+            {
+                prvDeleteTCB( pxTCB );
+            }
+
+            /* Force a reschedule if it is the currently running task that has just
+             * been deleted. */
+            #if ( configNUMBER_OF_CORES == 1 )
+            {
+                if( xSchedulerRunning != pdFALSE )
+                {
+                    if( pxTCB == pxCurrentTCB )
+                    {
+                        configASSERT( uxSchedulerSuspended == 0 );
+                        taskYIELD_WITHIN_API();
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
+                }
+            }
+            #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+        }
 
         traceRETURN_vTaskDelete();
     }
@@ -2580,14 +2716,14 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             else
         #endif
         {
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
                 pxStateList = listLIST_ITEM_CONTAINER( &( pxTCB->xStateListItem ) );
                 pxEventList = listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) );
                 pxDelayedList = pxDelayedTaskList;
                 pxOverflowedDelayedList = pxOverflowDelayedTaskList;
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
 
             if( pxEventList == &xPendingReadyList )
             {
@@ -2697,7 +2833,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskPriorityGet( xTask );
 
-        portBASE_TYPE_ENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             /* If null is passed in here then it is the priority of the task
              * that called uxTaskPriorityGet() that is being queried. */
@@ -2706,7 +2850,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxPriority;
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_uxTaskPriorityGet( uxReturn );
 
@@ -2747,7 +2899,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             /* If null is passed in here then it is the priority of the calling
              * task that is being queried. */
@@ -2756,7 +2908,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxPriority;
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_uxTaskPriorityGetFromISR( uxReturn );
 
@@ -2775,7 +2927,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskBasePriorityGet( xTask );
 
-        portBASE_TYPE_ENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             /* If null is passed in here then it is the base priority of the task
              * that called uxTaskBasePriorityGet() that is being queried. */
@@ -2784,7 +2944,15 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxBasePriority;
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_uxTaskBasePriorityGet( uxReturn );
 
@@ -2825,7 +2993,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             /* If null is passed in here then it is the base priority of the calling
              * task that is being queried. */
@@ -2834,7 +3002,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxBasePriority;
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_uxTaskBasePriorityGetFromISR( uxReturn );
 
@@ -2871,7 +3039,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             mtCOVERAGE_TEST_MARKER();
         }
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If null is passed in here then it is the priority of the calling
              * task that is being changed. */
@@ -2932,12 +3100,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     /* Setting the priority of a running task down means
                      * there may now be another task of higher priority that
                      * is ready to execute. */
-                    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxTCB->xPreemptionDisable == 0U )
-                    #endif
-                    {
-                        xYieldRequired = pdTRUE;
-                    }
+                    xYieldRequired = pdTRUE;
                 }
                 else
                 {
@@ -3051,7 +3214,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 ( void ) uxPriorityUsedOnEntry;
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskPrioritySet();
     }
@@ -3068,7 +3231,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskCoreAffinitySet( xTask, uxCoreAffinityMask );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
@@ -3109,7 +3272,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 }
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskCoreAffinitySet();
     }
@@ -3124,14 +3287,30 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskCoreAffinityGet( xTask );
 
-        portBASE_TYPE_ENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
 
             uxCoreAffinityMask = pxTCB->uxCoreAffinityMask;
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            kernelEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask );
 
@@ -3149,14 +3328,21 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskPreemptionDisable( xTask );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
-            pxTCB = prvGetTCBFromHandle( xTask );
-            configASSERT( pxTCB != NULL );
+            if( xSchedulerRunning != pdFALSE )
+            {
+                pxTCB = prvGetTCBFromHandle( xTask );
+                configASSERT( pxTCB != NULL );
 
-            pxTCB->xPreemptionDisable++;
+                pxTCB->uxPreemptionDisable++;
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskPreemptionDisable();
     }
@@ -3166,31 +3352,86 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-    void vTaskPreemptionEnable( const TaskHandle_t xTask )
+    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask )
     {
         TCB_t * pxTCB;
-        BaseType_t xCoreID;
+        UBaseType_t uxDeferredAction = 0U;
+        BaseType_t xAlreadyYielded = pdFALSE;
 
         traceENTER_vTaskPreemptionEnable( xTask );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
-            pxTCB = prvGetTCBFromHandle( xTask );
-            configASSERT( pxTCB != NULL );
-            configASSERT( pxTCB->xPreemptionDisable > 0U );
-
-            pxTCB->xPreemptionDisable--;
-
             if( xSchedulerRunning != pdFALSE )
             {
-                if( ( pxTCB->xPreemptionDisable == 0U ) && ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) )
+                pxTCB = prvGetTCBFromHandle( xTask );
+                configASSERT( pxTCB != NULL );
+                configASSERT( pxTCB->uxPreemptionDisable > 0U );
+
+                pxTCB->uxPreemptionDisable--;
+
+                if( pxTCB->uxPreemptionDisable == 0U )
                 {
-                    xCoreID = ( BaseType_t ) pxTCB->xTaskRunState;
-                    prvYieldCore( xCoreID );
+                    if( pxTCB->uxDeferredStateChange != 0U )
+                    {
+                        uxDeferredAction = pxTCB->uxDeferredStateChange;
+                    }
+                    else
+                    {
+                        if( ( xYieldPendings[ pxTCB->xTaskRunState ] != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) != pdFALSE ) )
+                        {
+                            prvYieldCore( pxTCB->xTaskRunState );
+                            xAlreadyYielded = pdTRUE;
+                        }
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
+                    }
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
                 }
             }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
+
+        if( uxDeferredAction != 0U )
+        {
+            if( uxDeferredAction & tskDEFERRED_DELETION )
+            {
+                vTaskDelete( xTask );
+            }
+            else if( uxDeferredAction & tskDEFERRED_SUSPENSION )
+            {
+                vTaskSuspend( xTask );
+            }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
+
+            /* Any deferred action on the task would result in a context switch. */
+            xAlreadyYielded = pdTRUE;
+        }
+
+        return xAlreadyYielded;
+    }
+#endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+
+    void vTaskPreemptionEnable( const TaskHandle_t xTask )
+    {
+        traceENTER_vTaskPreemptionEnable( xTask );
+
+        ( void ) prvTaskPreemptionEnable( xTask );
 
         traceRETURN_vTaskPreemptionEnable();
     }
@@ -3204,82 +3445,110 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * pxTCB;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xDeferredSuspension = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_vTaskSuspend( xTaskToSuspend );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If null is passed in here then it is the running task that is
              * being suspended. */
             pxTCB = prvGetTCBFromHandle( xTaskToSuspend );
             configASSERT( pxTCB != NULL );
 
-            traceTASK_SUSPEND( pxTCB );
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-            /* Remove task from the ready/delayed list and place in the
-             * suspended list. */
-            if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
-            {
-                taskRESET_READY_PRIORITY( pxTCB->uxPriority );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            /* Is the task waiting on an event also? */
-            if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
-            {
-                ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            vListInsertEnd( &xSuspendedTaskList, &( pxTCB->xStateListItem ) );
-
-            #if ( configUSE_TASK_NOTIFICATIONS == 1 )
-            {
-                BaseType_t x;
-
-                for( x = ( BaseType_t ) 0; x < ( BaseType_t ) configTASK_NOTIFICATION_ARRAY_ENTRIES; x++ )
+                /* If the task has disabled preemption, we need to defer the suspension until the
+                 * task enables preemption. The suspension will be performed in vTaskPreemptionEnable(). */
+                if( pxTCB->uxPreemptionDisable > 0U )
                 {
-                    if( pxTCB->ucNotifyState[ x ] == taskWAITING_NOTIFICATION )
+                    pxTCB->uxDeferredStateChange |= tskDEFERRED_SUSPENSION;
+                    xDeferredSuspension = pdTRUE;
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                if( xDeferredSuspension == pdFALSE )
+            #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+            {
+                traceTASK_SUSPEND( pxTCB );
+
+                /* Remove task from the ready/delayed list and place in the
+                 * suspended list. */
+                if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                {
+                    taskRESET_READY_PRIORITY( pxTCB->uxPriority );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                /* Is the task waiting on an event also? */
+                if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
+                {
+                    ( void ) uxListRemove( &( pxTCB->xEventListItem ) );
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                vListInsertEnd( &xSuspendedTaskList, &( pxTCB->xStateListItem ) );
+
+                #if ( configUSE_TASK_NOTIFICATIONS == 1 )
+                {
+                    BaseType_t x;
+
+                    for( x = ( BaseType_t ) 0; x < ( BaseType_t ) configTASK_NOTIFICATION_ARRAY_ENTRIES; x++ )
                     {
-                        /* The task was blocked to wait for a notification, but is
-                         * now suspended, so no notification was received. */
-                        pxTCB->ucNotifyState[ x ] = taskNOT_WAITING_NOTIFICATION;
+                        if( pxTCB->ucNotifyState[ x ] == taskWAITING_NOTIFICATION )
+                        {
+                            /* The task was blocked to wait for a notification, but is
+                             * now suspended, so no notification was received. */
+                            pxTCB->ucNotifyState[ x ] = taskNOT_WAITING_NOTIFICATION;
+                        }
                     }
                 }
-            }
-            #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
+                #endif /* if ( configUSE_TASK_NOTIFICATIONS == 1 ) */
 
-            /* In the case of SMP, it is possible that the task being suspended
-             * is running on another core. We must evict the task before
-             * exiting the critical section to ensure that the task cannot
-             * take an action which puts it back on ready/state/event list,
-             * thereby nullifying the suspend operation. Once evicted, the
-             * task won't be scheduled before it is resumed as it will no longer
-             * be on the ready list. */
-            #if ( configNUMBER_OF_CORES > 1 )
-            {
-                if( xSchedulerRunning != pdFALSE )
+                /* In the case of SMP, it is possible that the task being suspended
+                 * is running on another core. We must evict the task before
+                 * exiting the critical section to ensure that the task cannot
+                 * take an action which puts it back on ready/state/event list,
+                 * thereby nullifying the suspend operation. Once evicted, the
+                 * task won't be scheduled before it is resumed as it will no longer
+                 * be on the ready list. */
+                #if ( configNUMBER_OF_CORES > 1 )
                 {
-                    /* Reset the next expected unblock time in case it referred to the
-                     * task that is now in the Suspended state. */
-                    prvResetNextTaskUnblockTime();
-
-                    if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                    if( xSchedulerRunning != pdFALSE )
                     {
-                        if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+                        /* Reset the next expected unblock time in case it referred to the
+                         * task that is now in the Suspended state. */
+                        prvResetNextTaskUnblockTime();
+
+                        if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
                         {
-                            /* The current task has just been suspended. */
-                            configASSERT( uxSchedulerSuspended == 0 );
-                            vTaskYieldWithinAPI();
+                            if( pxTCB->xTaskRunState == ( BaseType_t ) portGET_CORE_ID() )
+                            {
+                                /* The current task has just been suspended. */
+                                configASSERT( uxSchedulerSuspended == 0 );
+                                vTaskYieldWithinAPI();
+                            }
+                            else
+                            {
+                                prvYieldCore( pxTCB->xTaskRunState );
+                            }
                         }
                         else
                         {
-                            prvYieldCore( pxTCB->xTaskRunState );
+                            mtCOVERAGE_TEST_MARKER();
                         }
                     }
                     else
@@ -3287,73 +3556,74 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
+                #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+            }
+        }
+        kernelEXIT_CRITICAL();
+
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            if( xDeferredSuspension == pdFALSE )
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+        {
+            #if ( configNUMBER_OF_CORES == 1 )
+            {
+                UBaseType_t uxCurrentListLength;
+
+                if( xSchedulerRunning != pdFALSE )
+                {
+                    /* Reset the next expected unblock time in case it referred to the
+                     * task that is now in the Suspended state. */
+                    kernelENTER_CRITICAL();
+                    {
+                        prvResetNextTaskUnblockTime();
+                    }
+                    kernelEXIT_CRITICAL();
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                if( pxTCB == pxCurrentTCB )
+                {
+                    if( xSchedulerRunning != pdFALSE )
+                    {
+                        /* The current task has just been suspended. */
+                        configASSERT( uxSchedulerSuspended == 0 );
+                        portYIELD_WITHIN_API();
+                    }
+                    else
+                    {
+                        /* The scheduler is not running, but the task that was pointed
+                         * to by pxCurrentTCB has just been suspended and pxCurrentTCB
+                         * must be adjusted to point to a different task. */
+
+                        /* Use a temp variable as a distinct sequence point for reading
+                         * volatile variables prior to a comparison to ensure compliance
+                         * with MISRA C 2012 Rule 13.2. */
+                        uxCurrentListLength = listCURRENT_LIST_LENGTH( &xSuspendedTaskList );
+
+                        if( uxCurrentListLength == uxCurrentNumberOfTasks )
+                        {
+                            /* No other tasks are ready, so set pxCurrentTCB back to
+                             * NULL so when the next task is created pxCurrentTCB will
+                             * be set to point to it no matter what its relative priority
+                             * is. */
+                            pxCurrentTCB = NULL;
+                        }
+                        else
+                        {
+                            vTaskSwitchContext();
+                        }
+                    }
+                }
                 else
                 {
                     mtCOVERAGE_TEST_MARKER();
                 }
             }
-            #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+            #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
         }
-        taskEXIT_CRITICAL();
-
-        #if ( configNUMBER_OF_CORES == 1 )
-        {
-            UBaseType_t uxCurrentListLength;
-
-            if( xSchedulerRunning != pdFALSE )
-            {
-                /* Reset the next expected unblock time in case it referred to the
-                 * task that is now in the Suspended state. */
-                taskENTER_CRITICAL();
-                {
-                    prvResetNextTaskUnblockTime();
-                }
-                taskEXIT_CRITICAL();
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-
-            if( pxTCB == pxCurrentTCB )
-            {
-                if( xSchedulerRunning != pdFALSE )
-                {
-                    /* The current task has just been suspended. */
-                    configASSERT( uxSchedulerSuspended == 0 );
-                    portYIELD_WITHIN_API();
-                }
-                else
-                {
-                    /* The scheduler is not running, but the task that was pointed
-                     * to by pxCurrentTCB has just been suspended and pxCurrentTCB
-                     * must be adjusted to point to a different task. */
-
-                    /* Use a temp variable as a distinct sequence point for reading
-                     * volatile variables prior to a comparison to ensure compliance
-                     * with MISRA C 2012 Rule 13.2. */
-                    uxCurrentListLength = listCURRENT_LIST_LENGTH( &xSuspendedTaskList );
-
-                    if( uxCurrentListLength == uxCurrentNumberOfTasks )
-                    {
-                        /* No other tasks are ready, so set pxCurrentTCB back to
-                         * NULL so when the next task is created pxCurrentTCB will
-                         * be set to point to it no matter what its relative priority
-                         * is. */
-                        pxCurrentTCB = NULL;
-                    }
-                    else
-                    {
-                        vTaskSwitchContext();
-                    }
-                }
-            }
-            else
-            {
-                mtCOVERAGE_TEST_MARKER();
-            }
-        }
-        #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
         traceRETURN_vTaskSuspend();
     }
@@ -3437,6 +3707,10 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         TCB_t * const pxTCB = xTaskToResume;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xTaskResumed = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_vTaskResume( xTaskToResume );
 
         /* It does not make sense to resume the calling task. */
@@ -3457,28 +3731,48 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             if( pxTCB != NULL )
         #endif
         {
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
-                if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
-                {
-                    traceTASK_RESUME( pxTCB );
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-                    /* The ready list can be accessed even if the scheduler is
-                     * suspended because this is inside a critical section. */
-                    ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
-                    prvAddTaskToReadyList( pxTCB );
+                    /* If the task being resumed is in a deferred suspension state,
+                     * we simply clear the deferred suspension state and return. */
+                    if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
+                    {
+                        pxTCB->uxDeferredStateChange &= ~tskDEFERRED_SUSPENSION;
+                        xTaskResumed = pdTRUE;
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
+                #endif /* configUSE_TASK_PREEMPTION_DISABLE */
 
-                    /* This yield may not cause the task just resumed to run,
-                     * but will leave the lists in the correct state for the
-                     * next yield. */
-                    taskYIELD_ANY_CORE_IF_USING_PREEMPTION( pxTCB );
-                }
-                else
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                    if( xTaskResumed == pdFALSE )
+                #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
+                    {
+                        traceTASK_RESUME( pxTCB );
+
+                        /* The ready list can be accessed even if the scheduler is
+                         * suspended because this is inside a critical section. */
+                        ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
+                        prvAddTaskToReadyList( pxTCB );
+
+                        /* This yield may not cause the task just resumed to run,
+                         * but will leave the lists in the correct state for the
+                         * next yield. */
+                        taskYIELD_ANY_CORE_IF_USING_PREEMPTION( pxTCB );
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
                 }
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
         }
         else
         {
@@ -3525,7 +3819,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
         {
             if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
             {
@@ -3581,7 +3875,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskResumeFromISR( xYieldRequired );
 
@@ -3963,45 +4257,45 @@ void vTaskSuspendAll( void )
              * do not otherwise exhibit real time behaviour. */
             portSOFTWARE_BARRIER();
 
-            #if ( portUSING_GRANULAR_LOCKS == 1 )
+            kernelGET_TASK_LOCK( xCoreID );
+
+            /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
+             * purpose is to prevent altering the variable when fromISR APIs are readying
+             * it. */
+            if( ( uxSchedulerSuspended == 0U )
+
+                /* If the scheduler is being suspended after taking a granular lock (in any data group)
+                 * then we do not check for the run state of a task and we let it run through until
+                 * the granular lock is released. */
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
+                    && ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+                )
             {
-                portGET_SPINLOCK( &xTaskSpinlock );
-                portGET_SPINLOCK( &xISRSpinlock );
-
-                /* Increment xPreemptionDisable to prevent preemption and also
-                 * track whether to yield in xTaskResumeAll(). */
-                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable++;
-
-                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
-                 * is used to allow calls to vTaskSuspendAll() to nest. */
-                ++uxSchedulerSuspended;
-
-                portRELEASE_SPINLOCK( &xISRSpinlock );
+                prvCheckForRunStateChange();
             }
-            #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+            else
             {
-                portGET_TASK_LOCK();
-
-                /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
-                 * purpose is to prevent altering the variable when fromISR APIs are readying
-                 * it. */
-                if( uxSchedulerSuspended == 0U )
-                {
-                    prvCheckForRunStateChange();
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
-
-                portGET_ISR_LOCK();
-
-                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
-                 * is used to allow calls to vTaskSuspendAll() to nest. */
-                ++uxSchedulerSuspended;
-                portRELEASE_ISR_LOCK();
+                mtCOVERAGE_TEST_MARKER();
             }
-            #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+            /* Query the coreID again as prvCheckForRunStateChange may have
+             * caused the task to get scheduled on a different core. The correct
+             * task lock for the core is acquired in prvCheckForRunStateChange. */
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+            kernelGET_ISR_LOCK( xCoreID );
+
+            /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
+             * is used to allow calls to vTaskSuspendAll() to nest. */
+            /* Record the core owning the (outermost) suspension. */
+            if( uxSchedulerSuspended == 0U )
+            {
+                xSchedulerSuspendedFromCore = xCoreID;
+            }
+
+            ++uxSchedulerSuspended;
+            kernelRELEASE_ISR_LOCK( xCoreID );
 
             portCLEAR_INTERRUPT_MASK( ulState );
         }
@@ -4097,7 +4391,7 @@ BaseType_t xTaskResumeAll( void )
          * removed task will have been added to the xPendingReadyList.  Once the
          * scheduler has been resumed it is safe to move all the pending ready
          * tasks from this list into their appropriate ready list. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
@@ -4106,24 +4400,15 @@ BaseType_t xTaskResumeAll( void )
             configASSERT( uxSchedulerSuspended != 0U );
 
             uxSchedulerSuspended = ( UBaseType_t ) ( uxSchedulerSuspended - 1U );
-            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-            {
-                configASSERT( pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable > 0 );
-
-                /* Decrement xPreemptionDisable. If 0, it means this we are not
-                 * in a nested suspension scenario, thus this function and yield
-                 * if necessary. */
-                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable--;
-
-                /* Release the kernel's task spinlock that was held throughout
-                 * the kernel suspension. */
-                portRELEASE_SPINLOCK( &xTaskSpinlock );
-            }
-            #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-            {
-                portRELEASE_TASK_LOCK();
-            }
-            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+            #if ( configNUMBER_OF_CORES > 1 )
+                if( uxSchedulerSuspended == 0U )
+                {
+                    xSchedulerSuspendedFromCore = -1;
+                }
+            #endif
+            #if ( configNUMBER_OF_CORES > 1 )
+                kernelRELEASE_TASK_LOCK( xCoreID );
+            #endif
 
             if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
             {
@@ -4238,7 +4523,7 @@ BaseType_t xTaskResumeAll( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
     }
 
     traceRETURN_xTaskResumeAll( xAlreadyYielded );
@@ -4720,11 +5005,11 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
             configASSERT( xTicksToJump != ( TickType_t ) 0 );
 
             /* Prevent the tick interrupt modifying xPendedTicks simultaneously. */
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
                 xPendedTicks++;
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
             xTicksToJump--;
         }
         else
@@ -4756,11 +5041,11 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
     vTaskSuspendAll();
 
     /* Prevent the tick interrupt modifying xPendedTicks simultaneously. */
-    taskENTER_CRITICAL();
+    kernelENTER_CRITICAL();
     {
         xPendedTicks += xTicksToCatchUp;
     }
-    taskEXIT_CRITICAL();
+    kernelEXIT_CRITICAL();
     xYieldOccurred = xTaskResumeAll();
 
     traceRETURN_xTaskCatchUpTicks( xYieldOccurred );
@@ -4797,7 +5082,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
                  * the event list too.  Interrupts can touch the event list item,
                  * even though the scheduler is suspended, so a critical section
                  * is used. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     if( listLIST_ITEM_CONTAINER( &( pxTCB->xEventListItem ) ) != NULL )
                     {
@@ -4813,7 +5098,7 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 /* Place the unblocked task into the appropriate ready list. */
                 prvAddTaskToReadyList( pxTCB );
@@ -4840,11 +5125,11 @@ BaseType_t xTaskCatchUpTicks( TickType_t xTicksToCatchUp )
                     }
                     #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                     {
-                        taskENTER_CRITICAL();
+                        kernelENTER_CRITICAL();
                         {
                             prvYieldForTask( pxTCB );
                         }
-                        taskEXIT_CRITICAL();
+                        kernelEXIT_CRITICAL();
                     }
                     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
                 }
@@ -4871,7 +5156,15 @@ BaseType_t xTaskIncrementTick( void )
     TickType_t xItemValue;
     BaseType_t xSwitchRequired = pdFALSE;
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        UBaseType_t uxSavedInterruptStatus;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceENTER_xTaskIncrementTick();
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* Called by the portable layer each time a tick interrupt occurs.
      * Increments the tick then checks to see if the new tick value will cause any
@@ -4973,7 +5266,8 @@ BaseType_t xTaskIncrementTick( void )
                             /* Preemption is on, but a context switch should
                              * only be performed if the unblocked task's
                              * priority is higher than the currently executing
-                             * task.
+                             * task and the currently executing task does not
+                             * have preemption disabled.
                              * The case of equal priority tasks sharing
                              * processing time (which happens when both
                              * preemption and time slicing are on) is
@@ -5071,7 +5365,7 @@ BaseType_t xTaskIncrementTick( void )
                 for( xCoreID = 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
                 {
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
+                        if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
                     #endif
                     {
                         if( xYieldPendings[ xCoreID ] != pdFALSE )
@@ -5109,6 +5403,10 @@ BaseType_t xTaskIncrementTick( void )
         #endif
     }
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_xTaskIncrementTick( xSwitchRequired );
 
     return xSwitchRequired;
@@ -5137,11 +5435,11 @@ BaseType_t xTaskIncrementTick( void )
 
         /* Save the hook function in the TCB.  A critical section is required as
          * the value can be accessed from an interrupt. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             xTCB->pxTaskTag = pxHookFunction;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_vTaskSetApplicationTaskTag();
     }
@@ -5164,11 +5462,11 @@ BaseType_t xTaskIncrementTick( void )
 
         /* Access the hook function in the TCB.  A critical section is required as
          * the value can be accessed from an interrupt. */
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             xReturn = pxTCB->pxTaskTag;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGetApplicationTaskTag( xReturn );
 
@@ -5197,11 +5495,11 @@ BaseType_t xTaskIncrementTick( void )
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
         {
             xReturn = pxTCB->pxTaskTag;
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskGetApplicationTaskTagFromISR( xReturn );
 
@@ -5346,18 +5644,25 @@ BaseType_t xTaskIncrementTick( void )
          *   and move on if another core suspended the scheduler. We should only
          *   do that if the current core has suspended the scheduler. */
 
-        portGET_TASK_LOCK( xCoreID ); /* Must always acquire the task lock first. */
-        portGET_ISR_LOCK( xCoreID );
+        kernelGET_TASK_LOCK( xCoreID ); /* Must always acquire the task lock first. */
+        kernelGET_ISR_LOCK( xCoreID );
         {
             /* vTaskSwitchContext() must never be called from within a critical section.
              * This is not necessarily true for single core FreeRTOS, but it is for this
              * SMP port. */
             configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 );
 
+            /* vTaskSwitchContext() must not be called with a task that has
+             * preemption disabled. */
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                configASSERT( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U );
+            #endif
+
             if( uxSchedulerSuspended != ( UBaseType_t ) 0U )
             {
-                /* The scheduler is currently suspended - do not allow a context
-                 * switch. */
+                /* The scheduler is currently suspended or the task
+                 * has requested to not be preempted - do not allow
+                 * a context switch. */
                 xYieldPendings[ xCoreID ] = pdTRUE;
             }
             else
@@ -5428,8 +5733,8 @@ BaseType_t xTaskIncrementTick( void )
                 #endif
             }
         }
-        portRELEASE_ISR_LOCK( xCoreID );
-        portRELEASE_TASK_LOCK( xCoreID );
+        kernelRELEASE_ISR_LOCK( xCoreID );
+        kernelRELEASE_TASK_LOCK( xCoreID );
 
         traceRETURN_vTaskSwitchContext();
     }
@@ -5443,8 +5748,15 @@ void vTaskPlaceOnEventList( List_t * const pxEventList,
 
     configASSERT( pxEventList );
 
-    /* THIS FUNCTION MUST BE CALLED WITH THE
-     * SCHEDULER SUSPENDED AND THE QUEUE BEING ACCESSED LOCKED. */
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* Suspend the kernel data group as we are about to access its members */
+        vTaskSuspendAll();
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+        /* THIS FUNCTION MUST BE CALLED WITH THE
+         * SCHEDULER SUSPENDED AND THE QUEUE BEING ACCESSED LOCKED. */
+        configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* Place the event list item of the TCB in the appropriate event list.
      * This is placed in the list in priority order so the highest priority task
@@ -5461,6 +5773,11 @@ void vTaskPlaceOnEventList( List_t * const pxEventList,
 
     prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* We are done accessing the kernel data group. Resume it. */
+        ( void ) xTaskResumeAll();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_vTaskPlaceOnEventList();
 }
 /*-----------------------------------------------------------*/
@@ -5473,9 +5790,16 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
     configASSERT( pxEventList );
 
-    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
-     * the event groups implementation. */
-    configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* Suspend the kernel data group as we are about to access its members */
+        vTaskSuspendAll();
+    #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+        /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
+         * the event groups implementation. */
+        configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* Store the item value in the event list item.  It is safe to access the
      * event list item here as interrupts won't access the event list item of a
@@ -5491,6 +5815,11 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
     prvAddCurrentTaskToDelayedList( xTicksToWait, pdTRUE );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* We are done accessing the kernel data group. Resume it. */
+        ( void ) xTaskResumeAll();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_vTaskPlaceOnUnorderedEventList();
 }
 /*-----------------------------------------------------------*/
@@ -5505,11 +5834,17 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
         configASSERT( pxEventList );
 
-        /* This function should not be called by application code hence the
-         * 'Restricted' in its name.  It is not part of the public API.  It is
-         * designed for use by kernel code, and has special calling requirements -
-         * it should be called with the scheduler suspended. */
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Suspend the kernel data group as we are about to access its members */
+            vTaskSuspendAll();
+        #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
+            /* This function should not be called by application code hence the
+             * 'Restricted' in its name.  It is not part of the public API.  It is
+             * designed for use by kernel code, and has special calling requirements -
+             * it should be called with the scheduler suspended. */
+            configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         /* Place the event list item of the TCB in the appropriate event list.
          * In this case it is assume that this is the only task that is going to
@@ -5528,6 +5863,11 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
         traceTASK_DELAY_UNTIL( ( xTickCount + xTicksToWait ) );
         prvAddCurrentTaskToDelayedList( xTicksToWait, xWaitIndefinitely );
 
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Resume it. */
+            ( void ) xTaskResumeAll();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
         traceRETURN_vTaskPlaceOnEventListRestricted();
     }
 
@@ -5539,10 +5879,34 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
     TCB_t * pxUnblockedTCB;
     BaseType_t xReturn;
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        UBaseType_t uxSavedInterruptStatus;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceENTER_xTaskRemoveFromEventList( pxEventList );
 
-    /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
-     * called from a critical section within an ISR. */
+    #if ( !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) )
+
+        /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
+         * called from a critical section within an ISR. */
+    #else /* #if ( ! ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) ) */
+        /* Lock the kernel data group as we are about to access its members */
+        if( portCHECK_IF_IN_ISR() == pdTRUE )
+        {
+            uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
+        }
+        else
+        {
+            uxSavedInterruptStatus = 0;
+            kernelENTER_CRITICAL();
+        }
+
+        /* Before taking the kernel lock, another task/ISR could have already
+         * emptied the pxEventList. So we insert a check here to see if
+         * pxEventList is empty before attempting to remove an item from it. */
+        if( listLIST_IS_EMPTY( pxEventList ) == pdFALSE )
+        {
+    #endif /* #if ( ! ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) ) */
 
     /* The event list is sorted in priority order, so the first in the list can
      * be removed as it is known to be the highest priority.  Remove the TCB from
@@ -5622,6 +5986,26 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
     }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+}
+else
+{
+    /* The pxEventList was emptied before we entered the critical
+     * section, Nothing to do except return pdFALSE. */
+    xReturn = pdFALSE;
+}
+
+/* We are done accessing the kernel data group. Unlock it. */
+if( portCHECK_IF_IN_ISR() == pdTRUE )
+{
+    kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+}
+else
+{
+    kernelEXIT_CRITICAL();
+}
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     traceRETURN_xTaskRemoveFromEventList( xReturn );
     return xReturn;
 }
@@ -5685,13 +6069,13 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
     {
         #if ( configUSE_PREEMPTION == 1 )
         {
-            taskENTER_CRITICAL();
+            kernelENTER_CRITICAL();
             {
                 prvYieldForTask( pxUnblockedTCB );
             }
-            taskEXIT_CRITICAL();
+            kernelEXIT_CRITICAL();
         }
-        #endif
+        #endif /* if ( configUSE_PREEMPTION == 1 ) */
     }
     #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
@@ -5704,12 +6088,12 @@ void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
     traceENTER_vTaskSetTimeOutState( pxTimeOut );
 
     configASSERT( pxTimeOut );
-    taskENTER_CRITICAL();
+    kernelENTER_CRITICAL();
     {
         pxTimeOut->xOverflowCount = xNumOfOverflows;
         pxTimeOut->xTimeOnEntering = xTickCount;
     }
-    taskEXIT_CRITICAL();
+    kernelEXIT_CRITICAL();
 
     traceRETURN_vTaskSetTimeOutState();
 }
@@ -5719,9 +6103,19 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 {
     traceENTER_vTaskInternalSetTimeOutState( pxTimeOut );
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* Lock the kernel data group as we are about to access its members */
+        kernelENTER_CRITICAL();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
     /* For internal use only as it does not use a critical section. */
     pxTimeOut->xOverflowCount = xNumOfOverflows;
     pxTimeOut->xTimeOnEntering = xTickCount;
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        /* We are done accessing the kernel data group. Unlock it. */
+        kernelEXIT_CRITICAL();
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     traceRETURN_vTaskInternalSetTimeOutState();
 }
@@ -5737,7 +6131,7 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
     configASSERT( pxTimeOut );
     configASSERT( pxTicksToWait );
 
-    taskENTER_CRITICAL();
+    kernelENTER_CRITICAL();
     {
         /* Minor optimisation.  The tick count cannot change in this block. */
         const TickType_t xConstTickCount = xTickCount;
@@ -5788,7 +6182,7 @@ BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
             xReturn = pdTRUE;
         }
     }
-    taskEXIT_CRITICAL();
+    kernelEXIT_CRITICAL();
 
     traceRETURN_xTaskCheckForTimeOut( xReturn );
 
@@ -6090,7 +6484,12 @@ STATIC portTASK_FUNCTION( prvIdleTask,
 
         traceENTER_eTaskConfirmSleepModeStatus();
 
-        /* This function must be called from a critical section. */
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Lock the kernel data group as we are about to access its members */
+            kernelENTER_CRITICAL();
+        #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+            /* This function must be called from a critical section. */
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         if( listCURRENT_LIST_LENGTH( &xPendingReadyList ) != 0U )
         {
@@ -6123,6 +6522,11 @@ STATIC portTASK_FUNCTION( prvIdleTask,
         {
             mtCOVERAGE_TEST_MARKER();
         }
+
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Unlock it. */
+            kernelEXIT_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         traceRETURN_eTaskConfirmSleepModeStatus( eReturn );
 
@@ -6255,7 +6659,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
         {
             #if ( configNUMBER_OF_CORES == 1 )
             {
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     {
                         /* MISRA Ref 11.5.3 [Void pointer assignment] */
@@ -6267,7 +6671,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
                         --uxDeletedTasksWaitingCleanUp;
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 prvDeleteTCB( pxTCB );
             }
@@ -6275,7 +6679,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
             {
                 pxTCB = NULL;
 
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     /* For SMP, multiple idles can be running simultaneously
                      * and we need to check that other idles did not cleanup while we were
@@ -6298,12 +6702,12 @@ STATIC void prvCheckTasksWaitingTermination( void )
                             /* The TCB to be deleted still has not yet been switched out
                              * by the scheduler, so we will just exit this loop early and
                              * try again next time. */
-                            taskEXIT_CRITICAL();
+                            kernelEXIT_CRITICAL();
                             break;
                         }
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 if( pxTCB != NULL )
                 {
@@ -6425,14 +6829,14 @@ STATIC void prvCheckTasksWaitingTermination( void )
                 /* Tasks can be in pending ready list and other state list at the
                  * same time. These tasks are in ready state no matter what state
                  * list the task is in. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     if( listIS_CONTAINED_WITHIN( &xPendingReadyList, &( pxTCB->xEventListItem ) ) != pdFALSE )
                     {
                         pxTaskStatus->eCurrentState = eReady;
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
             }
         }
         else
@@ -6752,7 +7156,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         else
         {
             #if ( configNUMBER_OF_CORES > 1 )
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
             #endif
             {
                 if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
@@ -6765,7 +7169,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
                 }
             }
             #if ( configNUMBER_OF_CORES > 1 )
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
             #endif
         }
 
@@ -6786,7 +7190,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
         traceENTER_xTaskPriorityInherit( pxMutexHolder );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* If the mutex is taken by an interrupt, the mutex holder is NULL. Priority
              * inheritance is not applied in this scenario. */
@@ -6874,7 +7278,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskPriorityInherit( xReturn );
 
@@ -6892,6 +7296,11 @@ STATIC void prvResetNextTaskUnblockTime( void )
         BaseType_t xReturn = pdFALSE;
 
         traceENTER_xTaskPriorityDisinherit( pxMutexHolder );
+
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Lock the kernel data group as we are about to access its members */
+            kernelENTER_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         if( pxMutexHolder != NULL )
         {
@@ -6970,6 +7379,11 @@ STATIC void prvResetNextTaskUnblockTime( void )
             mtCOVERAGE_TEST_MARKER();
         }
 
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Unlock it. */
+            kernelEXIT_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
         traceRETURN_xTaskPriorityDisinherit( xReturn );
 
         return xReturn;
@@ -6989,88 +7403,97 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
         traceENTER_vTaskPriorityDisinheritAfterTimeout( pxMutexHolder, uxHighestPriorityWaitingTask );
 
-        if( pxMutexHolder != NULL )
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
+            kernelENTER_CRITICAL();
+        #endif
         {
-            /* If pxMutexHolder is not NULL then the holder must hold at least
-             * one mutex. */
-            configASSERT( pxTCB->uxMutexesHeld );
+            if( pxMutexHolder != NULL )
+            {
+                /* If pxMutexHolder is not NULL then the holder must hold at least
+                 * one mutex. */
+                configASSERT( pxTCB->uxMutexesHeld );
 
-            /* Determine the priority to which the priority of the task that
-             * holds the mutex should be set.  This will be the greater of the
-             * holding task's base priority and the priority of the highest
-             * priority task that is waiting to obtain the mutex. */
-            if( pxTCB->uxBasePriority < uxHighestPriorityWaitingTask )
-            {
-                uxPriorityToUse = uxHighestPriorityWaitingTask;
-            }
-            else
-            {
-                uxPriorityToUse = pxTCB->uxBasePriority;
-            }
-
-            /* Does the priority need to change? */
-            if( pxTCB->uxPriority != uxPriorityToUse )
-            {
-                /* Only disinherit if no other mutexes are held.  This is a
-                 * simplification in the priority inheritance implementation.  If
-                 * the task that holds the mutex is also holding other mutexes then
-                 * the other mutexes may have caused the priority inheritance. */
-                if( pxTCB->uxMutexesHeld == uxOnlyOneMutexHeld )
+                /* Determine the priority to which the priority of the task that
+                 * holds the mutex should be set.  This will be the greater of the
+                 * holding task's base priority and the priority of the highest
+                 * priority task that is waiting to obtain the mutex. */
+                if( pxTCB->uxBasePriority < uxHighestPriorityWaitingTask )
                 {
-                    /* If a task has timed out because it already holds the
-                     * mutex it was trying to obtain then it cannot of inherited
-                     * its own priority. */
-                    configASSERT( pxTCB != pxCurrentTCB );
+                    uxPriorityToUse = uxHighestPriorityWaitingTask;
+                }
+                else
+                {
+                    uxPriorityToUse = pxTCB->uxBasePriority;
+                }
 
-                    /* Disinherit the priority, remembering the previous
-                     * priority to facilitate determining the subject task's
-                     * state. */
-                    traceTASK_PRIORITY_DISINHERIT( pxTCB, uxPriorityToUse );
-                    uxPriorityUsedOnEntry = pxTCB->uxPriority;
-                    pxTCB->uxPriority = uxPriorityToUse;
+                /* Does the priority need to change? */
+                if( pxTCB->uxPriority != uxPriorityToUse )
+                {
+                    /* Only disinherit if no other mutexes are held.  This is a
+                     * simplification in the priority inheritance implementation.  If
+                     * the task that holds the mutex is also holding other mutexes then
+                     * the other mutexes may have caused the priority inheritance. */
+                    if( pxTCB->uxMutexesHeld == uxOnlyOneMutexHeld )
+                    {
+                        /* If a task has timed out because it already holds the
+                         * mutex it was trying to obtain then it cannot of inherited
+                         * its own priority. */
+                        configASSERT( pxTCB != pxCurrentTCB );
 
-                    /* Only reset the event list item value if the value is not
-                     * being used for anything else. */
-                    if( ( listGET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
-                    {
-                        listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) uxPriorityToUse );
-                    }
-                    else
-                    {
-                        mtCOVERAGE_TEST_MARKER();
-                    }
+                        /* Disinherit the priority, remembering the previous
+                         * priority to facilitate determining the subject task's
+                         * state. */
+                        traceTASK_PRIORITY_DISINHERIT( pxTCB, uxPriorityToUse );
+                        uxPriorityUsedOnEntry = pxTCB->uxPriority;
+                        pxTCB->uxPriority = uxPriorityToUse;
 
-                    /* If the running task is not the task that holds the mutex
-                     * then the task that holds the mutex could be in either the
-                     * Ready, Blocked or Suspended states.  Only remove the task
-                     * from its current state list if it is in the Ready state as
-                     * the task's priority is going to change and there is one
-                     * Ready list per priority. */
-                    if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ uxPriorityUsedOnEntry ] ), &( pxTCB->xStateListItem ) ) != pdFALSE )
-                    {
-                        if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                        /* Only reset the event list item value if the value is not
+                         * being used for anything else. */
+                        if( ( listGET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
                         {
-                            /* It is known that the task is in its ready list so
-                             * there is no need to check again and the port level
-                             * reset macro can be called directly. */
-                            portRESET_READY_PRIORITY( uxPriorityUsedOnEntry, uxTopReadyPriority );
+                            listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) uxPriorityToUse );
                         }
                         else
                         {
                             mtCOVERAGE_TEST_MARKER();
                         }
 
-                        prvAddTaskToReadyList( pxTCB );
-                        #if ( configNUMBER_OF_CORES > 1 )
+                        /* If the running task is not the task that holds the mutex
+                         * then the task that holds the mutex could be in either the
+                         * Ready, Blocked or Suspended states.  Only remove the task
+                         * from its current state list if it is in the Ready state as
+                         * the task's priority is going to change and there is one
+                         * Ready list per priority. */
+                        if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ uxPriorityUsedOnEntry ] ), &( pxTCB->xStateListItem ) ) != pdFALSE )
                         {
-                            /* The priority of the task is dropped. Yield the core on
-                             * which the task is running. */
-                            if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                            if( uxListRemove( &( pxTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
                             {
-                                prvYieldCore( pxTCB->xTaskRunState );
+                                /* It is known that the task is in its ready list so
+                                 * there is no need to check again and the port level
+                                 * reset macro can be called directly. */
+                                portRESET_READY_PRIORITY( uxPriorityUsedOnEntry, uxTopReadyPriority );
                             }
+                            else
+                            {
+                                mtCOVERAGE_TEST_MARKER();
+                            }
+
+                            prvAddTaskToReadyList( pxTCB );
+                            #if ( configNUMBER_OF_CORES > 1 )
+                            {
+                                /* The priority of the task is dropped. Yield the core on
+                                 * which the task is running. */
+                                if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                                {
+                                    prvYieldCore( pxTCB->xTaskRunState );
+                                }
+                            }
+                            #endif /* if ( configNUMBER_OF_CORES > 1 ) */
                         }
-                        #endif /* if ( configNUMBER_OF_CORES > 1 ) */
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
                     }
                     else
                     {
@@ -7087,10 +7510,9 @@ STATIC void prvResetNextTaskUnblockTime( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        else
-        {
-            mtCOVERAGE_TEST_MARKER();
-        }
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
+            kernelEXIT_CRITICAL();
+        #endif
 
         traceRETURN_vTaskPriorityDisinheritAfterTimeout();
     }
@@ -7165,7 +7587,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     void vTaskEnterCritical( void )
     {
@@ -7177,11 +7599,24 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
             if( xSchedulerRunning != pdFALSE )
             {
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                /* When using granular locks, the critical section nesting count
+                 * might have already been incremented if this call is a nested
+                 * call from a data group critical section. Hence, we have to
+                 * acquire the kernel task and ISR locks unconditionally. */
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
                 {
-                    portGET_TASK_LOCK( xCoreID );
-                    portGET_ISR_LOCK( xCoreID );
+                    kernelGET_TASK_LOCK( xCoreID );
+                    kernelGET_ISR_LOCK( xCoreID );
                 }
+                #else /* portUSING_GRANULAR_LOCKS */
+                {
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        kernelGET_TASK_LOCK( xCoreID );
+                        kernelGET_ISR_LOCK( xCoreID );
+                    }
+                }
+                #endif /* portUSING_GRANULAR_LOCKS */
 
                 portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
 
@@ -7214,10 +7649,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskEnterCritical();
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     UBaseType_t vTaskEnterCriticalFromISR( void )
     {
@@ -7230,10 +7665,18 @@ STATIC void prvResetNextTaskUnblockTime( void )
         {
             uxSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
 
-            if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
             {
-                portGET_ISR_LOCK( xCoreID );
+                kernelGET_ISR_LOCK( xCoreID );
             }
+            #else /* portUSING_GRANULAR_LOCKS */
+            {
+                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                {
+                    kernelGET_ISR_LOCK( xCoreID );
+                }
+            }
+            #endif /* portUSING_GRANULAR_LOCKS */
 
             portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
         }
@@ -7247,7 +7690,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         return uxSavedInterruptStatus;
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) )
@@ -7295,7 +7738,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     void vTaskExitCritical( void )
     {
@@ -7315,32 +7758,79 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
             if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U )
             {
-                portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
-
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
                 {
                     BaseType_t xYieldCurrentTask;
 
-                    /* Get the xYieldPending stats inside the critical section. */
-                    xYieldCurrentTask = xYieldPendings[ xCoreID ];
-
-                    portRELEASE_ISR_LOCK( xCoreID );
-                    portRELEASE_TASK_LOCK( xCoreID );
-                    portENABLE_INTERRUPTS();
-
-                    /* When a task yields in a critical section it just sets
-                     * xYieldPending to true. So now that we have exited the
-                     * critical section check if xYieldPending is true, and
-                     * if so yield. */
-                    if( xYieldCurrentTask != pdFALSE )
+                    /* Get the xYieldPending status inside the critical section. */
+                    if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE )
+                        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                            && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
+                            ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
+                        #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+                        )
                     {
-                        portYIELD();
+                        xYieldCurrentTask = pdTRUE;
+                    }
+                    else
+                    {
+                        xYieldCurrentTask = pdFALSE;
+                    }
+
+                    /* Release the ISR and task locks first when using granular locks. */
+                    kernelRELEASE_ISR_LOCK( xCoreID );
+                    kernelRELEASE_TASK_LOCK( xCoreID );
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        portENABLE_INTERRUPTS();
+
+                        /* When a task yields in a critical section it just sets
+                         * xYieldPending to true. So now that we have exited the
+                         * critical section check if xYieldPending is true, and
+                         * if so yield. */
+                        if( xYieldCurrentTask != pdFALSE )
+                        {
+                            portYIELD();
+                        }
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                else
+                #else /* portUSING_GRANULAR_LOCKS */
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    /* Decrement first; release locks and enable interrupts when count reaches zero. */
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        BaseType_t xYieldCurrentTask;
+
+                        /* Get the xYieldPending stats inside the critical section. */
+                        xYieldCurrentTask = xYieldPendings[ xCoreID ];
+
+                        kernelRELEASE_ISR_LOCK( xCoreID );
+                        kernelRELEASE_TASK_LOCK( xCoreID );
+                        portENABLE_INTERRUPTS();
+
+                        /* When a task yields in a critical section it just sets
+                         * xYieldPending to true. So now that we have exited the
+                         * critical section check if xYieldPending is true, and
+                         * if so yield. */
+                        if( xYieldCurrentTask != pdFALSE )
+                        {
+                            portYIELD();
+                        }
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
                 }
+                #endif /* portUSING_GRANULAR_LOCKS */
             }
             else
             {
@@ -7355,10 +7845,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCritical();
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
-#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
+#if ( configNUMBER_OF_CORES > 1 )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
@@ -7376,17 +7866,28 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
             if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U )
             {
-                portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
+                {
+                    kernelRELEASE_ISR_LOCK( xCoreID );
 
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
-                {
-                    portRELEASE_ISR_LOCK( xCoreID );
-                    portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+                    }
                 }
-                else
+                #else /* portUSING_GRANULAR_LOCKS */
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                    if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                    {
+                        kernelRELEASE_ISR_LOCK( xCoreID );
+                        portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus );
+                    }
                 }
+                #endif /* portUSING_GRANULAR_LOCKS */
             }
             else
             {
@@ -7401,29 +7902,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCriticalFromISR();
     }
 
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-/*-----------------------------------------------------------*/
-
-#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-
-    BaseType_t xTaskUnlockCanYield( void )
-    {
-        BaseType_t xReturn;
-        BaseType_t xCoreID = portGET_CORE_ID();
-
-        if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE ) && ( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE ) )
-        {
-            xReturn = pdTRUE;
-        }
-        else
-        {
-            xReturn = pdFALSE;
-        }
-
-        return xReturn;
-    }
-
-#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )
@@ -7837,6 +8316,11 @@ TickType_t uxTaskResetEventItemValue( void )
 
         traceENTER_pvTaskIncrementMutexHeldCount();
 
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* Lock the kernel data group as we are about to access its members */
+            kernelENTER_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
         pxTCB = pxCurrentTCB;
 
         /* If xSemaphoreCreateMutex() is called before any tasks have been created
@@ -7845,6 +8329,11 @@ TickType_t uxTaskResetEventItemValue( void )
         {
             ( pxTCB->uxMutexesHeld )++;
         }
+
+        #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            /* We are done accessing the kernel data group. Unlock it. */
+            kernelEXIT_CRITICAL();
+        #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
         traceRETURN_pvTaskIncrementMutexHeldCount( pxTCB );
 
@@ -7879,7 +8368,7 @@ TickType_t uxTaskResetEventItemValue( void )
                  * has occurred and set the flag to indicate that we are waiting for
                  * a notification. If we do not do so, a notification sent from an ISR
                  * will get lost. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     /* Only block if the notification count is not already non-zero. */
                     if( pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ] == 0U )
@@ -7895,7 +8384,7 @@ TickType_t uxTaskResetEventItemValue( void )
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 /* We are now out of the critical section but the scheduler is still
                  * suspended, so we are safe to do non-deterministic operations such
@@ -7923,7 +8412,7 @@ TickType_t uxTaskResetEventItemValue( void )
             }
         }
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             traceTASK_NOTIFY_TAKE( uxIndexToWaitOn );
             ulReturn = pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ];
@@ -7946,7 +8435,7 @@ TickType_t uxTaskResetEventItemValue( void )
 
             pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskNOT_WAITING_NOTIFICATION;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_ulTaskGenericNotifyTake( ulReturn );
 
@@ -7981,7 +8470,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 /* We MUST enter a critical section to atomically check and update the
                  * task notification value. If we do not do so, a notification from
                  * an ISR will get lost. */
-                taskENTER_CRITICAL();
+                kernelENTER_CRITICAL();
                 {
                     /* Only block if a notification is not already pending. */
                     if( pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] != taskNOTIFICATION_RECEIVED )
@@ -8002,7 +8491,7 @@ TickType_t uxTaskResetEventItemValue( void )
                         mtCOVERAGE_TEST_MARKER();
                     }
                 }
-                taskEXIT_CRITICAL();
+                kernelEXIT_CRITICAL();
 
                 /* We are now out of the critical section but the scheduler is still
                  * suspended, so we are safe to do non-deterministic operations such
@@ -8030,7 +8519,7 @@ TickType_t uxTaskResetEventItemValue( void )
             }
         }
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             traceTASK_NOTIFY_WAIT( uxIndexToWaitOn );
 
@@ -8060,7 +8549,7 @@ TickType_t uxTaskResetEventItemValue( void )
 
             pxCurrentTCB->ucNotifyState[ uxIndexToWaitOn ] = taskNOT_WAITING_NOTIFICATION;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotifyWait( xReturn );
 
@@ -8088,7 +8577,7 @@ TickType_t uxTaskResetEventItemValue( void )
         configASSERT( xTaskToNotify );
         pxTCB = xTaskToNotify;
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             if( pulPreviousNotificationValue != NULL )
             {
@@ -8180,7 +8669,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotify( xReturn );
 
@@ -8232,7 +8721,7 @@ TickType_t uxTaskResetEventItemValue( void )
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             if( pulPreviousNotificationValue != NULL )
             {
@@ -8362,7 +8851,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
             }
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_xTaskGenericNotifyFromISR( xReturn );
 
@@ -8410,7 +8899,7 @@ TickType_t uxTaskResetEventItemValue( void )
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
         /* coverity[misra_c_2012_directive_4_7_violation] */
-        uxSavedInterruptStatus = ( UBaseType_t ) taskENTER_CRITICAL_FROM_ISR();
+        uxSavedInterruptStatus = ( UBaseType_t ) kernelENTER_CRITICAL_FROM_ISR();
         {
             ucOriginalNotifyState = pxTCB->ucNotifyState[ uxIndexToNotify ];
             pxTCB->ucNotifyState[ uxIndexToNotify ] = taskNOTIFICATION_RECEIVED;
@@ -8496,7 +8985,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
             }
         }
-        taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
 
         traceRETURN_vTaskGenericNotifyGiveFromISR();
     }
@@ -8521,7 +9010,7 @@ TickType_t uxTaskResetEventItemValue( void )
         pxTCB = prvGetTCBFromHandle( xTask );
         configASSERT( pxTCB != NULL );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             if( pxTCB->ucNotifyState[ uxIndexToClear ] == taskNOTIFICATION_RECEIVED )
             {
@@ -8533,7 +9022,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 xReturn = pdFAIL;
             }
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_xTaskGenericNotifyStateClear( xReturn );
 
@@ -8561,14 +9050,14 @@ TickType_t uxTaskResetEventItemValue( void )
         pxTCB = prvGetTCBFromHandle( xTask );
         configASSERT( pxTCB != NULL );
 
-        taskENTER_CRITICAL();
+        kernelENTER_CRITICAL();
         {
             /* Return the notification as it was before the bits were cleared,
              * then clear the bit mask. */
             ulReturn = pxTCB->ulNotifiedValue[ uxIndexToClear ];
             pxTCB->ulNotifiedValue[ uxIndexToClear ] &= ~ulBitsToClear;
         }
-        taskEXIT_CRITICAL();
+        kernelEXIT_CRITICAL();
 
         traceRETURN_ulTaskGenericNotifyValueClear( ulReturn );
 

--- a/tasks.c
+++ b/tasks.c
@@ -354,7 +354,73 @@
  * must be valid. This macro is not required in single core since there is only
  * one core to yield. */
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        #define prvYieldCore( xCoreID )                                                          \
+        #if ( portUSING_GRANULAR_LOCKS == 1 )
+
+/* xYieldPending indicates that a yield was requested but could not be
+ * processed immediately.
+ *
+ * This occurs in situations such as:
+ * 1. Task preemption is disabled.
+ * 2. A task requests itself to yield while inside a critical section.
+ *
+ * In these cases, xYieldPending is set to pdTRUE to indicate that the
+ * yield request should be serviced after exiting the critical section.
+ *
+ * With granular locking, the task disables preemption first before acquiring
+ * data group locks. A check for run state change is required before acquiring
+ * the data group locks to preserve priority ordering, for example, in queue
+ * operations. However, setting xYieldPending alone is not sufficient. Without
+ * setting the task run state to taskTASK_SCHEDULED_TO_YIELD, the task would
+ * not be able to relinquish the critical section for higher priority tasks.
+ *
+ * Key distinction:
+ * - xYieldPending: yield is serviced when leaving the critical section.
+ * - taskTASK_SCHEDULED_TO_YIELD: yield is serviced before entering the
+ *   critical section. */
+            #define prvYieldCore( xCoreID )                                                           \
+    do {                                                                                              \
+        const BaseType_t xCoreToYield = ( xCoreID );                                                  \
+        BaseType_t xCurrentCoreID = portGET_CORE_ID();                                                \
+        if( ( xCoreID ) == xCurrentCoreID )                                                           \
+        {                                                                                             \
+            /* Pending a yield for this core since it is in the critical section. */                  \
+            xYieldPendings[ xCoreToYield ] = pdTRUE;                                                  \
+            /* Do not force the suspension owner core to yield; only pend it. */                      \
+            if( xCoreToYield != xSchedulerSuspendedFromCore )                                         \
+            {                                                                                         \
+                pxCurrentTCBs[ xCoreToYield ]->xTaskRunState = taskTASK_SCHEDULED_TO_YIELD;           \
+            }                                                                                         \
+        }                                                                                             \
+        else                                                                                          \
+        {                                                                                             \
+            portGET_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreToYield ]->xTCBSpinlock ) );     \
+            {                                                                                         \
+                if( xCoreToYield == xSchedulerSuspendedFromCore )                                     \
+                {                                                                                     \
+                    /* Suspension owner: pend the yield only, never SCHEDULED_TO_YIELD. */            \
+                    xYieldPendings[ xCoreToYield ] = pdTRUE;                                          \
+                }                                                                                     \
+                else if( pxCurrentTCBs[ xCoreToYield ]->uxPreemptionDisable == 0U )                   \
+                {                                                                                     \
+                    /* Request other core to yield if it is not requested before. */                  \
+                    if( pxCurrentTCBs[ xCoreToYield ]->xTaskRunState != taskTASK_SCHEDULED_TO_YIELD ) \
+                    {                                                                                 \
+                        portYIELD_CORE( xCoreToYield );                                               \
+                        pxCurrentTCBs[ xCoreToYield ]->xTaskRunState = taskTASK_SCHEDULED_TO_YIELD;   \
+                    }                                                                                 \
+                }                                                                                     \
+                else                                                                                  \
+                {                                                                                     \
+                    xYieldPendings[ xCoreToYield ] = pdTRUE;                                          \
+                    pxCurrentTCBs[ xCoreToYield ]->xTaskRunState = taskTASK_SCHEDULED_TO_YIELD;       \
+                }                                                                                     \
+            }                                                                                         \
+            portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreToYield ]->xTCBSpinlock ) ); \
+        }                                                                                             \
+    } while( 0 )
+
+        #else /* if ( portUSING_GRANULAR_LOCKS == 1 ) */
+            #define prvYieldCore( xCoreID )                                                      \
     do {                                                                                         \
         if( ( xCoreID ) == ( BaseType_t ) portGET_CORE_ID() )                                    \
         {                                                                                        \
@@ -378,6 +444,7 @@
             }                                                                                    \
         }                                                                                        \
     } while( 0 )
+        #endif /* if ( portUSING_GRANULAR_LOCKS == 1 ) */
     #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
         #define prvYieldCore( xCoreID )                                                      \
     do {                                                                                     \
@@ -430,6 +497,33 @@
     #define kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )
 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
+/*
+ * Macros to mark the start and end of a critical code region that only accesses
+ * members of the current task's TCB. Granular locking has a dedicated TCB lock
+ * for this, which is cheaper than taking the whole kernel data group.
+ */
+#if ( portUSING_GRANULAR_LOCKS == 1 )
+    #define kernelTCB_ENTER_CRITICAL()    vTaskTCBEnterCritical()
+    #define kernelTCB_EXIT_CRITICAL()     vTaskTCBExitCritical()
+#else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+    #define kernelTCB_ENTER_CRITICAL()    kernelENTER_CRITICAL()
+    #define kernelTCB_EXIT_CRITICAL()     kernelEXIT_CRITICAL()
+#endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/*
+ * Helper macros that pick the appropriate critical-section primitive based on
+ * the number of cores configured.  On SMP builds, multi-core access requires
+ * the kernel data-group lock; on single-core builds, the lighter
+ * port-provided primitive is sufficient.
+ */
+#if ( configNUMBER_OF_CORES > 1 )
+    #define taskBASE_TYPE_ENTER_CRITICAL()    kernelENTER_CRITICAL()
+    #define taskBASE_TYPE_EXIT_CRITICAL()     kernelEXIT_CRITICAL()
+#else /* #if ( configNUMBER_OF_CORES > 1 ) */
+    #define taskBASE_TYPE_ENTER_CRITICAL()    portBASE_TYPE_ENTER_CRITICAL()
+    #define taskBASE_TYPE_EXIT_CRITICAL()     portBASE_TYPE_EXIT_CRITICAL()
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
 /*-----------------------------------------------------------*/
 
 /*
@@ -465,6 +559,10 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
 
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
         UBaseType_t uxDeferredStateChange; /**< Used to indicate if the task's state change is deferred. */
+    #endif
+
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        portSPINLOCK_TYPE xTCBSpinlock;
     #endif
 
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
@@ -599,14 +697,14 @@ STATIC const volatile UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
  * from either an ISR or a task. */
 PRIVILEGED_DATA STATIC volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t ) 0U;
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
 
 /* Core that owns the scheduler suspension. It must never be requested to yield while
  * it holds the suspension, as it cannot service the yield until it resumes the
  * scheduler. Set/cleared under the same locks as uxSchedulerSuspended. */
     PRIVILEGED_DATA STATIC volatile BaseType_t xSchedulerSuspendedFromCore = -1;
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 #if ( configGENERATE_RUN_TIME_STATS == 1 )
 
@@ -619,8 +717,8 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
 
 /* Kernel spinlock variables when using granular locking */
 #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-    PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_SPINLOCK_STATIC;
-    PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_SPINLOCK_STATIC;
+    PRIVILEGED_DATA STATIC portSPINLOCK_TYPE xTaskSpinlock = portINIT_SPINLOCK_STATIC;
+    PRIVILEGED_DATA STATIC portSPINLOCK_TYPE xISRSpinlock = portINIT_SPINLOCK_STATIC;
 #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
@@ -717,6 +815,12 @@ STATIC portTASK_FUNCTION_PROTO( prvIdleTask,
  * and its TCB deleted.
  */
 STATIC void prvCheckTasksWaitingTermination( void ) PRIVILEGED_FUNCTION;
+
+/*
+ * Private helper function to remove a task from an event list. This function
+ * is shared between the task context and ISR context versions.
+ */
+STATIC BaseType_t prvTaskRemoveFromEventList( const List_t * const pxEventList ) PRIVILEGED_FUNCTION;
 
 /*
  * The currently executing task is entering the Blocked state.  Add the task to
@@ -847,13 +951,6 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) */
 
 /*
- * Helper function to enable preemption for a task.
- */
-#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
-#endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
-
-/*
  * freertos_tasks_c_additions_init() should only be called if the user definable
  * macro FREERTOS_TASKS_C_ADDITIONS_INIT() is defined, as that is the only macro
  * called by the function.
@@ -894,6 +991,25 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                                         size_t n );
 
 #endif /* #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
+
+/*
+ * Helpers used to enter and exit the kernel critical section from a context
+ * that is already inside a data-group critical section (and therefore already
+ * holds the data-group's ISR spinlock with interrupts disabled).
+ *
+ * Unlike kernelENTER_CRITICAL_FROM_ISR/kernelEXIT_CRITICAL_FROM_ISR, these
+ * helpers do not touch the interrupt state: the outer data-group critical
+ * section is responsible for that.  They only acquire/release the kernel
+ * ISR spinlock and adjust the per-core kernel critical-nesting count, so
+ * that callers can safely access kernel-data-group members while remaining
+ * within the surrounding data-group critical section's lock hierarchy.
+ */
+#if ( configNUMBER_OF_CORES > 1 )
+    static void prvKernelEnterISROnlyCritical( void );
+
+    static void prvKernelExitISROnlyCritical( void );
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
 /*-----------------------------------------------------------*/
 
 #if ( configNUMBER_OF_CORES > 1 )
@@ -922,20 +1038,11 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             * and reacquire the correct locks. And then, do it all over again
             * if our state changed again during the reacquisition. */
             uxPrevCriticalNesting = portGET_CRITICAL_NESTING_COUNT( xCoreID );
+            portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
 
-            if( uxPrevCriticalNesting > 0U )
-            {
-                portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
-                kernelRELEASE_ISR_LOCK( xCoreID );
-            }
-            else
-            {
-                /* The scheduler is suspended. uxSchedulerSuspended is updated
-                 * only when the task is not requested to yield. */
-                mtCOVERAGE_TEST_MARKER();
-            }
-
+            kernelRELEASE_ISR_LOCK( xCoreID );
             kernelRELEASE_TASK_LOCK( xCoreID );
+
             portMEMORY_BARRIER();
             configASSERT( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD );
 
@@ -950,15 +1057,11 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             portDISABLE_INTERRUPTS();
 
             xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
             kernelGET_TASK_LOCK( xCoreID );
             kernelGET_ISR_LOCK( xCoreID );
 
             portSET_CRITICAL_NESTING_COUNT( xCoreID, uxPrevCriticalNesting );
-
-            if( uxPrevCriticalNesting == 0U )
-            {
-                kernelRELEASE_ISR_LOCK( xCoreID );
-            }
         }
     }
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
@@ -1021,14 +1124,30 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                                 {
+                                    /* Acquire the TCB lock to prevent the task from
+                                     * changing its preemption state. */
+                                    #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                        portGET_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreID ]->xTCBSpinlock ) );
+                                    #endif
+
                                     if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
                                     {
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            if( xLowestPriorityCore != -1 )
+                                            {
+                                                /* Release the previously held TCB lock. */
+                                                portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                                            }
+                                        #endif
                                         xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
                                         xLowestPriorityCore = xCoreID;
                                     }
                                     else
                                     {
                                         xYieldPendings[ xCoreID ] = pdTRUE;
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xCoreID ]->xTCBSpinlock ) );
+                                        #endif
                                     }
                                 }
                                 #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
@@ -1076,6 +1195,17 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             {
                 prvYieldCore( xLowestPriorityCore );
             }
+
+            /* After requesting the target core to yield, the TCB lock can be released.
+             * Any task attempting to set the preemption disable count will check its
+             * run state first. If a yield has already been requested, it will service
+             * the yield request first before retrying to set the preemption disable count. */
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
+                if( xLowestPriorityCore >= 0 )
+                {
+                    portRELEASE_SPINLOCK( xCurrentCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                }
+            #endif
 
             #if ( configRUN_MULTIPLE_PRIORITIES == 0 )
                 /* Verify that the calling core always yields to higher priority tasks. */
@@ -1257,9 +1387,13 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
                     for( x = ( BaseType_t ) 0; x < ( BaseType_t ) configNUMBER_OF_CORES; x++ )
                     {
-                        if( ( pxCurrentTCBs[ x ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U )
+                        /* Core xCoreID already selects the task to run. */
+                        if( x != xCoreID )
                         {
-                            prvYieldCore( x );
+                            if( ( pxCurrentTCBs[ x ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U )
+                            {
+                                prvYieldCore( x );
+                            }
                         }
                     }
                 }
@@ -1337,17 +1471,28 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 ( xYieldPendings[ uxCore ] == pdFALSE ) )
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                {
+                                    #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                        portGET_SPINLOCK( xCoreID, &( pxCurrentTCBs[ uxCore ]->xTCBSpinlock ) );
+                                    #endif
+
                                     if( pxCurrentTCBs[ uxCore ]->uxPreemptionDisable == 0U )
                                     {
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            if( xLowestPriorityCore != -1 )
+                                            {
+                                                portRELEASE_SPINLOCK( xCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                                            }
+                                        #endif
                                         xLowestPriority = xTaskPriority;
                                         xLowestPriorityCore = ( BaseType_t ) uxCore;
                                     }
                                     else
                                     {
                                         xYieldPendings[ uxCore ] = pdTRUE;
+                                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                                            portRELEASE_SPINLOCK( xCoreID, &( pxCurrentTCBs[ uxCore ]->xTCBSpinlock ) );
+                                        #endif
                                     }
-                                }
                                 #else /* if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                                 {
                                     xLowestPriority = xTaskPriority;
@@ -1361,6 +1506,10 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                     if( xLowestPriorityCore >= 0 )
                     {
                         prvYieldCore( xLowestPriorityCore );
+
+                        #if ( portUSING_GRANULAR_LOCKS == 1 )
+                            portRELEASE_SPINLOCK( xCoreID, &( pxCurrentTCBs[ xLowestPriorityCore ]->xTCBSpinlock ) );
+                        #endif
                     }
                 }
             }
@@ -2059,6 +2208,12 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     }
     #endif
 
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+    {
+        portINIT_SPINLOCK( &pxNewTCB->xTCBSpinlock );
+    }
+    #endif
+
     /* Initialize the TCB stack to look as if the task was already running,
      * but had been interrupted by the scheduler.  The return address is set
      * to the start of the task function. Once the stack has been initialised
@@ -2335,25 +2490,45 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         kernelENTER_CRITICAL();
         {
+            #if ( ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) )
+                const BaseType_t xCoreID = portGET_CORE_ID();
+            #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) */
+
             /* If null is passed in here then it is the calling task that is
              * being deleted. */
             pxTCB = prvGetTCBFromHandle( xTaskToDelete );
             configASSERT( pxTCB != NULL );
 
-            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-
-                /* If the task has disabled preemption, we need to defer the deletion until the
-                 * task enables preemption. The deletion will be performed in vTaskPreemptionEnable(). */
-                if( pxTCB->uxPreemptionDisable > 0U )
+            #if ( ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) )
+            {
+                /* Acquire the TCB lock before reading the preemption-disable
+                 * count to avoid a race with the target task running on another
+                 * core (which may be modifying uxPreemptionDisable concurrently). */
+                portGET_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
                 {
-                    pxTCB->uxDeferredStateChange |= tskDEFERRED_DELETION;
-                    xDeferredDeletion = pdTRUE;
+                    /* If the task has disabled preemption, we need to defer the deletion until the
+                     * task enables preemption. The deletion will be performed in vTaskPreemptionEnable(). */
+                    if( pxTCB->uxPreemptionDisable > 0U )
+                    {
+                        /* Deletion takes priority over any other deferred action.
+                         * Overwrite the flag word so that a previously-queued
+                         * tskDEFERRED_SUSPENSION cannot be dispatched after this point.
+                         * tskDEFERRED_DELETION will be dispatched in vTaskPreemptionEnable(). */
+                        pxTCB->uxDeferredStateChange = tskDEFERRED_DELETION;
+                        xDeferredDeletion = pdTRUE;
+                        portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                    }
+                    else
+                    {
+                        /* Reset all deferred state change flags since the task is
+                         * being deleted now. Any pending tskDEFERRED_SUSPENSION is irrelevant.
+                         * Failing to clear it would leave the tskDEFERRED_SUSPENSION latched
+                         * after the deletion completes, preventing the calling context from yielding. */
+                        pxTCB->uxDeferredStateChange = 0U;
+                    }
                 }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
-            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+            }
+            #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) */
 
             #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                 if( xDeferredDeletion == pdFALSE )
@@ -2459,6 +2634,10 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                      * the task that has just been deleted. */
                     prvResetNextTaskUnblockTime();
                 }
+
+                #if ( ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) )
+                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                #endif
             }
         }
         kernelEXIT_CRITICAL();
@@ -2833,15 +3012,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskPriorityGet( xTask );
 
-        #if ( ( configNUMBER_OF_CORES > 1 ) )
-        {
-            kernelENTER_CRITICAL();
-        }
-        #else
-        {
-            portBASE_TYPE_ENTER_CRITICAL();
-        }
-        #endif
+        taskBASE_TYPE_ENTER_CRITICAL();
         {
             /* If null is passed in here then it is the priority of the task
              * that called uxTaskPriorityGet() that is being queried. */
@@ -2850,15 +3021,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxPriority;
         }
-        #if ( ( configNUMBER_OF_CORES > 1 ) )
-        {
-            kernelEXIT_CRITICAL();
-        }
-        #else
-        {
-            portBASE_TYPE_EXIT_CRITICAL();
-        }
-        #endif
+        taskBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_uxTaskPriorityGet( uxReturn );
 
@@ -2927,15 +3090,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_uxTaskBasePriorityGet( xTask );
 
-        #if ( ( configNUMBER_OF_CORES > 1 ) )
-        {
-            kernelENTER_CRITICAL();
-        }
-        #else
-        {
-            portBASE_TYPE_ENTER_CRITICAL();
-        }
-        #endif
+        taskBASE_TYPE_ENTER_CRITICAL();
         {
             /* If null is passed in here then it is the base priority of the task
              * that called uxTaskBasePriorityGet() that is being queried. */
@@ -2944,15 +3099,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
             uxReturn = pxTCB->uxBasePriority;
         }
-        #if ( ( configNUMBER_OF_CORES > 1 ) )
-        {
-            kernelEXIT_CRITICAL();
-        }
-        #else
-        {
-            portBASE_TYPE_EXIT_CRITICAL();
-        }
-        #endif
+        taskBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_uxTaskBasePriorityGet( uxReturn );
 
@@ -3287,30 +3434,14 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         traceENTER_vTaskCoreAffinityGet( xTask );
 
-        #if ( ( configNUMBER_OF_CORES > 1 ) )
-        {
-            kernelENTER_CRITICAL();
-        }
-        #else
-        {
-            portBASE_TYPE_ENTER_CRITICAL();
-        }
-        #endif
+        taskBASE_TYPE_ENTER_CRITICAL();
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
 
             uxCoreAffinityMask = pxTCB->uxCoreAffinityMask;
         }
-        #if ( ( configNUMBER_OF_CORES > 1 ) )
-        {
-            kernelEXIT_CRITICAL();
-        }
-        #else
-        {
-            portBASE_TYPE_EXIT_CRITICAL();
-        }
-        #endif
+        taskBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask );
 
@@ -3320,15 +3451,234 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 /*-----------------------------------------------------------*/
 
-#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+#if ( portUSING_GRANULAR_LOCKS == 1 )
 
+    static void prvTaskTCBLockCheckForRunStateChange( void )
+    {
+        const TCB_t * pxThisTCB;
+        BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+        /* This must only be called from within a task. */
+        portASSERT_IF_IN_ISR();
+
+        /* This function is always called with interrupts disabled
+         * so this is safe. */
+        pxThisTCB = pxCurrentTCBs[ xCoreID ];
+
+        while( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD )
+        {
+            UBaseType_t uxPrevCriticalNesting;
+
+            /* We are only here if we just entered a critical section
+            * or if we just suspended the scheduler, and another task
+            * has requested that we yield.
+            *
+            * This is slightly complicated since we need to save and restore
+            * the suspension and critical nesting counts, as well as release
+            * and reacquire the correct locks. And then, do it all over again
+            * if our state changed again during the reacquisition. */
+            uxPrevCriticalNesting = portGET_CRITICAL_NESTING_COUNT( xCoreID );
+
+            if( uxPrevCriticalNesting > 0U )
+            {
+                portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
+                portRELEASE_SPINLOCK( xCoreID, &pxCurrentTCBs[ xCoreID ]->xTCBSpinlock );
+            }
+            else
+            {
+                /* The scheduler is suspended. uxSchedulerSuspended is updated
+                 * only when the task is not requested to yield. */
+                mtCOVERAGE_TEST_MARKER();
+            }
+
+            portMEMORY_BARRIER();
+
+            portENABLE_INTERRUPTS();
+
+            /* Enabling interrupts should cause this core to immediately service
+             * the pending interrupt and yield. After servicing the pending interrupt,
+             * the task needs to re-evaluate its run state within this loop, as
+             * other cores may have requested this task to yield, potentially altering
+             * its run state. */
+
+            portDISABLE_INTERRUPTS();
+
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
+            portGET_SPINLOCK( xCoreID, &pxCurrentTCBs[ xCoreID ]->xTCBSpinlock );
+
+            portSET_CRITICAL_NESTING_COUNT( xCoreID, uxPrevCriticalNesting );
+        }
+    }
+
+    void vTaskTCBEnterCritical( void )
+    {
+        if( xSchedulerRunning != pdFALSE )
+        {
+            portDISABLE_INTERRUPTS();
+            {
+                const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+                portGET_SPINLOCK( xCoreID, &pxCurrentTCBs[ xCoreID ]->xTCBSpinlock );
+
+                portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                if( ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U ) &&
+                    ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) )
+                {
+                    prvTaskTCBLockCheckForRunStateChange();
+                }
+            }
+        }
+    }
+
+    void vTaskTCBExitCritical( void )
+    {
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+        if( xSchedulerRunning != pdFALSE )
+        {
+            if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U )
+            {
+                BaseType_t xYieldCurrentTask = pdFALSE;
+
+                /* Get the xYieldPending stats inside the critical section. */
+                if( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+                {
+                    xYieldCurrentTask = xYieldPendings[ xCoreID ];
+                }
+
+                portRELEASE_SPINLOCK( xCoreID, &pxCurrentTCBs[ xCoreID ]->xTCBSpinlock );
+
+                portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+                /* If the critical nesting count is 0, enable interrupts */
+                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                {
+                    portENABLE_INTERRUPTS();
+
+                    if( xYieldCurrentTask != pdFALSE )
+                    {
+                        portYIELD();
+                    }
+                }
+            }
+        }
+    }
+
+    static void prvTaskDataGroupCheckForRunStateChange( portSPINLOCK_TYPE * pxTaskSpinlock,
+                                                        portSPINLOCK_TYPE * pxISRSpinlock )
+    {
+        const TCB_t * pxThisTCB;
+        BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+        /* This must only be called from within a task. */
+        portASSERT_IF_IN_ISR();
+
+        /* This function is always called with interrupts disabled
+         * so this is safe. */
+        pxThisTCB = pxCurrentTCBs[ xCoreID ];
+
+        while( pxThisTCB->xTaskRunState == taskTASK_SCHEDULED_TO_YIELD )
+        {
+            UBaseType_t uxPrevCriticalNesting;
+
+            /* We are only here if we just entered a critical section
+            * or if we just suspended the scheduler, and another task
+            * has requested that we yield.
+            *
+            * This is slightly complicated since we need to save and restore
+            * the suspension and critical nesting counts, as well as release
+            * and reacquire the correct locks. And then, do it all over again
+            * if our state changed again during the reacquisition. */
+            uxPrevCriticalNesting = portGET_CRITICAL_NESTING_COUNT( xCoreID );
+
+            /* Data group lock. */
+            if( uxPrevCriticalNesting > 0U )
+            {
+                portSET_CRITICAL_NESTING_COUNT( xCoreID, 0U );
+                portRELEASE_SPINLOCK( xCoreID, pxISRSpinlock );
+            }
+            else
+            {
+                /* The scheduler is suspended. uxSchedulerSuspended is updated
+                 * only when the task is not requested to yield. */
+                mtCOVERAGE_TEST_MARKER();
+            }
+
+            portENABLE_INTERRUPTS();
+
+            portRELEASE_SPINLOCK( xCoreID, pxTaskSpinlock );
+
+            portMEMORY_BARRIER();
+
+            xTaskPreemptionEnableWithYieldStatus( NULL );
+
+
+
+            /* Enabling interrupts should cause this core to immediately service
+             * the pending interrupt and yield. After servicing the pending interrupt,
+             * the task needs to re-evaluate its run state within this loop, as
+             * other cores may have requested this task to yield, potentially altering
+             * its run state. */
+
+            vTaskPreemptionDisable( NULL );
+
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
+            portGET_SPINLOCK( xCoreID, pxTaskSpinlock );
+            /* Disable interrupts */
+            portDISABLE_INTERRUPTS();
+            /* Take the ISR spinlock next */
+            portGET_SPINLOCK( xCoreID, pxISRSpinlock );
+            /* Increment the critical nesting count */
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+        }
+    }
+
+    void vTaskDataGroupEnterCritical( portSPINLOCK_TYPE * pxTaskSpinlock,
+                                      portSPINLOCK_TYPE * pxISRSpinlock )
+    {
+        /* Disable preemption to avoid task state changes during the critical section. */
+        vTaskPreemptionDisable( NULL );
+        {
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+            /* Task spinlock is always taken first */
+            portGET_SPINLOCK( xCoreID, pxTaskSpinlock );
+            /* Disable interrupts */
+            portDISABLE_INTERRUPTS();
+            /* Take the ISR spinlock next */
+            portGET_SPINLOCK( xCoreID, pxISRSpinlock );
+            /* Increment the critical nesting count */
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+
+            if( xSchedulerRunning == pdTRUE )
+            {
+                if( ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U ) &&
+                    ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 1U ) )
+                {
+                    prvTaskDataGroupCheckForRunStateChange( pxTaskSpinlock, pxISRSpinlock );
+                }
+            }
+        }
+    }
+
+    BaseType_t taskDataGroupUnlock( portSPINLOCK_TYPE * pxTaskSpinlock )
+    {
+        /* Release the task spinlock and re-enable preemption, returning whether
+         * re-enabling preemption requires the caller to yield. */
+        portRELEASE_SPINLOCK( portGET_CORE_ID(), pxTaskSpinlock );
+        return xTaskPreemptionEnableWithYieldStatus( NULL );
+    }
+#endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+/*-----------------------------------------------------------*/
+
+#if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
     void vTaskPreemptionDisable( const TaskHandle_t xTask )
     {
         TCB_t * pxTCB;
 
         traceENTER_vTaskPreemptionDisable( xTask );
 
-        kernelENTER_CRITICAL();
+        kernelTCB_ENTER_CRITICAL();
         {
             if( xSchedulerRunning != pdFALSE )
             {
@@ -3342,7 +3692,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        kernelEXIT_CRITICAL();
+        kernelTCB_EXIT_CRITICAL();
 
         traceRETURN_vTaskPreemptionDisable();
     }
@@ -3352,18 +3702,19 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
-    BaseType_t prvTaskPreemptionEnable( const TaskHandle_t xTask )
+    BaseType_t xTaskPreemptionEnableWithYieldStatus( const TaskHandle_t xTask )
     {
         TCB_t * pxTCB;
-        UBaseType_t uxDeferredAction = 0U;
+        BaseType_t xHasDeferredAction = pdFALSE;
         BaseType_t xAlreadyYielded = pdFALSE;
+        BaseType_t xTaskRequestedToYield = pdFALSE;
 
-        traceENTER_vTaskPreemptionEnable( xTask );
-
-        kernelENTER_CRITICAL();
+        kernelTCB_ENTER_CRITICAL();
         {
             if( xSchedulerRunning != pdFALSE )
             {
+                /* Current task running on the core can not be changed by other core.
+                * Get TCB from handle is safe to call within TCB critical section. */
                 pxTCB = prvGetTCBFromHandle( xTask );
                 configASSERT( pxTCB != NULL );
                 configASSERT( pxTCB->uxPreemptionDisable > 0U );
@@ -3374,14 +3725,20 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 {
                     if( pxTCB->uxDeferredStateChange != 0U )
                     {
-                        uxDeferredAction = pxTCB->uxDeferredStateChange;
+                        /* A deferred state change is pending. Record only the fact
+                         * that a deferred action is pending, rather than the specific
+                         * deferred action itself. This allows us to tolerate a concurrent
+                         * vTaskDelete()/vTaskSuspend() on another core that may have
+                         * upgraded the deferred action between the snapshot and the dispatch.
+                         * The actual deferred action will be read and dispatched in the
+                         * loop below after exiting the TCB critical section. */
+                        xHasDeferredAction = pdTRUE;
                     }
                     else
                     {
                         if( ( xYieldPendings[ pxTCB->xTaskRunState ] != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) != pdFALSE ) )
                         {
-                            prvYieldCore( pxTCB->xTaskRunState );
-                            xAlreadyYielded = pdTRUE;
+                            xTaskRequestedToYield = pdTRUE;
                         }
                         else
                         {
@@ -3399,25 +3756,49 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        kernelEXIT_CRITICAL();
+        kernelTCB_EXIT_CRITICAL();
 
-        if( uxDeferredAction != 0U )
+        if( xHasDeferredAction != pdFALSE )
         {
-            if( uxDeferredAction & tskDEFERRED_DELETION )
+            /* Read uxDeferredStateChange after exiting the TCB critical section.
+             * Between the snapshot and here, another core may have upgraded the
+             * deferred action. */
+            if( pxTCB->uxDeferredStateChange & tskDEFERRED_DELETION )
             {
                 vTaskDelete( xTask );
+                xAlreadyYielded = pdTRUE;
             }
-            else if( uxDeferredAction & tskDEFERRED_SUSPENSION )
+            else if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
             {
                 vTaskSuspend( xTask );
+                xAlreadyYielded = pdTRUE;
             }
             else
             {
+                /* Concurrent operation cleared the deferred state — nothing to do. */
                 mtCOVERAGE_TEST_MARKER();
             }
+        }
+        else
+        {
+            if( xTaskRequestedToYield != pdFALSE )
+            {
+                /* prvYieldCore must be called in critical section. */
+                kernelENTER_CRITICAL();
+                {
+                    pxTCB = prvGetTCBFromHandle( xTask );
 
-            /* Any deferred action on the task would result in a context switch. */
-            xAlreadyYielded = pdTRUE;
+                    /* There is gap between TCB critical section and kernel critical section.
+                     * Checking the yield pending again to prevent that the current task
+                     * already handle the yield request. */
+                    if( ( xYieldPendings[ pxTCB->xTaskRunState ] != pdFALSE ) && ( taskTASK_IS_RUNNING( pxTCB ) != pdFALSE ) )
+                    {
+                        prvYieldCore( pxTCB->xTaskRunState );
+                    }
+                }
+                kernelEXIT_CRITICAL();
+                xAlreadyYielded = pdTRUE;
+            }
         }
 
         return xAlreadyYielded;
@@ -3431,7 +3812,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         traceENTER_vTaskPreemptionEnable( xTask );
 
-        ( void ) prvTaskPreemptionEnable( xTask );
+        ( void ) xTaskPreemptionEnableWithYieldStatus( xTask );
 
         traceRETURN_vTaskPreemptionEnable();
     }
@@ -3453,30 +3834,72 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
         kernelENTER_CRITICAL();
         {
+            #if ( ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) )
+                const BaseType_t xCoreID = portGET_CORE_ID();
+            #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) */
+
             /* If null is passed in here then it is the running task that is
              * being suspended. */
             pxTCB = prvGetTCBFromHandle( xTaskToSuspend );
             configASSERT( pxTCB != NULL );
 
-            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            #if ( ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) )
+            {
+                /* Acquire the TCB lock before reading the preemption-disable
+                 * count to avoid a race with the target task running on another
+                 * core (which may be modifying uxPreemptionDisable concurrently). */
+                portGET_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
 
                 /* If the task has disabled preemption, we need to defer the suspension until the
                  * task enables preemption. The suspension will be performed in vTaskPreemptionEnable(). */
                 if( pxTCB->uxPreemptionDisable > 0U )
                 {
-                    pxTCB->uxDeferredStateChange |= tskDEFERRED_SUSPENSION;
+                    /* Only queue the suspension if a deletion is not already deferred.
+                     * Deletion takes priority — if both are requested, the dispatcher
+                     * will only process the deletion. Recording tskDEFERRED_SUSPENSION on top of
+                     * a pending tskDEFERRED_DELETION would have no effect. */
+                    if( ( pxTCB->uxDeferredStateChange & tskDEFERRED_DELETION ) == 0U )
+                    {
+                        pxTCB->uxDeferredStateChange |= tskDEFERRED_SUSPENSION;
+                    }
+
                     xDeferredSuspension = pdTRUE;
+                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    /* Reset the deferred state change flags */
+                    pxTCB->uxDeferredStateChange &= ~tskDEFERRED_SUSPENSION;
                 }
-            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+            }
+            #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) */
 
             #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                 if( xDeferredSuspension == pdFALSE )
             #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
             {
+                #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+                {
+                    /* In SMP + granular-locks builds, an earlier-deferred suspension
+                     * can be dispatched at the same time another core is calling
+                     * vTaskDelete() on the same TCB. The dispatcher in
+                     * xTaskPreemptionEnableWithYieldStatus releases the TCB
+                     * spinlock before calling us, leaving a small window in which
+                     * vTaskDelete can complete its immediate path and move the TCB
+                     * onto xTasksWaitingTermination. If that has happened, the
+                     * deletion takes precedence — abort here rather than moving
+                     * the TCB off the termination list (which would silently drop
+                     * the deletion request and leak the TCB). */
+                    if( listLIST_ITEM_CONTAINER( &( pxTCB->xStateListItem ) ) == &xTasksWaitingTermination )
+                    {
+                        portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                        kernelEXIT_CRITICAL();
+                        traceRETURN_vTaskSuspend();
+                        return;
+                    }
+                }
+                #endif /* ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) */
+
                 traceTASK_SUSPEND( pxTCB );
 
                 /* Remove task from the ready/delayed list and place in the
@@ -3557,6 +3980,9 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     }
                 }
                 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+                #if ( ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) && ( portUSING_GRANULAR_LOCKS == 1 ) )
+                    portRELEASE_SPINLOCK( xCoreID, &pxTCB->xTCBSpinlock );
+                #endif
             }
         }
         kernelEXIT_CRITICAL();
@@ -3734,7 +4160,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             kernelENTER_CRITICAL();
             {
                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-
+                {
                     /* If the task being resumed is in a deferred suspension state,
                      * we simply clear the deferred suspension state and return. */
                     if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
@@ -3746,6 +4172,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                     {
                         mtCOVERAGE_TEST_MARKER();
                     }
+                }
                 #endif /* configUSE_TASK_PREEMPTION_DISABLE */
 
                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
@@ -3794,6 +4221,10 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         TCB_t * const pxTCB = xTaskToResume;
         UBaseType_t uxSavedInterruptStatus;
 
+        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+            BaseType_t xTaskResumed = pdFALSE;
+        #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+
         traceENTER_xTaskResumeFromISR( xTaskToResume );
 
         configASSERT( xTaskToResume );
@@ -3821,58 +4252,82 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         /* coverity[misra_c_2012_directive_4_7_violation] */
         uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
         {
-            if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
             {
-                traceTASK_RESUME_FROM_ISR( pxTCB );
+                /* FIXME : Acquire the TCB lock before reading the preemptions
+                 * disable count. */
 
-                /* Check the ready lists can be accessed. */
-                if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
+                /* If the task being resumed is in a deferred suspension state,
+                 * we simply clear the deferred suspension state and return. */
+                if( pxTCB->uxDeferredStateChange & tskDEFERRED_SUSPENSION )
                 {
-                    #if ( configNUMBER_OF_CORES == 1 )
-                    {
-                        /* Ready lists can be accessed so move the task from the
-                         * suspended list to the ready list directly. */
-                        if( pxTCB->uxPriority > pxCurrentTCB->uxPriority )
-                        {
-                            xYieldRequired = pdTRUE;
-
-                            /* Mark that a yield is pending in case the user is not
-                             * using the return value to initiate a context switch
-                             * from the ISR using the port specific portYIELD_FROM_ISR(). */
-                            xYieldPendings[ 0 ] = pdTRUE;
-                        }
-                        else
-                        {
-                            mtCOVERAGE_TEST_MARKER();
-                        }
-                    }
-                    #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
-
-                    ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
-                    prvAddTaskToReadyList( pxTCB );
+                    pxTCB->uxDeferredStateChange &= ~tskDEFERRED_SUSPENSION;
+                    xTaskResumed = pdTRUE;
                 }
                 else
                 {
-                    /* The delayed or ready lists cannot be accessed so the task
-                     * is held in the pending ready list until the scheduler is
-                     * unsuspended. */
-                    vListInsertEnd( &( xPendingReadyList ), &( pxTCB->xEventListItem ) );
+                    mtCOVERAGE_TEST_MARKER();
                 }
-
-                #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
-                {
-                    prvYieldForTask( pxTCB );
-
-                    if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
-                    {
-                        xYieldRequired = pdTRUE;
-                    }
-                }
-                #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) ) */
             }
-            else
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
+
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                if( xTaskResumed == pdFALSE )
+            #endif /* configUSE_TASK_PREEMPTION_DISABLE */
             {
-                mtCOVERAGE_TEST_MARKER();
+                if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
+                {
+                    traceTASK_RESUME_FROM_ISR( pxTCB );
+
+                    /* Check the ready lists can be accessed. */
+                    if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
+                    {
+                        #if ( configNUMBER_OF_CORES == 1 )
+                        {
+                            /* Ready lists can be accessed so move the task from the
+                             * suspended list to the ready list directly. */
+                            if( pxTCB->uxPriority > pxCurrentTCB->uxPriority )
+                            {
+                                xYieldRequired = pdTRUE;
+
+                                /* Mark that a yield is pending in case the user is not
+                                 * using the return value to initiate a context switch
+                                 * from the ISR using the port specific portYIELD_FROM_ISR(). */
+                                xYieldPendings[ 0 ] = pdTRUE;
+                            }
+                            else
+                            {
+                                mtCOVERAGE_TEST_MARKER();
+                            }
+                        }
+                        #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
+
+                        ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
+                        prvAddTaskToReadyList( pxTCB );
+                    }
+                    else
+                    {
+                        /* The delayed or ready lists cannot be accessed so the task
+                         * is held in the pending ready list until the scheduler is
+                         * unsuspended. */
+                        vListInsertEnd( &( xPendingReadyList ), &( pxTCB->xEventListItem ) );
+                    }
+
+                    #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
+                    {
+                        prvYieldForTask( pxTCB );
+
+                        if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+                        {
+                            xYieldRequired = pdTRUE;
+                        }
+                    }
+                    #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) ) */
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
             }
         }
         kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
@@ -4259,6 +4714,13 @@ void vTaskSuspendAll( void )
 
             kernelGET_TASK_LOCK( xCoreID );
 
+            /* Task lock is acquired here to increase the scheduler suspended count.
+             * In granular lock, it is possible that prvYieldCore is called with only
+             * ISR spinlock is acquired in ISR. To remove the gap, the logic is updated
+             * to acquire the ISR spinlock before check for run state. The logic in
+             * prvCheckForRunStateChange() is updated accordingly. */
+            kernelGET_ISR_LOCK( xCoreID );
+
             /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
              * purpose is to prevent altering the variable when fromISR APIs are readying
              * it. */
@@ -4267,9 +4729,16 @@ void vTaskSuspendAll( void )
                 /* If the scheduler is being suspended after taking a granular lock (in any data group)
                  * then we do not check for the run state of a task and we let it run through until
                  * the granular lock is released. */
+
+                /* Task may acquire kernel lock in data group critical section.
+                * In this case, check for run state change is not required since
+                * we can't yield for other task when preemption is disabled. */
                 #if ( portUSING_GRANULAR_LOCKS == 1 )
                     && ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
                 #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                    && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+                #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
                 )
             {
                 prvCheckForRunStateChange();
@@ -4284,15 +4753,17 @@ void vTaskSuspendAll( void )
              * task lock for the core is acquired in prvCheckForRunStateChange. */
             xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
-            kernelGET_ISR_LOCK( xCoreID );
-
             /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
              * is used to allow calls to vTaskSuspendAll() to nest. */
-            /* Record the core owning the (outermost) suspension. */
-            if( uxSchedulerSuspended == 0U )
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
             {
-                xSchedulerSuspendedFromCore = xCoreID;
+                /* Record the core owning the (outermost) suspension. */
+                if( uxSchedulerSuspended == 0U )
+                {
+                    xSchedulerSuspendedFromCore = xCoreID;
+                }
             }
+            #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
             ++uxSchedulerSuspended;
             kernelRELEASE_ISR_LOCK( xCoreID );
@@ -4401,14 +4872,19 @@ BaseType_t xTaskResumeAll( void )
 
             uxSchedulerSuspended = ( UBaseType_t ) ( uxSchedulerSuspended - 1U );
             #if ( configNUMBER_OF_CORES > 1 )
-                if( uxSchedulerSuspended == 0U )
+            {
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
                 {
-                    xSchedulerSuspendedFromCore = -1;
+                    if( uxSchedulerSuspended == 0U )
+                    {
+                        xSchedulerSuspendedFromCore = -1;
+                    }
                 }
-            #endif
-            #if ( configNUMBER_OF_CORES > 1 )
+                #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
                 kernelRELEASE_TASK_LOCK( xCoreID );
-            #endif
+            }
+            #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
             if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
             {
@@ -4442,9 +4918,9 @@ BaseType_t xTaskResumeAll( void )
                         }
                         #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                         {
-                            /* All appropriate tasks yield at the moment a task is added to xPendingReadyList.
-                             * If the current core yielded then vTaskSwitchContext() has already been called
-                             * which sets xYieldPendings for the current core to pdTRUE. */
+                            /* Yield for the task when removing out from pending
+                             * ready list. */
+                            prvYieldForTask( pxTCB );
                         }
                         #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
                     }
@@ -5160,6 +5636,10 @@ BaseType_t xTaskIncrementTick( void )
         UBaseType_t uxSavedInterruptStatus;
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configUSE_TICK_HOOK == 1 ) )
+        BaseType_t xApplicationTickRequired = pdFALSE;
+    #endif
+
     traceENTER_xTaskIncrementTick();
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
@@ -5334,7 +5814,15 @@ BaseType_t xTaskIncrementTick( void )
              * count is being unwound (when the scheduler is being unlocked). */
             if( xPendedTicks == ( TickType_t ) 0 )
             {
-                vApplicationTickHook();
+                #if ( portUSING_GRANULAR_LOCKS == 1 )
+                {
+                    xApplicationTickRequired = pdTRUE;
+                }
+                #else
+                {
+                    vApplicationTickHook();
+                }
+                #endif
             }
             else
             {
@@ -5398,14 +5886,33 @@ BaseType_t xTaskIncrementTick( void )
          * scheduler is locked. */
         #if ( configUSE_TICK_HOOK == 1 )
         {
-            vApplicationTickHook();
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
+            {
+                xApplicationTickRequired = pdTRUE;
+            }
+            #else
+            {
+                vApplicationTickHook();
+            }
+            #endif
         }
-        #endif
+        #endif /* configUSE_TICK_HOOK */
     }
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configUSE_TICK_HOOK == 1 ) )
+    {
+        /* In order not to voilate granular lock critical section hierarchy, calling
+         * the vApplicationTickHook when leaving the kernel critical section. */
+        if( xApplicationTickRequired == pdTRUE )
+        {
+            vApplicationTickHook();
+        }
+    }
+    #endif
 
     traceRETURN_xTaskIncrementTick( xSwitchRequired );
 
@@ -5652,13 +6159,11 @@ BaseType_t xTaskIncrementTick( void )
              * SMP port. */
             configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 );
 
-            /* vTaskSwitchContext() must not be called with a task that has
-             * preemption disabled. */
-            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                configASSERT( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U );
-            #endif
-
-            if( uxSchedulerSuspended != ( UBaseType_t ) 0U )
+            if( ( uxSchedulerSuspended != ( UBaseType_t ) 0U )
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                    || ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable != 0U )
+                #endif
+                )
             {
                 /* The scheduler is currently suspended or the task
                  * has requested to not be preempted - do not allow
@@ -5876,137 +6381,152 @@ void vTaskPlaceOnUnorderedEventList( List_t * pxEventList,
 
 BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
 {
-    TCB_t * pxUnblockedTCB;
     BaseType_t xReturn;
-
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        UBaseType_t uxSavedInterruptStatus;
-    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     traceENTER_xTaskRemoveFromEventList( pxEventList );
 
-    #if ( !( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) )
-
-        /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
-         * called from a critical section within an ISR. */
-    #else /* #if ( ! ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) ) */
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         /* Lock the kernel data group as we are about to access its members */
-        if( portCHECK_IF_IN_ISR() == pdTRUE )
+        prvKernelEnterISROnlyCritical();
         {
-            uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
+            xReturn = prvTaskRemoveFromEventList( pxEventList );
+        }
+        prvKernelExitISROnlyCritical();
+    #else
+        xReturn = prvTaskRemoveFromEventList( pxEventList );
+    #endif
+
+    traceRETURN_xTaskRemoveFromEventList( xReturn );
+    return xReturn;
+}
+
+/*-----------------------------------------------------------*/
+
+BaseType_t xTaskRemoveFromEventListFromISR( const List_t * const pxEventList )
+{
+    BaseType_t xReturn;
+
+    traceENTER_xTaskRemoveFromEventListFromISR( pxEventList );
+
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    {
+        UBaseType_t uxSavedInterruptStatus;
+
+        /* Lock the kernel data group as we are about to access its members */
+        uxSavedInterruptStatus = kernelENTER_CRITICAL_FROM_ISR();
+        {
+            xReturn = prvTaskRemoveFromEventList( pxEventList );
+        }
+        kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
+    }
+    #else /* if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+    {
+        xReturn = prvTaskRemoveFromEventList( pxEventList );
+    }
+    #endif /* if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
+    traceRETURN_xTaskRemoveFromEventListFromISR( xReturn );
+    return xReturn;
+}
+
+/*-----------------------------------------------------------*/
+
+STATIC BaseType_t prvTaskRemoveFromEventList( const List_t * const pxEventList )
+{
+    TCB_t * pxUnblockedTCB;
+    BaseType_t xReturn;
+
+    /* THIS FUNCTION MUST BE CALLED FROM A CRITICAL SECTION.  It can also be
+     * called from a critical section within an ISR. */
+
+    /* Before proceeding, check if the event list is empty */
+    if( listLIST_IS_EMPTY( pxEventList ) == pdFALSE )
+    {
+        /* The event list is sorted in priority order, so the first in the list can
+         * be removed as it is known to be the highest priority.  Remove the TCB from
+         * the delayed list, and add it to the ready list.
+         *
+         * If an event is for a queue that is locked then this function will never
+         * get called - the lock count on the queue will get modified instead.  This
+         * means exclusive access to the event list is guaranteed here.
+         *
+         * This function assumes that a check has already been made to ensure that
+         * pxEventList is not empty. */
+        /* MISRA Ref 11.5.3 [Void pointer assignment] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
+        /* coverity[misra_c_2012_rule_11_5_violation] */
+        pxUnblockedTCB = listGET_OWNER_OF_HEAD_ENTRY( pxEventList );
+        configASSERT( pxUnblockedTCB );
+        listREMOVE_ITEM( &( pxUnblockedTCB->xEventListItem ) );
+
+        if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
+        {
+            listREMOVE_ITEM( &( pxUnblockedTCB->xStateListItem ) );
+            prvAddTaskToReadyList( pxUnblockedTCB );
+
+            #if ( configUSE_TICKLESS_IDLE != 0 )
+            {
+                /* If a task is blocked on a kernel object then xNextTaskUnblockTime
+                 * might be set to the blocked task's time out time.  If the task is
+                 * unblocked for a reason other than a timeout xNextTaskUnblockTime is
+                 * normally left unchanged, because it is automatically reset to a new
+                 * value when the tick count equals xNextTaskUnblockTime.  However if
+                 * tickless idling is used it might be more important to enter sleep mode
+                 * at the earliest possible time - so reset xNextTaskUnblockTime here to
+                 * ensure it is updated at the earliest possible time. */
+                prvResetNextTaskUnblockTime();
+            }
+            #endif
         }
         else
         {
-            uxSavedInterruptStatus = 0;
-            kernelENTER_CRITICAL();
+            /* The delayed and ready lists cannot be accessed, so hold this task
+             * pending until the scheduler is resumed. */
+            listINSERT_END( &( xPendingReadyList ), &( pxUnblockedTCB->xEventListItem ) );
         }
 
-        /* Before taking the kernel lock, another task/ISR could have already
-         * emptied the pxEventList. So we insert a check here to see if
-         * pxEventList is empty before attempting to remove an item from it. */
-        if( listLIST_IS_EMPTY( pxEventList ) == pdFALSE )
+        #if ( configNUMBER_OF_CORES == 1 )
         {
-    #endif /* #if ( ! ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) ) */
+            if( pxUnblockedTCB->uxPriority > pxCurrentTCB->uxPriority )
+            {
+                /* Return true if the task removed from the event list has a higher
+                 * priority than the calling task.  This allows the calling task to know if
+                 * it should force a context switch now. */
+                xReturn = pdTRUE;
 
-    /* The event list is sorted in priority order, so the first in the list can
-     * be removed as it is known to be the highest priority.  Remove the TCB from
-     * the delayed list, and add it to the ready list.
-     *
-     * If an event is for a queue that is locked then this function will never
-     * get called - the lock count on the queue will get modified instead.  This
-     * means exclusive access to the event list is guaranteed here.
-     *
-     * This function assumes that a check has already been made to ensure that
-     * pxEventList is not empty. */
-    /* MISRA Ref 11.5.3 [Void pointer assignment] */
-    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
-    /* coverity[misra_c_2012_rule_11_5_violation] */
-    pxUnblockedTCB = listGET_OWNER_OF_HEAD_ENTRY( pxEventList );
-    configASSERT( pxUnblockedTCB );
-    listREMOVE_ITEM( &( pxUnblockedTCB->xEventListItem ) );
-
-    if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
-    {
-        listREMOVE_ITEM( &( pxUnblockedTCB->xStateListItem ) );
-        prvAddTaskToReadyList( pxUnblockedTCB );
-
-        #if ( configUSE_TICKLESS_IDLE != 0 )
-        {
-            /* If a task is blocked on a kernel object then xNextTaskUnblockTime
-             * might be set to the blocked task's time out time.  If the task is
-             * unblocked for a reason other than a timeout xNextTaskUnblockTime is
-             * normally left unchanged, because it is automatically reset to a new
-             * value when the tick count equals xNextTaskUnblockTime.  However if
-             * tickless idling is used it might be more important to enter sleep mode
-             * at the earliest possible time - so reset xNextTaskUnblockTime here to
-             * ensure it is updated at the earliest possible time. */
-            prvResetNextTaskUnblockTime();
+                /* Mark that a yield is pending in case the user is not using the
+                 * "xHigherPriorityTaskWoken" parameter to an ISR safe FreeRTOS function. */
+                xYieldPendings[ 0 ] = pdTRUE;
+            }
+            else
+            {
+                xReturn = pdFALSE;
+            }
         }
-        #endif
+        #else /* #if ( configNUMBER_OF_CORES == 1 ) */
+        {
+            xReturn = pdFALSE;
+
+            #if ( configUSE_PREEMPTION == 1 )
+            {
+                prvYieldForTask( pxUnblockedTCB );
+
+                if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+                {
+                    xReturn = pdTRUE;
+                }
+            }
+            #endif /* #if ( configUSE_PREEMPTION == 1 ) */
+        }
+        #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
     }
     else
     {
-        /* The delayed and ready lists cannot be accessed, so hold this task
-         * pending until the scheduler is resumed. */
-        listINSERT_END( &( xPendingReadyList ), &( pxUnblockedTCB->xEventListItem ) );
-    }
-
-    #if ( configNUMBER_OF_CORES == 1 )
-    {
-        if( pxUnblockedTCB->uxPriority > pxCurrentTCB->uxPriority )
-        {
-            /* Return true if the task removed from the event list has a higher
-             * priority than the calling task.  This allows the calling task to know if
-             * it should force a context switch now. */
-            xReturn = pdTRUE;
-
-            /* Mark that a yield is pending in case the user is not using the
-             * "xHigherPriorityTaskWoken" parameter to an ISR safe FreeRTOS function. */
-            xYieldPendings[ 0 ] = pdTRUE;
-        }
-        else
-        {
-            xReturn = pdFALSE;
-        }
-    }
-    #else /* #if ( configNUMBER_OF_CORES == 1 ) */
-    {
+        /* The pxEventList was emptied before we entered the critical
+         * section, Nothing to do except return pdFALSE. */
         xReturn = pdFALSE;
-
-        #if ( configUSE_PREEMPTION == 1 )
-        {
-            prvYieldForTask( pxUnblockedTCB );
-
-            if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
-            {
-                xReturn = pdTRUE;
-            }
-        }
-        #endif /* #if ( configUSE_PREEMPTION == 1 ) */
     }
-    #endif /* #if ( configNUMBER_OF_CORES == 1 ) */
 
-    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-}
-else
-{
-    /* The pxEventList was emptied before we entered the critical
-     * section, Nothing to do except return pdFALSE. */
-    xReturn = pdFALSE;
-}
-
-/* We are done accessing the kernel data group. Unlock it. */
-if( portCHECK_IF_IN_ISR() == pdTRUE )
-{
-    kernelEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus );
-}
-else
-{
-    kernelEXIT_CRITICAL();
-}
-    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
-
-    traceRETURN_xTaskRemoveFromEventList( xReturn );
     return xReturn;
 }
 /*-----------------------------------------------------------*/
@@ -6018,9 +6538,12 @@ void vTaskRemoveFromUnorderedEventList( ListItem_t * pxEventListItem,
 
     traceENTER_vTaskRemoveFromUnorderedEventList( pxEventListItem, xItemValue );
 
-    /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
-     * the event flags implementation. */
-    configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #if ( !( portUSING_GRANULAR_LOCKS == 1 ) )
+
+        /* THIS FUNCTION MUST BE CALLED WITH THE SCHEDULER SUSPENDED.  It is used by
+         * the event flags implementation. */
+        configASSERT( uxSchedulerSuspended != ( UBaseType_t ) 0U );
+    #endif /* #if ( ! ( portUSING_GRANULAR_LOCKS == 1 ) ) */
 
     /* Store the new item value in the event list. */
     listSET_LIST_ITEM_VALUE( pxEventListItem, xItemValue | taskEVENT_LIST_ITEM_VALUE_IN_USE );
@@ -6105,7 +6628,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         /* Lock the kernel data group as we are about to access its members */
-        kernelENTER_CRITICAL();
+        prvKernelEnterISROnlyCritical();
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     /* For internal use only as it does not use a critical section. */
@@ -6114,7 +6637,7 @@ void vTaskInternalSetTimeOutState( TimeOut_t * const pxTimeOut )
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
         /* We are done accessing the kernel data group. Unlock it. */
-        kernelEXIT_CRITICAL();
+        prvKernelExitISROnlyCritical();
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
     traceRETURN_vTaskInternalSetTimeOutState();
@@ -7536,7 +8059,16 @@ STATIC void prvResetNextTaskUnblockTime( void )
         {
             const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
-            if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+            if( ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
+                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+
+                    /* Task yield can be called in a data group critilcal section.
+                     * Adding a preemption disable check to prevent invalid context
+                     * switch. */
+                    && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
+                    ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
+                #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+                )
             {
                 portYIELD();
             }
@@ -7626,7 +8158,11 @@ STATIC void prvResetNextTaskUnblockTime( void )
                  * interrupt.  Only assert if the critical nesting count is 1 to
                  * protect against recursive calls if the assert function also uses a
                  * critical section. */
-                if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U )
+                if( ( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 1U )
+                    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                        && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+                    #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+                    )
                 {
                     portASSERT_IF_IN_ISR();
 
@@ -7763,7 +8299,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
                     BaseType_t xYieldCurrentTask;
 
                     /* Get the xYieldPending status inside the critical section. */
-                    if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE )
+                    if( ( xYieldPendings[ xCoreID ] == pdTRUE )
                         #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
                             && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U ) &&
                             ( pxCurrentTCBs[ xCoreID ]->uxDeferredStateChange == 0U )
@@ -7903,6 +8439,43 @@ STATIC void prvResetNextTaskUnblockTime( void )
     }
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+/*-----------------------------------------------------------*/
+
+/* ISR only critical can only be used when multi-critical section is used.
+ * Therefore, run state change is not valid due to task can't be requested to yield. */
+#if ( configNUMBER_OF_CORES > 1 )
+    static void prvKernelEnterISROnlyCritical( void )
+    {
+        if( xSchedulerRunning != pdFALSE )
+        {
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+            configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );
+
+            /* Take only the ISR lock, not the task lock. */
+            kernelGET_ISR_LOCK( xCoreID );
+
+            portINCREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+        }
+    }
+/*-----------------------------------------------------------*/
+
+    static void prvKernelExitISROnlyCritical( void )
+    {
+        if( xSchedulerRunning != pdFALSE )
+        {
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+
+            configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );
+
+            /* Release only the ISR lock. */
+            kernelRELEASE_ISR_LOCK( xCoreID );
+
+            portDECREMENT_CRITICAL_NESTING_COUNT( xCoreID );
+        }
+    }
+#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )
@@ -8835,6 +9408,9 @@ TickType_t uxTaskResetEventItemValue( void )
                 #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                 {
                     #if ( configUSE_PREEMPTION == 1 )
+
+                    /* Yield for the unblocked task is required even when scheduler
+                     * is suspended. */
                     {
                         prvYieldForTask( pxTCB );
 
@@ -8969,6 +9545,9 @@ TickType_t uxTaskResetEventItemValue( void )
                 #else /* #if ( configNUMBER_OF_CORES == 1 ) */
                 {
                     #if ( configUSE_PREEMPTION == 1 )
+
+                    /* Yield for the unblocked task is required even when scheduler
+                     * is suspended. */
                     {
                         prvYieldForTask( pxTCB );
 
@@ -9515,4 +10094,33 @@ void vTaskResetState( void )
     }
     #endif /* #if ( configGENERATE_RUN_TIME_STATS == 1 ) */
 }
+/*-----------------------------------------------------------*/
+
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+    BaseType_t xTaskUnlockCanYield( void )
+    {
+        BaseType_t xReturn;
+        BaseType_t xCoreID = portGET_CORE_ID();
+
+        /* Current core to call this function should handle the yield request when
+         * the scheduler is suspended. In vTaskSwitchContext, the core will be blocking
+         * on TASK spinlocks until scheduler is resumed. */
+        if( ( xYieldPendings[ xCoreID ] == pdTRUE )
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                && ( pxCurrentTCBs[ xCoreID ]->uxPreemptionDisable == 0U )
+            #endif /* ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
+            )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+
+        return xReturn;
+    }
+
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -397,7 +397,7 @@ typedef struct tskTaskControlBlock       /* The old naming convention is used to
     char pcTaskName[ configMAX_TASK_NAME_LEN ]; /**< Descriptive name given to the task when created.  Facilitates debugging only. */
 
     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-        BaseType_t xPreemptionDisable; /**< Used to prevent the task from being preempted. */
+        UBaseType_t xPreemptionDisable; /**< Used to prevent the task from being preempted. */
     #endif
 
     #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
@@ -930,7 +930,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             #endif
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE )
+                                    if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
                                 #endif
                                 {
                                     xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
@@ -1236,7 +1236,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 ( xYieldPendings[ uxCore ] == pdFALSE ) )
                             {
                                 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == pdFALSE )
+                                    if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == 0U )
                                 #endif
                                 {
                                     xLowestPriority = xTaskPriority;
@@ -2928,7 +2928,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                      * there may now be another task of higher priority that
                      * is ready to execute. */
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxTCB->xPreemptionDisable == pdFALSE )
+                        if( pxTCB->xPreemptionDisable == 0U )
                     #endif
                     {
                         xYieldRequired = pdTRUE;
@@ -3149,7 +3149,7 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
 
-            pxTCB->xPreemptionDisable = pdTRUE;
+            pxTCB->xPreemptionDisable++;
         }
         taskEXIT_CRITICAL();
 
@@ -3172,12 +3172,13 @@ STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         {
             pxTCB = prvGetTCBFromHandle( xTask );
             configASSERT( pxTCB != NULL );
+            configASSERT( pxTCB->xPreemptionDisable > 0U );
 
-            pxTCB->xPreemptionDisable = pdFALSE;
+            pxTCB->xPreemptionDisable--;
 
             if( xSchedulerRunning != pdFALSE )
             {
-                if( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE )
+                if( ( pxTCB->xPreemptionDisable == 0U ) && ( taskTASK_IS_RUNNING( pxTCB ) == pdTRUE ) )
                 {
                     xCoreID = ( BaseType_t ) pxTCB->xTaskRunState;
                     prvYieldCore( xCoreID );
@@ -5034,7 +5035,7 @@ BaseType_t xTaskIncrementTick( void )
                 for( xCoreID = 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
                 {
                     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                        if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE )
+                        if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == 0U )
                     #endif
                     {
                         if( xYieldPendings[ xCoreID ] != pdFALSE )

--- a/tasks.c
+++ b/tasks.c
@@ -541,6 +541,11 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
 
 #endif
 
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_KERNEL_TASK_SPINLOCK_STATIC;
+    PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_KERNEL_ISR_SPINLOCK_STATIC;
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
 /*-----------------------------------------------------------*/
 
 /* File private functions. --------------------------------*/
@@ -550,14 +555,14 @@ PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
  */
 STATIC BaseType_t prvCreateIdleTasks( void );
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
 /*
  * Checks to see if another task moved the current task out of the ready
  * list while it was waiting to enter a critical section and yields, if so.
  */
     STATIC void prvCheckForRunStateChange( void );
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 #if ( configNUMBER_OF_CORES > 1 )
 
@@ -807,7 +812,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
     STATIC void prvCheckForRunStateChange( void )
     {
         UBaseType_t uxPrevCriticalNesting;
@@ -871,7 +876,7 @@ STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             }
         }
     }
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
 
@@ -3958,31 +3963,45 @@ void vTaskSuspendAll( void )
              * do not otherwise exhibit real time behaviour. */
             portSOFTWARE_BARRIER();
 
-            portGET_TASK_LOCK( xCoreID );
-
-            /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
-             * purpose is to prevent altering the variable when fromISR APIs are readying
-             * it. */
-            if( uxSchedulerSuspended == 0U )
+            #if ( portUSING_GRANULAR_LOCKS == 1 )
             {
-                prvCheckForRunStateChange();
+                portGET_SPINLOCK( &xTaskSpinlock );
+                portGET_SPINLOCK( &xISRSpinlock );
+
+                /* Increment xPreemptionDisable to prevent preemption and also
+                 * track whether to yield in xTaskResumeAll(). */
+                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable++;
+
+                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
+                 * is used to allow calls to vTaskSuspendAll() to nest. */
+                ++uxSchedulerSuspended;
+
+                portRELEASE_SPINLOCK( &xISRSpinlock );
             }
-            else
+            #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
             {
-                mtCOVERAGE_TEST_MARKER();
+                portGET_TASK_LOCK();
+
+                /* uxSchedulerSuspended is increased after prvCheckForRunStateChange. The
+                 * purpose is to prevent altering the variable when fromISR APIs are readying
+                 * it. */
+                if( uxSchedulerSuspended == 0U )
+                {
+                    prvCheckForRunStateChange();
+                }
+                else
+                {
+                    mtCOVERAGE_TEST_MARKER();
+                }
+
+                portGET_ISR_LOCK();
+
+                /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
+                 * is used to allow calls to vTaskSuspendAll() to nest. */
+                ++uxSchedulerSuspended;
+                portRELEASE_ISR_LOCK();
             }
-
-            /* Query the coreID again as prvCheckForRunStateChange may have
-             * caused the task to get scheduled on a different core. The correct
-             * task lock for the core is acquired in prvCheckForRunStateChange. */
-            xCoreID = ( BaseType_t ) portGET_CORE_ID();
-
-            portGET_ISR_LOCK( xCoreID );
-
-            /* The scheduler is suspended if uxSchedulerSuspended is non-zero. An increment
-             * is used to allow calls to vTaskSuspendAll() to nest. */
-            ++uxSchedulerSuspended;
-            portRELEASE_ISR_LOCK( xCoreID );
+            #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
 
             portCLEAR_INTERRUPT_MASK( ulState );
         }
@@ -4087,7 +4106,24 @@ BaseType_t xTaskResumeAll( void )
             configASSERT( uxSchedulerSuspended != 0U );
 
             uxSchedulerSuspended = ( UBaseType_t ) ( uxSchedulerSuspended - 1U );
-            portRELEASE_TASK_LOCK( xCoreID );
+            #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+            {
+                configASSERT( pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable > 0 );
+
+                /* Decrement xPreemptionDisable. If 0, it means this we are not
+                 * in a nested suspension scenario, thus this function and yield
+                 * if necessary. */
+                pxCurrentTCBs[ portGET_CORE_ID() ]->xPreemptionDisable--;
+
+                /* Release the kernel's task spinlock that was held throughout
+                 * the kernel suspension. */
+                portRELEASE_SPINLOCK( &xTaskSpinlock );
+            }
+            #else /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+            {
+                portRELEASE_TASK_LOCK();
+            }
+            #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
             if( uxSchedulerSuspended == ( UBaseType_t ) 0U )
             {
@@ -7129,7 +7165,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     void vTaskEnterCritical( void )
     {
@@ -7178,11 +7214,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskEnterCritical();
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
-
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     UBaseType_t vTaskEnterCriticalFromISR( void )
     {
@@ -7212,7 +7247,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         return uxSavedInterruptStatus;
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) )
@@ -7260,7 +7295,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
 #endif /* #if ( ( portCRITICAL_NESTING_IN_TCB == 1 ) && ( configNUMBER_OF_CORES == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     void vTaskExitCritical( void )
     {
@@ -7320,10 +7355,10 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCritical();
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( configNUMBER_OF_CORES > 1 )
+#if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
@@ -7366,7 +7401,29 @@ STATIC void prvResetNextTaskUnblockTime( void )
         traceRETURN_vTaskExitCriticalFromISR();
     }
 
-#endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 0 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+/*-----------------------------------------------------------*/
+
+#if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+
+    BaseType_t xTaskUnlockCanYield( void )
+    {
+        BaseType_t xReturn;
+        BaseType_t xCoreID = portGET_CORE_ID();
+
+        if( ( xYieldPendings[ xCoreID ] == pdTRUE ) && ( uxSchedulerSuspended == pdFALSE ) && ( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE ) )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+
+        return xReturn;
+    }
+
+#endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )

--- a/tasks.c
+++ b/tasks.c
@@ -6749,91 +6749,95 @@ STATIC void prvResetNextTaskUnblockTime( void )
 
         traceENTER_xTaskPriorityInherit( pxMutexHolder );
 
-        /* If the mutex is taken by an interrupt, the mutex holder is NULL. Priority
-         * inheritance is not applied in this scenario. */
-        if( pxMutexHolder != NULL )
+        taskENTER_CRITICAL();
         {
-            /* If the holder of the mutex has a priority below the priority of
-             * the task attempting to obtain the mutex then it will temporarily
-             * inherit the priority of the task attempting to obtain the mutex. */
-            if( pxMutexHolderTCB->uxPriority < pxCurrentTCB->uxPriority )
+            /* If the mutex is taken by an interrupt, the mutex holder is NULL. Priority
+             * inheritance is not applied in this scenario. */
+            if( pxMutexHolder != NULL )
             {
-                /* Adjust the mutex holder state to account for its new
-                 * priority.  Only reset the event list item value if the value is
-                 * not being used for anything else. */
-                if( ( listGET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
+                /* If the holder of the mutex has a priority below the priority of
+                 * the task attempting to obtain the mutex then it will temporarily
+                 * inherit the priority of the task attempting to obtain the mutex. */
+                if( pxMutexHolderTCB->uxPriority < pxCurrentTCB->uxPriority )
                 {
-                    listSET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxCurrentTCB->uxPriority );
-                }
-                else
-                {
-                    mtCOVERAGE_TEST_MARKER();
-                }
-
-                /* If the task being modified is in the ready state it will need
-                 * to be moved into a new list. */
-                if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ pxMutexHolderTCB->uxPriority ] ), &( pxMutexHolderTCB->xStateListItem ) ) != pdFALSE )
-                {
-                    if( uxListRemove( &( pxMutexHolderTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
+                    /* Adjust the mutex holder state to account for its new
+                     * priority.  Only reset the event list item value if the value is
+                     * not being used for anything else. */
+                    if( ( listGET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
                     {
-                        /* It is known that the task is in its ready list so
-                         * there is no need to check again and the port level
-                         * reset macro can be called directly. */
-                        portRESET_READY_PRIORITY( pxMutexHolderTCB->uxPriority, uxTopReadyPriority );
+                        listSET_LIST_ITEM_VALUE( &( pxMutexHolderTCB->xEventListItem ), ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxCurrentTCB->uxPriority );
                     }
                     else
                     {
                         mtCOVERAGE_TEST_MARKER();
                     }
 
-                    /* Inherit the priority before being moved into the new list. */
-                    pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
-                    prvAddTaskToReadyList( pxMutexHolderTCB );
-                    #if ( configNUMBER_OF_CORES > 1 )
+                    /* If the task being modified is in the ready state it will need
+                     * to be moved into a new list. */
+                    if( listIS_CONTAINED_WITHIN( &( pxReadyTasksLists[ pxMutexHolderTCB->uxPriority ] ), &( pxMutexHolderTCB->xStateListItem ) ) != pdFALSE )
                     {
-                        /* The priority of the task is raised. Yield for this task
-                         * if it is not running. */
-                        if( taskTASK_IS_RUNNING( pxMutexHolderTCB ) != pdTRUE )
+                        if( uxListRemove( &( pxMutexHolderTCB->xStateListItem ) ) == ( UBaseType_t ) 0 )
                         {
-                            prvYieldForTask( pxMutexHolderTCB );
+                            /* It is known that the task is in its ready list so
+                             * there is no need to check again and the port level
+                             * reset macro can be called directly. */
+                            portRESET_READY_PRIORITY( pxMutexHolderTCB->uxPriority, uxTopReadyPriority );
                         }
+                        else
+                        {
+                            mtCOVERAGE_TEST_MARKER();
+                        }
+
+                        /* Inherit the priority before being moved into the new list. */
+                        pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
+                        prvAddTaskToReadyList( pxMutexHolderTCB );
+                        #if ( configNUMBER_OF_CORES > 1 )
+                        {
+                            /* The priority of the task is raised. Yield for this task
+                             * if it is not running. */
+                            if( taskTASK_IS_RUNNING( pxMutexHolderTCB ) != pdTRUE )
+                            {
+                                prvYieldForTask( pxMutexHolderTCB );
+                            }
+                        }
+                        #endif /* if ( configNUMBER_OF_CORES > 1 ) */
                     }
-                    #endif /* if ( configNUMBER_OF_CORES > 1 ) */
-                }
-                else
-                {
-                    /* Just inherit the priority. */
-                    pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
-                }
+                    else
+                    {
+                        /* Just inherit the priority. */
+                        pxMutexHolderTCB->uxPriority = pxCurrentTCB->uxPriority;
+                    }
 
-                traceTASK_PRIORITY_INHERIT( pxMutexHolderTCB, pxCurrentTCB->uxPriority );
+                    traceTASK_PRIORITY_INHERIT( pxMutexHolderTCB, pxCurrentTCB->uxPriority );
 
-                /* Inheritance occurred. */
-                xReturn = pdTRUE;
-            }
-            else
-            {
-                if( pxMutexHolderTCB->uxBasePriority < pxCurrentTCB->uxPriority )
-                {
-                    /* The base priority of the mutex holder is lower than the
-                     * priority of the task attempting to take the mutex, but the
-                     * current priority of the mutex holder is not lower than the
-                     * priority of the task attempting to take the mutex.
-                     * Therefore the mutex holder must have already inherited a
-                     * priority, but inheritance would have occurred if that had
-                     * not been the case. */
+                    /* Inheritance occurred. */
                     xReturn = pdTRUE;
                 }
                 else
                 {
-                    mtCOVERAGE_TEST_MARKER();
+                    if( pxMutexHolderTCB->uxBasePriority < pxCurrentTCB->uxPriority )
+                    {
+                        /* The base priority of the mutex holder is lower than the
+                         * priority of the task attempting to take the mutex, but the
+                         * current priority of the mutex holder is not lower than the
+                         * priority of the task attempting to take the mutex.
+                         * Therefore the mutex holder must have already inherited a
+                         * priority, but inheritance would have occurred if that had
+                         * not been the case. */
+                        xReturn = pdTRUE;
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
+                    }
                 }
             }
+            else
+            {
+                mtCOVERAGE_TEST_MARKER();
+            }
         }
-        else
-        {
-            mtCOVERAGE_TEST_MARKER();
-        }
+        taskEXIT_CRITICAL();
 
         traceRETURN_xTaskPriorityInherit( xReturn );
 

--- a/timers.c
+++ b/timers.c
@@ -83,8 +83,8 @@
  * Macros to mark the start and end of a critical code region.
  */
     #if ( portUSING_GRANULAR_LOCKS == 1 )
-        #define tmrENTER_CRITICAL()    taskDATA_GROUP_ENTER_CRITICAL( &xTaskSpinlock, &xISRSpinlock )
-        #define tmrEXIT_CRITICAL()     taskDATA_GROUP_EXIT_CRITICAL( &xTaskSpinlock, &xISRSpinlock )
+        #define tmrENTER_CRITICAL()    taskDATA_GROUP_ENTER_CRITICAL( &xTimerTaskSpinlock, &xTimerISRSpinlock )
+        #define tmrEXIT_CRITICAL()     taskDATA_GROUP_EXIT_CRITICAL( &xTimerTaskSpinlock, &xTimerISRSpinlock )
     #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
         #define tmrENTER_CRITICAL()    taskENTER_CRITICAL()
         #define tmrEXIT_CRITICAL()     taskEXIT_CRITICAL()
@@ -161,8 +161,8 @@
     PRIVILEGED_DATA static TaskHandle_t xTimerTaskHandle = NULL;
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        PRIVILEGED_DATA static portSPINLOCK_TYPE xTaskSpinlock = portINIT_SPINLOCK_STATIC;
-        PRIVILEGED_DATA static portSPINLOCK_TYPE xISRSpinlock = portINIT_SPINLOCK_STATIC;
+        PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
+        PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
@@ -613,7 +613,15 @@
         traceENTER_xTimerGetReloadMode( xTimer );
 
         configASSERT( xTimer );
-        tmrENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            tmrENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_AUTORELOAD ) == 0U )
             {
@@ -626,7 +634,15 @@
                 xReturn = pdTRUE;
             }
         }
-        tmrEXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            tmrEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_xTimerGetReloadMode( xReturn );
 
@@ -1188,7 +1204,15 @@
         configASSERT( xTimer );
 
         /* Is the timer in the list of active timers? */
-        tmrENTER_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            tmrENTER_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_ENTER_CRITICAL();
+        }
+        #endif
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_ACTIVE ) == 0U )
             {
@@ -1199,7 +1223,15 @@
                 xReturn = pdTRUE;
             }
         }
-        tmrEXIT_CRITICAL();
+        #if ( ( configNUMBER_OF_CORES > 1 ) )
+        {
+            tmrEXIT_CRITICAL();
+        }
+        #else
+        {
+            portBASE_TYPE_EXIT_CRITICAL();
+        }
+        #endif
 
         traceRETURN_xTimerIsTimerActive( xReturn );
 

--- a/timers.c
+++ b/timers.c
@@ -161,8 +161,13 @@
     PRIVILEGED_DATA static TaskHandle_t xTimerTaskHandle = NULL;
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
-        PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
+        #ifdef portREMOVE_STATIC_QUALIFIER
+            PRIVILEGED_DATA portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
+            PRIVILEGED_DATA portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
+        #else
+            PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
+            PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
+        #endif
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/

--- a/timers.c
+++ b/timers.c
@@ -149,6 +149,16 @@
     PRIVILEGED_DATA static QueueHandle_t xTimerQueue = NULL;
     PRIVILEGED_DATA static TaskHandle_t xTimerTaskHandle = NULL;
 
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        #ifdef portREMOVE_STATIC_QUALIFIER
+            PRIVILEGED_DATA portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
+            PRIVILEGED_DATA portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
+        #else
+            PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
+            PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
+        #endif
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+
 /*-----------------------------------------------------------*/
 
 /*

--- a/timers.c
+++ b/timers.c
@@ -55,6 +55,16 @@
  * configUSE_TIMERS is set to 1 in FreeRTOSConfig.h. */
 #if ( configUSE_TIMERS == 1 )
 
+/*
+ * Some kernel aware debuggers require the data the debugger needs access to be
+ * global, rather than file scope.
+ */
+    #ifdef portREMOVE_STATIC_QUALIFIER
+        #define STATIC
+    #else
+        #define STATIC    static
+    #endif
+
 /* Misc definitions. */
     #define tmrNO_DELAY                    ( ( TickType_t ) 0U )
     #define tmrMAX_TIME_BEFORE_OVERFLOW    ( ( TickType_t ) -1 )
@@ -78,6 +88,31 @@
     #define tmrSTATUS_IS_ACTIVE                  ( 0x01U )
     #define tmrSTATUS_IS_STATICALLY_ALLOCATED    ( 0x02U )
     #define tmrSTATUS_IS_AUTORELOAD              ( 0x04U )
+
+/*
+ * Macros to mark the start and end of a critical code region.
+ */
+    #if ( portUSING_GRANULAR_LOCKS == 1 )
+        #define tmrENTER_CRITICAL()    taskDATA_GROUP_ENTER_CRITICAL( &xTimerTaskSpinlock, &xTimerISRSpinlock )
+        #define tmrEXIT_CRITICAL()     taskDATA_GROUP_EXIT_CRITICAL( &xTimerTaskSpinlock, &xTimerISRSpinlock )
+    #else /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+        #define tmrENTER_CRITICAL()    taskENTER_CRITICAL()
+        #define tmrEXIT_CRITICAL()     taskEXIT_CRITICAL()
+    #endif /* #if ( portUSING_GRANULAR_LOCKS == 1 ) */
+
+/*
+ * Macros to mark the start and end of a critical code region that only reads a
+ * single BaseType_t sized timer member. Ports that can read such a member
+ * atomically define portBASE_TYPE_ENTER_CRITICAL() away, so that path must be
+ * preserved wherever a data group critical section is not required.
+ */
+    #if ( configNUMBER_OF_CORES > 1 )
+        #define tmrBASE_TYPE_ENTER_CRITICAL()    tmrENTER_CRITICAL()
+        #define tmrBASE_TYPE_EXIT_CRITICAL()     tmrEXIT_CRITICAL()
+    #else
+        #define tmrBASE_TYPE_ENTER_CRITICAL()    portBASE_TYPE_ENTER_CRITICAL()
+        #define tmrBASE_TYPE_EXIT_CRITICAL()     portBASE_TYPE_EXIT_CRITICAL()
+    #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 /* The definition of the timers themselves. */
     typedef struct tmrTimerControl                                               /* The old naming convention is used to prevent breaking kernel aware debuggers. */
@@ -150,13 +185,8 @@
     PRIVILEGED_DATA static TaskHandle_t xTimerTaskHandle = NULL;
 
     #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
-        #ifdef portREMOVE_STATIC_QUALIFIER
-            PRIVILEGED_DATA portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
-            PRIVILEGED_DATA portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
-        #else
-            PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
-            PRIVILEGED_DATA static portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
-        #endif
+        PRIVILEGED_DATA STATIC portSPINLOCK_TYPE xTimerTaskSpinlock = portINIT_SPINLOCK_STATIC;
+        PRIVILEGED_DATA STATIC portSPINLOCK_TYPE xTimerISRSpinlock = portINIT_SPINLOCK_STATIC;
     #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
 
 /*-----------------------------------------------------------*/
@@ -584,7 +614,7 @@
         traceENTER_vTimerSetReloadMode( xTimer, xAutoReload );
 
         configASSERT( xTimer );
-        taskENTER_CRITICAL();
+        tmrENTER_CRITICAL();
         {
             if( xAutoReload != pdFALSE )
             {
@@ -595,7 +625,7 @@
                 pxTimer->ucStatus &= ( ( uint8_t ) ~tmrSTATUS_IS_AUTORELOAD );
             }
         }
-        taskEXIT_CRITICAL();
+        tmrEXIT_CRITICAL();
 
         traceRETURN_vTimerSetReloadMode();
     }
@@ -609,7 +639,7 @@
         traceENTER_xTimerGetReloadMode( xTimer );
 
         configASSERT( xTimer );
-        portBASE_TYPE_ENTER_CRITICAL();
+        tmrBASE_TYPE_ENTER_CRITICAL();
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_AUTORELOAD ) == 0U )
             {
@@ -622,7 +652,7 @@
                 xReturn = pdTRUE;
             }
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        tmrBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_xTimerGetReloadMode( xReturn );
 
@@ -1128,7 +1158,7 @@
         /* Check that the list from which active timers are referenced, and the
          * queue used to communicate with the timer service, have been
          * initialised. */
-        taskENTER_CRITICAL();
+        tmrENTER_CRITICAL();
         {
             if( xTimerQueue == NULL )
             {
@@ -1170,7 +1200,7 @@
                 mtCOVERAGE_TEST_MARKER();
             }
         }
-        taskEXIT_CRITICAL();
+        tmrEXIT_CRITICAL();
     }
 /*-----------------------------------------------------------*/
 
@@ -1184,7 +1214,7 @@
         configASSERT( xTimer );
 
         /* Is the timer in the list of active timers? */
-        portBASE_TYPE_ENTER_CRITICAL();
+        tmrBASE_TYPE_ENTER_CRITICAL();
         {
             if( ( pxTimer->ucStatus & tmrSTATUS_IS_ACTIVE ) == 0U )
             {
@@ -1195,7 +1225,7 @@
                 xReturn = pdTRUE;
             }
         }
-        portBASE_TYPE_EXIT_CRITICAL();
+        tmrBASE_TYPE_EXIT_CRITICAL();
 
         traceRETURN_xTimerIsTimerActive( xReturn );
 
@@ -1212,11 +1242,11 @@
 
         configASSERT( xTimer );
 
-        taskENTER_CRITICAL();
+        tmrENTER_CRITICAL();
         {
             pvReturn = pxTimer->pvTimerID;
         }
-        taskEXIT_CRITICAL();
+        tmrEXIT_CRITICAL();
 
         traceRETURN_pvTimerGetTimerID( pvReturn );
 
@@ -1233,11 +1263,11 @@
 
         configASSERT( xTimer );
 
-        taskENTER_CRITICAL();
+        tmrENTER_CRITICAL();
         {
             pxTimer->pvTimerID = pvNewID;
         }
-        taskEXIT_CRITICAL();
+        tmrEXIT_CRITICAL();
 
         traceRETURN_vTimerSetTimerID();
     }


### PR DESCRIPTION
This PR adds support for granular locking to the FreeRTOS kernel.

Description
-----------
Granular locking introduces the concept of having localized locks _per_ kernel data group for SMP configuration. This method is an optional replacement of the existing kernel locks and is controlled by a new port layer configuration, viz., `portUSING_GRANULAR_LOCKS`.

Test Steps
----------
A Common/Minimal demo runner for Espressif targets is included in this PR's branch under `FreeRTOS/Demo/Espressif_ESP32`. The Check task polls every standard demo task on a 3-second cycle and prints per-test `PASS` / `FAIL` lines in a Unity-style format, ending with a totals line and an `OK` / `FAILED` verdict.

### Resources

- **FreeRTOS granular locks kernel repository**: https://github.com/sudeep-mohanty/FreeRTOS-Kernel/tree/feature/smp_granular_locks_v4
- **Common/Minimal demo project tree**: https://github.com/sudeep-mohanty/FreeRTOS/tree/feature/smp_granular_locks_v4/FreeRTOS/Demo/Espressif_ESP32
- **Public ESP-IDF fork that tracks this work (includes a copy of the granular locks kernel)**: https://github.com/sudeep-mohanty/esp-idf/tree/feat/granular_locks_test

### To run the demo on an ESP32

**1. Clone the public ESP-IDF fork and set up the build environment:**
```sh
git clone -b feat/granular_locks_test https://github.com/sudeep-mohanty/esp-idf.git
cd esp-idf
./install.sh
. ./export.sh
```

**2. Build, flash, and monitor:**
```sh
cd /path/to/FreeRTOS/FreeRTOS/Demo/Espressif_ESP32
idf.py set-target esp32 build flash monitor
```

**3. Observe the output:**

Per-cycle:
```
----- Cycle N (tick X) -----
test_MessageBuffer:PASS
test_TaskNotification:PASS
...
Cycle N:  PASS   FAIL
```

Final summary (after the configured runtime, default 180 s):
```
-----------------------
Demo run complete: N cycles, M s.

Per-test totals (PASS / FAIL over N cycles):
  test_MessageBuffer         N /     0
  ...
  test_AbortDelay            N /     0

 Tests  Failures
OK | FAILED
-----------------------
```

**4. Configure the runtime (optional):**

The run length is set by `mainDEMO_DURATION_S` (seconds; `0` runs until reset), overridden through the `EXTRA_CFLAGS` environment variable. `EXTRA_CFLAGS` is read at CMake configure time, so run `idf.py fullclean` first (or use a fresh build directory) when you change it.
```sh
EXTRA_CFLAGS="-DmainDEMO_DURATION_S=3600" idf.py build flash monitor   # run for 1 hour
EXTRA_CFLAGS="-DmainDEMO_DURATION_S=0"    idf.py build flash monitor   # run until reset
```

Test Results
------------

| Test                | `portUSING_GRANULAR_LOCKS=1`<br>`configNUMBER_OF_CORES=2`<br>`configRUN_MULTIPLE_PRIORITIES=0` | `portUSING_GRANULAR_LOCKS=1`<br>`configNUMBER_OF_CORES=2`<br>`configRUN_MULTIPLE_PRIORITIES=1` |
| ------------------- | :--------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------: |
| MessageBuffer       | ✅ | ✅ |
| TaskNotification    | ✅ | ✅ |
| EventGroup          | ✅ | ➖ |
| IntMath             | ✅ | ✅ |
| QueuePeek           | ✅ | ➖ |
| BlockingQueue       | ✅ | ✅ |
| SemTest             | ✅ | ✅ |
| PollQueue           | ✅ | ✅ |
| Flop                | ✅ | ✅ |
| CountSem            | ✅ | ✅ |
| Death               | ✅ | ✅ |
| QueueOverwrite      | ✅ | ✅ |
| IntStreamBuffer     | ✅ | ✅ |
| MessageBufferAMP    | ✅ | ✅ |
| QueueSet            | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/89d97e2e5) | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/89d97e2e5) |
| QueueSetPolling     | ✅ | ✅ |
| DynamicPriority     | ✅ | ➖ |
| AbortDelay          | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/2b548d878) | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/2b548d878) |
| StreamBuffer        | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/724ea1f0a) | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/724ea1f0a) |
| GenericQueue        | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/1369a3ab5) | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/1369a3ab5) |
| IntSem              | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/3ef18a237) | ➖ |
| RecMutex            | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/f15b172da) | ➖ |
| IntQueue            | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/0d9211318) | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/0d9211318) |
| BlockTime           | ✅ | ➖ |
| StaticAllocation    | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/c07db16bb) | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/c07db16bb) |
| TimerDemo           | ✅ [🔧](https://github.com/FreeRTOS/FreeRTOS/pull/1434/commits/b621815f8) | ➖ |

The Common/Minimal test updates and the ESP32 demo these results were produced
with are in the companion PR FreeRTOS/FreeRTOS#1434.

Legend:
- ✅ — passes as-is on the Espressif_ESP32 demo runner
- ✅ [🔧](#) — passes after an upstream Common/Minimal test update; cell links to the commit in FreeRTOS/FreeRTOS#1434
- ➖ — not run in this configuration. The test's ordering premises require that tasks of
  different priorities cannot run at the same time, so the demo selects it out with the
  `mainENABLE_*` defines in `main_full.c`, following the pattern already used by the
  Standard_smp demo under `FreeRTOS/Demo/ThirdParty`.
- ❌ — fails

TODO
----
- [x] Publish test results
- [ ] 48 hour stress test against the current revision of the Common/Minimal updates.
      [Earlier results](https://gist.github.com/sudeep-mohanty/6059912d90fc4983196e044a13255338)
      were produced before those updates changed `IntQueue.c` and `death.c`.
- [ ] Publish granular-lock performance comparison results
- [ ] Re-enable the `➖` tests under `configRUN_MULTIPLE_PRIORITIES=1`. Each one asserts a
      peer task's scheduler state immediately after an operation expected to have blocked it,
      which cannot be observed from another core. Reworking them needs a synchronisation
      handshake rather than a wider tolerance.

Checklist
---------
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-------------
- Closes #905

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.












