### PR TITLE
fix(freertos): Limit idle task name length copy operation and ensure null-termination of the idle task name string

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3530,13 +3530,13 @@ static BaseType_t prvCreateIdleTasks( void )
     BaseType_t xIdleNameLen;
     BaseType_t xCopyLen;
 
-    configASSERT( configIDLE_TASK_NAME != NULL && configMAX_TASK_NAME_LEN > 3 );
+    configASSERT( ( configIDLE_TASK_NAME != NULL ) && ( configMAX_TASK_NAME_LEN > 3 ) );
 
     /* The length of the idle task name is limited to the minimum of the length
      * of configIDLE_TASK_NAME and configMAX_TASK_NAME_LEN - 2, keeping space
      * for the core ID suffix and the null-terminator. */
     xIdleNameLen = sizeof( configIDLE_TASK_NAME ) - 1;
-    xCopyLen = ( xIdleNameLen < configMAX_TASK_NAME_LEN - 2 ) ? xIdleNameLen : configMAX_TASK_NAME_LEN - 2;
+    xCopyLen = xIdleNameLen < ( configMAX_TASK_NAME_LEN - 2 ) ? xIdleNameLen : ( configMAX_TASK_NAME_LEN - 2 );
 
     for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < xCopyLen; xIdleTaskNameIndex++ )
     {

--- a/tasks.c
+++ b/tasks.c
@@ -3535,7 +3535,7 @@ static BaseType_t prvCreateIdleTasks( void )
     /* The length of the idle task name is limited to the minimum of the length
      * of configIDLE_TASK_NAME and configMAX_TASK_NAME_LEN - 2, keeping space
      * for the core ID suffix and the null-terminator. */
-    xIdleNameLen = sizeof( configIDLE_TASK_NAME ) - 1;
+    xIdleNameLen = strlen( configIDLE_TASK_NAME );
     xCopyLen = xIdleNameLen < ( configMAX_TASK_NAME_LEN - 2 ) ? xIdleNameLen : ( configMAX_TASK_NAME_LEN - 2 );
 
     for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < xCopyLen; xIdleTaskNameIndex++ )


### PR DESCRIPTION
 This PR:
    - Limits the idle task name length copy operation to prevent Out-of-bounds memory access warnings from static code analyzers.
    - Fixes a bug where in the idle task name could be non null-terminated string for SMP configuration.

Description
-----------
- In the function `prvCreateIdleTasks()`, we have the operation -
```
       for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < ( BaseType_t ) configMAX_TASK_NAME_LEN; xIdleTaskNameIndex++ )
       {
          cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
  
          /* Don't copy all configMAX_TASK_NAME_LEN if the string is shorter than
           * configMAX_TASK_NAME_LEN characters just in case the memory after the
           * string is not accessible (extremely unlikely). */
          if( cIdleName[ xIdleTaskNameIndex ] == ( char ) 0x00 )
          {
             break;
          }
          else
          {
             mtCOVERAGE_TEST_MARKER();
          }     
       }
  ```

- Static code analyzers could flag this copy operation as an Out-of-bounds memory access because they see `configIDLE_TASK_NAME` as an array of 5 bytes (I, D, L, E, \0) but the loop running for `configMAX_TASK_NAME_LEN` iterations which could be more than 5.
- They also do not assume that a `\0` character is present in the `configIDLE_TASK_NAME` array and hence can not predict that the loop will break before an Out-of-bounds memory access is made.
- Therefore, this PR limits the copy operation to the minimum of either `configIDLE_TASK_NAME` or `configMAX_TASK_NAME_LEN`. This ensures that the copy operation runs for exactly the required number of iterations to copy the idle task name, 5 by default.
- The PR also fixes a bug with null-termination of the `IDLE` task name if `strlen(configIDLE_TASK_NAME) = configMAX_TASK_NAME_LEN - 1` when SMP configuration is enabled. The current code would append the core ID to the task name and in the process overwrites the null terminator. It then exists the loop as there is no more space to add a null terminator. 

Test Steps
-----------
- Run a static code analysis of `tasks.c` on a tool like Coverity.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.

Related Issue
-----------
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
