### PR TITLE
Regression Bug Fix: Fix Incorrect Return of MSVC-MingW portYIELD_FROM_ISR

### DIFF
--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -112,7 +112,7 @@ extern volatile BaseType_t xInsideInterrupt;
 
 /* Simulated interrupts return pdFALSE if no context switch should be performed,
  * or a non-zero number if a context switch should be performed. */
-#define portYIELD_FROM_ISR( x )       ( void ) x
+#define portYIELD_FROM_ISR( x )       return x
 #define portEND_SWITCHING_ISR( x )    portYIELD_FROM_ISR( ( x ) )
 
 void vPortCloseRunningThread( void * pvTaskToDelete,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
This is a regression issue introduced in https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/cfc268814a94a4deb8ddc8322b63ccae270a8669.
That PR was intended to update MIT licensed header from v9 to v10.
But it accidentally changed "portYIELD_FROM_ISR( x )" in MSVC-MingW/portmacro.h.
It caused "portYIELD_FROM_ISR( x )" does not return correct value to "prvProcessSimulatedInterrupts".
![image](https://github.com/user-attachments/assets/347460ad-2076-4219-990f-72f5cda50724)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
"prvProcessSimulatedInterrupts" checks the return value of ISR (portYIELD_FROM_ISR( x )) and updates ulSwitchRequired.
![image](https://github.com/user-attachments/assets/97820c2e-5d2a-46f2-929f-fc78e86d4031)
I tested on my laptop. The current return value is 0x52 which is due to missing return value of portYIELD_FROM_ISR( x ). 
![image](https://github.com/user-attachments/assets/7bd2f65b-c36d-4c0b-a56c-9e7a21e694b4)
After this patch, the returned value is correct. 
![image](https://github.com/user-attachments/assets/337673a7-270f-4082-8c88-9f796831e158)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://github.com/FreeRTOS/FreeRTOS/issues/1310

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
