### PR TITLE
fix[RL78 Port] incorrect register image for pvParameters in FAR mode (#1316)

### DIFF
--- a/portable/IAR/RL78/port.c
+++ b/portable/IAR/RL78/port.c
@@ -95,10 +95,10 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     uint32_t * pulLocal;
 
     /* With large code and large data sizeof( StackType_t ) == 2, and
-    * sizeof( StackType_t * ) == 4.  With small code and small data
-    * sizeof( StackType_t ) == 2 and sizeof( StackType_t * ) == 2. */
+     * sizeof( StackType_t * ) == 4.  With small code and small data
+     * sizeof( StackType_t ) == 2 and sizeof( StackType_t * ) == 2. */
 
-    #if __DATA_MODEL__ == __DATA_MODEL_FAR__
+#if __DATA_MODEL__ == __DATA_MODEL_FAR__
     {
         /* Far pointer parameters are passed using the A:DE registers (24-bit).
          * Although they are stored in memory as a 32-bit value.  Hence decrement
@@ -124,13 +124,44 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         *pulLocal = ( ( ( uint32_t ) pxCode ) | ( portPSW << 24UL ) );
         pxTopOfStack--;
 
-        /* An initial value for the AX register. */
-        *pxTopOfStack = ( StackType_t ) 0x1111;
+        /* In FAR data model, the compiler expects the task parameter (pvParameters)
+         * to be passed in the A:DE registers (24-bit). Therefore the parameter is
+         * split into:
+         *   - DE = low 16 bits
+         *   - A  = high 8 bits (loaded through the AX register image, X = 0)
+         * This ensures that the task entry function receives pvParameters in the
+         * format required by the C calling convention. */
+        {
+            uint32_t p = ( uint32_t ) pvParameters;
+            /* low 16 bits */
+            uint16_t de_init = (uint16_t)( p & 0xFFFFU );
+            /* A = high byte, X = 0 */   
+            uint16_t ax_init = (uint16_t)( ((p >> 16) & 0xFFU) << 8 );  
+
+            /* AX register image */
+            *pxTopOfStack = ( StackType_t ) ax_init;   
+            pxTopOfStack--;
+
+            /* HL register image (dummy) */
+            *pxTopOfStack = ( StackType_t ) 0x2222;    
+            pxTopOfStack--;
+
+            /* CS:ES register image */
+            *pxTopOfStack = ( StackType_t ) 0x0F00;    
+            pxTopOfStack--;
+
+            /* DE register image */
+            *pxTopOfStack = ( StackType_t ) de_init;   
+            pxTopOfStack--;
+        }
+
+        /* BC remains a dummy value (not used for parameter passing). */
+        *pxTopOfStack = ( StackType_t ) 0xBCBC;
         pxTopOfStack--;
     }
-    #else /* if __DATA_MODEL__ == __DATA_MODEL_FAR__ */
+#else /* if __DATA_MODEL__ == __DATA_MODEL_FAR__ */
     {
-        /* The return address, leaving space for the first two bytes of the
+       /* The return address, leaving space for the first two bytes of the
          * 32-bit value.  See the comments above the prvTaskExitError() prototype
          * at the top of this file. */
         pxTopOfStack--;
@@ -150,22 +181,22 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
         /* The parameter is passed in AX. */
         *pxTopOfStack = ( StackType_t ) pvParameters;
         pxTopOfStack--;
+
+        /* An initial value for the HL register. */
+        *pxTopOfStack = ( StackType_t ) 0x2222;
+        pxTopOfStack--;
+
+        /* CS and ES registers. */
+        *pxTopOfStack = ( StackType_t ) 0x0F00;
+        pxTopOfStack--;
+
+        /* The remaining general purpose registers DE and BC */
+        *pxTopOfStack = ( StackType_t ) 0xDEDE;
+        pxTopOfStack--;
+        *pxTopOfStack = ( StackType_t ) 0xBCBC; 
+        pxTopOfStack--;
     }
-    #endif /* if __DATA_MODEL__ == __DATA_MODEL_FAR__ */
-
-    /* An initial value for the HL register. */
-    *pxTopOfStack = ( StackType_t ) 0x2222;
-    pxTopOfStack--;
-
-    /* CS and ES registers. */
-    *pxTopOfStack = ( StackType_t ) 0x0F00;
-    pxTopOfStack--;
-
-    /* The remaining general purpose registers DE and BC */
-    *pxTopOfStack = ( StackType_t ) 0xDEDE;
-    pxTopOfStack--;
-    *pxTopOfStack = ( StackType_t ) 0xBCBC;
-    pxTopOfStack--;
+#endif /* __DATA_MODEL__ */
 
     /* Finally the critical section nesting count is set to zero when the task
      * first starts. */


### PR DESCRIPTION
### Title
fix[RL78 Port] incorrect register image for pvParameters in FAR mode (#1316)

### Description
In the RL78 FAR data model, pxPortInitialiseStack() did not correctly
initialize the register image in the task stack for the parameter (pvParameters).

The saved A:DE registers were filled with dummy values instead of the actual pointer value.

As a result, when the first context restore occurred, the compiler's function prologue read a corrupted parameter from the register image.

This only affected FAR builds; NEAR model was not impacted.

This patch updates the RL78 FAR path so that the register image matches the RL78 calling convention:
DE = low 16 bits of pvParameters
A = high 8 bits of pvParameters (via AX register image, X = 0)

With this change, tasks in FAR model receive the correct parameter at entry, while NEAR model remains unchanged.

### Test Steps
- Build FreeRTOS for RL78 with FAR data model.
- Create a task with xTaskCreate(task, "name", stack, pvParameters, prio, NULL).
- Inspect pvParameters inside the task:

**Before fix:** value corrupted (dummy registers A:DE = 0x1111/0xDEDE).

**After fix:** value matches the pointer passed to xTaskCreate.

Confirm no regression with NEAR model build.

### Checklist
- [x]  I have tested my changes. No regression in existing tests.

- [ ]  I have modified and/or added unit-tests to cover the code changes in this Pull Request.



### Related Issue
 #1316