### PR TITLE
Suppress MISRA 4.7 for SMP taskENTER_CRITICAL_FROM_ISR

### DIFF
--- a/portable/template/port.c
+++ b/portable/template/port.c
@@ -65,6 +65,9 @@ static void prvTickISR( void )
         /* Tasks or ISRs running on other cores may still in critical section in
          * multiple cores environment. Incrementing tick needs to performed in
          * critical section. */
+        /* MISRA Ref 4.7.1 [Return value shall be checked] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
+        /* coverity[misra_c_2012_directive_4_7_violation] */
         ulPreviousMask = taskENTER_CRITICAL_FROM_ISR();
 
         /* Maintain the tick count. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Suppresses directive 4.7 in the SMP port template
as this function does not return error data.

Test Steps
-----------
Manually executed Coverity to verify issue is no longer present.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
