### PR TITLE
fix: SA violation fixes and simplification for idle task length restrictions

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -115,6 +115,25 @@ _Ref 11.5.5_
    because data storage buffers are implemented as uint8_t arrays for the
    ease of sizing, alignment and access.
 
+#### Rule 14.3
+
+MISRA C-2012 Rule 14.3: Controlling expressions shall not be invariant.
+
+_Ref 14.3.1_
+ - The `configMAX_TASK_NAME_LEN` and `taskRESERVED_TASK_NAME_LENGTH` values
+   constant at compile time however can vary depending on build configuration.
+   This condition takes into account the build configuration of the system.
+
+#### Rule 18.1
+
+MISRA C-2012 Rule 18.1: A pointer resulting from arithmetic on a pointer operand
+shall address an element of the same array as that pointer operand.
+
+_Ref 18.1_
+ - The array access is limited to in-bounds values as the null termination
+   of the IDLE task name results in breaking from the loop. Alternatively, if
+   the size is smaller than the IDLE task name length, the loop will exit normally.
+
 #### Rule 21.6
 
 MISRA C-2012 Rule 21.6: The Standard Library input/output functions shall not

--- a/MISRA.md
+++ b/MISRA.md
@@ -120,7 +120,8 @@ _Ref 11.5.5_
 MISRA C-2012 Rule 14.3: Controlling expressions shall not be invariant.
 
 _Ref 14.3_
- - The `configMAX_TASK_NAME_LEN` and `taskRESERVED_TASK_NAME_LENGTH` values
+ - The `configMAX_TASK_NAME_LEN` and `taskRESERVED_TASK_NAME_LENGTH` are
+  evaluated to constants at compile time and may vary based on the build configuration.
    constant at compile time however can vary depending on build configuration.
    This condition takes into account the build configuration of the system.
 
@@ -130,7 +131,9 @@ MISRA C-2012 Rule 18.1: A pointer resulting from arithmetic on a pointer operand
 shall address an element of the same array as that pointer operand.
 
 _Ref 18.1_
- - The array access is limited to in-bounds values as the null termination
+ - Array access remains within bounds since either the null terminator in
+   the IDLE task name will break the loop, or the loop will break normally
+   if the array size is smaller than the IDLE task name length.
    of the IDLE task name results in breaking from the loop. Alternatively, if
    the size is smaller than the IDLE task name length, the loop will exit normally.
 

--- a/MISRA.md
+++ b/MISRA.md
@@ -121,9 +121,8 @@ MISRA C-2012 Rule 14.3: Controlling expressions shall not be invariant.
 
 _Ref 14.3_
  - The `configMAX_TASK_NAME_LEN` and `taskRESERVED_TASK_NAME_LENGTH` are
-  evaluated to constants at compile time and may vary based on the build configuration.
-   constant at compile time however can vary depending on build configuration.
-   This condition takes into account the build configuration of the system.
+   evaluated to constants at compile time and may vary based on the build
+   configuration.
 
 #### Rule 18.1
 
@@ -134,8 +133,6 @@ _Ref 18.1_
  - Array access remains within bounds since either the null terminator in
    the IDLE task name will break the loop, or the loop will break normally
    if the array size is smaller than the IDLE task name length.
-   of the IDLE task name results in breaking from the loop. Alternatively, if
-   the size is smaller than the IDLE task name length, the loop will exit normally.
 
 #### Rule 21.6
 

--- a/MISRA.md
+++ b/MISRA.md
@@ -119,7 +119,7 @@ _Ref 11.5.5_
 
 MISRA C-2012 Rule 14.3: Controlling expressions shall not be invariant.
 
-_Ref 14.3.1_
+_Ref 14.3_
  - The `configMAX_TASK_NAME_LEN` and `taskRESERVED_TASK_NAME_LENGTH` values
    constant at compile time however can vary depending on build configuration.
    This condition takes into account the build configuration of the system.

--- a/tasks.c
+++ b/tasks.c
@@ -3546,7 +3546,7 @@ static BaseType_t prvCreateIdleTasks( void )
     TaskFunction_t pxIdleTaskFunction = NULL;
     UBaseType_t xIdleTaskNameIndex;
 
-    /* MISRA Ref 14.3 [Configuration dependent invariant] */
+    /* MISRA Ref 14.3.1 [Configuration dependent invariant] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-143 */
     /* coverity[misra_c_2012_rule_14_3_violation] */
     for( xIdleTaskNameIndex = 0U; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )

