### PR TITLE
Allow dynamic heap_4 size by removing size from extern declaration

### DIFF
--- a/portable/MemMang/heap_4.c
+++ b/portable/MemMang/heap_4.c
@@ -90,7 +90,7 @@
 
 /* The application writer has already defined the array used for the RTOS
  * heap - probably so it can be placed in a special segment or address. */
-    extern uint8_t ucHeap[ configTOTAL_HEAP_SIZE ];
+    extern uint8_t ucHeap[ ];
 #else
     PRIVILEGED_DATA static uint8_t ucHeap[ configTOTAL_HEAP_SIZE ];
 #endif /* configAPPLICATION_ALLOCATED_HEAP */


### PR DESCRIPTION
Allow dynamic size for heap_4 implementation

Description
-----------
The size specification in the heap declaration offers no real benefit, but restricts `configTOTAL_HEAP_SIZE` to a compile-time known value. By dropping the size in the declaration the heap size can be specified at link or runtime.

Test Steps
-----------

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
