### PR TITLE
Fix GCC/Posix port compilation on FreeBSD (#1239)

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -303,8 +303,8 @@ BaseType_t xPortStartScheduler( void )
         memset( ( void * ) &hSigSetupThread.__opaque, 0, sizeof( hSigSetupThread.__opaque ) );
         memset( ( void * ) &hThreadKeyOnce.__opaque, 0, sizeof( hThreadKeyOnce.__opaque ) );
     #else /* Linux PTHREAD library*/
-        hSigSetupThread = PTHREAD_ONCE_INIT;
-        hThreadKeyOnce = PTHREAD_ONCE_INIT;
+        hSigSetupThread = ( pthread_once_t ) PTHREAD_ONCE_INIT;
+        hThreadKeyOnce = ( pthread_once_t ) PTHREAD_ONCE_INIT;
     #endif /* __APPLE__*/
 
     /* Restore original signal mask. */


### PR DESCRIPTION
On FreeBSD pthread_once_t is a struct and cast is required. Otherwise there's compilation error:
```
../../mocks/freertos/port.c:261:23: error: expected expression
    hSigSetupThread = PTHREAD_ONCE_INIT;
                      ^
```
`PTHREAD_ONCE_INIT` is defined as: `{ PTHREAD_NEEDS_INIT, NULL }` on FreeBSD

<!--- Title -->

Description
-----------
On FreeBSD `pthread_once_t` is a struct containing two elements and compiler complains about it.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Build demo app for Posix/GCC.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
- [x] I have tested my changes by compiling demo app for Posix/GCC on Ubuntu and FreeBSD. NOTE: On FreeBSD `PTHREAD_STACK_MIN` is not defined. As it is used in `FreeRTOSConfig.h` I've modified this locally to `16 * 1024`.
 
Related Issue
-----------
#1239 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
