### PR TITLE
[FIX] add NULL pointer check to xTaskIncrementTick()

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -4766,6 +4766,11 @@ BaseType_t xTaskIncrementTick( void )
         {
             for( ; ; )
             {
+                /* if the system tick interrupt is started independent from the
+                 * scheduler the first tick increment might occur before the
+                 * the first task is created and therefore pxDelayedTaskList is
+                 * still not set */
+                configASSERT( pxDelayedTaskList != NULL );
                 if( listLIST_IS_EMPTY( pxDelayedTaskList ) != pdFALSE )
                 {
                     /* The delayed list is empty.  Set xNextTaskUnblockTime

--- a/tasks.c
+++ b/tasks.c
@@ -4771,6 +4771,7 @@ BaseType_t xTaskIncrementTick( void )
                  * the first task is created and therefore pxDelayedTaskList is
                  * still not set */
                 configASSERT( pxDelayedTaskList != NULL );
+
                 if( listLIST_IS_EMPTY( pxDelayedTaskList ) != pdFALSE )
                 {
                     /* The delayed list is empty.  Set xNextTaskUnblockTime


### PR DESCRIPTION
add NULL pointer check of pxDelayedTaskList to xTaskIncrementTick()

Description
-----------
if the system tick interrupt is started independent from the
scheduler the first tick increment might occur before the
the first task is created and therefore pxDelayedTaskList is
still not set

Test Steps
-----------
Set up the system tick hander before the scheduler is started

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
