### PR TITLE
Remove Unused Code and Preprocessor Directives in RP2040 Port

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -243,35 +243,28 @@ void vPortStartFirstTask( void )
                 "   ldr r0, [r0]                    \n"
                 "   msr msp, r0                     \n" /* Set the msp back to the start of the stack. */
             #endif /* configRESET_STACK_POINTER */
-            #if ( configNUMBER_OF_CORES != 1 )
                 "   adr r1, ulAsmLocals             \n" /* Get the location of the current TCB for the current core. */
                 "   ldmia r1!, {r2, r3}             \n"
                 "   ldr r2, [r2]                    \n" /* r2 = Core number */
                 "   lsls r2, #2                     \n"
                 "   ldr r3, [r3, r2]                \n" /* r3 = pxCurrentTCBs[get_core_num()] */
-            #else /* configNUMBER_OF_CORES != 1 */
-                "   ldr r3, =pxCurrentTCBs          \n"
-                "   ldr r3, [r3]                    \n"  /* r3 = pxCurrentTCBs[0] */
-            #endif /* configNUMBER_OF_CORES != 1 */
-            "    ldr  r0, [r3]                       \n" /* The first item in pxCurrentTCB is the task top of stack. */
-            "    adds r0, #32                        \n" /* Discard everything up to r0. */
-            "    msr  psp, r0                        \n" /* This is now the new top of stack to use in the task. */
-            "    movs r0, #2                         \n" /* Switch to the psp stack. */
-            "    msr  CONTROL, r0                    \n"
-            "    isb                                 \n"
-            "    pop  {r0-r5}                        \n" /* Pop the registers that are saved automatically. */
-            "    mov  lr, r5                         \n" /* lr is now in r5. */
-            "    pop  {r3}                           \n" /* Return address is now in r3. */
-            "    pop  {r2}                           \n" /* Pop and discard XPSR. */
-            "    cpsie i                             \n" /* The first task has its context and interrupts can be enabled. */
-            "    bx   r3                             \n" /* Finally, jump to the user defined task code. */
-            #if configNUMBER_OF_CORES != 1
+                "   ldr  r0, [r3]                   \n" /* The first item in pxCurrentTCB is the task top of stack. */
+                "   adds r0, #32                    \n" /* Discard everything up to r0. */
+                "   msr  psp, r0                    \n" /* This is now the new top of stack to use in the task. */
+                "   movs r0, #2                     \n" /* Switch to the psp stack. */
+                "   msr  CONTROL, r0                \n"
+                "   isb                             \n"
+                "   pop  {r0-r5}                    \n" /* Pop the registers that are saved automatically. */
+                "   mov  lr, r5                     \n" /* lr is now in r5. */
+                "   pop  {r3}                       \n" /* Return address is now in r3. */
+                "   pop  {r2}                       \n" /* Pop and discard XPSR. */
+                "   cpsie i                         \n" /* The first task has its context and interrupts can be enabled. */
+                "   bx   r3                         \n" /* Finally, jump to the user defined task code. */
                 "                                   \n"
                 "     .align 4                      \n"
                 "ulAsmLocals:                       \n"
                 "    .word 0xD0000000               \n" /* SIO */
                 "    .word pxCurrentTCBs            \n"
-            #endif /* portRUNNING_ON_BOTH_CORES */
             );
     #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 }

--- a/portable/ThirdParty/GCC/RP2040/port.c
+++ b/portable/ThirdParty/GCC/RP2040/port.c
@@ -362,14 +362,11 @@ void vPortStartFirstTask( void )
         spin_lock_claim( configSMP_SPINLOCK_0 );
         spin_lock_claim( configSMP_SPINLOCK_1 );
 
-        #if configNUMBER_OF_CORES != 1
-            ucPrimaryCoreNum = configTICK_CORE;
-            configASSERT( get_core_num() == 0 ); /* we must be started on core 0 */
-            multicore_reset_core1();
-            multicore_launch_core1( prvDisableInterruptsAndPortStartSchedulerOnCore );
-        #else
-            ucPrimaryCoreNum = get_core_num();
-        #endif
+        ucPrimaryCoreNum = configTICK_CORE;
+        configASSERT( get_core_num() == 0 ); /* we must be started on core 0 */
+        multicore_reset_core1();
+        multicore_launch_core1( prvDisableInterruptsAndPortStartSchedulerOnCore );
+
         xPortStartSchedulerOnCore();
 
         /* Should not get here! */
@@ -611,13 +608,9 @@ void xPortPendSVHandler( void )
             "                                       \n"
             "   adr    r0, ulAsmLocals2             \n" /* Get the location of the current TCB for the current core. */
             "   ldmia r0!, {r2, r3}                 \n"
-            #if configNUMBER_OF_CORES != 1
-                "   ldr r0, [r2]                    \n" /* r0 = Core number */
-                "   lsls r0, r0, #2                 \n"
-                "   adds r3, r0                     \n" /* r3 = &pxCurrentTCBs[get_core_num()] */
-            #else
-                "                                   \n" /* r3 = &pxCurrentTCBs[0] */
-            #endif /* portRUNNING_ON_BOTH_CORES */
+            "   ldr r0, [r2]                        \n" /* r0 = Core number */
+            "   lsls r0, r0, #2                     \n"
+            "   adds r3, r0                         \n" /* r3 = &pxCurrentTCBs[get_core_num()] */
             "   ldr    r0, [r3]                     \n" /* r0 = pxCurrentTCB */
             "                                       \n"
             "   subs r1, r1, #32                    \n" /* Make space for the remaining low registers. */
@@ -651,11 +644,7 @@ void xPortPendSVHandler( void )
                 "   subs r1, r1, #48                \n"
                 "   stmia r1!, {r4-r7}              \n"
             #endif /* portUSE_DIVIDER_SAVE_RESTORE */
-            #if configNUMBER_OF_CORES != 1
-                "   ldr r0, [r2]                    \n" /* r0 = Core number */
-            #else
-                "   movs r0, #0                     \n"
-            #endif /* configNUMBER_OF_CORES != 1 */
+            "   ldr r0, [r2]                        \n" /* r0 = Core number */
             "   push {r3, r14}                      \n"
             "   cpsid i                             \n"
             "   bl vTaskSwitchContext               \n"


### PR DESCRIPTION
Remove Unused Code and Preprocessor Directives in RP2040 Port

Description
-----------

- Ever since the variables to enable/disable SMP were standardized to "configNUMBER_OF_CORES" in #1193, there have been some code regions that use duplicate or inconsistent preprocessor conditions
- Consider the following example

```c
#if ( configNUMBER_OF_CORES == 1 )
// some code
#else // implicitly configNUMBER_OF_CORES != 1 
    #if ( configNUMBER_OF_CORES != 1 )
        // always selected
    #else 
        // never selected (redundant/unnecessary)
    #endif
#endif
```
- In this case, the entire second set of preprocessor directives can be removed, with the always selected code staying and the redundant code also being deleted.
- Most of this was done for inline assembly code, in total for 4 instances total.
- Open to any feedback

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run limited compilation tests locally, tbh unsure of how to run the full test suite but happy to do so.
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
