### PR TITLE
Fix: avoid set but unused variable warning in GCC/Posix pxPortInitialiseStack

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -229,6 +229,7 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
     /* Ensure that there is enough space to store Thread_t on the stack. */
     ulStackSize = ( size_t ) ( pxTopOfStack + 1 - pxEndOfStack ) * sizeof( *pxTopOfStack );
     configASSERT( ulStackSize > sizeof( Thread_t ) );
+    ( void ) ulStackSize; /* suppress set but not used warning */
 
     thread->pxCode = pxCode;
     thread->pvParams = pvParameters;


### PR DESCRIPTION
Fix: suppress unused-variable warning in GCC/Posix `pxPortInitialiseStack`

Description
-----------
Silences a compiler warning when `configASSERT()` compiles to a no-op by casting `ulStackSize` to `(void)`. No logic or runtime behavior changed.

```
FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix/port.c:218:12: warning:
variable 'ulStackSize' set but not used [-Wunused-but-set-variable]
  218 |     size_t ulStackSize;
      |            ^
1 warning generated.
```

Test Steps
-----------
- Build with `configASSERT` disabled → compiles cleanly, no warnings

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.