### PR TITLE
Add memory protection support to RISC-V port

### DIFF
--- a/portable/GCC/RISC-V/chip_specific_extensions/RISCV_MTIME_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
+++ b/portable/GCC/RISC-V/chip_specific_extensions/RISCV_MTIME_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
@@ -58,12 +58,26 @@
 #define portasmHAS_MTIME                  1
 #define portasmADDITIONAL_CONTEXT_SIZE    0
 
+/* Memory protection-related definitions */
+#define portMPU_REGION_READ_WRITE    0x03
+#define portMPU_REGION_READ_ONLY     0x06
+#define portMPU_REGION_NO_ACCESS     0x00
+
 .macro portasmSAVE_ADDITIONAL_REGISTERS
 /* No additional registers to save, so this macro does nothing. */
    .endm
 
    .macro portasmRESTORE_ADDITIONAL_REGISTERS
 /* No additional registers to restore, so this macro does nothing. */
+   .endm
+
+/* Macros for saving and restoring memory protection context */
+.macro portasmSAVE_MEMORY_PROTECTION_CONTEXT
+/* Add code to save memory protection context here */
+   .endm
+
+   .macro portasmRESTORE_MEMORY_PROTECTION_CONTEXT
+/* Add code to restore memory protection context here */
    .endm
 
 #endif /* __FREERTOS_RISC_V_EXTENSIONS_H__ */

--- a/portable/GCC/RISC-V/port.c
+++ b/portable/GCC/RISC-V/port.c
@@ -206,3 +206,14 @@ void vPortEndScheduler( void )
     }
 }
 /*-----------------------------------------------------------*/
+
+/* Add functions for enabling and disabling memory protection */
+void vPortEnableMemoryProtection( void )
+{
+    __asm volatile ( "csrs mstatus, 0x10000" );
+}
+
+void vPortDisableMemoryProtection( void )
+{
+    __asm volatile ( "csrc mstatus, 0x10000" );
+}

--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -382,3 +382,13 @@ application_exception_handler:
 processed_source:
     portcontextRESTORE_CONTEXT
 /*-----------------------------------------------------------*/
+
+/* Update the portcontextSAVE_CONTEXT_INTERNAL macro to save memory protection context */
+.macro portcontextSAVE_CONTEXT_INTERNAL
+    portasmSAVE_MEMORY_PROTECTION_CONTEXT
+.endm
+
+/* Update the portcontextRESTORE_CONTEXT macro to restore memory protection context */
+.macro portcontextRESTORE_CONTEXT
+    portasmRESTORE_MEMORY_PROTECTION_CONTEXT
+.endm

--- a/portable/IAR/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
+++ b/portable/IAR/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
@@ -58,6 +58,11 @@
 #define portasmHAS_MTIME                  1
 #define portasmADDITIONAL_CONTEXT_SIZE    0 /* Must be even number on 32-bit cores. */
 
+/* Memory protection-related definitions */
+#define portMPU_REGION_READ_WRITE    0x03
+#define portMPU_REGION_READ_ONLY     0x06
+#define portMPU_REGION_NO_ACCESS     0x00
+
 portasmSAVE_ADDITIONAL_REGISTERS MACRO
 /* No additional registers to save, so this macro does nothing. */
 ENDM
@@ -65,5 +70,14 @@ ENDM
 portasmRESTORE_ADDITIONAL_REGISTERS MACRO
 /* No additional registers to restore, so this macro does nothing. */
     ENDM
+
+/* Macros for saving and restoring memory protection context */
+portasmSAVE_MEMORY_PROTECTION_CONTEXT MACRO
+/* Add code to save memory protection context here */
+ENDM
+
+portasmRESTORE_MEMORY_PROTECTION_CONTEXT MACRO
+/* Add code to restore memory protection context here */
+ENDM
 
 #endif /* __FREERTOS_RISC_V_EXTENSIONS_H__ */

--- a/portable/IAR/RISC-V/port.c
+++ b/portable/IAR/RISC-V/port.c
@@ -239,3 +239,14 @@ void vPortEndScheduler( void )
     }
 }
 /*-----------------------------------------------------------*/
