### PR TITLE
Move windows headers to port.c

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -33,6 +33,14 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
+#ifdef WIN32_LEAN_AND_MEAN
+    #include <winsock2.h>
+#else
+    #include <winsock.h>
+#endif
+
+#include <timeapi.h>
+
 #ifdef __GNUC__
     #include "mmsystem.h"
 #else

--- a/portable/MSVC-MingW/portmacro.h
+++ b/portable/MSVC-MingW/portmacro.h
@@ -29,17 +29,6 @@
 #ifndef PORTMACRO_H
 #define PORTMACRO_H
 
-#ifdef WIN32_LEAN_AND_MEAN
-    #include <winsock2.h>
-#else
-    #include <winsock.h>
-#endif
-
-#include <windows.h>
-#include <timeapi.h>
-#include <mmsystem.h>
-#include <winbase.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Move windows header files to port.c

Description
-----------
This prevents the inclusion of windows.h. into all header files using FreeRTOS.h and thus defining several macros conflicting with common definitions. This is a more minimal fix compared to https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1282

Test Steps
-----------
None, just a build issue.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
