### PR TITLE
RISC-V documentation fixes

### DIFF
--- a/portable/GCC/RISC-V/chip_specific_extensions/Pulpino_Vega_RV32M1RM/freertos_risc_v_chip_specific_extensions.h
+++ b/portable/GCC/RISC-V/chip_specific_extensions/Pulpino_Vega_RV32M1RM/freertos_risc_v_chip_specific_extensions.h
@@ -31,7 +31,7 @@
  * common across all currently supported RISC-V chips (implementations of the
  * RISC-V ISA), and code that tailors the port to a specific RISC-V chip:
  *
- * + FreeRTOS\Source\portable\GCC\RISC-V-RV32\portASM.S contains the code that
+ * + FreeRTOS\Source\portable\GCC\RISC-V\portASM.S contains the code that
  *   is common to all currently supported RISC-V chips.  There is only one
  *   portASM.S file because the same file is built for all RISC-V target chips.
  *
@@ -46,7 +46,7 @@
  * compiler's!) include path.  For example, if the chip in use includes a core
  * local interrupter (CLINT) and does not include any chip specific register
  * extensions then add the path below to the assembler's include path:
- * FreeRTOS\Source\portable\GCC\RISC-V-RV32\chip_specific_extensions\RV32I_CLINT_no_extensions
+ * FreeRTOS\Source\portable\GCC\RISC-V\chip_specific_extensions\RV32I_CLINT_no_extensions
  *
  */
 

--- a/portable/GCC/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
+++ b/portable/GCC/RISC-V/chip_specific_extensions/RV32I_CLINT_no_extensions/freertos_risc_v_chip_specific_extensions.h
@@ -31,7 +31,7 @@
  * common across all currently supported RISC-V chips (implementations of the
  * RISC-V ISA), and code that tailors the port to a specific RISC-V chip:
  *
- * + FreeRTOS\Source\portable\GCC\RISC-V-RV32\portASM.S contains the code that
+ * + FreeRTOS\Source\portable\GCC\RISC-V\portASM.S contains the code that
  *   is common to all currently supported RISC-V chips.  There is only one
  *   portASM.S file because the same file is built for all RISC-V target chips.
  *
@@ -46,7 +46,7 @@
  * compiler's!) include path.  For example, if the chip in use includes a core
  * local interrupter (CLINT) and does not include any chip specific register
  * extensions then add the path below to the assembler's include path:
- * FreeRTOS\Source\portable\GCC\RISC-V-RV32\chip_specific_extensions\RV32I_CLINT_no_extensions
+ * FreeRTOS\Source\portable\GCC\RISC-V\chip_specific_extensions\RV32I_CLINT_no_extensions
  *
  */
 

--- a/portable/GCC/RISC-V/chip_specific_extensions/readme.txt
+++ b/portable/GCC/RISC-V/chip_specific_extensions/readme.txt
@@ -3,7 +3,7 @@
  * common across all currently supported RISC-V chips (implementations of the
  * RISC-V ISA), and code that tailors the port to a specific RISC-V chip:
  *
- * + FreeRTOS\Source\portable\GCC\RISC-V-RV32\portASM.S contains the code that
+ * + FreeRTOS\Source\portable\GCC\RISC-V\portASM.S contains the code that
  *   is common to all currently supported RISC-V chips.  There is only one
  *   portASM.S file because the same file is built for all RISC-V target chips.
  *
@@ -18,6 +18,6 @@
  * compiler's!) include path.  For example, if the chip in use includes a core
  * local interrupter (CLINT) and does not include any chip specific register
  * extensions then add the path below to the assembler's include path:
- * FreeRTOS\Source\portable\GCC\RISC-V-RV32\chip_specific_extensions\RV32I_CLINT_no_extensions
+ * FreeRTOS\Source\portable\GCC\RISC-V\chip_specific_extensions\RV32I_CLINT_no_extensions
  *
  */

--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -32,7 +32,7 @@
  * RISC-V ISA), and code which tailors the port to a specific RISC-V chip:
  *
  * + The code that is common to all RISC-V chips is implemented in
- *   FreeRTOS\Source\portable\GCC\RISC-V-RV32\portASM.S.  There is only one
+ *   FreeRTOS\Source\portable\GCC\RISC-V\portASM.S.  There is only one
  *   portASM.S file because the same file is used no matter which RISC-V chip is
  *   in use.
  *

--- a/portable/GCC/RISC-V/readme.txt
+++ b/portable/GCC/RISC-V/readme.txt
@@ -3,7 +3,7 @@
  * common across all currently supported RISC-V chips (implementations of the
  * RISC-V ISA), and code that tailors the port to a specific RISC-V chip:
  *
- * + FreeRTOS\Source\portable\GCC\RISC-V-RV32\portASM.S contains the code that
+ * + FreeRTOS\Source\portable\GCC\RISC-V\portASM.S contains the code that
  *   is common to all currently supported RISC-V chips.  There is only one
  *   portASM.S file because the same file is built for all RISC-V target chips.
  *
@@ -18,6 +18,6 @@
  * compiler's!) include path.  For example, if the chip in use includes a core
  * local interrupter (CLINT) and does not include any chip specific register
  * extensions then add the path below to the assembler's include path:
- * FreeRTOS\Source\portable\GCC\RISC-V-RV32\chip_specific_extensions\RV32I_CLINT_no_extensions
+ * FreeRTOS\Source\portable\GCC\RISC-V\chip_specific_extensions\RV32I_CLINT_no_extensions
  *
  */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Whilst reading through the RISC-V `portASM.S`, I noticed the documentation on lines 35 and 49 referenced an old directory (`RISC-V-RV32/`). After grepping through the other files in the directory, I noticed some discrepancies (some referencing `RISC-V/`, and some referencing `RISC-V-RV32/`). I've gone through and made the necessary changes.  

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