+
+/* Add functions for enabling and disabling memory protection */
+void vPortEnableMemoryProtection( void )
+{
+    __asm volatile ( "csrs mstatus, 0x10000" );
+}
+
+void vPortDisableMemoryProtection( void )
+{
+    __asm volatile ( "csrc mstatus, 0x10000" );
+}

--- a/portable/IAR/RISC-V/portASM.s
+++ b/portable/IAR/RISC-V/portASM.s
@@ -397,3 +397,13 @@ application_exception_handler:
 processed_source:
     portcontextRESTORE_CONTEXT
 /*-----------------------------------------------------------*/
+
+/* Update the portcontextSAVE_CONTEXT_INTERNAL macro to save memory protection context */
+portcontextSAVE_CONTEXT_INTERNAL MACRO
+    portasmSAVE_MEMORY_PROTECTION_CONTEXT
+    ENDM
+
+/* Update the portcontextRESTORE_CONTEXT macro to restore memory protection context */
+portcontextRESTORE_CONTEXT MACRO
+    portasmRESTORE_MEMORY_PROTECTION_CONTEXT
+    ENDM

--- a/portable/IAR/RISC-V/portmacro.h
+++ b/portable/IAR/RISC-V/portmacro.h
@@ -3,27 +3,27 @@
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
+ * 
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
- *
+ * 
  */
 
 
@@ -120,6 +120,7 @@ extern size_t xCriticalNesting;
 #define portENTER_CRITICAL()      \
     {                             \
         portDISABLE_INTERRUPTS(); \
+        portDISABLE_MEMORY_PROTECTION(); \
         xCriticalNesting++;       \
     }
 
@@ -128,6 +129,7 @@ extern size_t xCriticalNesting;
         xCriticalNesting--;          \
         if( xCriticalNesting == 0 )  \
         {                            \
+            portENABLE_MEMORY_PROTECTION(); \
             portENABLE_INTERRUPTS(); \
         }                            \
     }
@@ -188,6 +190,15 @@ extern size_t xCriticalNesting;
 #elif !defined( configMTIME_BASE_ADDRESS ) || !defined( configMTIMECMP_BASE_ADDRESS )
     #error "configMTIME_BASE_ADDRESS and configMTIMECMP_BASE_ADDRESS must be defined in FreeRTOSConfig.h.  Set them to zero if there is no MTIME (machine time) clock.  See www.FreeRTOS.org/Using-FreeRTOS-on-RISC-V.html"
 #endif /* if defined( configCLINT_BASE_ADDRESS ) && !defined( configMTIME_BASE_ADDRESS ) && ( configCLINT_BASE_ADDRESS == 0 ) */
+
+/* Memory protection related configurations and settings */
+#define portMPU_REGION_READ_WRITE    0x03
+#define portMPU_REGION_READ_ONLY     0x06
+#define portMPU_REGION_NO_ACCESS     0x00
+
+/* Macros for enabling and disabling memory protection */
+#define portENABLE_MEMORY_PROTECTION()    __asm volatile ( "csrs mstatus, 0x10000" )
+#define portDISABLE_MEMORY_PROTECTION()   __asm volatile ( "csrc mstatus, 0x10000" )
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus


### PR DESCRIPTION
Related to #908

Add memory protection support to the RISC-V port.

* **Memory Protection Configurations and Settings**
  - Add memory protection-related configurations and settings in `portable/GCC/RISC-V/portmacro.h` and `portable/IAR/RISC-V/portmacro.h`.
  - Define macros for enabling and disabling memory protection in both files.

* **Critical Section Handling**
  - Update the `portENTER_CRITICAL` and `portEXIT_CRITICAL` macros in `portable/GCC/RISC-V/portmacro.h` and `portable/IAR/RISC-V/portmacro.h` to handle memory protection.

* **Chip-Specific Extensions**
  - Add memory protection-related definitions and macros in `portable/GCC/RISC-V/chip_specific_extensions/RISCV_MTIME_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h` and `portable/IAR/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h`.
  - Define macros for saving and restoring memory protection context in both files.

* **Port Functions**
  - Add functions for enabling and disabling memory protection in `portable/GCC/RISC-V/port.c` and `portable/IAR/RISC-V/port.c`.

Working on still: portASM.s planning to implement ASAP

