### PR TITLE
POSIX Simulator: Remove unused __APPLE__ mach_vm.h include

### DIFF
--- a/.github/workflows/kernel-demos.yml
+++ b/.github/workflows/kernel-demos.yml
@@ -150,16 +150,25 @@ jobs:
         with:
           path: ./FreeRTOS/Source
 
-      - name: Install MSP430 Toolchain
+      - env:
+          stepName: Install MSP430 Toolchain
         shell: bash
         run: |
-          sudo apt-get -y update
-          sudo apt-get -y install gcc-msp430 build-essential
+          # ${{ env.stepName }}
+          echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+          curl -L -O https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-LlCjWuAbzH/9.3.1.2/msp430-gcc-full-linux-x64-installer-9.3.1.2.7z
+          sudo apt update -y
+          sudo apt install -y p7zip-full
+          7z x ./msp430-gcc-full-linux-x64-installer-9.3.1.2.7z
+          chmod +x ./msp430-gcc-full-linux-x64-installer-9.3.1.2.run
+          sudo ./msp430-gcc-full-linux-x64-installer-9.3.1.2.run --prefix /usr/bin/msp430-gcc --mode unattended
+          echo "::endgroup::"
+          echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
       - name: Build msp430_GCC Demo
         shell: bash
         working-directory: FreeRTOS/Demo/msp430_GCC
-        run: make -j
+        run: make -j CC=/usr/bin/msp430-gcc/bin/msp430-elf-gcc OPT="-Os -I/usr/bin/msp430-gcc/include -L/usr/bin/msp430-gcc/include"
 
   MicroBlaze-GCC:
     name: GCC MicroBlaze Toolchain

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -65,10 +65,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef __APPLE__
-    #include <mach/mach_vm.h>
-#endif
-
 /* Scheduler includes. */
 #include "FreeRTOS.h"
 #include "task.h"


### PR DESCRIPTION
Remove unused `__APPLE__` `mach_vm.h` include

Description
-----------
Looks like this was left over from https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/674 but the rest of that code (The `mach_vm_round_page`/`mach_vm_trunc_page` bits) are no longer in the codebase.

Including this file breaks compilation for iOS.

Test Steps
-----------
Run the POSIX sim on macOS. It still works!

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.