### PR TITLE
FreeRTOS SMP: direct access to current TCB inside stack macros

### DIFF
--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -238,7 +238,11 @@
 
 /* Remove stack overflow macro if not being used. */
 #ifndef taskCHECK_FOR_STACK_OVERFLOW
-    #define taskCHECK_FOR_STACK_OVERFLOW()
+    #if ( configNUMBER_OF_CORES == 1 )
+        #define taskCHECK_FOR_STACK_OVERFLOW()
+    #else
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )
+    #endif
 #endif
 
 

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -86,7 +86,7 @@
         #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
     do                                                                                   \
     {                                                                                    \
-        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
+        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                        \
                                                                                          \
         /* Is the currently saved stack pointer within the stack limit? */               \
         if( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING )            \
@@ -123,7 +123,7 @@
         #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
     do                                                                                   \
     {                                                                                    \
-        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
+        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                        \
                                                                                          \
         /* Is the currently saved stack pointer within the stack limit? */               \
         if( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )       \
@@ -164,7 +164,7 @@
         #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
     do                                                                                   \
     {                                                                                    \
-        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
+        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                        \
         const uint32_t * const pulStack = ( uint32_t * ) pxTCB->pxStack;                 \
         const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                          \
                                                                                          \
@@ -213,7 +213,7 @@
         #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                   \
     do                                                                                                                                    \
     {                                                                                                                                     \
-        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \
+        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                                                                         \
         int8_t * pcEndOfStack = ( int8_t * ) pxTCB->pxEndOfStack;                                                                         \
         static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
                                                         tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -68,8 +68,8 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-/* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                  \
+    /* Only the current stack state is to be checked. */
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                      \
     do                                                                                          \
     {                                                                                           \
         /* Is the currently saved stack pointer within the stack limit? */                      \
@@ -82,8 +82,8 @@
 
     #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-/* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
+    /* Only the current stack state is to be checked. */
+    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                      \
     do                                                                                   \
     {                                                                                    \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
@@ -105,8 +105,8 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-/* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
+    /* Only the current stack state is to be checked. */
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
     do                                                                                           \
     {                                                                                            \
         /* Is the currently saved stack pointer within the stack limit? */                       \
@@ -119,8 +119,8 @@
 
     #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-/* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
+    /* Only the current stack state is to be checked. */
+    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                      \
     do                                                                                   \
     {                                                                                    \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
@@ -142,7 +142,7 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
     do                                                                                           \
     {                                                                                            \
         const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
@@ -161,7 +161,7 @@
 
     #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
+    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                      \
     do                                                                                   \
     {                                                                                    \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
@@ -188,7 +188,7 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                            \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                                \
     do                                                                                                                                    \
     {                                                                                                                                     \
         int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
@@ -210,7 +210,7 @@
 
     #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                   \
+    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                       \
     do                                                                                                                                    \
     {                                                                                                                                     \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -164,9 +164,9 @@
         #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                         \
         do                                                                                      \
         {                                                                                       \
-            const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;             \
-            const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                             \
             const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                               \
+            const uint32_t * const pulStack = ( uint32_t * ) pxTCB->pxStack;                    \
+            const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                             \
                                                                                                 \
             if( ( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING ) ||          \
                 ( pulStack[ 0 ] != ulCheckValue ) ||                                            \
@@ -213,13 +213,13 @@
         #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                       \
         do                                                                                                                                    \
         {                                                                                                                                     \
-            int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
+            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \
+            int8_t * pcEndOfStack = ( int8_t * ) pxTCB->pxEndOfStack;                                                                         \
             static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
                                                             tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
                                                             tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
                                                             tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
                                                             tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
-            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \
                                                                                                                                               \
             pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
                                                                                                                                               \

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -66,172 +66,172 @@
  */
 #if ( ( configCHECK_FOR_STACK_OVERFLOW == 1 ) && ( portSTACK_GROWTH < 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if( configNUMBER_OF_CORES == 1 )
+    #if ( configNUMBER_OF_CORES == 1 )
 
-        /* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                      \
-        do                                                                                          \
-        {                                                                                           \
-            /* Is the currently saved stack pointer within the stack limit? */                      \
-            if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )     \
-            {                                                                                       \
-                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                               \
-                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
-            }                                                                                       \
-        } while( 0 )
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                  \
+    do                                                                                          \
+    {                                                                                           \
+        /* Is the currently saved stack pointer within the stack limit? */                      \
+        if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )     \
+        {                                                                                       \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                               \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
+        }                                                                                       \
+    } while( 0 )
 
-    #else
+    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-            /* Only the current stack state is to be checked. */
-            #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                         \
-            do                                                                                      \
-            {                                                                                       \
-                const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                               \
-                                                                                                    \
-                /* Is the currently saved stack pointer within the stack limit? */                  \
-                if( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING )               \
-                {                                                                                   \
-                    char * pcOverflowTaskName = pxTCB->pcTaskName;                                  \
-                    vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );    \
-                }                                                                                   \
-            } while( 0 )
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
+    do                                                                                   \
+    {                                                                                    \
+        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
+                                                                                         \
+        /* Is the currently saved stack pointer within the stack limit? */               \
+        if( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING )            \
+        {                                                                                \
+            char * pcOverflowTaskName = pxTCB->pcTaskName;                               \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName ); \
+        }                                                                                \
+    } while( 0 )
 
-    #endif
+    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW == 1 ) && ( portSTACK_GROWTH > 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if( configNUMBER_OF_CORES == 1 )
+    #if ( configNUMBER_OF_CORES == 1 )
 
-        /* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
-        do                                                                                           \
-        {                                                                                            \
-            /* Is the currently saved stack pointer within the stack limit? */                       \
-            if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) \
-            {                                                                                        \
-                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
-                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
-            }                                                                                        \
-        } while( 0 )
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
+    do                                                                                           \
+    {                                                                                            \
+        /* Is the currently saved stack pointer within the stack limit? */                       \
+        if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) \
+        {                                                                                        \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
+        }                                                                                        \
+    } while( 0 )
 
-    #else
+    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-        /* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                         \
-        do                                                                                      \
-        {                                                                                       \
-            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                               \
-                                                                                                \
-            /* Is the currently saved stack pointer within the stack limit? */                  \
-            if( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )          \
-            {                                                                                   \
-                char * pcOverflowTaskName = pxTCB->pcTaskName;                                  \
-                vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );    \
-            }                                                                                   \
-        } while( 0 )
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
+    do                                                                                   \
+    {                                                                                    \
+        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
+                                                                                         \
+        /* Is the currently saved stack pointer within the stack limit? */               \
+        if( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )       \
+        {                                                                                \
+            char * pcOverflowTaskName = pxTCB->pcTaskName;                               \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName ); \
+        }                                                                                \
+    } while( 0 )
 
-    #endif
+    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH < 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if( configNUMBER_OF_CORES == 1 )
+    #if ( configNUMBER_OF_CORES == 1 )
 
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
-        do                                                                                           \
-        {                                                                                            \
-            const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
-            const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                  \
-                                                                                                     \
-            if( ( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING ) || \
-                ( pulStack[ 0 ] != ulCheckValue ) ||                                                 \
-                ( pulStack[ 1 ] != ulCheckValue ) ||                                                 \
-                ( pulStack[ 2 ] != ulCheckValue ) ||                                                 \
-                ( pulStack[ 3 ] != ulCheckValue ) )                                                  \
-            {                                                                                        \
-                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
-                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
-            }                                                                                        \
-        } while( 0 )
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
+    do                                                                                           \
+    {                                                                                            \
+        const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
+        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                  \
+                                                                                                 \
+        if( ( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING ) || \
+            ( pulStack[ 0 ] != ulCheckValue ) ||                                                 \
+            ( pulStack[ 1 ] != ulCheckValue ) ||                                                 \
+            ( pulStack[ 2 ] != ulCheckValue ) ||                                                 \
+            ( pulStack[ 3 ] != ulCheckValue ) )                                                  \
+        {                                                                                        \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
+        }                                                                                        \
+    } while( 0 )
 
-    #else
+    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                         \
-        do                                                                                      \
-        {                                                                                       \
-            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                               \
-            const uint32_t * const pulStack = ( uint32_t * ) pxTCB->pxStack;                    \
-            const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                             \
-                                                                                                \
-            if( ( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING ) ||          \
-                ( pulStack[ 0 ] != ulCheckValue ) ||                                            \
-                ( pulStack[ 1 ] != ulCheckValue ) ||                                            \
-                ( pulStack[ 2 ] != ulCheckValue ) ||                                            \
-                ( pulStack[ 3 ] != ulCheckValue ) )                                             \
-            {                                                                                   \
-                char * pcOverflowTaskName = pxTCB->pcTaskName;                                  \
-                vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );    \
-            }                                                                                   \
-        } while( 0 )
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
+    do                                                                                   \
+    {                                                                                    \
+        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
+        const uint32_t * const pulStack = ( uint32_t * ) pxTCB->pxStack;                 \
+        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                          \
+                                                                                         \
+        if( ( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING ) ||       \
+            ( pulStack[ 0 ] != ulCheckValue ) ||                                         \
+            ( pulStack[ 1 ] != ulCheckValue ) ||                                         \
+            ( pulStack[ 2 ] != ulCheckValue ) ||                                         \
+            ( pulStack[ 3 ] != ulCheckValue ) )                                          \
+        {                                                                                \
+            char * pcOverflowTaskName = pxTCB->pcTaskName;                               \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName ); \
+        }                                                                                \
+    } while( 0 )
 
-    #endif
+    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH > 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if( configNUMBER_OF_CORES == 1 )
+    #if ( configNUMBER_OF_CORES == 1 )
 
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                                \
-        do                                                                                                                                    \
-        {                                                                                                                                     \
-            int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
-            static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
-                                                                                                                                              \
-            pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
-                                                                                                                                              \
-            if( ( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                     \
-                ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
-            {                                                                                                                                 \
-                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                         \
-                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
-            }                                                                                                                                 \
-        } while( 0 )
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                            \
+    do                                                                                                                                    \
+    {                                                                                                                                     \
+        int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
+        static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
+                                                                                                                                          \
+        pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
+                                                                                                                                          \
+        if( ( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                     \
+            ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
+        {                                                                                                                                 \
+            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                         \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
+        }                                                                                                                                 \
+    } while( 0 )
 
-    #else
+    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
 
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                       \
-        do                                                                                                                                    \
-        {                                                                                                                                     \
-            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \
-            int8_t * pcEndOfStack = ( int8_t * ) pxTCB->pxEndOfStack;                                                                         \
-            static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
-                                                                                                                                              \
-            pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
-                                                                                                                                              \
-            if( ( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                                   \
-                ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
-            {                                                                                                                                 \
-                char * pcOverflowTaskName = pxTCB->pcTaskName;                                                                                \
-                vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );                                                  \
-            }                                                                                                                                 \
-        } while( 0 )
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                   \
+    do                                                                                                                                    \
+    {                                                                                                                                     \
+        const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \
+        int8_t * pcEndOfStack = ( int8_t * ) pxTCB->pxEndOfStack;                                                                         \
+        static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
+                                                                                                                                          \
+        pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
+                                                                                                                                          \
+        if( ( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                                   \
+            ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
+        {                                                                                                                                 \
+            char * pcOverflowTaskName = pxTCB->pcTaskName;                                                                                \
+            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );                                                  \
+        }                                                                                                                                 \
+    } while( 0 )
 
-    #endif
+    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
 /*-----------------------------------------------------------*/

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -68,8 +68,8 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-    /* Only the current stack state is to be checked. */
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                      \
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                  \
     do                                                                                          \
     {                                                                                           \
         /* Is the currently saved stack pointer within the stack limit? */                      \
@@ -80,10 +80,10 @@
         }                                                                                       \
     } while( 0 )
 
-    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
+    #else /* if ( configNUMBER_OF_CORES == 1 ) */
 
-    /* Only the current stack state is to be checked. */
-    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                      \
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
     do                                                                                   \
     {                                                                                    \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
@@ -105,8 +105,8 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-    /* Only the current stack state is to be checked. */
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
     do                                                                                           \
     {                                                                                            \
         /* Is the currently saved stack pointer within the stack limit? */                       \
@@ -117,10 +117,10 @@
         }                                                                                        \
     } while( 0 )
 
-    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
+    #else /* if ( configNUMBER_OF_CORES == 1 ) */
 
-    /* Only the current stack state is to be checked. */
-    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                      \
+/* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
     do                                                                                   \
     {                                                                                    \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
@@ -142,7 +142,7 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
     do                                                                                           \
     {                                                                                            \
         const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
@@ -159,9 +159,9 @@
         }                                                                                        \
     } while( 0 )
 
-    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
+    #else /* if ( configNUMBER_OF_CORES == 1 ) */
 
-    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                      \
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
     do                                                                                   \
     {                                                                                    \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                            \
@@ -188,7 +188,7 @@
 
     #if ( configNUMBER_OF_CORES == 1 )
 
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                                \
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                            \
     do                                                                                                                                    \
     {                                                                                                                                     \
         int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
@@ -208,9 +208,9 @@
         }                                                                                                                                 \
     } while( 0 )
 
-    #else  /* if ( configNUMBER_OF_CORES == 1 ) */
+    #else /* if ( configNUMBER_OF_CORES == 1 ) */
 
-    #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                       \
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                   \
     do                                                                                                                                    \
     {                                                                                                                                     \
         const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \

--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -66,81 +66,172 @@
  */
 #if ( ( configCHECK_FOR_STACK_OVERFLOW == 1 ) && ( portSTACK_GROWTH < 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-/* Only the current stack state is to be checked. */
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                      \
-    do                                                                                          \
-    {                                                                                           \
-        /* Is the currently saved stack pointer within the stack limit? */                      \
-        if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )     \
-        {                                                                                       \
-            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                               \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
-        }                                                                                       \
-    } while( 0 )
+    #if( configNUMBER_OF_CORES == 1 )
+
+        /* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                      \
+        do                                                                                          \
+        {                                                                                           \
+            /* Is the currently saved stack pointer within the stack limit? */                      \
+            if( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING )     \
+            {                                                                                       \
+                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                               \
+                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName ); \
+            }                                                                                       \
+        } while( 0 )
+
+    #else
+
+            /* Only the current stack state is to be checked. */
+            #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                         \
+            do                                                                                      \
+            {                                                                                       \
+                const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                               \
+                                                                                                    \
+                /* Is the currently saved stack pointer within the stack limit? */                  \
+                if( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING )               \
+                {                                                                                   \
+                    char * pcOverflowTaskName = pxTCB->pcTaskName;                                  \
+                    vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );    \
+                }                                                                                   \
+            } while( 0 )
+
+    #endif
 
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW == 1 ) && ( portSTACK_GROWTH > 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-/* Only the current stack state is to be checked. */
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
-    do                                                                                           \
-    {                                                                                            \
-        /* Is the currently saved stack pointer within the stack limit? */                       \
-        if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) \
-        {                                                                                        \
-            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
-        }                                                                                        \
-    } while( 0 )
+    #if( configNUMBER_OF_CORES == 1 )
+
+        /* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
+        do                                                                                           \
+        {                                                                                            \
+            /* Is the currently saved stack pointer within the stack limit? */                       \
+            if( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) \
+            {                                                                                        \
+                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
+                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
+            }                                                                                        \
+        } while( 0 )
+
+    #else
+
+        /* Only the current stack state is to be checked. */
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                         \
+        do                                                                                      \
+        {                                                                                       \
+            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                               \
+                                                                                                \
+            /* Is the currently saved stack pointer within the stack limit? */                  \
+            if( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )          \
+            {                                                                                   \
+                char * pcOverflowTaskName = pxTCB->pcTaskName;                                  \
+                vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );    \
+            }                                                                                   \
+        } while( 0 )
+
+    #endif
 
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH < 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
-    do                                                                                           \
-    {                                                                                            \
-        const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
-        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                  \
-                                                                                                 \
-        if( ( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING ) || \
-            ( pulStack[ 0 ] != ulCheckValue ) ||                                                 \
-            ( pulStack[ 1 ] != ulCheckValue ) ||                                                 \
-            ( pulStack[ 2 ] != ulCheckValue ) ||                                                 \
-            ( pulStack[ 3 ] != ulCheckValue ) )                                                  \
-        {                                                                                        \
-            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
-        }                                                                                        \
-    } while( 0 )
+    #if( configNUMBER_OF_CORES == 1 )
+
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
+        do                                                                                           \
+        {                                                                                            \
+            const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
+            const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                                  \
+                                                                                                     \
+            if( ( pxCurrentTCB->pxTopOfStack <= pxCurrentTCB->pxStack + portSTACK_LIMIT_PADDING ) || \
+                ( pulStack[ 0 ] != ulCheckValue ) ||                                                 \
+                ( pulStack[ 1 ] != ulCheckValue ) ||                                                 \
+                ( pulStack[ 2 ] != ulCheckValue ) ||                                                 \
+                ( pulStack[ 3 ] != ulCheckValue ) )                                                  \
+            {                                                                                        \
+                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                \
+                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );  \
+            }                                                                                        \
+        } while( 0 )
+
+    #else
+
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                         \
+        do                                                                                      \
+        {                                                                                       \
+            const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;             \
+            const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                             \
+            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                               \
+                                                                                                \
+            if( ( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING ) ||          \
+                ( pulStack[ 0 ] != ulCheckValue ) ||                                            \
+                ( pulStack[ 1 ] != ulCheckValue ) ||                                            \
+                ( pulStack[ 2 ] != ulCheckValue ) ||                                            \
+                ( pulStack[ 3 ] != ulCheckValue ) )                                             \
+            {                                                                                   \
+                char * pcOverflowTaskName = pxTCB->pcTaskName;                                  \
+                vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );    \
+            }                                                                                   \
+        } while( 0 )
+
+    #endif
 
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH > 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                                \
-    do                                                                                                                                    \
-    {                                                                                                                                     \
-        int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
-        static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
-                                                                                                                                          \
-        pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
-                                                                                                                                          \
-        if( ( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                     \
-            ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
-        {                                                                                                                                 \
-            char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                         \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
-        }                                                                                                                                 \
-    } while( 0 )
+    #if( configNUMBER_OF_CORES == 1 )
+
+        #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                                \
+        do                                                                                                                                    \
+        {                                                                                                                                     \
+            int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
+            static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
+                                                                                                                                              \
+            pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
+                                                                                                                                              \
+            if( ( pxCurrentTCB->pxTopOfStack >= pxCurrentTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                     \
+                ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
+            {                                                                                                                                 \
+                char * pcOverflowTaskName = pxCurrentTCB->pcTaskName;                                                                         \
+                vApplicationStackOverflowHook( ( TaskHandle_t ) pxCurrentTCB, pcOverflowTaskName );                                           \
+            }                                                                                                                                 \
+        } while( 0 )
+
+    #else
+
+        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                       \
+        do                                                                                                                                    \
+        {                                                                                                                                     \
+            int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
+            static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
+                                                            tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
+            const TCB_t * const pxTCB = pxCurrentTCBs[ xCoreID ];                                                                             \
+                                                                                                                                              \
+            pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
+                                                                                                                                              \
+            if( ( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                                   \
+                ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
+            {                                                                                                                                 \
+                char * pcOverflowTaskName = pxTCB->pcTaskName;                                                                                \
+                vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );                                                  \
+            }                                                                                                                                 \
+        } while( 0 )
+
+    #endif
 
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
 /*-----------------------------------------------------------*/

--- a/tasks.c
+++ b/tasks.c
@@ -5251,7 +5251,7 @@ BaseType_t xTaskIncrementTick( void )
                 #endif /* configGENERATE_RUN_TIME_STATS */
 
                 /* Check for stack overflow, if configured. */
-                taskCHECK_FOR_STACK_OVERFLOW();
+                taskCHECK_FOR_STACK_OVERFLOW( xCoreID );
 
                 /* Before the currently running task is switched out, save its errno. */
                 #if ( configUSE_POSIX_ERRNO == 1 )


### PR DESCRIPTION
<!--- Title -->
Fix access to current TCB inside the stack macros in SMP

Description
-----------
The problem is already described [here](https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1269).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
[#1269](https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1269)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
