### PR TITLE
stream_buffer: require batching buffers to exceed the trigger level

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -257,6 +257,15 @@ typedef struct StreamBufferDef_t
 static size_t prvBytesInBuffer( const StreamBuffer_t * const pxStreamBuffer ) PRIVILEGED_FUNCTION;
 
 /*
+ * Returns pdTRUE when the amount of buffered data should unblock a task that
+ * is waiting to receive data. Stream batching buffers require the buffered
+ * data to exceed the trigger level, whereas stream and message buffers unblock
+ * when the trigger level is reached.
+ */
+static BaseType_t prvBytesInBufferMeetTriggerLevel( const StreamBuffer_t * const pxStreamBuffer,
+                                                    size_t xBytesInBuffer ) PRIVILEGED_FUNCTION;
+
+/*
  * Add xCount bytes from pucData into the pxStreamBuffer's data storage area.
  * This function does not update the buffer's xHead pointer, so multiple writes
  * may be chained together "atomically". This is useful for Message Buffers where
@@ -919,7 +928,7 @@ size_t xStreamBufferSend( StreamBufferHandle_t xStreamBuffer,
         traceSTREAM_BUFFER_SEND( xStreamBuffer, xReturn );
 
         /* Was a task waiting for the data? */
-        if( prvBytesInBuffer( pxStreamBuffer ) >= pxStreamBuffer->xTriggerLevelBytes )
+        if( prvBytesInBufferMeetTriggerLevel( pxStreamBuffer, prvBytesInBuffer( pxStreamBuffer ) ) != pdFALSE )
         {
             prvSEND_COMPLETED( pxStreamBuffer );
         }
@@ -976,7 +985,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
     if( xReturn > ( size_t ) 0 )
     {
         /* Was a task waiting for the data? */
-        if( prvBytesInBuffer( pxStreamBuffer ) >= pxStreamBuffer->xTriggerLevelBytes )
+        if( prvBytesInBufferMeetTriggerLevel( pxStreamBuffer, prvBytesInBuffer( pxStreamBuffer ) ) != pdFALSE )
         {
             /* MISRA Ref 4.7.1 [Return value shall be checked] */
             /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */
@@ -1584,6 +1593,35 @@ static size_t prvBytesInBuffer( const StreamBuffer_t * const pxStreamBuffer )
     }
 
     return xCount;
+}
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvBytesInBufferMeetTriggerLevel( const StreamBuffer_t * const pxStreamBuffer,
+                                                    size_t xBytesInBuffer )
+{
+    BaseType_t xReturn = pdFALSE;
+
+    if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_BATCHING_BUFFER ) != ( uint8_t ) 0 )
+    {
+        if( xBytesInBuffer > pxStreamBuffer->xTriggerLevelBytes )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            mtCOVERAGE_TEST_MARKER();
+        }
+    }
+    else if( xBytesInBuffer >= pxStreamBuffer->xTriggerLevelBytes )
+    {
+        xReturn = pdTRUE;
+    }
+    else
+    {
+        mtCOVERAGE_TEST_MARKER();
+    }
+
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
Batching stream buffers are documented to unblock receivers only after the buffered byte count exceeds the trigger level. Both `xStreamBufferSend()` and `xStreamBufferSendFromISR()` currently notify as soon as the count reaches that level, which wakes a blocked receiver too early and can make `xStreamBufferReceive()` return `0` bytes while the buffer still holds exactly trigger-level data.

This change routes both send paths through a shared helper so batching buffers require a strict greater-than check, while stream and message buffers keep their existing trigger semantics.

Test Steps
-----------
1. Built the existing `FreeRTOS/Test/CMock/stream_buffer/api` harness against the updated `FreeRTOS-Kernel` working tree.
2. Ran focused local batching-buffer regression cases against that harness for both the task send path and the ISR send path.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1375

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.