### PR TITLE
Fix AutoReload variable name

### DIFF
--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -335,7 +335,7 @@ BaseType_t MPU_xTimerGenericCommandFromTask( TimerHandle_t xTimer,
 BaseType_t MPU_xTimerGenericCommandFromTaskEntry( const xTimerGenericCommandFromTaskParams_t * pxParams ) FREERTOS_SYSTEM_CALL;
 const char * MPU_pcTimerGetName( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                              const BaseType_t uxAutoReload ) FREERTOS_SYSTEM_CALL;
+                              const BaseType_t xAutoReload ) FREERTOS_SYSTEM_CALL;
 BaseType_t MPU_xTimerGetReloadMode( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 UBaseType_t MPU_uxTimerGetReloadMode( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
 TickType_t MPU_xTimerGetPeriod( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/mpu_wrappers_v2_asm.c
@@ -1546,10 +1546,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/mpu_wrappers_v2_asm.c
@@ -1546,10 +1546,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/mpu_wrappers_v2_asm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -1799,7 +1799,7 @@
 
     #if ( configUSE_TIMERS == 1 )
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* FREERTOS_SYSTEM_CALL */
         {
             if( portIS_PRIVILEGED() == pdFALSE )
             {

--- a/portable/GCC/ARM_CM0/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM0/mpu_wrappers_v2_asm.c
@@ -1648,10 +1648,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM23/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM23/non_secure/mpu_wrappers_v2_asm.c
@@ -1546,10 +1546,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1546,10 +1546,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM33/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM33/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM35P/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM35P/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM3_MPU/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM3_MPU/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM55/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM55/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM85/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM85/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/mpu_wrappers_v2_asm.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/mpu_wrappers_v2_asm.c
@@ -1495,10 +1495,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
+                                      const BaseType_t xAutoReload ) __attribute__( ( naked ) ) FREERTOS_SYSTEM_CALL;
 
         void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                      const BaseType_t uxAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
+                                      const BaseType_t xAutoReload ) /* __attribute__ (( naked )) FREERTOS_SYSTEM_CALL */
         {
             __asm volatile
             (

--- a/portable/RVDS/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
+++ b/portable/RVDS/ARM_CM4_MPU/mpu_wrappers_v2_asm.c
@@ -1240,10 +1240,10 @@ MPU_pcTimerGetName_Unpriv
 #if ( configUSE_TIMERS == 1 )
 
 void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                              const BaseType_t uxAutoReload ) FREERTOS_SYSTEM_CALL;
+                              const BaseType_t xAutoReload ) FREERTOS_SYSTEM_CALL;
 
 __asm void MPU_vTimerSetReloadMode( TimerHandle_t xTimer,
-                                    const BaseType_t uxAutoReload ) /* FREERTOS_SYSTEM_CALL */
+                                    const BaseType_t xAutoReload ) /* FREERTOS_SYSTEM_CALL */
 {
     PRESERVE8
     extern MPU_vTimerSetReloadModeImpl


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Removes the 'u' prefix as the variable is
no longer unsigned.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
See https://github.com/search?q=repo%3AFreeRTOS%2FFreeRTOS-Kernel%20uxAutoReload%20&type=code

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
  - Will test through CI jobs.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
  - N/A - Simple variable renaming.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1165


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
