### PR TITLE
[Work In Progress] Adding the xPortIsInsideInterrupt to the PIC32MZ port

### DIFF
--- a/portable/MPLAB/PIC32MZ/port.c
+++ b/portable/MPLAB/PIC32MZ/port.c
@@ -372,3 +372,25 @@ void vPortClearInterruptMaskFromISR( UBaseType_t uxSavedStatusRegister )
 #endif /* __mips_hard_float == 1 */
 
 /*-----------------------------------------------------------*/
+
+__attribute__((always_inline)) static BaseType_t xPortIsInsideInterrupt( void )
+{
+    uint32_t ulCurrentInterrupt;
+    BaseType_t xReturn;
+
+    /* Obtain the number of the currently executing interrupt. */
+    __asm volatile("mfc0 %0, $12" : "=r" (ulCurrentInterrupt));
+
+    if( ulCurrentInterrupt == 0 )
+    {
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
+
+    return xReturn;
+}
+
+/*-----------------------------------------------------------*/

--- a/portable/MPLAB/PIC32MZ/portmacro.h
+++ b/portable/MPLAB/PIC32MZ/portmacro.h
@@ -146,6 +146,8 @@ extern void vPortClearInterruptMaskFromISR( UBaseType_t );
 #define portSET_INTERRUPT_MASK_FROM_ISR() uxPortSetInterruptMaskFromISR()
 #define portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedStatusRegister ) vPortClearInterruptMaskFromISR( uxSavedStatusRegister )
 
+extern BaseType_t xPortIsInsideInterrupt( void );
+
 #if ( __mips_hard_float == 0 ) && ( configUSE_TASK_FPU_SUPPORT == 1 )
     #error configUSE_TASK_FPU_SUPPORT can only be set to 1 when the part supports a hardware FPU module.
 #endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
