### PR TITLE
Fix add overflow check on recursive mutex counter

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -833,6 +833,10 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         if( pxMutex->u.xSemaphore.xMutexHolder == xTaskGetCurrentTaskHandle() )
         {
             ( pxMutex->u.xSemaphore.uxRecursiveCallCount )++;
+
+            /* check if an overflow occurred */
+            configASSERT( pxMutex->u.xSemaphore.uxRecursiveCallCount );
+
             xReturn = pdPASS;
         }
         else

--- a/queue.c
+++ b/queue.c
@@ -849,6 +849,9 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
             if( xReturn != pdFAIL )
             {
                 ( pxMutex->u.xSemaphore.uxRecursiveCallCount )++;
+
+                /* Check if an overflow occurred. */
+                configASSERT( pxMutex->u.xSemaphore.uxRecursiveCallCount );
             }
             else
             {

--- a/queue.c
+++ b/queue.c
@@ -834,7 +834,7 @@ static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,
         {
             ( pxMutex->u.xSemaphore.uxRecursiveCallCount )++;
 
-            /* check if an overflow occurred */
+            /* Check if an overflow occurred. */
             configASSERT( pxMutex->u.xSemaphore.uxRecursiveCallCount );
 
             xReturn = pdPASS;


### PR DESCRIPTION
Fix add overflow check on recursive mutex counter

Description
-----------
There is no overflow check of the recursive mutex counter yet.
If the counter overflows, the mutex will be released on the next call of xQueueGiveMutexRecursive(),
even if the number of calls does not match the number of calls of xQueueTakeMutexRecursive().

This would lead to unpredictable behavior in the application.

Test Steps
-----------
call xQueueTakeMutexRecursive() more than the maximum value of UBaseType_t

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
