### PR TITLE
Add support for Vector context save support on RISC-V

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -786,6 +786,7 @@ SHPR
 SHTIM
 SIFIVE
 sinclude
+slli
 SODR
 SOFTIRQ
 SPCK
@@ -937,6 +938,7 @@ USRIO
 utest
 utilises
 utilising
+vcsr
 VDDCORE
 vect
 Vect
@@ -947,6 +949,7 @@ visualisation
 vldmdbeq
 vldmia
 vldmiaeq
+vlenb
 VMSRNE
 vpop
 VPOPNE
@@ -954,6 +957,7 @@ vpush
 VPUSHNE
 VRPM
 Vrtc
+vsetvl
 vstmdbeq
 vstmiaeq
 VTOR

--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -191,8 +191,8 @@ definitions. */
  * x6
  * x5
  * portTASK_RETURN_ADDRESS
- * [VPU registers (when enabled/available) go here]
  * [FPU registers (when enabled/available) go here]
+ * [VPU registers (when enabled/available) go here]
  * [chip specific registers go here]
  * mstatus
  * pxCode

--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -191,6 +191,7 @@ definitions. */
  * x6
  * x5
  * portTASK_RETURN_ADDRESS
+ * [VPU registers (when enabled/available) go here]
  * [FPU registers (when enabled/available) go here]
  * [chip specific registers go here]
  * mstatus
@@ -230,6 +231,14 @@ chip_specific_stack_frame:              /* First add any chip specific registers
     li t1, ~MSTATUS_FS_MASK
     and t0, t0, t1
     li t1, MSTATUS_FS_CLEAN
+    or t0, t0, t1
+#endif
+
+#if( configENABLE_VPU == 1 )
+    /* Mark the VPU as clean in the mstatus value. */
+    li t1, ~MSTATUS_VS_MASK
+    and t0, t0, t1
+    li t1, MSTATUS_VS_CLEAN
     or t0, t0, t1
 #endif
 


### PR DESCRIPTION
Save the vector context when changing the task

Description
-----------
An approach similar to #1250 has been used:

* Add the storage for the vector context next to the FPU context
* Enable the VPU as part of the task stack preparation
* Use the VS flags and values to avoid saving and restoring the context
* Save the 32 vector registers, `vl`, `vtype`, `vstart` and `vcsr`
    * The 32 vector registers are saved/restored according to the configured length

Test Steps
-----------
A separate PR in the FreeRTOS repository will be created. That PR contains an enhanced RegTest that includes the vector registers.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
An approach similar to #1250 was followed. I'll link the corresponding PR with the Demo once it is created


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
