### PR TITLE
Fix: Change PUBLIC to INTERFACE for interface library in error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT TARGET freertos_config )
             "    INTERFACE\n"
             "      include) # The config file directory\n"
             "  target_compile_definitions(freertos_config\n"
-            "    PUBLIC\n"
+            "    INTERFACE\n"
             "    projCOVERAGE_TEST=0)\n")
     else()
         message(WARNING " Using deprecated 'FREERTOS_CONFIG_FILE_DIRECTORY' - please update your project CMakeLists.txt file:\n"
@@ -34,7 +34,7 @@ if(NOT TARGET freertos_config )
             "    INTERFACE\n"
             "      include) # The config file directory\n"
             "  target_compile_definitions(freertos_config\n"
-            "    PUBLIC\n"
+            "    INTERFACE\n"
             "    projCOVERAGE_TEST=0)\n")
     endif()
 endif()


### PR DESCRIPTION
Correct target_compile_definitions scope in CMake error message for INTERFACE library

Description
-----------
This CMake error shows incorrect usage of PUBLIC scope with an INTERFACE library. This fix corrects the message code.

Test Steps
-----------
Verify the message now shows correct CMake syntax with INTERFACE instead of PUBLIC
Run CMake configuration to confirm it no longer generates scope errors

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
