### PR TITLE
Heap: add new API to reset xMinimumEverFreeBytesRemaining.

### DIFF
--- a/include/portable.h
+++ b/include/portable.h
@@ -193,6 +193,7 @@ void vPortFree( void * pv ) PRIVILEGED_FUNCTION;
 void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetMinimumEverFreeHeapSize( void ) PRIVILEGED_FUNCTION;
+void xPortResetHeapMinimumEverFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 
 #if ( configSTACK_ALLOCATION_FROM_SEPARATE_HEAP == 1 )
     void * pvPortMallocStack( size_t xSize ) PRIVILEGED_FUNCTION;

--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -422,6 +422,12 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 }
 /*-----------------------------------------------------------*/
 
+void xPortResetHeapMinimumEverFreeHeapSize( void )
+{
+    xMinimumEverFreeBytesRemaining = xFreeBytesRemaining;
+}
+/*-----------------------------------------------------------*/
+
 void vPortInitialiseBlocks( void )
 {
     /* This just exists to keep the linker quiet. */


### PR DESCRIPTION
Heap: add new API to reset xMinimumEverFreeBytesRemaining.

Description
-----------
This commit adds new API functionality to reset xMinimumEverFreeBytesRemaining. 
This functionality provides ability to get heap statistics during a particular period of time.
For example, such use case could be required in a application that support FreeRTOS as OS and the software diagnostic cluster "reset watermarks" command.

Test Steps
-----------
- Allocate 10 times 100 bytes [pvPortMalloc()].
- xMinimumEverFreeBytesRemaining will decrease by 1000 bytes.
- Free 5 times 100 bytes [vPortFree()].
- xMinimumEverFreeBytesRemaining will remain unchanged.
- Call xPortResetHeapMinimumEverFreeHeapSize()
- xMinimumEverFreeBytesRemaining will be set to current free bytes remaining.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1188


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
