### PR TITLE
Delete thread key on process exit

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -140,6 +140,8 @@ static void prvThreadKeyDestructor( void * pvData )
 static void prvInitThreadKey( void )
 {
     pthread_key_create( &xThreadKey, prvThreadKeyDestructor );
+    /* Destroy xThreadKey when the process exits. */
+    atexit( prvDestroyThreadKey );
 }
 /*-----------------------------------------------------------*/
 
@@ -314,8 +316,6 @@ BaseType_t xPortStartScheduler( void )
 
     /* Restore original signal mask. */
     ( void ) pthread_sigmask( SIG_SETMASK, &xSchedulerOriginalSignalMask, NULL );
-
-    prvDestroyThreadKey();
 
     return 0;
 }


### PR DESCRIPTION
Description
-----------
Previously, the shared thread key was deleted in `xPortStartScheduler` after scheduler was ended. This created a race condition where `prvThreadKeyDestructor` (responsible for freeing thread-specific heap memory) would not be called if `xPortStartScheduler` deleted the key before the last task deletion, as destructors are not invoked after key deletion (see https://github.com/walac/glibc/blob/master/nptl/pthread_create.c#L145-L150).

Move thread key deletion to process exit to ensure all thread-specific memory is properly freed.

Test Steps
-----------
The LeakSanitzer reports leak without this change for the following program:
```c
#include <FreeRTOS.h>
#include <task.h>

#include <stdbool.h>
#include <stddef.h>
#include <stdio.h>

static StackType_t stack[4096];
static StaticTask_t task;
static TaskHandle_t taskHandle;

static void callback(void *unused)
{
    (void)unused;
    vTaskEndScheduler();
}

int main(void)
{
    taskHandle = xTaskCreateStatic(callback, "thread", 4096, NULL,
                      FREERTOS_PRIORITY_NORMAL, stack, &task);
    vTaskStartScheduler();
    vTaskDelete(taskHandle);
    return 0;
}
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://forums.freertos.org/t/leaksanitizer-detects-memory-leaks-occasionally-in-gcc-posix/23387


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
