### PR TITLE
RISCV Add FPU context save

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -23,6 +23,7 @@ AIRCR
 ALMIEN
 ALMV
 ANDC
+andi
 ANDCCR
 APIC
 APROCFREQ
@@ -47,6 +48,7 @@ bcpc
 BCPC
 beevt
 BEEVT
+beqz
 BERR
 bfextu
 Biagioni
@@ -298,6 +300,7 @@ FADD
 FCMD
 fcolor
 FCSE
+fcsr
 fdiagnostics
 fdiv
 FDIV

--- a/portable/GCC/RISC-V/chip_extensions.cmake
+++ b/portable/GCC/RISC-V/chip_extensions.cmake
@@ -3,7 +3,8 @@ if( FREERTOS_PORT STREQUAL "GCC_RISC_V_GENERIC" )
             "Pulpino_Vega_RV32M1RM"
             "RISCV_MTIME_CLINT_no_extensions"
             "RISCV_no_extensions"
-            "RV32I_CLINT_no_extensions" )
+            "RV32I_CLINT_no_extensions"
+	    "RV32IF_CLINT")
 
     if( ( NOT FREERTOS_RISCV_EXTENSION ) OR ( NOT ( ${FREERTOS_RISCV_EXTENSION} IN_LIST VALID_CHIP_EXTENSIONS ) ) )
         message(FATAL_ERROR

--- a/portable/GCC/RISC-V/chip_specific_extensions/RV32IF_CLINT/freertos_risc_v_chip_specific_extensions.h
+++ b/portable/GCC/RISC-V/chip_specific_extensions/RV32IF_CLINT/freertos_risc_v_chip_specific_extensions.h
@@ -1,0 +1,70 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/*
+ * The FreeRTOS kernel's RISC-V port is split between the the code that is
+ * common across all currently supported RISC-V chips (implementations of the
+ * RISC-V ISA), and code that tailors the port to a specific RISC-V chip:
+ *
+ * + FreeRTOS\Source\portable\GCC\RISC-V\portASM.S contains the code that
+ *   is common to all currently supported RISC-V chips.  There is only one
+ *   portASM.S file because the same file is built for all RISC-V target chips.
+ *
+ * + Header files called freertos_risc_v_chip_specific_extensions.h contain the
+ *   code that tailors the FreeRTOS kernel's RISC-V port to a specific RISC-V
+ *   chip.  There are multiple freertos_risc_v_chip_specific_extensions.h files
+ *   as there are multiple RISC-V chip implementations.
+ *
+ * !!!NOTE!!!
+ * TAKE CARE TO INCLUDE THE CORRECT freertos_risc_v_chip_specific_extensions.h
+ * HEADER FILE FOR THE CHIP IN USE.  This is done using the assembler's (not the
+ * compiler's!) include path.  For example, if the chip in use includes a core
+ * local interrupter (CLINT) and does not include any chip specific register
+ * extensions then add the path below to the assembler's include path:
+ * FreeRTOS\Source\portable\GCC\RISC-V\chip_specific_extensions\RV32I_CLINT_no_extensions
+ *
+ */
+
+
+#ifndef __FREERTOS_RISC_V_EXTENSIONS_H__
+#define __FREERTOS_RISC_V_EXTENSIONS_H__
+
+#define portasmHAS_SIFIVE_CLINT           1
+#define portasmHAS_MTIME                  1
+#define portasmADDITIONAL_CONTEXT_SIZE    0 /* Must be even number on 32-bit cores. */
+#define portasmSTORE_FPU_CONTEXT          1
+
+.macro portasmSAVE_ADDITIONAL_REGISTERS
+/* No additional registers to save, so this macro does nothing. */
+   .endm
+
+   .macro portasmRESTORE_ADDITIONAL_REGISTERS
+/* No additional registers to restore, so this macro does nothing. */
+   .endm
+
+#endif /* __FREERTOS_RISC_V_EXTENSIONS_H__ */

--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -197,7 +197,7 @@ definitions. */
  */
 pxPortInitialiseStack:
     csrr t0, mstatus                    /* Obtain current mstatus value. */
-    andi t0, t0, ~0x8                   /* Ensure interrupts are disabled when the stack is restored within an ISR.  Required when a task is created after the schedulre has been started, otherwise interrupts would be disabled anyway. */
+    andi t0, t0, ~0x8                   /* Ensure interrupts are disabled when the stack is restored within an ISR.  Required when a task is created after the scheduler has been started, otherwise interrupts would be disabled anyway. */
     addi t1, x0, 0x188                  /* Generate the value 0x1880, which are the MPIE and MPP bits to set in mstatus. */
     slli t1, t1, 4
     or t0, t0, t1                       /* Set MPIE and MPP bits in mstatus value. */

--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -162,6 +162,7 @@ definitions. */
  * where the global and thread pointers are currently assumed to be constant so
  * are not saved:
  *
+ * [FPU registers (when enabled/available) go here]
  * mstatus
  * xCriticalNesting
  * x31
@@ -196,6 +197,7 @@ definitions. */
  * pxCode
  */
 pxPortInitialiseStack:
+    addi a0, a0, -portFPUCONTEXT_SIZE
     csrr t0, mstatus                    /* Obtain current mstatus value. */
     andi t0, t0, ~0x8                   /* Ensure interrupts are disabled when the stack is restored within an ISR.  Required when a task is created after the scheduler has been started, otherwise interrupts would be disabled anyway. */
     addi t1, x0, 0x188                  /* Generate the value 0x1880, which are the MPIE and MPP bits to set in mstatus. */

--- a/portable/GCC/RISC-V/portContext.h
+++ b/portable/GCC/RISC-V/portContext.h
@@ -97,6 +97,97 @@
    .extern pxCriticalNesting
 /*-----------------------------------------------------------*/
 
+    .macro portcontexSAVE_FPU_CONTEXT_INTERNAL
+/* Check if the FPU has been used, if it has not, skip the context save */
+srl t1, t0, MSTATUS_FS_USED_OFFSET
+andi t1, t1, 1
+beqz t1, 1f   /* The FPU has not been used (FS either initial or clean), skip context save */
+/* Store the fp registers */
+store_f f0, portFPUREG_OFFSET(0)( sp )
+store_f f1, portFPUREG_OFFSET(1)( sp )
+store_f f2, portFPUREG_OFFSET(2)( sp )
+store_f f3, portFPUREG_OFFSET(3)( sp )
+store_f f4, portFPUREG_OFFSET(4)( sp )
+store_f f5, portFPUREG_OFFSET(5)( sp )
+store_f f6, portFPUREG_OFFSET(6)( sp )
+store_f f7, portFPUREG_OFFSET(7)( sp )
+store_f f8, portFPUREG_OFFSET(8)( sp )
+store_f f9, portFPUREG_OFFSET(9)( sp )
+store_f f10, portFPUREG_OFFSET(10)( sp )
+store_f f11, portFPUREG_OFFSET(11)( sp )
+store_f f12, portFPUREG_OFFSET(12)( sp )
+store_f f13, portFPUREG_OFFSET(13)( sp )
+store_f f14, portFPUREG_OFFSET(14)( sp )
+store_f f15, portFPUREG_OFFSET(15)( sp )
+store_f f16, portFPUREG_OFFSET(16)( sp )
+store_f f17, portFPUREG_OFFSET(17)( sp )
+store_f f18, portFPUREG_OFFSET(18)( sp )
+store_f f19, portFPUREG_OFFSET(19)( sp )
+store_f f20, portFPUREG_OFFSET(20)( sp )
+store_f f21, portFPUREG_OFFSET(21)( sp )
+store_f f22, portFPUREG_OFFSET(22)( sp )
+store_f f23, portFPUREG_OFFSET(23)( sp )
+store_f f24, portFPUREG_OFFSET(24)( sp )
+store_f f25, portFPUREG_OFFSET(25)( sp )
+store_f f26, portFPUREG_OFFSET(26)( sp )
+store_f f27, portFPUREG_OFFSET(27)( sp )
+store_f f28, portFPUREG_OFFSET(28)( sp )
+store_f f29, portFPUREG_OFFSET(29)( sp )
+store_f f30, portFPUREG_OFFSET(30)( sp )
+store_f f31, portFPUREG_OFFSET(31)( sp )
+csrr t0, fcsr
+store_x t0, portFPUREG_OFFSET(32)( sp )
+/* Mark the FPU as clean */
+li t1, ~MSTATUS_FS_MASK
+and t0, t0, t1
+li t1, MSTATUS_FS_CLEAN
+or t0, t0, t1
+csrw mstatus, t0
+1:
+    .endm
+/*-----------------------------------------------------------*/
+
+    .macro portasmRESTORE_FPU_CONTEXT_INTERNAL
+/* Restore fp registers from context */
+load_f f0, portFPUREG_OFFSET(0)( sp )
+load_f f1, portFPUREG_OFFSET(0)( sp )
+load_f f1, portFPUREG_OFFSET(1)( sp )
+load_f f2, portFPUREG_OFFSET(2)( sp )
+load_f f3, portFPUREG_OFFSET(3)( sp )
+load_f f4, portFPUREG_OFFSET(4)( sp )
+load_f f5, portFPUREG_OFFSET(5)( sp )
+load_f f6, portFPUREG_OFFSET(6)( sp )
+load_f f7, portFPUREG_OFFSET(7)( sp )
+load_f f8, portFPUREG_OFFSET(8)( sp )
+load_f f9, portFPUREG_OFFSET(9)( sp )
+load_f f10, portFPUREG_OFFSET(10)( sp )
+load_f f11, portFPUREG_OFFSET(11)( sp )
+load_f f12, portFPUREG_OFFSET(12)( sp )
+load_f f13, portFPUREG_OFFSET(13)( sp )
+load_f f14, portFPUREG_OFFSET(14)( sp )
+load_f f15, portFPUREG_OFFSET(15)( sp )
+load_f f16, portFPUREG_OFFSET(16)( sp )
+load_f f17, portFPUREG_OFFSET(17)( sp )
+load_f f18, portFPUREG_OFFSET(18)( sp )
+load_f f19, portFPUREG_OFFSET(19)( sp )
+load_f f20, portFPUREG_OFFSET(20)( sp )
+load_f f21, portFPUREG_OFFSET(21)( sp )
+load_f f22, portFPUREG_OFFSET(22)( sp )
+load_f f23, portFPUREG_OFFSET(23)( sp )
+load_f f24, portFPUREG_OFFSET(24)( sp )
+load_f f25, portFPUREG_OFFSET(25)( sp )
+load_f f26, portFPUREG_OFFSET(26)( sp )
+load_f f27, portFPUREG_OFFSET(27)( sp )
+load_f f28, portFPUREG_OFFSET(28)( sp )
+load_f f29, portFPUREG_OFFSET(29)( sp )
+load_f f30, portFPUREG_OFFSET(30)( sp )
+load_f f31, portFPUREG_OFFSET(31)( sp )
+load_x t0, portFPUREG_OFFSET(32)( sp )
+csrw fcsr, t0
+1:
+    .endm
+/*-----------------------------------------------------------*/
+
    .macro portcontextSAVE_CONTEXT_INTERNAL
 addi sp, sp, -portCONTEXT_SIZE
 store_x x1, 1 * portWORD_SIZE( sp )
@@ -136,6 +227,9 @@ store_x t0, portCRITICAL_NESTING_OFFSET * portWORD_SIZE( sp ) /* Store the criti
 
 csrr t0, mstatus /* Required for MPIE bit. */
 store_x t0, portMSTATUS_OFFSET * portWORD_SIZE( sp )
+#ifdef portasmSTORE_FPU_CONTEXT
+portcontexSAVE_FPU_CONTEXT_INTERNAL
+#endif /* ifdef portasmSTORE_FPU_CONTEXT */
 
 
 portasmSAVE_ADDITIONAL_REGISTERS /* Defined in freertos_risc_v_chip_specific_extensions.h to save any registers unique to the RISC-V implementation. */
@@ -175,6 +269,10 @@ csrw mepc, t0
 
 /* Defined in freertos_risc_v_chip_specific_extensions.h to restore any registers unique to the RISC-V implementation. */
 portasmRESTORE_ADDITIONAL_REGISTERS
+
+#ifdef portasmSTORE_FPU_CONTEXT
+    portasmRESTORE_FPU_CONTEXT_INTERNAL
+#endif /* ifdef portasmSTORE_FPU_CONTEXT */
 
 /* Load mstatus with the interrupt enable bits used by the task. */
 load_x t0, portMSTATUS_OFFSET * portWORD_SIZE( sp )

--- a/portable/GCC/RISC-V/portContext.h
+++ b/portable/GCC/RISC-V/portContext.h
@@ -49,15 +49,17 @@
  * specific version of freertos_risc_v_chip_specific_extensions.h.  See the
  * notes at the top of portASM.S file. */
 #ifdef __riscv_32e
-    #define portCONTEXT_SIZE               ( 15 * portWORD_SIZE )
+    #define portIREG_COUNT                 15
     #define portCRITICAL_NESTING_OFFSET    13
     #define portMSTATUS_OFFSET             14
 #else
-    #define portCONTEXT_SIZE               ( 31 * portWORD_SIZE )
+    #define portIREG_COUNT                 31
     #define portCRITICAL_NESTING_OFFSET    29
     #define portMSTATUS_OFFSET             30
 #endif
+#define portICONTEXT_SIZE ( portIREG_COUNT * portWORD_SIZE )
 
+#define portCONTEXT_SIZE               ( portICONTEXT_SIZE )
 /*-----------------------------------------------------------*/
 
 .extern pxCurrentTCB


### PR DESCRIPTION
Add FPU context switch support for the RISC-V port

Description
-----------
Current context switch in the RISC-V port only supports the integer (`x`) registers. Which means that having two tasks using FPU code will corrupt one another's work.

This PR 
* Creates a chip_specific_extension define (`portasmSTORE_FPU_CONTEXT`) to identify if the FPU context should be saved and does it when the FPU is present and the flag is set. To that have a platform that can tested I also added a `RV32IF_CLINT` under `risc_v_chip_specific_extensions` 
* Create `portFPUCONTEXT_SIZE` macro, that is defined as 0 when the FPU support is not present or is not enabled
* Creates a couple of macros to save/restore the FPU context and uses it when `portasmSTORE_FPU_CONTEXT` is enabled

Test Steps
-----------
A Demo using QEMU was created. That demo also adds a couple of tasks modifying the FPU registers to check that they values are maintained across context switch. This is part of another PR in the FreeRTOS repo

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
