### PR TITLE
fix: Correct xStreamBufferReceive and xMessageBufferReceiveFromISR example and timeout

### DIFF
--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -560,14 +560,14 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  *
  * Example use:
  * @code{c}
- * void vAFunction( MessageBuffer_t xMessageBuffer )
+ * void vAFunction( MessageBufferHandle_t xMessageBuffer )
  * {
  * uint8_t ucRxData[ 20 ];
  * size_t xReceivedBytes;
  * const TickType_t xBlockTime = pdMS_TO_TICKS( 20 );
  *
  *  // Receive the next message from the message buffer.  Wait in the Blocked
- *  // state (so not using any CPU processing time) for a maximum of 100ms for
+ *  // state (so not using any CPU processing time) for a maximum of 20ms for
  *  // a message to become available.
  *  xReceivedBytes = xMessageBufferReceive( xMessageBuffer,
  *                                          ( void * ) ucRxData,
@@ -655,7 +655,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * Example use:
  * @code{c}
  * // A message buffer that has already been created.
- * MessageBuffer_t xMessageBuffer;
+ * MessageBufferHandle_t xMessageBuffer;
  *
  * void vAnInterruptServiceRoutine( void )
  * {

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -1218,7 +1218,7 @@ UBaseType_t uxStreamBufferGetStreamBufferNotificationIndex( StreamBufferHandle_t
  * stream_buffer.h
  *
  * @code{c}
- * void vStreamBufferSetStreamBufferNotificationIndex ( StreamBuffer_t xStreamBuffer, UBaseType_t uxNotificationIndex );
+ * void vStreamBufferSetStreamBufferNotificationIndex ( StreamBufferHandle_t xStreamBuffer, UBaseType_t uxNotificationIndex );
  * @endcode
  *
  * Set the task notification index used for the supplied stream buffer.

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -760,7 +760,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
  *
  * Example use:
  * @code{c}
- * void vAFunction( StreamBuffer_t xStreamBuffer )
+ * void vAFunction( StreamBufferHandle_t xStreamBuffer )
  * {
  * uint8_t ucRxData[ 20 ];
  * size_t xReceivedBytes;
@@ -768,7 +768,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
  *
  *  // Receive up to another sizeof( ucRxData ) bytes from the stream buffer.
  *  // Wait in the Blocked state (so not using any CPU processing time) for a
- *  // maximum of 100ms for the full sizeof( ucRxData ) number of bytes to be
+ *  // maximum of 20ms for the full sizeof( ucRxData ) number of bytes to be
  *  // available.
  *  xReceivedBytes = xStreamBufferReceive( xStreamBuffer,
  *                                         ( void * ) ucRxData,


### PR DESCRIPTION
fix: Correct xStreamBufferReceive and xMessageBufferReceiveFromISR example and timeout

Description
-----------
1. Changed `MessageBuffer_t` to `MessageBufferHandle_t` in two function examples. The examples reference `MessageBuffer_t`, but the header only defines and exports `MessageBufferHandle_t` as the public interface type.
2. The comment describing a 100ms timeout doesn't match the actual code `pdMS_TO_TICKS(20)`. The comment has been updated to accurately state 20ms.

Test Steps
-----------
The sample verification code compiles and runs without issues. The corrected examples now work correctly with MessageBufferHandle_t.
Verified that the `pdMS_TO_TICKS(20)` value matches the updated 20ms description.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
