### PR TITLE
Revert PR 1270: Direct access to current TCB inside stack macros

### DIFF
--- a/include/stack_macros.h
+++ b/include/stack_macros.h
@@ -66,10 +66,8 @@
  */
 #if ( ( configCHECK_FOR_STACK_OVERFLOW == 1 ) && ( portSTACK_GROWTH < 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if ( configNUMBER_OF_CORES == 1 )
-
 /* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                  \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                      \
     do                                                                                          \
     {                                                                                           \
         /* Is the currently saved stack pointer within the stack limit? */                      \
@@ -80,33 +78,13 @@
         }                                                                                       \
     } while( 0 )
 
-    #else /* if ( configNUMBER_OF_CORES == 1 ) */
-
-/* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
-    do                                                                                   \
-    {                                                                                    \
-        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                        \
-                                                                                         \
-        /* Is the currently saved stack pointer within the stack limit? */               \
-        if( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING )            \
-        {                                                                                \
-            char * pcOverflowTaskName = pxTCB->pcTaskName;                               \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName ); \
-        }                                                                                \
-    } while( 0 )
-
-    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
-
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW == 1 ) && ( portSTACK_GROWTH > 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if ( configNUMBER_OF_CORES == 1 )
-
 /* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
     do                                                                                           \
     {                                                                                            \
         /* Is the currently saved stack pointer within the stack limit? */                       \
@@ -117,32 +95,12 @@
         }                                                                                        \
     } while( 0 )
 
-    #else /* if ( configNUMBER_OF_CORES == 1 ) */
-
-/* Only the current stack state is to be checked. */
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
-    do                                                                                   \
-    {                                                                                    \
-        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                        \
-                                                                                         \
-        /* Is the currently saved stack pointer within the stack limit? */               \
-        if( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING )       \
-        {                                                                                \
-            char * pcOverflowTaskName = pxTCB->pcTaskName;                               \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName ); \
-        }                                                                                \
-    } while( 0 )
-
-    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
-
 #endif /* configCHECK_FOR_STACK_OVERFLOW == 1 */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH < 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if ( configNUMBER_OF_CORES == 1 )
-
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                   \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                       \
     do                                                                                           \
     {                                                                                            \
         const uint32_t * const pulStack = ( uint32_t * ) pxCurrentTCB->pxStack;                  \
@@ -159,36 +117,12 @@
         }                                                                                        \
     } while( 0 )
 
-    #else /* if ( configNUMBER_OF_CORES == 1 ) */
-
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                  \
-    do                                                                                   \
-    {                                                                                    \
-        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                        \
-        const uint32_t * const pulStack = ( uint32_t * ) pxTCB->pxStack;                 \
-        const uint32_t ulCheckValue = ( uint32_t ) 0xa5a5a5a5U;                          \
-                                                                                         \
-        if( ( pxTCB->pxTopOfStack <= pxTCB->pxStack + portSTACK_LIMIT_PADDING ) ||       \
-            ( pulStack[ 0 ] != ulCheckValue ) ||                                         \
-            ( pulStack[ 1 ] != ulCheckValue ) ||                                         \
-            ( pulStack[ 2 ] != ulCheckValue ) ||                                         \
-            ( pulStack[ 3 ] != ulCheckValue ) )                                          \
-        {                                                                                \
-            char * pcOverflowTaskName = pxTCB->pcTaskName;                               \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName ); \
-        }                                                                                \
-    } while( 0 )
-
-    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
-
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ( configCHECK_FOR_STACK_OVERFLOW > 1 ) && ( portSTACK_GROWTH > 0 ) && ( portUSING_MPU_WRAPPERS != 1 ) )
 
-    #if ( configNUMBER_OF_CORES == 1 )
-
-        #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                            \
+    #define taskCHECK_FOR_STACK_OVERFLOW()                                                                                                \
     do                                                                                                                                    \
     {                                                                                                                                     \
         int8_t * pcEndOfStack = ( int8_t * ) pxCurrentTCB->pxEndOfStack;                                                                  \
@@ -208,41 +142,12 @@
         }                                                                                                                                 \
     } while( 0 )
 
-    #else /* if ( configNUMBER_OF_CORES == 1 ) */
-
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )                                                                                   \
-    do                                                                                                                                    \
-    {                                                                                                                                     \
-        TCB_t * pxTCB = pxCurrentTCBs[ xCoreID ];                                                                                         \
-        int8_t * pcEndOfStack = ( int8_t * ) pxTCB->pxEndOfStack;                                                                         \
-        static const uint8_t ucExpectedStackBytes[] = { tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE,   \
-                                                        tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE, tskSTACK_FILL_BYTE }; \
-                                                                                                                                          \
-        pcEndOfStack -= sizeof( ucExpectedStackBytes );                                                                                   \
-                                                                                                                                          \
-        if( ( pxTCB->pxTopOfStack >= pxTCB->pxEndOfStack - portSTACK_LIMIT_PADDING ) ||                                                   \
-            ( memcmp( ( void * ) pcEndOfStack, ( void * ) ucExpectedStackBytes, sizeof( ucExpectedStackBytes ) ) != 0 ) )                 \
-        {                                                                                                                                 \
-            char * pcOverflowTaskName = pxTCB->pcTaskName;                                                                                \
-            vApplicationStackOverflowHook( ( TaskHandle_t ) pxTCB, pcOverflowTaskName );                                                  \
-        }                                                                                                                                 \
-    } while( 0 )
-
-    #endif /* if ( configNUMBER_OF_CORES == 1 ) */
-
 #endif /* #if( configCHECK_FOR_STACK_OVERFLOW > 1 ) */
 /*-----------------------------------------------------------*/
 
 /* Remove stack overflow macro if not being used. */
 #ifndef taskCHECK_FOR_STACK_OVERFLOW
-    #if ( configNUMBER_OF_CORES == 1 )
-        #define taskCHECK_FOR_STACK_OVERFLOW()
-    #else
-        #define taskCHECK_FOR_STACK_OVERFLOW( xCoreID )
-    #endif
+    #define taskCHECK_FOR_STACK_OVERFLOW()
 #endif
 
 

--- a/tasks.c
+++ b/tasks.c
@@ -5251,7 +5251,7 @@ BaseType_t xTaskIncrementTick( void )
                 #endif /* configGENERATE_RUN_TIME_STATS */
 
                 /* Check for stack overflow, if configured. */
-                taskCHECK_FOR_STACK_OVERFLOW( xCoreID );
+                taskCHECK_FOR_STACK_OVERFLOW();
 
                 /* Before the currently running task is switched out, save its errno. */
                 #if ( configUSE_POSIX_ERRNO == 1 )


### PR DESCRIPTION
Description
-----------
This reverts PR 1270. As concluded in the discussion [here](https://forums.freertos.org/t/cortex-a9-port-disable-interrupts-before-writing-to-icc-pmr/22952/14), if `portSET_INTERRUPT_MASK` and `portCLEAR_INTERRUPT_MASK` are implemented correctly to support recursive calls, this change is not needed.

Test Steps
-----------
NA.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
