### PR TITLE
Fix data type of queue item length macros

### DIFF
--- a/include/semphr.h
+++ b/include/semphr.h
@@ -37,8 +37,8 @@
 
 typedef QueueHandle_t SemaphoreHandle_t;
 
-#define semBINARY_SEMAPHORE_QUEUE_LENGTH    ( ( uint8_t ) 1U )
-#define semSEMAPHORE_QUEUE_ITEM_LENGTH      ( ( uint8_t ) 0U )
+#define semBINARY_SEMAPHORE_QUEUE_LENGTH    ( ( UBaseType_t ) 1U )
+#define semSEMAPHORE_QUEUE_ITEM_LENGTH      ( ( UBaseType_t ) 0U )
 #define semGIVE_BLOCK_TIME                  ( ( TickType_t ) 0U )
 
 


### PR DESCRIPTION
Description
-----------
The `uxItemSize` parameter in `xQueueGenericCreate` and `xQueueGeneenericCreateStatic` APIs expects a `UBaseType_t` type. Previously, the `semSEMAPHORE_QUEUE_ITEM_LENGTH` macro incorrectly cast the value to `uint8_t`, causing type mismatch warnings. This change resolves the issue by properly casting the value to `UBaseType_t`.

Test Steps
-----------
Tested using Posix_GCC demo.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1285

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
