### PR TITLE
Correct RISC-V port #endif preprocessor comments

### DIFF
--- a/portable/GCC/RISC-V/port.c
+++ b/portable/GCC/RISC-V/port.c
@@ -154,7 +154,7 @@ size_t xTaskReturnAddress = ( size_t ) portTASK_RETURN_ADDRESS;
         ullNextTime += ( uint64_t ) uxTimerIncrementsForOneTick;
     }
 
-#endif /* ( configMTIME_BASE_ADDRESS != 0 ) && ( configMTIME_BASE_ADDRESS != 0 ) */
+#endif /* ( configMTIME_BASE_ADDRESS != 0 ) && ( configMTIMECMP_BASE_ADDRESS != 0 ) */
 /*-----------------------------------------------------------*/
 
 BaseType_t xPortStartScheduler( void )

--- a/portable/IAR/RISC-V/port.c
+++ b/portable/IAR/RISC-V/port.c
@@ -187,7 +187,7 @@ static void prvTaskExitError( void )
         ullNextTime += ( uint64_t ) uxTimerIncrementsForOneTick;
     }
 
-#endif /* ( configMTIME_BASE_ADDRESS != 0 ) && ( configMTIME_BASE_ADDRESS != 0 ) */
+#endif /* ( configMTIME_BASE_ADDRESS != 0 ) && ( configMTIMECMP_BASE_ADDRESS != 0 ) */
 /*-----------------------------------------------------------*/
 
 BaseType_t xPortStartScheduler( void )


### PR DESCRIPTION
## Summary
Fix the `#endif` comment after `vPortSetupTimerInterrupt` in GCC and IAR RISC-V `port.c`: the comment duplicated `configMTIME_BASE_ADDRESS` and did not mention `configMTIMECMP_BASE_ADDRESS`, unlike the matching `#if` condition.

## Files
- `portable/GCC/RISC-V/port.c`
- `portable/IAR/RISC-V/port.c`

This is a comment-only fix; preprocessor behavior is unchanged.