### PR TITLE
Provide alternative approach for consuming freeRTOS by cmake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_minimum_required(VERSION 3.15)
 # implementation (e.g. when only static allocation is used).
 
 # `freertos_config` target defines the path to FreeRTOSConfig.h and optionally other freertos based config files
+if(NOT CMAKE_INTERFACE_LIBRARY)
 if(NOT TARGET freertos_config )
     if (NOT DEFINED FREERTOS_CONFIG_FILE_DIRECTORY )
 
@@ -255,8 +256,12 @@ endif()
 add_library(freertos_kernel STATIC)
 
 ########################################################################
+endif()
+
 add_subdirectory(include)
 add_subdirectory(portable)
+
+if (NOT CMAKE_INTERFACE_LIBRARY)
 
 target_sources(freertos_kernel PRIVATE
     croutine.c
@@ -285,5 +290,29 @@ target_link_libraries(freertos_kernel
         freertos_kernel_port
 
 )
+else()
+    message(WARNING " CMAKE_INTERFACE_LIBRARY is set. FreeRTOS will be configured as INTERFACE library.\n"
+    "Please make sure to link freertos_kernel, config and desired port & heap libraries to your executable target")
+
+add_library(freertos_kernel INTERFACE)
+target_sources(freertos_kernel INTERFACE
+    croutine.c
+    event_groups.c
+    list.c
+    queue.c
+    stream_buffer.c
+    tasks.c
+    timers.c
+)
+
+target_link_libraries(freertos_kernel
+    INTERFACE
+        freertos_kernel_include
+
+)
+
+endif()
+
+
 
 ########################################################################

--- a/README.md
+++ b/README.md
@@ -104,6 +104,39 @@ target_compile_definitions(freertos_config INTERFACE ${definitions})
 target_compile_options(freertos_config INTERFACE ${options})
 ```
 
+### Consume as interface libraries
+
+If Your project contains multiple target architectures You can use the alternative approach for consuming FreeRTOS.
+
+Instead of setting up HEAP / PORT / CONFIG variables required by freeRTOS static library build
+
+set only CMAKE_INTERFACE_LIBRARY
+```cmake
+set(CMAKE_INTERFACE_LIBRARY 1)
+add_subdirectory(${FREERTOS_PATH})
+```
+
+And for any target in the project simply link kernel and desired port / heap libraries. Since they will be interface libraries their sources becomes sources
+of target that links them. 
+
+```cmake
+    target_link_libraries(my_cm0_application INTERFACE
+        freertos_kernel
+        freertos_kernel_port_CM0
+        freertos_kernel_mem_heap4
+    )
+
+    target_link_libraries(some_cm4_application INTERFACE
+        freertos_kernel
+        freertos_kernel_port_CM4
+        freertos_kernel_mem_heap3
+    )
+```
+
+Note that each target that consumes the same FreeRTOS sources can specify different compile options.
+
+! For now only a few ( heap 3 & 4 / Port CM0 & CM4 ) interface libraries are defined but specifying the rest (portable/CMakeLists.txt) is extremely easy. 
+
 ### Consuming stand-alone - Cloning this repository
 
 To clone using HTTPS:

--- a/portable/CMakeLists.txt
+++ b/portable/CMakeLists.txt
@@ -1,3 +1,5 @@
+if (NOT CMAKE_INTERFACE_LIBRARY)
+
 if( FREERTOS_PORT STREQUAL "GCC_RISC_V_GENERIC" )
     include( GCC/RISC-V/chip_extensions.cmake )
 endif()
@@ -1354,3 +1356,23 @@ target_link_libraries(freertos_kernel_port
         "$<$<STREQUAL:${FREERTOS_PORT},GCC_RP2040>:hardware_clocks;hardware_exception;pico_multicore>"
         $<$<STREQUAL:${FREERTOS_PORT},MSVC_MINGW>:winmm> # Windows library which implements timers
 )
+
+else()
+
+    #Add missing heap / port interface libraries if Your project use them...
+     
+    add_library(freertos_kernel_mem_heap4 INTERFACE)
+    target_sources(freertos_kernel_mem_heap4 INTERFACE MemMang/heap_4.c)
+
+    add_library(freertos_kernel_mem_heap3 INTERFACE)
+    target_sources(freertos_kernel_mem_heap3 INTERFACE MemMang/heap_3.c)
+
+    add_library(freertos_kernel_port_CM0 INTERFACE)
+    target_sources(freertos_kernel_port_CM0 INTERFACE GCC/ARM_CM0/port.c GCC/ARM_CM0/portasm.c GCC/ARM_CM0/mpu_wrappers_v2_asm.c)
+    target_include_directories(freertos_kernel_port_CM0 INTERFACE ${CMAKE_CURRENT_LIST_DIR}/GCC/ARM_CM0)
+
+    add_library(freertos_kernel_port_CM4 INTERFACE)
+    target_sources(freertos_kernel_port_CM4 INTERFACE GCC/ARM_CM4F/port.c)
+    target_include_directories(freertos_kernel_port_CM4 INTERFACE ${CMAKE_CURRENT_LIST_DIR}/GCC/ARM_CM4F)
+
+endif()


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Provide possibility to consume freeRTOS sources as CMake Interface libraries without compromising existing solution.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
