### PR TITLE
Move configASSERT default definition above before including portable.h.

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -94,6 +94,13 @@
     #define configUSE_MALLOC_FAILED_HOOK    0
 #endif
 
+#ifndef configASSERT
+    #define configASSERT( x )
+    #define configASSERT_DEFINED    0
+#else
+    #define configASSERT_DEFINED    1
+#endif
+
 /* Basic FreeRTOS definitions. */
 #include "projdefs.h"
 
@@ -362,13 +369,6 @@
 
 #if configMAX_TASK_NAME_LEN < 1
     #error configMAX_TASK_NAME_LEN must be set to a minimum of 1 in FreeRTOSConfig.h
-#endif
-
-#ifndef configASSERT
-    #define configASSERT( x )
-    #define configASSERT_DEFINED    0
-#else
-    #define configASSERT_DEFINED    1
 #endif
 
 /* configPRECONDITION should be defined as configASSERT.

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/CCS/ARM_CM3/portmacro.h
+++ b/portable/CCS/ARM_CM3/portmacro.h
@@ -170,7 +170,7 @@
     #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-    #ifdef configASSERT
+    #if configASSERT_DEFINED == 1
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif

--- a/portable/CCS/ARM_CM3/portmacro.h
+++ b/portable/CCS/ARM_CM3/portmacro.h
@@ -170,7 +170,7 @@
     #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-    #if configASSERT_DEFINED == 1
+    #if ( configASSERT_DEFINED == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif

--- a/portable/CCS/ARM_CM4F/portmacro.h
+++ b/portable/CCS/ARM_CM4F/portmacro.h
@@ -164,7 +164,7 @@
     #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-    #ifdef configASSERT
+    #if configASSERT_DEFINED == 1
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif

--- a/portable/CCS/ARM_CM4F/portmacro.h
+++ b/portable/CCS/ARM_CM4F/portmacro.h
@@ -164,7 +164,7 @@
     #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-    #if configASSERT_DEFINED == 1
+    #if ( configASSERT_DEFINED == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif

--- a/portable/GCC/ARM_AARCH64/portmacro.h
+++ b/portable/GCC/ARM_AARCH64/portmacro.h
@@ -169,7 +169,7 @@ void FreeRTOS_Tick_Handler( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/ARM_AARCH64/portmacro.h
+++ b/portable/GCC/ARM_AARCH64/portmacro.h
@@ -169,7 +169,7 @@ void FreeRTOS_Tick_Handler( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/ARM_AARCH64_SRE/portmacro.h
+++ b/portable/GCC/ARM_AARCH64_SRE/portmacro.h
@@ -160,7 +160,7 @@ void vPortTaskUsesFPU( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/ARM_AARCH64_SRE/portmacro.h
+++ b/portable/GCC/ARM_AARCH64_SRE/portmacro.h
@@ -160,7 +160,7 @@ void vPortTaskUsesFPU( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/ARM_CA9/portmacro.h
+++ b/portable/GCC/ARM_CA9/portmacro.h
@@ -157,7 +157,7 @@ void FreeRTOS_Tick_Handler( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/ARM_CA9/portmacro.h
+++ b/portable/GCC/ARM_CA9/portmacro.h
@@ -157,7 +157,7 @@ void FreeRTOS_Tick_Handler( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -171,7 +171,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM3/portmacro.h
+++ b/portable/GCC/ARM_CM3/portmacro.h
@@ -171,7 +171,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -247,7 +247,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -247,7 +247,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -174,7 +174,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM4F/portmacro.h
+++ b/portable/GCC/ARM_CM4F/portmacro.h
@@ -174,7 +174,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -341,7 +341,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -341,7 +341,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -171,7 +171,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM7/r0p1/portmacro.h
+++ b/portable/GCC/ARM_CM7/r0p1/portmacro.h
@@ -171,7 +171,7 @@ extern void vPortExitCritical( void );
 
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/GCC/ARM_CR5/portmacro.h
+++ b/portable/GCC/ARM_CR5/portmacro.h
@@ -163,7 +163,7 @@ void FreeRTOS_Tick_Handler( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/ARM_CR5/portmacro.h
+++ b/portable/GCC/ARM_CR5/portmacro.h
@@ -163,7 +163,7 @@ void FreeRTOS_Tick_Handler( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif /* configASSERT */

