### PR TITLE
Update instruction to suppress SIGUSR1 in Posix with LLDB debugger

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -52,7 +52,7 @@
 * Note: When using LLDB (the default debugger on macOS) with this port, 
 * suppress SIGUSR1 to prevent debugger interference. This can be
 * done by adding the following line to ~/.lldbinit:
-* `process handle SIGUSR1 -n true -p true -s false`
+* `process handle SIGUSR1 -n true -p false -s false`
 *----------------------------------------------------------*/
 #ifdef __linux__
     #define _GNU_SOURCE

--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -48,6 +48,11 @@
 * stdio (printf() and friends) should be called from a single task
 * only or serialized with a FreeRTOS primitive such as a binary
 * semaphore or mutex.
+* 
+* Note: When using LLDB (the default debugger on macOS) with this port, 
+* suppress SIGUSR1 to prevent debugger interference. This can be
+* done by adding the following line to ~/.lldbinit:
+* `process handle SIGUSR1 -n true -p true -s false`
 *----------------------------------------------------------*/
 #ifdef __linux__
     #define _GNU_SOURCE


### PR DESCRIPTION
<!--- Title -->
Update instruction to suppress SIGUSR1 in Posix with LLDB debugger

Description
-----------
<!--- Describe your changes in detail. -->
Both PASS and STOP have to be set to false [here](https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1245#discussion_r1953203343) to successfully suppress SIGUSR1 in Posix with LLDB debugger.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
#1245 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#1224 
#1245 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
