### PR TITLE
freertos-config: Fix library definitions scope

### DIFF
--- a/portable/CMakeLists.txt
+++ b/portable/CMakeLists.txt
@@ -804,7 +804,7 @@ if (DEFINED FREERTOS_ARM_V_8_1_M_PACBTI_CONFIG )
                         -mbranch-protection=bti+pac-ret+leaf
                 )
                 target_compile_definitions(freertos_config
-                    PUBLIC
+                    INTERFACE
                         configENABLE_PAC=1
                         configENABLE_BTI=1
                 )
@@ -815,7 +815,7 @@ if (DEFINED FREERTOS_ARM_V_8_1_M_PACBTI_CONFIG )
             target_compile_options(freertos_kernel_port PUBLIC $<$<STREQUAL:${CMAKE_C_COMPILER_ID},ARMClang>:-mbranch-protection=pac-ret>)
             target_compile_options(freertos_kernel_port PUBLIC $<$<STREQUAL:${CMAKE_C_COMPILER_ID},IAR>:$<$<COMPILE_LANGUAGE:C,CXX>:--branch_protection=pac-ret>>)
             target_compile_definitions(freertos_config
-                PUBLIC
+                INTERFACE
                     configENABLE_PAC=1
             )
         elseif(FREERTOS_ARM_V_8_1_M_PACBTI_CONFIG STREQUAL "ARM_V_8_1_M_PACBTI_CONFIG_PACRET_LEAF")
@@ -825,7 +825,7 @@ if (DEFINED FREERTOS_ARM_V_8_1_M_PACBTI_CONFIG )
                         -mbranch-protection=pac-ret+leaf
                 )
                 target_compile_definitions(freertos_config
-                    PUBLIC
+                    INTERFACE
                         configENABLE_PAC=1
                 )
             elseif(${CMAKE_C_COMPILER_ID} STREQUAL "IAR")
@@ -835,7 +835,7 @@ if (DEFINED FREERTOS_ARM_V_8_1_M_PACBTI_CONFIG )
             target_compile_options(freertos_kernel_port PUBLIC $<$<STREQUAL:${CMAKE_C_COMPILER_ID},ARMClang>:-mbranch-protection=bti>)
             target_compile_options(freertos_kernel_port PUBLIC $<$<STREQUAL:${CMAKE_C_COMPILER_ID},IAR>:$<$<COMPILE_LANGUAGE:C,CXX>:--branch_protection=bti>>)
             target_compile_definitions(freertos_config
-                PUBLIC
+                INTERFACE
                     configENABLE_BTI=1
             )
         elseif(FREERTOS_ARM_V_8_1_M_PACBTI_CONFIG STREQUAL "ARM_V_8_1_M_PACBTI_CONFIG_NONE")
@@ -846,7 +846,7 @@ if (DEFINED FREERTOS_ARM_V_8_1_M_PACBTI_CONFIG )
                 )
             endif()
             target_compile_definitions(freertos_config
-                PUBLIC
+                INTERFACE
                     configENABLE_PAC=0
                     configENABLE_BTI=0
             )


### PR DESCRIPTION


<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Since `freertos_config` is an interface library, `INTERFACE` scope shall be used to define compile definitions.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
