### PR TITLE
Add xPortResetHeapMinimumEverFreeHeapSize to heap5

### DIFF
--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -457,6 +457,12 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 }
 /*-----------------------------------------------------------*/
 
+void xPortResetHeapMinimumEverFreeHeapSize( void )
+{
+    xMinimumEverFreeBytesRemaining = xFreeBytesRemaining;
+}
+/*-----------------------------------------------------------*/
+
 void * pvPortCalloc( size_t xNum,
                      size_t xSize )
 {


### PR DESCRIPTION
Description
-----------
The same was added to heap 4 in this PR - https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1189.

Test Steps
-----------
Build Posix_GCC demo with heap_5. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1188


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
