### PR TITLE
[Fixed the Issue] Fixed the Issue#1102 of RL78 of the Context switch …

### DIFF
--- a/portable/GCC/RL78/portmacro.h
+++ b/portable/GCC/RL78/portmacro.h
@@ -106,7 +106,18 @@ typedef unsigned short   UBaseType_t;
 
 /* Task utilities. */
 #define portYIELD()                                       __asm volatile ( "BRK" )
-#define portYIELD_FROM_ISR( xHigherPriorityTaskWoken )    do { if( xHigherPriorityTaskWoken ) vTaskSwitchContext( ); } while( 0 )
+#ifndef configREQUIRE_ASM_ISR_WRAPPER
+    #define configREQUIRE_ASM_ISR_WRAPPER    1
+#endif
+#if( configREQUIRE_ASM_ISR_WRAPPER == 1 )
+    /* You must implement an assembly ISR wrapper (see the below for details) if you need an ISR to cause a context switch.
+     * https://www.freertos.org/Documentation/02-Kernel/03-Supported-devices/04-Demos/Renesas/RTOS_RL78_IAR_Demos#writing-interrupt-service-routines */
+    #define portYIELD_FROM_ISR( xHigherPriorityTaskWoken )    do { if( xHigherPriorityTaskWoken != pdFALSE ) vTaskSwitchContext(); } while( 0 )
+#else
+    /* You must not implement an assembly ISR wrapper even if you need an ISR to cause a context switch.
+     * The portYIELD, which is similar to role of an assembly ISR wrapper, runs only when a context switch is required. */
+    #define portYIELD_FROM_ISR( xHigherPriorityTaskWoken )    do { if( xHigherPriorityTaskWoken != pdFALSE ) portYIELD(); } while( 0 )
+#endif
 #define portNOP()                                         __asm volatile ( "NOP" )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/RL78/portmacro.h
+++ b/portable/IAR/RL78/portmacro.h
@@ -130,7 +130,18 @@
 /* Task utilities. */
     #define portNOP()                                         __asm( "NOP" )
     #define portYIELD()                                       __asm( "BRK" )
-    #define portYIELD_FROM_ISR( xHigherPriorityTaskWoken )    do { if( xHigherPriorityTaskWoken ) vTaskSwitchContext( ); } while( 0 )
+    #ifndef configREQUIRE_ASM_ISR_WRAPPER
+        #define configREQUIRE_ASM_ISR_WRAPPER    1
+    #endif
+    #if( configREQUIRE_ASM_ISR_WRAPPER == 1 )
+        /* You must implement an assembly ISR wrapper (see the below for details) if you need an ISR to cause a context switch.
+         * https://www.freertos.org/Documentation/02-Kernel/03-Supported-devices/04-Demos/Renesas/RTOS_RL78_IAR_Demos#writing-interrupt-service-routines */
+        #define portYIELD_FROM_ISR( xHigherPriorityTaskWoken )    do { if( xHigherPriorityTaskWoken != pdFALSE ) vTaskSwitchContext(); } while( 0 )
+    #else
+        /* You must not implement an assembly ISR wrapper even if you need an ISR to cause a context switch.
+         * The portYIELD, which is similar to role of an assembly ISR wrapper, runs only when a context switch is required. */
+        #define portYIELD_FROM_ISR( xHigherPriorityTaskWoken )    do { if( xHigherPriorityTaskWoken != pdFALSE ) portYIELD(); } while( 0 )
+    #endif
 /*-----------------------------------------------------------*/
 
 /* Hardware specifics. */


### PR DESCRIPTION
Fixed issue #1102  of the RL78 MCU of the Context Switch . https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1102

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

The RL78 had an issue with the context switch in the ISR.
It could not work the context switch as reported by #1102 issue.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

- Tested the URL below to reproduce this issue project.

https://github.com/KeitaKashima/kernel_issue_740


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [   ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

   We don't modify and add this fix of unit-tests.


Related Issue
-----------
<!-- If any, please provide issue ID. -->

#1102 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
