### PR TITLE
Prefer xTaskDelayUntil in config template

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -653,7 +653,7 @@
 #define INCLUDE_uxTaskPriorityGet              1
 #define INCLUDE_vTaskDelete                    1
 #define INCLUDE_vTaskSuspend                   1
-#define INCLUDE_vTaskDelayUntil                1
+#define INCLUDE_xTaskDelayUntil                1
 #define INCLUDE_vTaskDelay                     1
 #define INCLUDE_xTaskGetSchedulerState         1
 #define INCLUDE_xTaskGetCurrentTaskHandle      1


### PR DESCRIPTION
<!--- Title -->

Description
-----------
xTaskDelayUntil is more featured and should
be preferred by new users.

Test Steps
-----------
No manual testing performed. I'm relying on automated testing for this small PR.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
https://forums.freertos.org/t/include-xtaskdelayuntil-vs-include-vtaskdelayuntil/24656


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
