### PR TITLE
Fix the context array size for MPU ports

### DIFF
--- a/.github/workflows/kernel-demos.yml
+++ b/.github/workflows/kernel-demos.yml
@@ -268,12 +268,12 @@ jobs:
           fetch-depth: 1
 
       - env:
-          stepName: Fetch Community-Supported-Demos Submodule
+          stepName: Fetch Dependencies
         shell: bash
         run: |
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
-          git submodule update --checkout --init --depth 1 FreeRTOS/Demo/ThirdParty/Community-Supported-Demos
+          git submodule update --checkout --init --depth 1 FreeRTOS/Demo/ThirdParty/Community-Supported-Demos FreeRTOS-Plus/Source/FreeRTOS-Plus-Trace
           echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
       # Checkout user pull request changes

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM3_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM3_MPU/portmacro.h
@@ -125,6 +125,14 @@ typedef struct MPU_REGION_SETTINGS
 
 #endif /* #if ( configUSE_MPU_WRAPPERS_V1 == 0 ) */
 
+/*
+ * +------------------------------+-------------------------------+-----+
+ * |  CONTROL, r4-r11, EXC_RETURN | PSP, r0-r3, r12, LR, PC, xPSR |     |
+ * +------------------------------+-------------------------------+-----+
+ *
+ * <-----------------------------><-------------------------------><---->
+ *                10                             9                   1
+ */
 #define MAX_CONTEXT_SIZE                    ( 20 )
 
 /* Size of an Access Control List (ACL) entry in bits. */

--- a/portable/GCC/ARM_CM4_MPU/portmacro.h
+++ b/portable/GCC/ARM_CM4_MPU/portmacro.h
@@ -219,7 +219,16 @@ typedef struct MPU_REGION_SETTINGS
 
 #endif /* configUSE_MPU_WRAPPERS_V1 == 0 */
 
-#define MAX_CONTEXT_SIZE                    ( 52 )
+/*
+ * +---------+---------------+-----------------+-----------------+-----+
+ * | s16-s31 | s0-s15, FPSCR | CONTROL, r4-r11 | PSP, r0-r3, r12 |     |
+ * |         |               | EXC_RETURN      | LR, PC, xPSR    |     |
+ * +---------+---------------+-----------------+-----------------+-----+
+ *
+ * <--------><---------------><----------------><----------------><---->
+ *     16           17               10                 9           1
+ */
+#define MAX_CONTEXT_SIZE                    ( 53 )
 
 /* Size of an Access Control List (ACL) entry in bits. */
 #define portACL_ENTRY_SIZE_BITS             ( 32U )

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM4F_MPU/portmacro.h
+++ b/portable/IAR/ARM_CM4F_MPU/portmacro.h
@@ -221,7 +221,16 @@ typedef struct MPU_REGION_SETTINGS
 
 #endif /* configUSE_MPU_WRAPPERS_V1 == 0 */
 
-#define MAX_CONTEXT_SIZE                    ( 52 )
+/*
+ * +---------+---------------+-----------------+-----------------+-----+
+ * | s16-s31 | s0-s15, FPSCR | CONTROL, r4-r11 | PSP, r0-r3, r12 |     |
+ * |         |               | EXC_RETURN      | LR, PC, xPSR    |     |
+ * +---------+---------------+-----------------+-----------------+-----+
+ *
+ * <--------><---------------><----------------><----------------><---->
+ *     16           17               10                 9           1
+ */
+#define MAX_CONTEXT_SIZE                    ( 53 )
 
 /* Size of an Access Control List (ACL) entry in bits. */
 #define portACL_ENTRY_SIZE_BITS             ( 32U )

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -251,9 +251,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><-----------><---->
-             *      16             16            8               8                     5                     16         1
+             *      16             17            8               8                     5                     16         1
              */
-            #define MAX_CONTEXT_SIZE    70
+            #define MAX_CONTEXT_SIZE    71
 
         #elif ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 0 ) )
 
@@ -264,9 +264,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+------------------------------+-----+
              *
              * <-----------><--------------><---------><----------------><-----------------------------><---->
-             *      16             16            8               8                     5                   1
+             *      16             17            8               8                     5                   1
              */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #elif ( ( configENABLE_TRUSTZONE == 0 ) && ( configENABLE_PAC == 1 ) )
 
@@ -277,9 +277,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><-----------><---->
-             *      16             16            8               8                  4                16         1
+             *      16             17            8               8                  4                16         1
              */
-            #define MAX_CONTEXT_SIZE    69
+            #define MAX_CONTEXT_SIZE    70
 
         #else /* if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 
@@ -290,9 +290,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
              * +-----------+---------------+----------+-----------------+----------------------+-----+
              *
              * <-----------><--------------><---------><----------------><---------------------><---->
-             *      16             16            8               8                  4              1
+             *      16             17            8               8                  4              1
              */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if ( ( configENABLE_TRUSTZONE == 1 ) && ( configENABLE_PAC == 1 ) ) */
 

--- a/portable/RVDS/ARM_CM4_MPU/portmacro.h
+++ b/portable/RVDS/ARM_CM4_MPU/portmacro.h
@@ -218,7 +218,16 @@ typedef struct MPU_REGION_SETTINGS
 
 #endif /* #if ( configUSE_MPU_WRAPPERS_V1 == 0 ) */
 
-#define MAX_CONTEXT_SIZE                    ( 52 )
+/*
+ * +---------+---------------+-----------------+-----------------+-----+
+ * | s16-s31 | s0-s15, FPSCR | CONTROL, r4-r11 | PSP, r0-r3, r12 |     |
+ * |         |               | EXC_RETURN      | LR, PC, xPSR    |     |
+ * +---------+---------------+-----------------+-----------------+-----+
+ *
+ * <--------><---------------><----------------><----------------><---->
+ *     16           17               10                 9           1
+ */
+#define MAX_CONTEXT_SIZE                    ( 53 )
 
 /* Size of an Access Control List (ACL) entry in bits. */
 #define portACL_ENTRY_SIZE_BITS             ( 32U )


### PR DESCRIPTION
Description
-----------
Ensure the saved context location falls within the reserved context area rather than overlapping with the next `MPU_SETTINGS` structure member.

This never caused a problem because actual read/write operations start from one word before the saved context location.

Thanks to @dajiang0055 for reporting this.

Test Steps
-----------
Verified on Cortex-M33 hardware.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
