### PR TITLE
Fix SMP scheduler evicting task when preemption is disabled

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -3524,12 +3524,9 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
                 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
                 {
-                    BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
-
                     prvYieldForTask( pxTCB );
 
-                    if( ( xYieldPendingBefore == pdFALSE ) &&
-                        ( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE ) )
+                    if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
                     {
                         xYieldRequired = pdTRUE;
                     }
@@ -5497,12 +5494,9 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
 
         #if ( configUSE_PREEMPTION == 1 )
         {
-            BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
-
             prvYieldForTask( pxUnblockedTCB );
 
-            if( ( xYieldPendingBefore == pdFALSE ) &&
-                ( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE ) )
+            if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
             {
                 xReturn = pdTRUE;
             }
@@ -8211,12 +8205,9 @@ TickType_t uxTaskResetEventItemValue( void )
                 {
                     #if ( configUSE_PREEMPTION == 1 )
                     {
-                        BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
-
                         prvYieldForTask( pxTCB );
 
-                        if( ( xYieldPendingBefore == pdFALSE ) &&
-                            ( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE ) )
+                        if( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE )
                         {
                             if( pxHigherPriorityTaskWoken != NULL )
                             {
@@ -8348,12 +8339,9 @@ TickType_t uxTaskResetEventItemValue( void )
                 {
                     #if ( configUSE_PREEMPTION == 1 )
                     {
-                        BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
-
                         prvYieldForTask( pxTCB );
 
-                        if( ( xYieldPendingBefore == pdFALSE ) &&
-                            ( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE ) )
+                        if( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE )
                         {
                             if( pxHigherPriorityTaskWoken != NULL )
                             {

--- a/tasks.c
+++ b/tasks.c
@@ -3524,9 +3524,12 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
                 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
                 {
+                    BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
+
                     prvYieldForTask( pxTCB );
 
-                    if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+                    if( ( xYieldPendingBefore == pdFALSE ) &&
+                        ( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE ) )
                     {
                         xYieldRequired = pdTRUE;
                     }
@@ -4890,7 +4893,12 @@ BaseType_t xTaskIncrementTick( void )
                 {
                     if( listCURRENT_LIST_LENGTH( &( pxReadyTasksLists[ pxCurrentTCBs[ xCoreID ]->uxPriority ] ) ) > 1U )
                     {
-                        xYieldPendings[ xCoreID ] = pdTRUE;
+                        #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                            if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE )
+                        #endif
+                        {
+                            xYieldPendings[ xCoreID ] = pdTRUE;
+                        }
                     }
                     else
                     {
@@ -5222,6 +5230,16 @@ BaseType_t xTaskIncrementTick( void )
              * SMP port. */
             configASSERT( portGET_CRITICAL_NESTING_COUNT( xCoreID ) == 0 );
 
+            #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable != pdFALSE )
+                {
+                    /* The current task has preemption disabled - do not allow a
+                     * context switch. The yield will be performed when preemption
+                     * is re-enabled. */
+                    xYieldPendings[ xCoreID ] = pdTRUE;
+                }
+                else
+            #endif /* #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 ) */
             if( uxSchedulerSuspended != ( UBaseType_t ) 0U )
             {
                 /* The scheduler is currently suspended - do not allow a context
@@ -5479,9 +5497,12 @@ BaseType_t xTaskRemoveFromEventList( const List_t * const pxEventList )
 
         #if ( configUSE_PREEMPTION == 1 )
         {
+            BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
+
             prvYieldForTask( pxUnblockedTCB );
 
-            if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+            if( ( xYieldPendingBefore == pdFALSE ) &&
+                ( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE ) )
             {
                 xReturn = pdTRUE;
             }
@@ -8190,9 +8211,12 @@ TickType_t uxTaskResetEventItemValue( void )
                 {
                     #if ( configUSE_PREEMPTION == 1 )
                     {
+                        BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
+
                         prvYieldForTask( pxTCB );
 
-                        if( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE )
+                        if( ( xYieldPendingBefore == pdFALSE ) &&
+                            ( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE ) )
                         {
                             if( pxHigherPriorityTaskWoken != NULL )
                             {
@@ -8324,9 +8348,12 @@ TickType_t uxTaskResetEventItemValue( void )
                 {
                     #if ( configUSE_PREEMPTION == 1 )
                     {
+                        BaseType_t xYieldPendingBefore = xYieldPendings[ portGET_CORE_ID() ];
+
                         prvYieldForTask( pxTCB );
 
-                        if( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE )
+                        if( ( xYieldPendingBefore == pdFALSE ) &&
+                            ( xYieldPendings[ portGET_CORE_ID() ] == pdTRUE ) )
                         {
                             if( pxHigherPriorityTaskWoken != NULL )
                             {


### PR DESCRIPTION
## Summary

Fixes #1376 — SMP scheduler evicting a task that has preemption disabled via `vTaskPreemptionDisable()`.

In the SMP time-slicing path of `xTaskIncrementTick()`, `xYieldPendings[xCoreID]` was set to `pdTRUE` unconditionally without checking `xPreemptionDisable`. The later yield-processing block correctly skipped acting on it for preemption-disabled cores, but the **stale flag remained**. When a subsequent ISR (e.g. `xTaskGenericNotifyFromISR()`) called `prvYieldForTask()` — which correctly did not yield — it then checked `xYieldPendings[portGET_CORE_ID()]` and found the stale `pdTRUE`, erroneously setting `*pxHigherPriorityTaskWoken = pdTRUE`. This triggered `portYIELD_FROM_ISR()` → `vTaskSwitchContext()` → `prvSelectHighestPriorityTask()`, which evicted the preemption-disabled task.

## Changes (three-layer fix)

- **Root cause** (`xTaskIncrementTick`): Guard the time-slicing `xYieldPendings[]` assignment with a `configUSE_TASK_PREEMPTION_DISABLE` check so the flag is never set for cores running preemption-disabled tasks.

- **Defense in depth** (4 functions): In `xTaskResumeFromISR`, `xTaskRemoveFromEventList`, `xTaskGenericNotifyFromISR`, and `vTaskGenericNotifyGiveFromISR` — save `xYieldPendings[portGET_CORE_ID()]` before calling `prvYieldForTask()` and only report a yield if the flag transitioned from `pdFALSE` to `pdTRUE`. This eliminates false positives from any stale flags.

- **Safety net** (`vTaskSwitchContext` SMP path): Add a `xPreemptionDisable` check analogous to the existing `uxSchedulerSuspended` check. If a context switch is somehow triggered for a core whose task has preemption disabled, the switch is deferred (`xYieldPendings = pdTRUE`) and will execute when `vTaskPreemptionEnable()` calls `prvYieldCore()`.

## Configuration

Only affects SMP builds with:
```
configNUMBER_OF_CORES > 1
configUSE_TASK_PREEMPTION_DISABLE == 1
configUSE_PREEMPTION == 1
configUSE_TIME_SLICING == 1
```

Single-core builds are completely unaffected (all changes are inside `#if ( configNUMBER_OF_CORES > 1 )` or equivalent guards).

## Test plan

- [ ] Verify existing FreeRTOS SMP unit tests pass
- [ ] Test on dual-core SMP hardware (e.g. ESP32-S3) with preemption-disabled task + concurrent ISR notifications + same-priority time-slicing tasks (the scenario from #1376)
- [ ] Verify that preemption re-enablement (`vTaskPreemptionEnable`) still triggers deferred yields correctly
- [ ] Verify single-core builds are unaffected
