### PR TITLE
fix(legal): Workaround reuse tool

### DIFF
--- a/.github/scripts/kernel_checker.py
+++ b/.github/scripts/kernel_checker.py
@@ -125,7 +125,7 @@ KERNEL_HEADER = [
     ' * FreeRTOS Kernel <DEVELOPMENT BRANCH>\n',
     ' * Copyright (C) 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.\n',
     ' *\n',
-    ' * SPDX-License-Identifier: MIT\n',
+    ' * SPDX', '-License-Identifier: MIT\n',
     ' *\n',
     ' * Permission is hereby granted, free of charge, to any person obtaining a copy of\n',
     ' * this software and associated documentation files (the "Software"), to deal in\n',


### PR DESCRIPTION
I noticed while using https://reuse.software/
this false positive error:

    reuse.extract - ERROR - Could not parse 'MIT\n','
    reuse.extract - ERROR - \
      '.../FreeRTOS-Kernel/.github/scripts/kernel_checker.py' \
      holds an SPDX expression that cannot be parsed, skipping the file

Relate-to: https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1321

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
