### PR TITLE
Add a stack pointer bounds check when configCHECK_FOR_STACK_OVERFLOW is set to 2.

### DIFF
--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -88,25 +88,20 @@
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH < 0 ) )
 
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                      \
-    do {                                                                                        \
-        const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                 \
-        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                 \
-                                                                                                \
-        char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                   \
-        if( ( pulStack[ 0 ] != ulCheckValue ) ||                                                \
-            ( pulStack[ 1 ] != ulCheckValue ) ||                                                \
-            ( pulStack[ 2 ] != ulCheckValue ) ||                                                \
-            ( pulStack[ 3 ] != ulCheckValue ) )                                                 \
-        {                                                                                       \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
-        }                                                                                       \
-                                                                                                \
-        /* Is the currently saved stack pointer within the stack limit? */                      \
-        if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )     \
-        {                                                                                       \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
-        }                                                                                       \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                          \
+    do {                                                                                            \
+        const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                     \
+        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                     \
+                                                                                                    \
+        if( ( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING ) ||    \
+            ( pulStack[ 0 ] != ulCheckValue ) ||                                                    \
+            ( pulStack[ 1 ] != ulCheckValue ) ||                                                    \
+            ( pulStack[ 2 ] != ulCheckValue ) ||                                                    \
+            ( pulStack[ 3 ] != ulCheckValue ) )                                                     \
+        {                                                                                           \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                   \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );     \
+        }                                                                                           \
     } while( 0 )
 
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
@@ -126,16 +121,10 @@
                                                                                                                                           \
         pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
                                                                                                                                           \
-        char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                             \
-        /* Has the extremity of the task stack ever been written over? */                                                                 \
-        if( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 )                     \
+        if( ( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                     \
+            ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
         {                                                                                                                                 \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
-        }                                                                                                                                 \
-                                                                                                                                          \
-        /* Is the currently saved stack pointer within the stack limit? */                                                                \
-        if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )                                          \
-        {                                                                                                                                 \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                         \
             vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
         }                                                                                                                                 \
     } while( 0 )

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -93,12 +93,18 @@
         const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                 \
         const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                 \
                                                                                                 \
+        char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                   \
         if( ( pulStack[ 0 ] != ulCheckValue ) ||                                                \
             ( pulStack[ 1 ] != ulCheckValue ) ||                                                \
             ( pulStack[ 2 ] != ulCheckValue ) ||                                                \
             ( pulStack[ 3 ] != ulCheckValue ) )                                                 \
         {                                                                                       \
-            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                               \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
+        }                                                                                       \
+                                                                                                \
+        /* Is the currently saved stack pointer within the stack limit? */                      \
+        if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )     \
+        {                                                                                       \
             vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
         }                                                                                       \
     } while( 0 )
@@ -120,10 +126,16 @@
                                                                                                                                           \
         pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
                                                                                                                                           \
+        char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                             \
         /* Has the extremity of the task stack ever been written over? */                                                                 \
         if( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 )                     \
         {                                                                                                                                 \
-            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                         \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
+        }                                                                                                                                 \
+                                                                                                                                          \
+        /* Is the currently saved stack pointer within the stack limit? */                                                                \
+        if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )                                          \
+        {                                                                                                                                 \
             vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
         }                                                                                                                                 \
     } while( 0 )

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -88,20 +88,20 @@
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH < 0 ) )
 
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                          \
-    do {                                                                                            \
-        const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                     \
-        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                     \
-                                                                                                    \
-        if( ( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING ) ||    \
-            ( pulStack[ 0 ] != ulCheckValue ) ||                                                    \
-            ( pulStack[ 1 ] != ulCheckValue ) ||                                                    \
-            ( pulStack[ 2 ] != ulCheckValue ) ||                                                    \
-            ( pulStack[ 3 ] != ulCheckValue ) )                                                     \
-        {                                                                                           \
-            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                   \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );     \
-        }                                                                                           \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
+    do {                                                                                         \
+        const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
+        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                  \
+                                                                                                 \
+        if( ( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING ) || \
+            ( pulStack[ 0 ] != ulCheckValue ) ||                                                 \
+            ( pulStack[ 1 ] != ulCheckValue ) ||                                                 \
+            ( pulStack[ 2 ] != ulCheckValue ) ||                                                 \
+            ( pulStack[ 3 ] != ulCheckValue ) )                                                  \
+        {                                                                                        \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
+        }                                                                                        \
     } while( 0 )
 
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */


### PR DESCRIPTION
Add a stack pointer bounds check when configCHECK_FOR_STACK_OVERFLOW is set to 2.

Description
-----------
I'm working on a small STM32F4 project using FreeRTOS. I've encountered a problem with stack overflow checks:

I am unsure how many bytes I need for my shell thread, so I set the stack size to 1024 bytes.

As documented in _FreeRTOS-Kernel/include/stack_macros.h_:
> Setting configCHECK_FOR_STACK_OVERFLOW to 1 will cause the macro to check
 the current stack state only - comparing the current top of stack value to
 the stack limit.  Setting configCHECK_FOR_STACK_OVERFLOW to greater than 1
 will also cause the last few stack bytes to be checked to ensure the value
 to which the bytes were set when the task was created have not been
 overwritten.  Note this second test does not guarantee that an overflowed
 stack will always be recognised.

And as it says, setting configCHECK_FOR_STACK_OVERFLOW = 2 "**will also**" check the last few stack bytes. This suggests it should check both the stack bounds and the last few bytes.

However, here’s the problem I encountered:
```c
int do_something(){
     uint8_t big_array[1024];
     ......
}
void shell_thread(void *parameters)
{
   ......
   ret = do_something();
   ......
}
#define SHELL_TASK_STACK_SIZE 256
StackType_t xShellStack[SHELL_TASK_STACK_SIZE];
xHandle = xTaskCreateStatic(shellTask,
                            "shell", 
                            SHELL_TASK_STACK_SIZE,
                            &shell, 
                            tskIDLE_PRIORITY, 
                            xShellStack,
                            &xTaskBuffer);
```
In this scenario, the FreeRTOS kernel crashes, and the MCU enters a hard fault. The stack overflow check fails to detect the issue because configCHECK_FOR_STACK_OVERFLOW = 2 only verifies whether the last few stack bytes have been overwritten. However, in the above scenario, the stack has overflowed without overwriting the monitored bytes.


This patch fixes the issue by adding a stack pointer bounds check when configCHECK_FOR_STACK_OVERFLOW is set to 2. This improves the reliability of stack overflow detection and also aligns with the behavior described in _stack_macros.h_.

<br/>
<br/>

_*Side Effects_
_Adding the stack pointer bounds check introduces extra overhead during the stack overflow detection process, which may slightly reduce performance._


Test Steps
-----------

1. Set configCHECK_FOR_STACK_OVERFLOW = 2.
2. Create a task with a stack and allocate a large array on the stack without initializing it.
3. Verify that the program correctly detects the overflow and invokes vApplicationStackOverflowHook.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
