### PR TITLE
Revert "Regression Bug Fix: Fix Incorrect Return of MSVC-MingW portYIELD_FROM_ISR (#1207)"

### DIFF
--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -112,7 +112,7 @@ extern volatile BaseType_t xInsideInterrupt;
 
 /* Simulated interrupts return pdFALSE if no context switch should be performed,
  * or a non-zero number if a context switch should be performed. */
-#define portYIELD_FROM_ISR( x )       return x
+#define portYIELD_FROM_ISR( x )       ( void ) x
 #define portEND_SWITCHING_ISR( x )    portYIELD_FROM_ISR( ( x ) )
 
 void vPortCloseRunningThread( void * pvTaskToDelete,


### PR DESCRIPTION
Description
-----------
PR https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1207 reverted portYieldFromISR to an earlier implementation that did a return. That has broken the demo and real world code on main as calling portYieldFromISR does a return where it isn't expected.

The description of the PR says the reason is that prvProcessSimulatedInterrupts calls portYIELD_FROM_ISR but that's not the case in current main.

Returning from portYieldFromISR doesn't match the behaviour of the other ports as they only act on the value and don't return a result.

It looks like the revert and tests were done at an earlier commit before current main was merged in the PR.
![image](https://github.com/user-attachments/assets/44794036-434e-4916-978c-ec1fb3347ea5)

Test Steps
-----------
Build the demo project in Visual Studio and the build will succeed with a warning.
![image](https://github.com/user-attachments/assets/c627aec7-0b87-410e-8149-1545fad5cde7)

Build the demo project in Eclipse and it is treated as a build failure.
![image](https://github.com/user-attachments/assets/c744aca5-09ef-4668-8963-d20ec896b88b)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
