### PR TITLE
armv8.1-m: Remove portHAS_PACBTI_FEATURE macro

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -3034,14 +3034,12 @@
 
 /* Set configENABLE_PAC and/or configENABLE_BTI to 1 to enable PAC and/or BTI
  * support and 0 to disable them. These are currently used in ARMv8.1-M ports. */
-#if ( portHAS_PACBTI_FEATURE == 1 )
-    #ifndef configENABLE_PAC
-        #define configENABLE_PAC    0
-    #endif
+#ifndef configENABLE_PAC
+    #define configENABLE_PAC    0
+#endif
 
-    #ifndef configENABLE_BTI
-        #define configENABLE_BTI    0
-    #endif
+#ifndef configENABLE_BTI
+    #define configENABLE_BTI    0
 #endif
 
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23_NTZ/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33_NTZ/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM35P/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM55/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM85/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23_NTZ/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33_NTZ/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM35P/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM55/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM85/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           1
 #define portDONT_DISCARD                 __attribute__( ( used ) )
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M23"
 #define portHAS_ARMV8M_MAIN_EXTENSION    0
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M33"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -53,7 +51,6 @@
 #define portARCH_NAME                    "Cortex-M35P"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         0
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM55/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M55"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           0
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM85/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -380,7 +380,7 @@ typedef void ( * portISR_t )( void );
 /**
  * @brief Constants required to check and configure PACBTI security feature implementation.
  */
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     #define portID_ISAR5_REG         ( *( ( volatile uint32_t * ) 0xe000ed74 ) )
 
@@ -389,7 +389,7 @@ typedef void ( * portISR_t )( void );
     #define portCONTROL_UBTI_EN      ( 1UL << 5UL )
     #define portCONTROL_BTI_EN       ( 1UL << 4UL )
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/
 
 /**
@@ -427,7 +427,7 @@ static void prvTaskExitError( void );
     static void prvSetupFPU( void ) PRIVILEGED_FUNCTION;
 #endif /* configENABLE_FPU */
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
 /**
  * @brief Configures PACBTI features.
@@ -445,7 +445,7 @@ static void prvTaskExitError( void );
  */
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister );
 
-#endif /* portHAS_PACBTI_FEATURE */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
 /**
  * @brief Setup the timer to generate the tick interrupts.
@@ -1541,13 +1541,13 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
         xMPUSettings->ulContext[ ulIndex ] = ( uint32_t ) pxEndOfStack;         /* PSPLIM. */
         ulIndex++;
 
-        #if ( portHAS_PACBTI_FEATURE == 1 )
+        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
         {
             /* Check PACBTI security feature configuration before pushing the
              * CONTROL register's value on task's TCB. */
             ulControl = prvConfigurePACBTI( pdFALSE );
         }
-        #endif /* portHAS_PACBTI_FEATURE */
+        #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
         if( xRunPrivileged == pdTRUE )
         {
@@ -1786,13 +1786,13 @@ BaseType_t xPortStartScheduler( void ) /* PRIVILEGED_FUNCTION */
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = 0;
 
-    #if ( portHAS_PACBTI_FEATURE == 1 )
+    #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
     {
         /* Set the CONTROL register value based on PACBTI security feature
          * configuration before starting the first task. */
         ( void) prvConfigurePACBTI( pdTRUE );
     }
-    #endif /* portHAS_PACBTI_FEATURE */
+    #endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 
     #if ( configENABLE_MPU == 1 )
     {
@@ -2213,7 +2213,7 @@ BaseType_t xPortIsInsideInterrupt( void )
 #endif /* #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( portHAS_PACBTI_FEATURE == 1 )
+#if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
 
     static uint32_t prvConfigurePACBTI( BaseType_t xWriteControlRegister )
     {
@@ -2222,12 +2222,8 @@ BaseType_t xPortIsInsideInterrupt( void )
         /* Ensure that PACBTI is implemented. */
         configASSERT( portID_ISAR5_REG != 0x0 );
 
-        /* Enable UsageFault exception if PAC or BTI is enabled. */
-        #if( ( configENABLE_PAC == 1 ) || ( configENABLE_BTI == 1 ) )
-        {
-            portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
-        }
-        #endif
+        /* Enable UsageFault exception. */
+        portSCB_SYS_HANDLER_CTRL_STATE_REG |= portSCB_USG_FAULT_ENABLE_BIT;
 
         #if( configENABLE_PAC == 1 )
         {
@@ -2249,5 +2245,5 @@ BaseType_t xPortIsInsideInterrupt( void )
         return ulControl;
     }
 
-#endif /* #if ( portHAS_PACBTI_FEATURE == 1 ) */
+#endif /* configENABLE_PAC == 1 || configENABLE_BTI == 1 */
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacro.h
@@ -1,8 +1,6 @@
 /*
  * FreeRTOS Kernel <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * Copyright 2024 Arm Limited and/or its affiliates
- * <open-source-office@arm.com>
  *
  * SPDX-License-Identifier: MIT
  *
@@ -58,7 +56,6 @@
 #define portARCH_NAME                    "Cortex-M85"
 #define portHAS_ARMV8M_MAIN_EXTENSION    1
 #define portARMV8M_MINOR_VERSION         1
-#define portHAS_PACBTI_FEATURE           1
 #define portDONT_DISCARD                 __root
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
The PACBTI is an optional hardware security feature, the current implementation assumes that every SoC that has Armv8.1-M architecture extension, has the PACBTI hardware feature, which does not have to be the case. Hence, the `portHAS_PACBTI_FEATURE` is removed and the implementation is modified to rely on `configENABLE_PAC` and `configENABLE_BTI` macros that can either be set using CMake or FreeRTOSConfig.h header file.

Enabling PAC and/or BTI on a port variant that doesn't have the PACBTI hardware feature would be caught by a `configASSERT` statement.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
