### PR TITLE
Update manifest to use 'V'

### DIFF
--- a/.github/scripts/manifest_updater.py
+++ b/.github/scripts/manifest_updater.py
@@ -11,7 +11,7 @@ def update_manifest_file(new_version_number):
         for line in f:
             line = line.strip()
             if line.startswith('version'):
-                updated_lines.append(f'version: "v{new_version_number}"\n')
+                updated_lines.append(f'version: "V{new_version_number}"\n')
             else:
                 updated_lines.append(f'{line}\n')
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 name : "FreeRTOS-Kernel"
-version: "v11.0.1+"
+version: "V11.0.1+"
 description: "FreeRTOS Kernel."
 license: "MIT"


### PR DESCRIPTION
Description
-----------
Release tags use a capitalized V.
Our manifest tag is used by our SBOM
script to generate the URL and so
this needs to be capitalized to generate
a valid URL.

Test Steps
-----------
Testing the manifest updater...
```
./manifest_updater.py -v 12.34.56
```
manifest.yml contents
```
name : "FreeRTOS-Kernel"
version: "V12.34.56"
description: "FreeRTOS Kernel."
license: "MIT"
```

Verifying the SBOM generator...
```
export GITHUB_REPOSITORY=FreeRTOS/FreeRTOS-Kernel
python3 ./scan_dir.py --repo-root-path /Users/kstribrn/workspace/forks/FreeRTOS-Kernel
```

```
SPDXVersion: SPDX-2.2
DataLicense: CC0-1.0
SPDXID: SPDXRef-DOCUMENT
DocumentName: FreeRTOS-Kernel
DocumentNamespace: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/V11.1.0/sbom.spdx
Creator: Organization:Amazon Web Services
Created: 2024-11-29T10:04:23Z
CreatorComment: NOASSERTION
DocumentComment: NOASSERTION

PackageName: FreeRTOS-Kernel
SPDXID: SPDXRef-Package-FreeRTOS-Kernel
PackageVersion: V11.1.0
ExternalRef: SECURITY cpe23Type cpe:2.3:o:amazon:freertos:V11.1.0:*:*:*:*:*:*:*
PackageDownloadLocation: https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/V11.1.0
PackageLicenseDeclared: MIT
PackageLicenseConcluded: MIT
PackageLicenseInfoFromFiles: NOASSERTION
FilesAnalyzed: true
PackageVerificationCode: da39a3ee5e6b4b0d3255bfef95601890afd80709
PackageCopyrightText: NOASSERTION
PackageSummary: NOASSERTION
PackageDescription: FreeRTOS Kernel.
```

The repo tag URL is valid.


Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [N/A] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1200


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
