### PR TITLE
RISC-V port enhancements

### DIFF
--- a/portable/GCC/RISC-V/port.c
+++ b/portable/GCC/RISC-V/port.c
@@ -54,7 +54,7 @@
 #ifdef configTASK_RETURN_ADDRESS
     #define portTASK_RETURN_ADDRESS    configTASK_RETURN_ADDRESS
 #else
-    #define portTASK_RETURN_ADDRESS    0
+    #define portTASK_RETURN_ADDRESS    NULL
 #endif
 
 /* The stack used by interrupt service routines.  Set configISR_STACK_SIZE_WORDS
@@ -99,7 +99,7 @@ size_t xCriticalNesting = ( size_t ) 0xaaaaaaaa;
 size_t * pxCriticalNesting = &xCriticalNesting;
 
 /* Used to catch tasks that attempt to return from their implementing function. */
-size_t xTaskReturnAddress = ( size_t ) portTASK_RETURN_ADDRESS;
+ReturnFunctionType_t xTaskReturnAddress = ( ReturnFunctionType_t ) portTASK_RETURN_ADDRESS;
 
 /* Set configCHECK_FOR_STACK_OVERFLOW to 3 to add ISR stack checking to task
  * stack checking.  A problem in the ISR stack will trigger an assert, not call

--- a/portable/GCC/RISC-V/portmacro.h
+++ b/portable/GCC/RISC-V/portmacro.h
@@ -66,6 +66,7 @@ typedef portSTACK_TYPE   StackType_t;
 typedef portBASE_TYPE    BaseType_t;
 typedef portUBASE_TYPE   UBaseType_t;
 typedef portUBASE_TYPE   TickType_t;
+typedef void (*ReturnFunctionType_t)( void );
 
 /* Legacy type definitions. */
 #define portCHAR                   char

--- a/portable/GCC/RISC-V/portmacro.h
+++ b/portable/GCC/RISC-V/portmacro.h
@@ -48,19 +48,19 @@
 
 /* Type definitions. */
 #if __riscv_xlen == 64
-    #define portSTACK_TYPE           uint64_t
     #define portBASE_TYPE            int64_t
     #define portUBASE_TYPE           uint64_t
     #define portMAX_DELAY            ( TickType_t ) 0xffffffffffffffffUL
-    #define portPOINTER_SIZE_TYPE    uint64_t
 #elif __riscv_xlen == 32
-    #define portSTACK_TYPE           uint32_t
     #define portBASE_TYPE            int32_t
     #define portUBASE_TYPE           uint32_t
     #define portMAX_DELAY            ( TickType_t ) 0xffffffffUL
 #else /* if __riscv_xlen == 64 */
     #error "Assembler did not define __riscv_xlen"
 #endif /* if __riscv_xlen == 64 */
+
+#define portPOINTER_SIZE_TYPE    intptr_t
+#define portSTACK_TYPE           uintptr_t
 
 typedef portSTACK_TYPE   StackType_t;
 typedef portBASE_TYPE    BaseType_t;


### PR DESCRIPTION
RISC-V port enhancements

Description
-----------
Non-breaking, backward-compatible enhancements to the RISC-V port mostly to do with types in order to make it more portable across architectures (eg: CHERI extensions that enforce memory safety and pointer provenance by separating pointer vs integer types) and environments (eg: POSIX).

Test Steps
-----------
Normal RISC-V demos should work, tested with `main_blinky`. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
