### PR TITLE
Fix risk of Win32 timer setup call getting ignored

### DIFF
--- a/portable/MSVC-MingW/port.c
+++ b/portable/MSVC-MingW/port.c
@@ -152,6 +152,7 @@ static DWORD WINAPI prvSimulatedPeripheralTimer( LPVOID lpParameter )
     TickType_t xWaitTimeBetweenTicks = portTICK_PERIOD_MS;
     HANDLE hTimer = NULL;
     LARGE_INTEGER liDueTime;
+    BOOL bSuccess;
 
     /* Set the timer resolution to the maximum possible. */
     if( timeGetDevCaps( &xTimeCaps, sizeof( xTimeCaps ) ) == MMSYSERR_NOERROR )
@@ -190,7 +191,8 @@ static DWORD WINAPI prvSimulatedPeripheralTimer( LPVOID lpParameter )
 
     /* Set the Waitable Timer. The timer is set to run periodically at every
     xWaitTimeBetweenTicks milliseconds. */
-    configASSERT( SetWaitableTimer( hTimer, &liDueTime, xWaitTimeBetweenTicks, NULL, NULL, 0 ) );
+    bSuccess = SetWaitableTimer( hTimer, &liDueTime, xWaitTimeBetweenTicks, NULL, NULL, 0 );
+    configASSERT( bSuccess );
 
     while( xPortRunning == pdTRUE )
     {


### PR DESCRIPTION
Description
-----------
If a user configures the `configASSERT` macro to expand to nothing, a call to the Win32 API `SetWaitableTimer()` doesn't get compiled.

This can happen if, for example, `configASSERT` set defined as `assert` (from assert.h) which expands to nothing when `NDEBUG` is set (common for "release" builds).

This PR has a patch to fix the issue.

Test Steps
-----------
Using the Win32 port, define `configASSERT` as follows:
```
#define configASSERT( x ) ( (void)0 )
```
then the scheduler doesn't "tick" and calls to, fx., `vTaskDelay()` won't return.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
