### PR TITLE
Reinstate "Fix inaccurate ticks in windows port"

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -141,6 +141,9 @@ static DWORD WINAPI prvSimulatedPeripheralTimer( LPVOID lpParameter )
 {
     TickType_t xMinimumWindowsBlockTime;
     TIMECAPS xTimeCaps;
+    TickType_t xWaitTimeBetweenTicks = portTICK_PERIOD_MS;
+    HANDLE hTimer = NULL;
+    LARGE_INTEGER liDueTime;
 
     /* Set the timer resolution to the maximum possible. */
     if( timeGetDevCaps( &xTimeCaps, sizeof( xTimeCaps ) ) == MMSYSERR_NOERROR )
@@ -160,22 +163,33 @@ static DWORD WINAPI prvSimulatedPeripheralTimer( LPVOID lpParameter )
     /* Just to prevent compiler warnings. */
     ( void ) lpParameter;
 
+    /* Tick time for the timer is adjusted with the maximum available
+     resolution. */
+    if( portTICK_PERIOD_MS < xMinimumWindowsBlockTime )
+    {
+        xWaitTimeBetweenTicks = xMinimumWindowsBlockTime;
+    }
+
+    /* Convert the tick time in milliseconds to nanoseconds resolution
+     for the Waitable Timer. */
+    liDueTime.u.LowPart = xWaitTimeBetweenTicks * 1000 * 1000;
+    liDueTime.u.HighPart = 0;
+
+    /* Create a synchronization Waitable Timer.*/
+    hTimer = CreateWaitableTimer( NULL, FALSE, NULL );
+
+    configASSERT( hTimer != NULL );
+
+    /* Set the Waitable Timer. The timer is set to run periodically at every
+    xWaitTimeBetweenTicks milliseconds. */
+    configASSERT( SetWaitableTimer( hTimer, &liDueTime, xWaitTimeBetweenTicks, NULL, NULL, 0 ) );
+
     while( xPortRunning == pdTRUE )
     {
         /* Wait until the timer expires and we can access the simulated interrupt
-         * variables.  *NOTE* this is not a 'real time' way of generating tick
-         * events as the next wake time should be relative to the previous wake
-         * time, not the time that Sleep() is called.  It is done this way to
-         * prevent overruns in this very non real time simulated/emulated
-         * environment. */
-        if( portTICK_PERIOD_MS < xMinimumWindowsBlockTime )
-        {
-            Sleep( xMinimumWindowsBlockTime );
-        }
-        else
-        {
-            Sleep( portTICK_PERIOD_MS );
-        }
+         * variables. */
+
+        WaitForSingleObject( hTimer, INFINITE );
 
         vPortGenerateSimulatedInterruptFromWindowsThread( portINTERRUPT_TICK );
     }


### PR DESCRIPTION
Reinstate "Fix inaccurate ticks in windows port"

Description
-----------
Reinstates PR #142 by that was reverted in #143 by . The reason given for the reversion was "Backing this out to merge it after the next Kernel release" which was in August 2020.

Test Steps
-----------
When running the Windows port with configTICK_RATE_HZ 1000 the program runs at roughly half real time speed. 
Tested on Windows 11 24H2 on a 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#143 and #143 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
