### PR TITLE
fix: use inherited priority for event item value in vTaskPrioritySet

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -2936,7 +2936,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                  * being used for anything else. */
                 if( ( listGET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ) ) & taskEVENT_LIST_ITEM_VALUE_IN_USE ) == ( ( TickType_t ) 0U ) )
                 {
-                    listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) uxNewPriority ) );
+                    listSET_LIST_ITEM_VALUE( &( pxTCB->xEventListItem ), ( ( TickType_t ) configMAX_PRIORITIES - ( TickType_t ) pxTCB->uxPriority ) );
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #1364

## Problem
When `vTaskPrioritySet()` is called on a task that holds a mutex and has
an inherited priority, the event list item value is set using `uxNewPriority`
(the requested new priority) instead of `pxTCB->uxPriority` (the effective
current priority after inheritance).

This incorrect ordering in the event waiting list can cause the task to
never be unblocked when attempting to acquire additional mutexes, leading
to deadlock.

## Fix
Replace `uxNewPriority` with `pxTCB->uxPriority` when setting the event
list item value, consistent with how `xTaskPriorityInherit()` and
`vTaskPriorityDisinheritAfterTimeout()` handle this.

## Testing
Reproducer and test case provided by the original reporter at:
https://github.com/wirelinker/FreeRTOS_kernel_test_for_RP2040/tree/vTaskPrioritySet_event_item_value_deadlock_test