### PR TITLE
fix[IAR/RL78 Port] Compilation fails on portasm.s file

### DIFF
--- a/portable/IAR/RL78/portmacro.h
+++ b/portable/IAR/RL78/portmacro.h
@@ -187,7 +187,7 @@
               * ; * memory mode) registers the _usCriticalNesting value and the Stack Pointer
               * ; * of the active Task onto the task stack.
               * ; *---------------------------------------------------------------------------*/
-    portSAVE_CONTEXT MACRO
+portSAVE_CONTEXT MACRO
     PUSH AX; /* Save AX Register to stack. */
     PUSH HL
     #if  __CODE_MODEL__ == __CODE_MODEL_FAR__
@@ -217,7 +217,7 @@
  * ; * general purpose registers and the CS and ES (only in __far memory mode)
  * ; * of the selected task from the task stack.
  * ; *---------------------------------------------------------------------------*/
-    portRESTORE_CONTEXT MACRO
+portRESTORE_CONTEXT MACRO
     MOVW AX, _pxCurrentTCB; /* Restore the Task stack pointer. */
     MOVW HL, AX
     MOVW AX, [ HL ]


### PR DESCRIPTION
# Compilation failure on portasm.s file for IAR/RL78 port

Description
-----------
Compilation of the ASM file fails when using IAR version 5.10.3. See issue #1277 for more details.

To resolve this, the indentation of ASM macros in the portmacro.h file was adjusted. The IAR assembler only accepts ASM macro definitions that begin at the start of the line; indenting the macro name causes a compilation error.

This behavior was observed with IAR 5.10.3. Earlier versions have not been tested.

Test Steps
-----------
See issue #1277

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Bug #1277


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