--- a/tasks.c
+++ b/tasks.c
@@ -3551,11 +3551,11 @@ static BaseType_t prvCreateIdleTasks( void )
     /* coverity[misra_c_2012_rule_14_3_violation] */
     for( xIdleTaskNameIndex = 0U; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )
     {
-        cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
-
         /* MISRA Ref 18.1.1 [Configuration dependent bounds checking] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-181 */
         /* coverity[misra_c_2012_rule_18_1_violation] */
+        cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
+
         if( cIdleName[ xIdleTaskNameIndex ] == ( char ) 0x00 )
         {
             break;

--- a/tasks.c
+++ b/tasks.c
@@ -3546,13 +3546,16 @@ static BaseType_t prvCreateIdleTasks( void )
     TaskFunction_t pxIdleTaskFunction = NULL;
     UBaseType_t xIdleTaskNameIndex;
 
+    /* MISRA Ref 18.1 [Configuration dependent invariant] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-143 */
+    /* coverity[misra_c_2012_rule_14_3_violation] */
     for( xIdleTaskNameIndex = 0U; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )
     {
         cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
 
-        /* Don't copy all configMAX_TASK_NAME_LEN if the string is shorter than
-         * configMAX_TASK_NAME_LEN characters just in case the memory after the
-         * string is not accessible (extremely unlikely). */
+        /* MISRA Ref 18.1.1 [Configuration dependent bounds checking] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-181 */
+        /* coverity[misra_c_2012_rule_18_1_violation] */
         if( cIdleName[ xIdleTaskNameIndex ] == ( char ) 0x00 )
         {
             break;

--- a/tasks.c
+++ b/tasks.c
@@ -3546,7 +3546,7 @@ static BaseType_t prvCreateIdleTasks( void )
     TaskFunction_t pxIdleTaskFunction = NULL;
     UBaseType_t xIdleTaskNameIndex;
 
-    /* MISRA Ref 18.1 [Configuration dependent invariant] */
+    /* MISRA Ref 14.3 [Configuration dependent invariant] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-143 */
     /* coverity[misra_c_2012_rule_14_3_violation] */
     for( xIdleTaskNameIndex = 0U; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )

--- a/tasks.c
+++ b/tasks.c
@@ -163,7 +163,7 @@
     #endif
     #define taskRESERVED_TASK_NAME_LENGTH    2U
 
-#elif ( configNUMBER_OF_CORES > 10 )
+#elif ( configNUMBER_OF_CORES > 9 )
     #warning Please increase taskRESERVED_TASK_NAME_LENGTH. 1 character is insufficient to store the core ID.
 #else
     /* Reserve space for null termination */
@@ -3544,9 +3544,9 @@ static BaseType_t prvCreateIdleTasks( void )
     BaseType_t xCoreID;
     char cIdleName[ configMAX_TASK_NAME_LEN ] = { 0 };
     TaskFunction_t pxIdleTaskFunction = NULL;
-    BaseType_t xIdleTaskNameIndex;
+    UBaseType_t xIdleTaskNameIndex;
 
-    for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )
+    for( xIdleTaskNameIndex = 0U; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )
     {
         cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
 

--- a/tasks.c
+++ b/tasks.c
@@ -3545,14 +3545,6 @@ static BaseType_t prvCreateIdleTasks( void )
     char cIdleName[ configMAX_TASK_NAME_LEN ] = { 0 };
     TaskFunction_t pxIdleTaskFunction = NULL;
     BaseType_t xIdleTaskNameIndex;
-    BaseType_t xIdleNameLen;
-    BaseType_t xCopyLen;
-
-    /* The length of the idle task name is limited to the minimum of the length
-     * of configIDLE_TASK_NAME and configMAX_TASK_NAME_LEN - 2, keeping space
-     * for the core ID suffix and the null-terminator. */
-    xIdleNameLen = strlen( configIDLE_TASK_NAME );
-    xCopyLen = xIdleNameLen < ( configMAX_TASK_NAME_LEN - 2 ) ? xIdleNameLen : ( configMAX_TASK_NAME_LEN - 2 );
 
     for( xIdleTaskNameIndex = ( BaseType_t ) 0; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )
     {

--- a/tasks.c
+++ b/tasks.c
@@ -157,7 +157,7 @@
 #endif
 
 #if ( configNUMBER_OF_CORES > 1 )
-    /* Reserve space for Core ID and null termination */
+    /* Reserve space for Core ID and null termination. */
     #if ( configMAX_TASK_NAME_LEN < 2U )
         #error Minimum required task name length is 2. Please increase configMAX_TASK_NAME_LEN.
     #endif
@@ -166,7 +166,7 @@
 #elif ( configNUMBER_OF_CORES > 9 )
     #warning Please increase taskRESERVED_TASK_NAME_LENGTH. 1 character is insufficient to store the core ID.
 #else
-    /* Reserve space for null termination */
+    /* Reserve space for null termination. */
     #if ( configMAX_TASK_NAME_LEN < 1U )
         #error Minimum required task name length is 1. Please increase configMAX_TASK_NAME_LEN.
     #endif
@@ -3547,12 +3547,12 @@ static BaseType_t prvCreateIdleTasks( void )
     UBaseType_t xIdleTaskNameIndex;
 
     /* MISRA Ref 14.3.1 [Configuration dependent invariant] */
-    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-143 */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-143. */
     /* coverity[misra_c_2012_rule_14_3_violation] */
     for( xIdleTaskNameIndex = 0U; xIdleTaskNameIndex < ( configMAX_TASK_NAME_LEN - taskRESERVED_TASK_NAME_LENGTH ); xIdleTaskNameIndex++ )
     {
         /* MISRA Ref 18.1.1 [Configuration dependent bounds checking] */
-        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-181 */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-181. */
         /* coverity[misra_c_2012_rule_18_1_violation] */
         cIdleName[ xIdleTaskNameIndex ] = configIDLE_TASK_NAME[ xIdleTaskNameIndex ];
 


### PR DESCRIPTION
Description
-----------
This change:
* Removes the dependency on strings.h for the prvCreateIdleTask function
* Resolves several static analysis violations reported by tools like Parasoft

Test Steps
-----------
This change is being introduced for our upcoming safety certification release. This has been tested by our safety UTs.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Builds off of https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1203


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
