### PR TITLE
remove stray semicolon from gcc-ARM_CRx_MPU port.c

### DIFF
--- a/portable/GCC/ARM_CRx_MPU/port.c
+++ b/portable/GCC/ARM_CRx_MPU/port.c
@@ -418,7 +418,7 @@ void vPortStoreTaskMPUSettings( xMPU_SETTINGS * xMPUSettings,
             ulIndex = portSTACK_REGION;
             xMPUSettings->xRegion[ ulIndex ].ulRegionBaseAddress = ( uint32_t ) pxBottomOfStack;
             xMPUSettings->xRegion[ ulIndex ].ulRegionSize = ( ulRegionLengthEncoded |
-                                                              portMPU_REGION_ENABLE );;
+                                                              portMPU_REGION_ENABLE );
             xMPUSettings->xRegion[ ulIndex ].ulRegionAttribute = ( portMPU_REGION_PRIV_RW_USER_RW_NOEXEC |
                                                                    portMPU_REGION_NORMAL_OIWTNOWA_SHARED );
         }


### PR DESCRIPTION
Remove stray semicolon from gcc-ARM_CRx_MPU port.c.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
