### PR TITLE
fix stream/message buffer type and timeout in example

### DIFF
--- a/include/message_buffer.h
+++ b/include/message_buffer.h
@@ -560,14 +560,14 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  *
  * Example use:
  * @code{c}
- * void vAFunction( MessageBuffer_t xMessageBuffer )
+ * void vAFunction( MessageBufferHandle_t xMessageBuffer )
  * {
  * uint8_t ucRxData[ 20 ];
  * size_t xReceivedBytes;
  * const TickType_t xBlockTime = pdMS_TO_TICKS( 20 );
  *
  *  // Receive the next message from the message buffer.  Wait in the Blocked
- *  // state (so not using any CPU processing time) for a maximum of 100ms for
+ *  // state (so not using any CPU processing time) for a maximum of 20ms for
  *  // a message to become available.
  *  xReceivedBytes = xMessageBufferReceive( xMessageBuffer,
  *                                          ( void * ) ucRxData,
@@ -655,7 +655,7 @@ typedef StreamBufferHandle_t MessageBufferHandle_t;
  * Example use:
  * @code{c}
  * // A message buffer that has already been created.
- * MessageBuffer_t xMessageBuffer;
+ * MessageBufferHandle_t xMessageBuffer;
  *
  * void vAnInterruptServiceRoutine( void )
  * {

--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -760,7 +760,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
  *
  * Example use:
  * @code{c}
- * void vAFunction( StreamBuffer_t xStreamBuffer )
+ * void vAFunction( StreamBufferHandle_t xStreamBuffer )
  * {
  * uint8_t ucRxData[ 20 ];
  * size_t xReceivedBytes;
@@ -768,7 +768,7 @@ size_t xStreamBufferSendFromISR( StreamBufferHandle_t xStreamBuffer,
  *
  *  // Receive up to another sizeof( ucRxData ) bytes from the stream buffer.
  *  // Wait in the Blocked state (so not using any CPU processing time) for a
- *  // maximum of 100ms for the full sizeof( ucRxData ) number of bytes to be
+ *  // maximum of 20ms for the full sizeof( ucRxData ) number of bytes to be
  *  // available.
  *  xReceivedBytes = xStreamBufferReceive( xStreamBuffer,
  *                                         ( void * ) ucRxData,
@@ -840,7 +840,7 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
  * Example use:
  * @code{c}
  * // A stream buffer that has already been created.
- * StreamBuffer_t xStreamBuffer;
+ * StreamBufferHandle_t xStreamBuffer;
  *
  * void vAnInterruptServiceRoutine( void )
  * {
@@ -1218,7 +1218,7 @@ UBaseType_t uxStreamBufferGetStreamBufferNotificationIndex( StreamBufferHandle_t
  * stream_buffer.h
  *
  * @code{c}
- * void vStreamBufferSetStreamBufferNotificationIndex ( StreamBuffer_t xStreamBuffer, UBaseType_t uxNotificationIndex );
+ * void vStreamBufferSetStreamBufferNotificationIndex ( StreamBufferHandle_t xStreamBuffer, UBaseType_t uxNotificationIndex );
  * @endcode
  *
  * Set the task notification index used for the supplied stream buffer.


### PR DESCRIPTION
fix stream/message buffer type and timeout in example

Description
-----------
Changed `MessageBuffer_t` to `MessageBufferHandle_t` in two function examples. 
Changed `StreamBuffer_t` to `StreamBufferHandle_t` in two function examples. 
The examples incorrectly reference  MessageBuffer_t  and  StreamBuffer_t , but the public API only exposes  MessageBufferHandle_t  and  StreamBufferHandle_t  (which are typedefs for pointers to those structs).
Both comments describing a 100ms timeout don't match the actual code pdMS_TO_TICKS(20). The comments have been updated to accurately state 20ms.

Test Steps
-----------
- The sample code compiles and runs without issues. The corrected examples now work correctly.
- Verified that both the `pdMS_TO_TICKS(20)` value matches the updated 20ms description.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
