### PR TITLE
Pass core ID to critical nesting count macros

### DIFF
--- a/.github/scripts/manifest_updater.py
+++ b/.github/scripts/manifest_updater.py
@@ -11,7 +11,7 @@ def update_manifest_file(new_version_number):
         for line in f:
             line = line.strip()
             if line.startswith('version'):
-                updated_lines.append(f'version: "v{new_version_number}"\n')
+                updated_lines.append(f'version: "V{new_version_number}"\n')
             else:
                 updated_lines.append(f'{line}\n')
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 name : "FreeRTOS-Kernel"
-version: "v11.0.1+"
+version: "V11.0.1+"
 description: "FreeRTOS Kernel."
 license: "MIT"

--- a/tasks.c
+++ b/tasks.c
@@ -3869,7 +3869,6 @@ void vTaskSuspendAll( void )
     #else /* #if ( configNUMBER_OF_CORES == 1 ) */
     {
         UBaseType_t ulState;
-        BaseType_t xCoreID;
 
         /* This must only be called from within a task. */
         portASSERT_IF_IN_ISR();
@@ -3882,10 +3881,9 @@ void vTaskSuspendAll( void )
              * It is safe to re-enable interrupts after releasing the ISR lock and incrementing
              * uxSchedulerSuspended since that will prevent context switches. */
             ulState = portSET_INTERRUPT_MASK();
-            xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
             /* This must never be called from inside a critical section. */
-            configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 );
+            configASSERT( portGET_CRITICAL_NESTING_COUNT( portGET_CORE_ID() ) == 0 );
 
             /* portSOFTWARE_BARRIER() is only implemented for emulated/simulated ports that
              * do not otherwise exhibit real time behaviour. */
@@ -7198,12 +7196,14 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+        BaseType_t xCoreID;
 
         traceENTER_vTaskExitCriticalFromISR( uxSavedInterruptStatus );
 
         if( xSchedulerRunning != pdFALSE )
         {
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
+            
             /* If critical nesting count is zero then this function
              * does not match a previous call to vTaskEnterCritical(). */
             configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );

--- a/tasks.c
+++ b/tasks.c
@@ -807,7 +807,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         UBaseType_t uxPrevCriticalNesting;
         const TCB_t * pxThisTCB;
-        const UBaseType_t xCoreID = portGET_CORE_ID();
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         /* This must only be called from within a task. */
         portASSERT_IF_IN_ISR();
