### PR TITLE
Fix RISC-V configMTIMECMP_BASE_ADDRESS (64-bit) stored in 32-bit int

### DIFF
--- a/portable/GCC/RISC-V/port.c
+++ b/portable/GCC/RISC-V/port.c
@@ -27,8 +27,8 @@
  */
 
 /*-----------------------------------------------------------
-* Implementation of functions defined in portable.h for the RISC-V port.
-*----------------------------------------------------------*/
+ * Implementation of functions defined in portable.h for the RISC-V port.
+ *----------------------------------------------------------*/
 
 /* Scheduler includes. */
 #include "FreeRTOS.h"
@@ -90,7 +90,7 @@ void vPortSetupTimerInterrupt( void ) __attribute__( ( weak ) );
 uint64_t ullNextTime = 0ULL;
 const uint64_t * pullNextTime = &ullNextTime;
 const size_t uxTimerIncrementsForOneTick = ( size_t ) ( ( configCPU_CLOCK_HZ ) / ( configTICK_RATE_HZ ) ); /* Assumes increment won't go over 32-bits. */
-uint32_t const ullMachineTimerCompareRegisterBase = configMTIMECMP_BASE_ADDRESS;
+uint64_t const ullMachineTimerCompareRegisterBase = configMTIMECMP_BASE_ADDRESS;
 volatile uint64_t * pullMachineTimerCompareRegister = NULL;
 
 /* Holds the critical nesting value - deliberately non-zero at start up to

--- a/portable/IAR/RISC-V/port.c
+++ b/portable/IAR/RISC-V/port.c
@@ -27,8 +27,8 @@
  */
 
 /*-----------------------------------------------------------
-* Implementation of functions defined in portable.h for the RISC-V port.
-*----------------------------------------------------------*/
+ * Implementation of functions defined in portable.h for the RISC-V port.
+ *----------------------------------------------------------*/
 
 /* Scheduler includes. */
 #include "FreeRTOS.h"
@@ -98,7 +98,7 @@ void vPortSetupTimerInterrupt( void ) __attribute__( ( weak ) );
 uint64_t ullNextTime = 0ULL;
 const uint64_t * pullNextTime = &ullNextTime;
 const size_t uxTimerIncrementsForOneTick = ( size_t ) ( ( configCPU_CLOCK_HZ ) / ( configTICK_RATE_HZ ) ); /* Assumes increment won't go over 32-bits. */
-uint32_t const ullMachineTimerCompareRegisterBase = configMTIMECMP_BASE_ADDRESS;
+uint64_t const ullMachineTimerCompareRegisterBase = configMTIMECMP_BASE_ADDRESS;
 volatile uint64_t * pullMachineTimerCompareRegister = NULL;
 
 /* Holds the critical nesting value - deliberately non-zero at start up to


### PR DESCRIPTION
Related to #189

Update `configMTIMECMP_BASE_ADDRESS` to be stored in a 64-bit integer.

* Change the type of `ullMachineTimerCompareRegisterBase` to `uint64_t` in `portable/GCC/RISC-V/port.c`.
* Change the type of `ullMachineTimerCompareRegisterBase` to `uint64_t` in `portable/IAR/RISC-V/port.c`.
* Update the initialization of `ullMachineTimerCompareRegisterBase` to use `configMTIMECMP_BASE_ADDRESS` in both files.

