### PR TITLE
Define security extension configs before portable.h

### DIFF
--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -101,6 +101,16 @@
     #define configASSERT_DEFINED    1
 #endif
 
+/* Set configENABLE_PAC and/or configENABLE_BTI to 1 to enable PAC and/or BTI
+ * support and 0 to disable them. These are currently used in ARMv8.1-M ports. */
+#ifndef configENABLE_PAC
+    #define configENABLE_PAC    0
+#endif
+
+#ifndef configENABLE_BTI
+    #define configENABLE_BTI    0
+#endif
+
 /* Basic FreeRTOS definitions. */
 #include "projdefs.h"
 
@@ -3038,16 +3048,6 @@
  * infinite loop in idle task function when performing unit tests. */
 #ifndef configCONTROL_INFINITE_LOOP
     #define configCONTROL_INFINITE_LOOP()
-#endif
-
-/* Set configENABLE_PAC and/or configENABLE_BTI to 1 to enable PAC and/or BTI
- * support and 0 to disable them. These are currently used in ARMv8.1-M ports. */
-#ifndef configENABLE_PAC
-    #define configENABLE_PAC    0
-#endif
-
-#ifndef configENABLE_BTI
-    #define configENABLE_BTI    0
 #endif
 
 /* Sometimes the FreeRTOSConfig.h settings only allow a task to be created using


### PR DESCRIPTION
Description
-----------
Define`configENABLE_PAC` and `configENABLE_BTI` before including portable.h to prevent "used before definition" warnings when these macros are not set in FreeRTOSConfig.h.

Test Steps
-----------
M33 Demo project builds successfully.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1293


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