@@ -3868,7 +3868,7 @@ void vTaskSuspendAll( void )
     #else /* #if ( configNUMBER_OF_CORES == 1 ) */
     {
         UBaseType_t ulState;
-        const UBaseType_t xCoreID = portGET_CORE_ID();
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         /* This must only be called from within a task. */
         portASSERT_IF_IN_ISR();
@@ -4006,8 +4006,7 @@ BaseType_t xTaskResumeAll( void )
          * tasks from this list into their appropriate ready list. */
         taskENTER_CRITICAL();
         {
-            BaseType_t xCoreID;
-            xCoreID = ( BaseType_t ) portGET_CORE_ID();
+            const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
             /* If uxSchedulerSuspended is zero then this function does not match a
              * previous call to vTaskSuspendAll(). */
@@ -6940,7 +6939,7 @@ static void prvResetNextTaskUnblockTime( void )
  */
     void vTaskYieldWithinAPI( void )
     {
-        const UBaseType_t xCoreID = portGET_CORE_ID();
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         traceENTER_vTaskYieldWithinAPI();
 
@@ -6997,7 +6996,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskEnterCritical( void )
     {
-        const UBaseType_t xCoreID = portGET_CORE_ID();
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         traceENTER_vTaskEnterCritical();
 
@@ -7050,7 +7049,7 @@ static void prvResetNextTaskUnblockTime( void )
     UBaseType_t vTaskEnterCriticalFromISR( void )
     {
         UBaseType_t uxSavedInterruptStatus = 0;
-        const UBaseType_t xCoreID = portGET_CORE_ID();
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         traceENTER_vTaskEnterCriticalFromISR();
 
@@ -7127,7 +7126,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCritical( void )
     {
-        const UBaseType_t xCoreID = portGET_CORE_ID();
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         traceENTER_vTaskExitCritical();
 
@@ -7190,7 +7189,7 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus )
     {
-        const UBaseType_t xCoreID = portGET_CORE_ID();
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         traceENTER_vTaskExitCriticalFromISR( uxSavedInterruptStatus );
 

--- a/tasks.c
+++ b/tasks.c
@@ -807,7 +807,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
     {
         UBaseType_t uxPrevCriticalNesting;
         const TCB_t * pxThisTCB;
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+        BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         /* This must only be called from within a task. */
         portASSERT_IF_IN_ISR();
@@ -855,6 +855,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
             portDISABLE_INTERRUPTS();
             portGET_TASK_LOCK();
             portGET_ISR_LOCK();
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
             portSET_CRITICAL_NESTING_COUNT( xCoreID, uxPrevCriticalNesting );
 
@@ -3868,7 +3869,7 @@ void vTaskSuspendAll( void )
     #else /* #if ( configNUMBER_OF_CORES == 1 ) */
     {
         UBaseType_t ulState;
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+        BaseType_t xCoreID;
 
         /* This must only be called from within a task. */
         portASSERT_IF_IN_ISR();
@@ -3881,6 +3882,7 @@ void vTaskSuspendAll( void )
              * It is safe to re-enable interrupts after releasing the ISR lock and incrementing
              * uxSchedulerSuspended since that will prevent context switches. */
             ulState = portSET_INTERRUPT_MASK();
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
             /* This must never be called from inside a critical section. */
             configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 );
@@ -6996,11 +6998,11 @@ static void prvResetNextTaskUnblockTime( void )
 
     void vTaskEnterCritical( void )
     {
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
-
         traceENTER_vTaskEnterCritical();
 
         portDISABLE_INTERRUPTS();
+
+        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
         if( xSchedulerRunning != pdFALSE )
         {
@@ -7049,13 +7051,14 @@ static void prvResetNextTaskUnblockTime( void )
     UBaseType_t vTaskEnterCriticalFromISR( void )
     {
         UBaseType_t uxSavedInterruptStatus = 0;
-        const BaseType_t xCoreID = ( BaseType_t ) portGET_CORE_ID();
+        BaseType_t xCoreID;
 
         traceENTER_vTaskEnterCriticalFromISR();
 
         if( xSchedulerRunning != pdFALSE )
         {
             uxSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
+            xCoreID = ( BaseType_t ) portGET_CORE_ID();
 
             if( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0U )
             {

--- a/tasks.c
+++ b/tasks.c
@@ -7203,7 +7203,7 @@ static void prvResetNextTaskUnblockTime( void )
         if( xSchedulerRunning != pdFALSE )
         {
             xCoreID = ( BaseType_t ) portGET_CORE_ID();
-            
+
             /* If critical nesting count is zero then this function
              * does not match a previous call to vTaskEnterCritical(). */
             configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) > 0U );


### PR DESCRIPTION
Description
-----------
Passes the core ID as an argument to the critical nesting count macros `port{GET/SET/INCREMENT/DECREMENT}_CRITICAL_NESTING_COUNT` in `tasks.c`. This allows the functions that use these macros to read and store the core ID once per call using `portGET_CORE_ID()` when using FreeRTOS SMP, thereby reducing the number of unnecessary, and generally slow, accesses to a peripheral register. I have summarised the worst-case number of calls to `portGET_CORE_ID()` before and after these changes:

| Function | # of calls (before) |  # of calls (after) |
| -------- | ------------------- | ------------------- |
| `prvCheckForRunStateChange()` | 4 | 1 |
| `prvYieldForTask()` | 5 | 1 |
| `vTaskSwitchContext()` | 2 | 1 |
| `vTaskYieldWithinAPI()` | 2 | 1 |
| `vTaskEnterCritical()` | 3 | 1 |
| `vTaskEnterCriticalFromISR()` | 2 | 1 |
| `vTaskExitCritical()` | 4 | 1 |
| `vTaskExitCriticalFromISR()` | 4 | 1 |

The execution time of each of the above functions has been reduced on the architecture I tested (an ARM Cortex-M7), though I expect this will yield similar improvements on most ISAs. Further improvements are possible by also passing the core ID to the `port{GET/RELEASE}_{ISR/TASK}_LOCK}()` macros, but this involves changes to the port API so I haven't included them here.

Test Steps
-----------
I compared the execution time of the functions listed in the table above using ETM trace on an NXP S32K396 microcontroller running FreeRTOS v11.1 in SMP mode. I looked at the execution time for 10 random calls to each function while the system is running:

| Function | Mean execution time (before) | Mean execution time (after) | % reduction |
| -------- | ---------------------------- | ---------------------------- | ----------- |
| `prvCheckForRunStateChange()` | 768 ns | 769 ns | 0% |
| `prvYieldForTask()` | 2995 ns | 3050 ns | -2% |
| `vTaskSwitchContext()` | 11963 ns | 11055 ns | 8% |
| `vTaskEnterCritical()` | 4936 ns | 4695 ns | 5% |
| `vTaskEnterCriticalFromISR()` | 3095 ns | 2799 ns | 10% |
| `vTaskExitCritical()` | 5342 ns | 5352 ns | 0% |
| `vTaskExitCriticalFromISR()` | 3974 ns | 2665 ns | 33% | 

I was not able to get individual results for `vTaskYieldWithinAPI()` because it calls some of the other functions above. For `prvCheckForRunStateChange()` and `prvYieldForTask()`, I noticed that the number of calls to `portGET_CORE_ID()` on my system were the same as before, so my code is not branching to the worst-case path. These are average-case results on my particular project and not definitive, but certain functions do see a clear improvement.

These changes are made under the assumption that the core ID cannot change within the context of each function, which I believe is true.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1204


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
