### PR TITLE
Fix RP2040 build without configASSERT defined

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -215,12 +215,12 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
 
     #ifdef configASSERT
         configASSERT( ulLockNum < portRTOS_SPINLOCK_COUNT );
-    #endif
+    #endif /* configASSERT */
     uint32_t ulCoreNum = get_core_num();
     uint32_t ulLockBit = 1u << ulLockNum;
     #ifdef configASSERT
         configASSERT( ulLockBit < 256u );
-    #endif
+    #endif /* configASSERT */
 
     if( uxAcquire )
     {
@@ -230,7 +230,7 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
             {
                 #ifdef configASSERT
                     configASSERT( ucRecursionCountByLock[ ulLockNum ] != 255u );
-                #endif
+                #endif /* configASSERT */
                 ucRecursionCountByLock[ ulLockNum ]++;
                 return;
             }
@@ -243,7 +243,7 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
         __mem_fence_acquire();
         #ifdef configASSERT
             configASSERT( ucRecursionCountByLock[ ulLockNum ] == 0 );
-        #endif
+        #endif /* configASSERT */
         ucRecursionCountByLock[ ulLockNum ] = 1;
         ucOwnedByCore[ ulCoreNum ] |= ulLockBit;
     }
@@ -252,7 +252,7 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
         #ifdef configASSERT
             configASSERT( ( ucOwnedByCore[ ulCoreNum ] & ulLockBit ) != 0 );
             configASSERT( ucRecursionCountByLock[ ulLockNum ] != 0 );
-        #endif
+        #endif /* configASSERT */
 
         if( !--ucRecursionCountByLock[ ulLockNum ] )
         {

--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -213,10 +213,14 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
     static uint8_t ucOwnedByCore[ portMAX_CORE_COUNT ];
     static uint8_t ucRecursionCountByLock[ portRTOS_SPINLOCK_COUNT ];
 
-    configASSERT( ulLockNum < portRTOS_SPINLOCK_COUNT );
+    #ifdef configASSERT
+        configASSERT( ulLockNum < portRTOS_SPINLOCK_COUNT );
+    #endif
     uint32_t ulCoreNum = get_core_num();
     uint32_t ulLockBit = 1u << ulLockNum;
-    configASSERT( ulLockBit < 256u );
+    #ifdef configASSERT
+        configASSERT( ulLockBit < 256u );
+    #endif
 
     if( uxAcquire )
     {
@@ -224,7 +228,9 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
         {
             if( ucOwnedByCore[ ulCoreNum ] & ulLockBit )
             {
-                configASSERT( ucRecursionCountByLock[ ulLockNum ] != 255u );
+                #ifdef configASSERT
+                    configASSERT( ucRecursionCountByLock[ ulLockNum ] != 255u );
+                #endif
                 ucRecursionCountByLock[ ulLockNum ]++;
                 return;
             }
@@ -235,14 +241,18 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
         }
 
         __mem_fence_acquire();
-        configASSERT( ucRecursionCountByLock[ ulLockNum ] == 0 );
+        #ifdef configASSERT
+            configASSERT( ucRecursionCountByLock[ ulLockNum ] == 0 );
+        #endif
         ucRecursionCountByLock[ ulLockNum ] = 1;
         ucOwnedByCore[ ulCoreNum ] |= ulLockBit;
     }
     else
     {
-        configASSERT( ( ucOwnedByCore[ ulCoreNum ] & ulLockBit ) != 0 );
-        configASSERT( ucRecursionCountByLock[ ulLockNum ] != 0 );
+        #ifdef configASSERT
+            configASSERT( ( ucOwnedByCore[ ulCoreNum ] & ulLockBit ) != 0 );
+            configASSERT( ucRecursionCountByLock[ ulLockNum ] != 0 );
+        #endif
 
         if( !--ucRecursionCountByLock[ ulLockNum ] )
         {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fixes building the RP2040 port without `configASSERT` defined. It seems like no other ports use `configASSERT` in `portmacro.h`, so this isn't an issue anywhere else. Normally `FreeRTOS.h` defines `configASSERT`, but that can't be included in `portmacro.h`.

This may be a bit easier to review with whitespace changes ignored: https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1170/files?w=1

Test Steps
-----------
Build the RP2040 port without `configASSERT` defined.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
