### PR TITLE
Fix variable name mismatch, mpu_wrappers type mismatch.

### DIFF
--- a/include/mpu_prototypes.h
+++ b/include/mpu_prototypes.h
@@ -346,12 +346,12 @@ TickType_t MPU_xTimerGetExpiryTime( TimerHandle_t xTimer ) FREERTOS_SYSTEM_CALL;
  * with all the APIs. */
 TimerHandle_t MPU_xTimerCreate( const char * const pcTimerName,
                                 const TickType_t xTimerPeriodInTicks,
-                                const UBaseType_t uxAutoReload,
+                                const BaseType_t xAutoReload,
                                 void * const pvTimerID,
                                 TimerCallbackFunction_t pxCallbackFunction ) PRIVILEGED_FUNCTION;
 TimerHandle_t MPU_xTimerCreateStatic( const char * const pcTimerName,
                                       const TickType_t xTimerPeriodInTicks,
-                                      const UBaseType_t uxAutoReload,
+                                      const BaseType_t xAutoReload,
                                       void * const pvTimerID,
                                       TimerCallbackFunction_t pxCallbackFunction,
                                       StaticTimer_t * pxTimerBuffer ) PRIVILEGED_FUNCTION;

--- a/portable/Common/mpu_wrappers.c
+++ b/portable/Common/mpu_wrappers.c
@@ -1806,7 +1806,7 @@
                 portRAISE_PRIVILEGE();
                 portMEMORY_BARRIER();
 
-                vTimerSetReloadMode( xTimer, uxAutoReload );
+                vTimerSetReloadMode( xTimer, xAutoReload );
                 portMEMORY_BARRIER();
 
                 portRESET_PRIVILEGE();
@@ -1814,7 +1814,7 @@
             }
             else
             {
-                vTimerSetReloadMode( xTimer, uxAutoReload );
+                vTimerSetReloadMode( xTimer, xAutoReload );
             }
         }
     #endif /* if ( configUSE_TIMERS == 1 ) */

--- a/portable/Common/mpu_wrappers_v2.c
+++ b/portable/Common/mpu_wrappers_v2.c
@@ -3558,10 +3558,10 @@
     #if ( configUSE_TIMERS == 1 )
 
         void MPU_vTimerSetReloadModeImpl( TimerHandle_t xTimer,
-                                          const UBaseType_t uxAutoReload ) PRIVILEGED_FUNCTION;
+                                          const BaseType_t xAutoReload ) PRIVILEGED_FUNCTION;
 
         void MPU_vTimerSetReloadModeImpl( TimerHandle_t xTimer,
-                                          const UBaseType_t uxAutoReload ) /* PRIVILEGED_FUNCTION */
+                                          const BaseType_t xAutoReload ) /* PRIVILEGED_FUNCTION */
         {
             TimerHandle_t xInternalTimerHandle = NULL;
             int32_t lIndex;
@@ -3579,7 +3579,7 @@
 
                     if( xInternalTimerHandle != NULL )
                     {
-                        vTimerSetReloadMode( xInternalTimerHandle, uxAutoReload );
+                        vTimerSetReloadMode( xInternalTimerHandle, xAutoReload );
                     }
                 }
             }
@@ -3733,7 +3733,7 @@
 
         TimerHandle_t MPU_xTimerCreate( const char * const pcTimerName,
                                         const TickType_t xTimerPeriodInTicks,
-                                        const UBaseType_t uxAutoReload,
+                                        const BaseType_t xAutoReload,
                                         void * const pvTimerID,
                                         TimerCallbackFunction_t pxCallbackFunction ) /* PRIVILEGED_FUNCTION */
         {
@@ -3745,7 +3745,7 @@
 
             if( lIndex != -1 )
             {
-                xInternalTimerHandle = xTimerCreate( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, MPU_TimerCallback );
+                xInternalTimerHandle = xTimerCreate( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, MPU_TimerCallback );
 
                 if( xInternalTimerHandle != NULL )
                 {
@@ -3768,7 +3768,7 @@
 
         TimerHandle_t MPU_xTimerCreateStatic( const char * const pcTimerName,
                                               const TickType_t xTimerPeriodInTicks,
-                                              const UBaseType_t uxAutoReload,
+                                              const BaseType_t xAutoReload,
                                               void * const pvTimerID,
                                               TimerCallbackFunction_t pxCallbackFunction,
                                               StaticTimer_t * pxTimerBuffer ) /* PRIVILEGED_FUNCTION */
@@ -3781,7 +3781,7 @@
 
             if( lIndex != -1 )
             {
-                xInternalTimerHandle = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, uxAutoReload, pvTimerID, MPU_TimerCallback, pxTimerBuffer );
+                xInternalTimerHandle = xTimerCreateStatic( pcTimerName, xTimerPeriodInTicks, xAutoReload, pvTimerID, MPU_TimerCallback, pxTimerBuffer );
 
                 if( xInternalTimerHandle != NULL )
                 {


### PR DESCRIPTION
Description
-----------
Fix variable name mismatch introduced by #1166.
Fix MPU v2 wrappers incorrectly using UBaseType_t instead of BaseType.

Test Steps
-----------
Allowing the CI jobs to execute.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1165


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
