### PR TITLE
SMP: Set affinity for idle tasks

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3676,6 +3676,9 @@ static BaseType_t prvCreateIdleTasks( void )
                 /* Assign idle task to each core before SMP scheduler is running. */
                 xIdleTaskHandles[ xCoreID ]->xTaskRunState = xCoreID;
                 pxCurrentTCBs[ xCoreID ] = xIdleTaskHandles[ xCoreID ];
+                #if ( configUSE_CORE_AFFINITY == 1 )
+                vTaskCoreAffinitySet(xIdleTaskHandles[ xCoreID ], 1 << xCoreID);
+                #endif
             }
             #endif
         }


### PR DESCRIPTION
If configUSE_CORE_AFFINITY is set, update prvCreateIdleTasks() to restrict idle tasks to each run only on their intended core.  

The default of (configTASK_DEFAULT_CORE_AFFINITY == tskNO_AFFINITY) allows multiple idle tasks to be started on the same core.  More importantly, some cores could have no idle task running.  This results in the following potential hang:

1. Core 0 attempts to yield core N by calling prvYieldCore(), which sets pxCurrentTCBs[N-1]->xTaskRunState to -2 (taskTASK_SCHEDULED_TO_YIELD) and calls portYIELD_CORE(N-1).
2. In our port, portYIELD_CORE triggers an interrupt on core (N-1); the subsequent ISR calls portYIELD_FROM_ISR(1) -> vPortYieldFromInt() -> vTaskSwitchContext() -> prvSelectHighestPriorityTask(), which correctly does not change pxCurrentTCBs[N-1] but incorrectly **does not change** pxCurrentTCBs [N-1]->xTaskRunState.
3. The next time core 0 attempts to yield core N,  pxCurrentTCBs[N-1]->xTaskRunState is still set to taskTASK_SCHEDULED_TO_YIELD, which prevents any further calls to portYIELD_CORE(N-1).

Pinning the yield task to core N-1 allows prvSelectHighestPriorityTask() in step 2 to correctly update pxCurrentTCBs[N-1]->xTaskRunState to N, and the subsequent interrupt in step 3 to trigger again.

- [ X ] I have tested my changes. No regression in existing tests.
- [ X ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
