### PR TITLE
RP2040: Fix use of deprecated volatile semantics for C++20 (#1318)

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -227,7 +227,7 @@ static inline void vPortRecursiveLock( BaseType_t xCoreID,
             if( ucOwnedByCore[ xCoreID ][ ulLockNum ] )
             {
                 configASSERT( ucRecursionCountByLock[ ulLockNum ] != 255u );
-                ucRecursionCountByLock[ ulLockNum ]++;
+                ucRecursionCountByLock[ ulLockNum ] = ucRecursionCountByLock[ ulLockNum ] + 1;
                 return;
             }
             spin_lock_unsafe_blocking(pxSpinLock);
@@ -241,7 +241,8 @@ static inline void vPortRecursiveLock( BaseType_t xCoreID,
         configASSERT( ( ucOwnedByCore[ xCoreID ] [ulLockNum ] ) != 0 );
         configASSERT( ucRecursionCountByLock[ ulLockNum ] != 0 );
 
-        if( !--ucRecursionCountByLock[ ulLockNum ] )
+        ucRecursionCountByLock[ ulLockNum ] = ucRecursionCountByLock[ ulLockNum ] - 1;
+        if ( ucRecursionCountByLock[ ulLockNum ] == 0U )
         {
             ucOwnedByCore[ xCoreID ] [ ulLockNum ] = 0;
             spin_unlock_unsafe(pxSpinLock);


### PR DESCRIPTION
## Fix use of deprecated volatile semantics for C++20
In C++ 20 the use of increments and decrements on volatiles are deprecated, and gives a warning when compiling for the RP2040. This PR fixes this and makes the code a bit easier to read. 

Related Issue
-----------
#1318 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
