### PR TITLE
Add macro guard configUSE_MPU_WRAPPERS_V1 to remove definition missing warning.

### DIFF
--- a/.github/allowed_urls.txt
+++ b/.github/allowed_urls.txt
@@ -1,0 +1,3 @@
+https://www.renesas.com/us/en/document/mah/rh850f1k-group-users-manual-hardware?r=1170166
+https://www.renesas.com/us/en/products/microcontrollers-microprocessors/rh850-automotive-mcus
+https://www.renesas.com/us/en/software-tool/c-compiler-package-rh850-family#downloads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Link Verification
         uses: FreeRTOS/CI-CD-Github-Actions/link-verifier@main
+        with:
+          allowlist-file: '.github/allowed_urls.txt'
 
   verify-manifest:
     runs-on: ubuntu-latest

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0   */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0  */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 
 #if ( configENABLE_MPU == 1 )
 
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0 */
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -398,7 +398,7 @@ typedef void ( * portISR_t )( void );
  */
 static void prvTaskExitError( void );
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
 /**
  * @brief Extract MPU region's access permissions from the Region Base Address
@@ -409,7 +409,7 @@ static void prvTaskExitError( void );
  * @return uint32_t Access permissions.
  */
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) PRIVILEGED_FUNCTION;
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 
 #if ( configENABLE_MPU == 1 )
 
@@ -871,7 +871,7 @@ static void prvTaskExitError( void )
 }
 /*-----------------------------------------------------------*/
 
-#if ( configENABLE_MPU == 1 )
+#if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )
 
     static uint32_t prvGetRegionAccessPermissions( uint32_t ulRBARValue ) /* PRIVILEGED_FUNCTION */
     {
@@ -890,7 +890,7 @@ static void prvTaskExitError( void )
         return ulAccessPermissions;
     }
 
-#endif /* configENABLE_MPU */
+#endif /* configENABLE_MPU == 1 && configUSE_MPU_WRAPPERS_V1 == 0*/
 /*-----------------------------------------------------------*/
 
 #if ( configENABLE_MPU == 1 )


### PR DESCRIPTION
Description
-----------
This PR adds the guard `configUSE_MPU_WRAPPERS_V1` to the function `prvGetRegionAccessPermissions` to remove warning . 

Test Steps
-----------
NA.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1205 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
