### PR TITLE
Add stack size validation in SecureContext_AllocateContext

### DIFF
--- a/portable/ARMv8M/secure/context/secure_context.c
+++ b/portable/ARMv8M/secure/context/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/GCC/ARM_CM23/secure/secure_context.c
+++ b/portable/GCC/ARM_CM23/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/GCC/ARM_CM33/secure/secure_context.c
+++ b/portable/GCC/ARM_CM33/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/GCC/ARM_CM35P/secure/secure_context.c
+++ b/portable/GCC/ARM_CM35P/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/GCC/ARM_CM52/secure/secure_context.c
+++ b/portable/GCC/ARM_CM52/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/GCC/ARM_CM55/secure/secure_context.c
+++ b/portable/GCC/ARM_CM55/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/GCC/ARM_CM85/secure/secure_context.c
+++ b/portable/GCC/ARM_CM85/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/GCC/ARM_STAR_MC3/secure/secure_context.c
+++ b/portable/GCC/ARM_STAR_MC3/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/IAR/ARM_CM23/secure/secure_context.c
+++ b/portable/IAR/ARM_CM23/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/IAR/ARM_CM33/secure/secure_context.c
+++ b/portable/IAR/ARM_CM33/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/IAR/ARM_CM35P/secure/secure_context.c
+++ b/portable/IAR/ARM_CM35P/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/IAR/ARM_CM52/secure/secure_context.c
+++ b/portable/IAR/ARM_CM52/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/IAR/ARM_CM55/secure/secure_context.c
+++ b/portable/IAR/ARM_CM55/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/IAR/ARM_CM85/secure/secure_context.c
+++ b/portable/IAR/ARM_CM85/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {

--- a/portable/IAR/ARM_STAR_MC3/secure/secure_context.c
+++ b/portable/IAR/ARM_STAR_MC3/secure/secure_context.c
@@ -213,8 +213,15 @@ secureportNON_SECURE_CALLABLE void SecureContext_Init( void )
         /* Were we able to get a free context? */
         if( ulSecureContextIndex < secureconfigMAX_SECURE_CONTEXTS )
         {
-            /* Allocate the stack space. */
-            pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            /* Allocate the stack space if possible. */
+            if( ulSecureStackSize > ( UINT32_MAX - securecontextSTACK_SEAL_SIZE ) )
+            {
+                pucStackMemory = NULL;
+            }
+            else
+            {
+                pucStackMemory = pvPortMalloc( ulSecureStackSize + securecontextSTACK_SEAL_SIZE );
+            }
 
             if( pucStackMemory != NULL )
             {


### PR DESCRIPTION
Validate that ulSecureStackSize + securecontextSTACK_SEAL_SIZE does not overflow before calling pvPortMalloc in the ARMv8-M secure context ports.

Reported by Jordan Mecom (Block, Inc.)

Test Steps
-----------
Change is validated on a LPCXpresso55S69 (NXP LPC55S69, Cortex-M33 with TrustZone) board.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
