### PR TITLE
Update codecov badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CMock Unit Tests](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/workflows/unit-tests.yml/badge.svg?branch=main&event=push)](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/workflows/unit-tests.yml?query=branch%3Amain+event%3Apush+workflow%3A%22CMock+Unit+Tests%22++)
-[![codecov](https://codecov.io/gh/FreeRTOS/FreeRTOS-Kernel/badge.svg?branch=main)](https://codecov.io/gh/FreeRTOS/FreeRTOS-Kernel)
+[![codecov](https://app.codecov.io/gh/FreeRTOS/FreeRTOS-Kernel/badge.svg?branch=main)](https://codecov.io/gh/FreeRTOS/FreeRTOS-Kernel)
 
 ## Getting started
 


### PR DESCRIPTION
Description
-----------
This PR updates the codecov badge url in the readme file as the CI-CD-GithubActions repository's link verifier CI check fail. For instance refer to [this run](https://github.com/FreeRTOS/CI-CD-Github-Actions/actions/runs/15633479705/job/44159504380?pr=131).

Test Steps
-----------
NA

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
NA
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
NA 

Related Issue
-----------
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
