### PR TITLE
Fix incorrect error checking of prvCreateIdleTasks

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3630,7 +3630,7 @@ static BaseType_t prvCreateIdleTasks( void )
         #endif /* configSUPPORT_STATIC_ALLOCATION */
 
         /* Break the loop if any of the idle task is failed to be created. */
-        if( xReturn == pdFAIL )
+        if( xReturn != pdPASS )
         {
             break;
         }


### PR DESCRIPTION
<!--- Title -->
Fix incorrect error checking of prvCreateIdleTasks

Description
-----------
<!--- Describe your changes in detail. -->
In environments that do not support static allocation (`configSUPPORT_STATIC_ALLOCATION == 0`), at `prvCreateIdleTasks()`, it calls `xCreateTask()` and compares its return value to `pdFAIL` (0) to check whether `xCreateTask()` failed. However, `xCreateTask()` returns `errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY` (-1) as the error value, so the result of this comparison is always false.

This MR fixes this problem by changing the return value comparison to `!= pdPASS` instead of `== pdFAIL`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.