### PR TITLE
Add instruction to suppress SIGUSR1 in Posix with LLDB debugger

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -48,6 +48,11 @@
 * stdio (printf() and friends) should be called from a single task
 * only or serialized with a FreeRTOS primitive such as a binary
 * semaphore or mutex.
+* 
+* Note: When using LLDB (the default debugger on macOS) with this port, 
+* suppress SIGUSR1 to prevent debugger interference. This can be
+* done by adding the following line to ~/.lldbinit:
+* `process handle SIGUSR1 -n true -p true -s false`
 *----------------------------------------------------------*/
 #ifdef __linux__
     #define _GNU_SOURCE


### PR DESCRIPTION
<!--- Title -->
Add instruction to suppress SIGUSR1 in Posix with LLDB debugger (macOS)

Description
-----------
<!--- Describe your changes in detail. -->
While using the macOS default LLDB debugger, a call to vTaskEndScheduler results in an unhandled SIGUSR1 (aka SIGRESUME) when restoring the scheduler thread's signals with [pthread_sigmask](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1224/files#diff-e52a551c2f42efff2bb76b7f63f1bdd88b6b2d740fe7a66fd684a462201eda4fR342). This crashes the program.

Added instructions in `portable/ThirdParty/GCC/Posix/port.c` to suppress SIGUSR1 to prevent LLDB debugger interference when exiting xPortStartScheduler

Thanks to: @johnboiles for pointing it out in [1224](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1224)

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Tested with this example:
```
#include <FreeRTOS.h>
#include <task.h>
#include <stdio.h>
#include <stdlib.h>
#include <assert.h>

void task_function(void *param) {
    ( void ) param;
    printf("FreeRTOS scheduler started\n");
    vTaskDelay(pdMS_TO_TICKS(1000));
    printf("Task Done, ending scheduler\n");
    vTaskEndScheduler();
    assert(0 && "After scheduler ended (SHOULD NOT GET HERE)");
}

int main_test() {
    TaskHandle_t task;
    xTaskCreate( task_function, "start", 10000, NULL, 1, &task );
    printf("Starting FreeRTOS scheduler\n");
    vTaskStartScheduler();
    printf("FreeRTOS scheduler exited\n");
    vTaskDelete(task);
    return 0;
}
```

Before the fix:
```
(lldb) pro la
Process 28916 launched: '/Users/johnboiles/Developer/repos/FreeRTOS/freertos-pr1224/build/freertos_posix_example' (arm64)
Starting FreeRTOS scheduler
FreeRTOS scheduler started
Task Done, ending scheduler
Process 28916 stopped and restarted: thread 1 received signal: SIGUSR1
Process 28916 exited with status = 30 (0x0000001e) Terminated due to signal 30
```

After the fix:
```
(lldb) run
Process 59557 launched: '/Users/bhoomrs/P3/FreeRTOS/FreeRTOS/Demo/Posix_GCC/build/posix_demo' (arm64)

Trace started.
The trace will be dumped to disk if a call to configASSERT() fails.
Starting full demo
Starting FreeRTOS scheduler
FreeRTOS scheduler started
Task Done, ending scheduler
FreeRTOS scheduler exited
Process 59557 exited with status = 0 (0x00000000) 
```
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#1224 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
