### PR TITLE
POSIX Simulator: Assert if vPortYield called from a non-FreeRTOS thread

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -384,6 +384,10 @@ static void prvPortYieldFromISR( void )
 
 void vPortYield( void )
 {
+    /* This must never be called from outside of a FreeRTOS-owned thread, or
+     * the thread could get stuck in a suspended state. */
+    configASSERT( prvIsFreeRTOSThread() == pdTRUE );
+
     vPortEnterCritical();
 
     prvPortYieldFromISR();


### PR DESCRIPTION
Assert if `vPortYield` called from a non-FreeRTOS thread

Description
-----------
As requested by @aggarg [here](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1237#issuecomment-2652827488) I'm adding an assert to obviously crash if `vPortYield` gets called from a non-FreeRTOS thread. This avoids intermittent freezes depending on the state of `pxCurrentTCB` where FreeRTOS may suspend the non-FreeRTOS thread (and never un-suspend it). Instead, with this PR, the program crashes, making the underlying issue more easily findable & fixable.

Test Steps
-----------
Call xTaskCreate outside of a FreeRTOS thread after the scheduler is started. Sometimes this will lead to the calling thread getting suspended forever.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1237