--- a/portable/GCC/RX100/portmacro.h
+++ b/portable/GCC/RX100/portmacro.h
@@ -111,7 +111,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX100/portmacro.h
+++ b/portable/GCC/RX100/portmacro.h
@@ -111,7 +111,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX200/portmacro.h
+++ b/portable/GCC/RX200/portmacro.h
@@ -113,7 +113,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX200/portmacro.h
+++ b/portable/GCC/RX200/portmacro.h
@@ -113,7 +113,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX600/portmacro.h
+++ b/portable/GCC/RX600/portmacro.h
@@ -113,7 +113,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX600/portmacro.h
+++ b/portable/GCC/RX600/portmacro.h
@@ -113,7 +113,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX600v2/portmacro.h
+++ b/portable/GCC/RX600v2/portmacro.h
@@ -113,7 +113,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX600v2/portmacro.h
+++ b/portable/GCC/RX600v2/portmacro.h
@@ -113,7 +113,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL    #0" )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL    %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX700v3_DPFPU/portmacro.h
+++ b/portable/GCC/RX700v3_DPFPU/portmacro.h
@@ -137,7 +137,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL  #0" )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL  %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/GCC/RX700v3_DPFPU/portmacro.h
+++ b/portable/GCC/RX700v3_DPFPU/portmacro.h
@@ -137,7 +137,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __asm volatile ( "MVTIPL  #0" )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( ulPortGetIPL() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( ulPortGetIPL() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __asm volatile( "MVTIPL  %0" ::"i" ( configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
 #else

--- a/portable/IAR/ARM_CA9/portmacro.h
+++ b/portable/IAR/ARM_CA9/portmacro.h
@@ -151,7 +151,7 @@
 
     #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-    #ifdef configASSERT
+    #if configASSERT_DEFINED == 1
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif /* configASSERT */

--- a/portable/IAR/ARM_CA9/portmacro.h
+++ b/portable/IAR/ARM_CA9/portmacro.h
@@ -151,7 +151,7 @@
 
     #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-    #if configASSERT_DEFINED == 1
+    #if ( configASSERT_DEFINED == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif /* configASSERT */

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM3/portmacro.h
+++ b/portable/IAR/ARM_CM3/portmacro.h
@@ -173,7 +173,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM3/portmacro.h
+++ b/portable/IAR/ARM_CM3/portmacro.h
@@ -173,7 +173,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM4F/portmacro.h
+++ b/portable/IAR/ARM_CM4F/portmacro.h
@@ -172,7 +172,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM4F/portmacro.h
+++ b/portable/IAR/ARM_CM4F/portmacro.h
@@ -172,7 +172,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -345,7 +345,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -345,7 +345,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM7/r0p1/portmacro.h
+++ b/portable/IAR/ARM_CM7/r0p1/portmacro.h
@@ -175,7 +175,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM7/r0p1/portmacro.h
+++ b/portable/IAR/ARM_CM7/r0p1/portmacro.h
@@ -175,7 +175,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -312,7 +312,7 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * @brief Validate priority of ISRs that are allowed to call FreeRTOS
  * system calls.
  */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #if ( portHAS_ARMV8M_MAIN_EXTENSION == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()

--- a/portable/IAR/RX100/portmacro.h
+++ b/portable/IAR/RX100/portmacro.h
@@ -108,7 +108,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/IAR/RX100/portmacro.h
+++ b/portable/IAR/RX100/portmacro.h
@@ -108,7 +108,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/IAR/RX600/portmacro.h
+++ b/portable/IAR/RX600/portmacro.h
@@ -110,7 +110,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/IAR/RX600/portmacro.h
+++ b/portable/IAR/RX600/portmacro.h
@@ -110,7 +110,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/IAR/RX700v3_DPFPU/portmacro.h
+++ b/portable/IAR/RX700v3_DPFPU/portmacro.h
@@ -143,7 +143,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/IAR/RX700v3_DPFPU/portmacro.h
+++ b/portable/IAR/RX700v3_DPFPU/portmacro.h
@@ -143,7 +143,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/IAR/RXv2/portmacro.h
+++ b/portable/IAR/RXv2/portmacro.h
@@ -110,7 +110,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/IAR/RXv2/portmacro.h
+++ b/portable/IAR/RXv2/portmacro.h
@@ -110,7 +110,7 @@ typedef unsigned long    UBaseType_t;
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
 #define portENABLE_INTERRUPTS()                           __set_interrupt_level( ( uint8_t ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( __get_interrupt_level() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()                      if( __get_interrupt_level() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) __set_interrupt_level( ( uint8_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/MPLAB/PIC32MEC14xx/portmacro.h
+++ b/portable/MPLAB/PIC32MEC14xx/portmacro.h
@@ -148,7 +148,7 @@ value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY when an ISR
 safe FreeRTOS API function was executed.  ISR safe FreeRTOS API functions are
 those that end in FromISR.  FreeRTOS maintains a separate interrupt API to
 ensure API function and interrupt entry is as fast and as simple as possible. */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portDISABLE_INTERRUPTS()                                                                            \
     {                                                                                                           \
     uint32_t ulStatus;                                                                                          \

--- a/portable/MPLAB/PIC32MEC14xx/portmacro.h
+++ b/portable/MPLAB/PIC32MEC14xx/portmacro.h
@@ -148,7 +148,7 @@ value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY when an ISR
 safe FreeRTOS API function was executed.  ISR safe FreeRTOS API functions are
 those that end in FromISR.  FreeRTOS maintains a separate interrupt API to
 ensure API function and interrupt entry is as fast and as simple as possible. */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portDISABLE_INTERRUPTS()                                                                            \
     {                                                                                                           \
     uint32_t ulStatus;                                                                                          \

--- a/portable/MPLAB/PIC32MX/portmacro.h
+++ b/portable/MPLAB/PIC32MX/portmacro.h
@@ -95,7 +95,7 @@ value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY when an ISR
 safe FreeRTOS API function was executed.  ISR safe FreeRTOS API functions are
 those that end in FromISR.  FreeRTOS maintains a separate interrupt API to
 ensure API function and interrupt entry is as fast and as simple as possible. */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portDISABLE_INTERRUPTS()                                            \
     {                                                                           \
     uint32_t ulStatus;                                                      \

--- a/portable/MPLAB/PIC32MX/portmacro.h
+++ b/portable/MPLAB/PIC32MX/portmacro.h
@@ -95,7 +95,7 @@ value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY when an ISR
 safe FreeRTOS API function was executed.  ISR safe FreeRTOS API functions are
 those that end in FromISR.  FreeRTOS maintains a separate interrupt API to
 ensure API function and interrupt entry is as fast and as simple as possible. */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portDISABLE_INTERRUPTS()                                            \
     {                                                                           \
     uint32_t ulStatus;                                                      \

--- a/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/portable/MPLAB/PIC32MZ/portmacro.h
@@ -97,7 +97,7 @@ value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY when an ISR
 safe FreeRTOS API function was executed.  ISR safe FreeRTOS API functions are
 those that end in FromISR.  FreeRTOS maintains a separate interrupt API to
 ensure API function and interrupt entry is as fast and as simple as possible. */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portDISABLE_INTERRUPTS()                                            \
     {                                                                           \
     uint32_t ulStatus;                                                          \

--- a/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/portable/MPLAB/PIC32MZ/portmacro.h
@@ -97,7 +97,7 @@ value was found to be above configMAX_SYSCALL_INTERRUPT_PRIORITY when an ISR
 safe FreeRTOS API function was executed.  ISR safe FreeRTOS API functions are
 those that end in FromISR.  FreeRTOS maintains a separate interrupt API to
 ensure API function and interrupt entry is as fast and as simple as possible. */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portDISABLE_INTERRUPTS()                                            \
     {                                                                           \
     uint32_t ulStatus;                                                          \

--- a/portable/MikroC/ARM_CM4F/portmacro.h
+++ b/portable/MikroC/ARM_CM4F/portmacro.h
@@ -175,7 +175,7 @@
 
 /*-----------------------------------------------------------*/
 
-    #if configASSERT_DEFINED == 1
+    #if ( configASSERT_DEFINED == 1 )
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif

--- a/portable/MikroC/ARM_CM4F/portmacro.h
+++ b/portable/MikroC/ARM_CM4F/portmacro.h
@@ -175,7 +175,7 @@
 
 /*-----------------------------------------------------------*/
 
-    #ifdef configASSERT
+    #if configASSERT_DEFINED == 1
         void vPortValidateInterruptPriority( void );
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
     #endif

--- a/portable/RVDS/ARM_CA9/portmacro.h
+++ b/portable/RVDS/ARM_CA9/portmacro.h
@@ -153,7 +153,7 @@ void vPortTaskUsesFPU( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CA9/portmacro.h
+++ b/portable/RVDS/ARM_CA9/portmacro.h
@@ -153,7 +153,7 @@ void vPortTaskUsesFPU( void );
 
 #endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM3/portmacro.h
+++ b/portable/RVDS/ARM_CM3/portmacro.h
@@ -165,7 +165,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM3/portmacro.h
+++ b/portable/RVDS/ARM_CM3/portmacro.h
@@ -165,7 +165,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM4F/portmacro.h
+++ b/portable/RVDS/ARM_CM4F/portmacro.h
@@ -165,7 +165,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM4F/portmacro.h
+++ b/portable/RVDS/ARM_CM4F/portmacro.h
@@ -165,7 +165,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -334,7 +334,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -334,7 +334,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM7/r0p1/portmacro.h
+++ b/portable/RVDS/ARM_CM7/r0p1/portmacro.h
@@ -165,7 +165,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/RVDS/ARM_CM7/r0p1/portmacro.h
+++ b/portable/RVDS/ARM_CM7/r0p1/portmacro.h
@@ -165,7 +165,7 @@ extern void vPortExitCritical( void );
 #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     void vPortValidateInterruptPriority( void );
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    vPortValidateInterruptPriority()
 #endif

--- a/portable/Renesas/RX100/portmacro.h
+++ b/portable/Renesas/RX100/portmacro.h
@@ -112,7 +112,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX100/portmacro.h
+++ b/portable/Renesas/RX100/portmacro.h
@@ -112,7 +112,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX200/portmacro.h
+++ b/portable/Renesas/RX200/portmacro.h
@@ -112,7 +112,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX200/portmacro.h
+++ b/portable/Renesas/RX200/portmacro.h
@@ -112,7 +112,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX600/portmacro.h
+++ b/portable/Renesas/RX600/portmacro.h
@@ -113,7 +113,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX600/portmacro.h
+++ b/portable/Renesas/RX600/portmacro.h
@@ -113,7 +113,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX600v2/portmacro.h
+++ b/portable/Renesas/RX600v2/portmacro.h
@@ -113,7 +113,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX600v2/portmacro.h
+++ b/portable/Renesas/RX600v2/portmacro.h
@@ -113,7 +113,7 @@ functions are those that end in FromISR.  FreeRTOS maintains a separate
 interrupt API to ensure API function and interrupt entry is as fast and as
 simple as possible. */
 #define portENABLE_INTERRUPTS()     set_ipl( ( long ) 0 )
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID() configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
     #define portDISABLE_INTERRUPTS()    if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
 #else

--- a/portable/Renesas/RX700v3_DPFPU/portmacro.h
+++ b/portable/Renesas/RX700v3_DPFPU/portmacro.h
@@ -138,7 +138,7 @@
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
     #define portENABLE_INTERRUPTS()                           set_ipl( ( long ) 0 )
-    #ifdef configASSERT
+    #if configASSERT_DEFINED == 1
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
         #define portDISABLE_INTERRUPTS()                      if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
     #else

--- a/portable/Renesas/RX700v3_DPFPU/portmacro.h
+++ b/portable/Renesas/RX700v3_DPFPU/portmacro.h
@@ -138,7 +138,7 @@
  * interrupt API to ensure API function and interrupt entry is as fast and as
  * simple as possible. */
     #define portENABLE_INTERRUPTS()                           set_ipl( ( long ) 0 )
-    #if configASSERT_DEFINED == 1
+    #if ( configASSERT_DEFINED == 1 )
         #define portASSERT_IF_INTERRUPT_PRIORITY_INVALID()    configASSERT( ( get_ipl() <= configMAX_SYSCALL_INTERRUPT_PRIORITY ) )
         #define portDISABLE_INTERRUPTS()                      if( get_ipl() < configMAX_SYSCALL_INTERRUPT_PRIORITY ) set_ipl( ( long ) configMAX_SYSCALL_INTERRUPT_PRIORITY )
     #else

--- a/portable/ThirdParty/GCC/Xtensa_ESP32/include/FreeRTOSConfig_arch.h
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/include/FreeRTOSConfig_arch.h
@@ -85,7 +85,7 @@
 
 /* If CONFIG_FREERTOS_ASSERT_DISABLE is set then configASSERT is defined empty later in FreeRTOS.h and the macro */
 /* configASSERT_DEFINED remains unset (meaning some warnings are avoided) */
-#ifdef configASSERT
+#if configASSERT_DEFINED == 1
     #undef configASSERT
     #if defined( CONFIG_FREERTOS_ASSERT_FAIL_PRINT_CONTINUE )
         #define configASSERT( a )                                           \

--- a/portable/ThirdParty/GCC/Xtensa_ESP32/include/FreeRTOSConfig_arch.h
+++ b/portable/ThirdParty/GCC/Xtensa_ESP32/include/FreeRTOSConfig_arch.h
@@ -85,7 +85,7 @@
 
 /* If CONFIG_FREERTOS_ASSERT_DISABLE is set then configASSERT is defined empty later in FreeRTOS.h and the macro */
 /* configASSERT_DEFINED remains unset (meaning some warnings are avoided) */
-#if configASSERT_DEFINED == 1
+#if ( configASSERT_DEFINED == 1 )
     #undef configASSERT
     #if defined( CONFIG_FREERTOS_ASSERT_FAIL_PRINT_CONTINUE )
         #define configASSERT( a )                                           \

--- a/tasks.c
+++ b/tasks.c
@@ -3882,7 +3882,7 @@ void vTaskSuspendAll( void )
             /* This must never be called from inside a critical section. */
             configASSERT( portGET_CRITICAL_NESTING_COUNT() == 0 );
 
-            /* portSOFRWARE_BARRIER() is only implemented for emulated/simulated ports that
+            /* portSOFTWARE_BARRIER() is only implemented for emulated/simulated ports that
              * do not otherwise exhibit real time behaviour. */
             portSOFTWARE_BARRIER();
 


### PR DESCRIPTION
<!--- Title -->
Move configASSERT default definition above before including portable.h.

Description
-----------
<!--- Describe your changes in detail. -->
As #1170 mentioned, for RP2040 port, there is a compile error if users don't define configASSERT in FreeRTOSConfig.h.
In this PR, we move the configASSERT default definition above before including `portable.h` to solve this problem in a generic method.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. Remove configASSERT definition in FreeRTOS/Test/Target/boards/pico/FreeRTOSConfig.h.
2. Updating Kernel submodule pointer to the working forked branch.
3. Compile RP2040 target testing load.
4. Pass compilation.
```
export PICO_SDK_PATH=$PATH_TO_PICO_SDK
rm -fr $PATH_TO_FREERTOS/FreeRTOS/FreeRTOS/Test/Target/boards/pico/build
cd $PATH_TO_FREERTOS/FreeRTOS/FreeRTOS/Test/Target/boards/pico
export FREERTOS_KERNEL_PATH=$PATH_TO_FREERTOS/FreeRTOS/FreeRTOS/Source
cmake -S . -B build
cd build
make -j
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
