### PR TITLE
Fix variable shadowing warning in GCC

### DIFF
--- a/portable/GCC/ARM_CA9/port.c
+++ b/portable/GCC/ARM_CA9/port.c
@@ -208,9 +208,9 @@ volatile uint32_t ulPortYieldRequired = pdFALSE;
 volatile uint32_t ulPortInterruptNesting = 0UL;
 
 /* Used in the asm file. */
-__attribute__( ( used ) ) const uint32_t ulICCIAR = portICCIAR_INTERRUPT_ACKNOWLEDGE_REGISTER_ADDRESS;
-__attribute__( ( used ) ) const uint32_t ulICCEOIR = portICCEOIR_END_OF_INTERRUPT_REGISTER_ADDRESS;
-__attribute__( ( used ) ) const uint32_t ulICCPMR = portICCPMR_PRIORITY_MASK_REGISTER_ADDRESS;
+__attribute__( ( used ) ) const uint32_t ulICCIARAddress = portICCIAR_INTERRUPT_ACKNOWLEDGE_REGISTER_ADDRESS;
+__attribute__( ( used ) ) const uint32_t ulICCEOIRAddress = portICCEOIR_END_OF_INTERRUPT_REGISTER_ADDRESS;
+__attribute__( ( used ) ) const uint32_t ulICCPMRAddress = portICCPMR_PRIORITY_MASK_REGISTER_ADDRESS;
 __attribute__( ( used ) ) const uint32_t ulMaxAPIPriorityMask = ( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT );
 
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CA9/portASM.S
+++ b/portable/GCC/ARM_CA9/portASM.S
@@ -33,10 +33,10 @@
     .set SVC_MODE,  0x13
     .set IRQ_MODE,  0x12
 
-    /* Hardware registers. */
-    .extern ulICCIAR
-    .extern ulICCEOIR
-    .extern ulICCPMR
+    /* Hardware registers addresses. */
+    .extern ulICCIARAddress
+    .extern ulICCEOIRAddress
+    .extern ulICCPMRAddress
 
     /* Variables and functions. */
     .extern ulMaxAPIPriorityMask
@@ -317,9 +317,9 @@ vApplicationIRQHandler:
     POP {PC}
 
 
-ulICCIARConst:  .word ulICCIAR
-ulICCEOIRConst: .word ulICCEOIR
-ulICCPMRConst: .word ulICCPMR
+ulICCIARConst:  .word ulICCIARAddress
+ulICCEOIRConst: .word ulICCEOIRAddress
+ulICCPMRConst: .word ulICCPMRAddress
 pxCurrentTCBConst: .word pxCurrentTCB
 ulCriticalNestingConst: .word ulCriticalNesting
 ulPortTaskHasFPUContextConst: .word ulPortTaskHasFPUContext


### PR DESCRIPTION
# Fix variable shadowing warning in GCC

Description
-----------
The function vApplicationFPUSafeIRQHandler gets the value of ICCIAR as parameter, but a constant containing the address of ICCIAR was also defined. Fix the name of the constant to align it with what it actually holds.

Test Steps
-----------
I have a build of FreeRTOS with variable shadowing warnings enabled, before the PR it produces a warning, afterwards it doesn't.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
