### PR TITLE
Add title for each column in the table from vTaskListTasks

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -141,7 +141,7 @@
 #define tskREADY_CHAR        ( 'R' )
 #define tskDELETED_CHAR      ( 'D' )
 #define tskSUSPENDED_CHAR    ( 'S' )
-
+#define tskTITLE_STR         "TaskName     State Priority WaterMark TaskID"
 /*
  * Some kernel aware debuggers require the data the debugger needs access to be
  * global, rather than file scope.
@@ -7311,6 +7311,18 @@ static void prvResetNextTaskUnblockTime( void )
         {
             /* Generate the (binary) data. */
             uxArraySize = uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, NULL );
+
+            /* Create title for each column of task table */
+            if (uxArraySize > 0)
+            {
+                iSnprintfReturnValue = snprintf(pcWriteBuffer,
+                                                uxBufferLength - uxConsumedBufferLength,
+                                                "%s\r\n",
+                                                tskTITLE_STR);
+                uxCharsWrittenBySnprintf = prvSnprintfReturnValueToCharsWritten(iSnprintfReturnValue, uxBufferLength - uxConsumedBufferLength);
+                uxConsumedBufferLength += uxCharsWrittenBySnprintf;
+                pcWriteBuffer += uxCharsWrittenBySnprintf;
+            }
 
             /* Create a human readable table from the binary data. */
             for( x = 0; x < uxArraySize; x++ )


### PR DESCRIPTION
Description
-----------
The task table returned by vTaskListTasks is human readable. But it misses a description for each column.
Add a title row for better human readability.
Before: 
![image](https://github.com/user-attachments/assets/ee7fb61f-6c1f-4cca-a1a7-a22dae5d737a)
After:
![image](https://github.com/user-attachments/assets/9e1cdb37-29a9-42cb-9abf-41bd59bcbbab)

Test Steps
-----------
Smaller Buffer than vTaskListTasks() actually needs. 
I assigned buffer length as 150. No error reported by Windows MSVC emulator. 
![image](https://github.com/user-attachments/assets/793a7691-202f-456d-904a-fda44fc297d1)
The table is correct. Only problem is the last row is missing due to buffer is not enough. 
![image](https://github.com/user-attachments/assets/ea7240cf-8f6e-4868-921d-2d9aa97229fc)

Larger Buffer than vTaskListTasks() actually needs. 
No error reported by Windows MSVC emulator.
![image](https://github.com/user-attachments/assets/a25f65db-b815-42f0-86e1-9b42d6fedb74)
![image](https://github.com/user-attachments/assets/6c92a885-9463-4b69-8338-411859be74e9)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [Yes] I have tested my changes. No regression in existing tests.
- [Yes] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
I submitted a feature request.
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1213

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
