### PR TITLE
Batching buffers read when reaching threshold

### DIFF
--- a/include/stream_buffer.h
+++ b/include/stream_buffer.h
@@ -292,10 +292,8 @@ typedef void (* StreamBufferCallbackFunction_t)( StreamBufferHandle_t xStreamBuf
  * - The task reading from a non-empty stream buffer returns immediately
  *   regardless of the amount of data in the buffer.
  * - The task reading from a non-empty steam batching buffer blocks until the
- *   amount of data in the buffer exceeds the trigger level or the block time
+ *   amount of data in the buffer reaches the trigger level or the block time
  *   expires.
- *
- * @param xBufferSizeBytes The total number of bytes the stream batching buffer
  * will be able to hold at any one time.
  *
  * @param xTriggerLevelBytes The number of bytes that must be in the stream
@@ -380,10 +378,8 @@ typedef void (* StreamBufferCallbackFunction_t)( StreamBufferHandle_t xStreamBuf
  * - The task reading from a non-empty stream buffer returns immediately
  *   regardless of the amount of data in the buffer.
  * - The task reading from a non-empty steam batching buffer blocks until the
- *   amount of data in the buffer exceeds the trigger level or the block time
+ *   amount of data in the buffer reaches the trigger level or the block time
  *   expires.
- *
- * @param xBufferSizeBytes The size, in bytes, of the buffer pointed to by the
  * pucStreamBufferStorageArea parameter.
  *
  * @param xTriggerLevelBytes The number of bytes that must be in the stream

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -224,7 +224,7 @@
 /* Bits stored in the ucFlags field of the stream buffer. */
     #define sbFLAGS_IS_MESSAGE_BUFFER          ( ( uint8_t ) 1 ) /* Set if the stream buffer was created as a message buffer, in which case it holds discrete messages rather than a stream. */
     #define sbFLAGS_IS_STATICALLY_ALLOCATED    ( ( uint8_t ) 2 ) /* Set if the stream buffer was created using statically allocated memory. */
-    #define sbFLAGS_IS_BATCHING_BUFFER         ( ( uint8_t ) 4 ) /* Set if the stream buffer was created as a batching buffer, meaning the receiver task will only unblock when the trigger level exceededs. */
+    #define sbFLAGS_IS_BATCHING_BUFFER         ( ( uint8_t ) 4 ) /* Set if the stream buffer was created as a batching buffer, meaning the receiver task will only unblock when the trigger level is reached. */
 
 /*-----------------------------------------------------------*/
 
@@ -1077,9 +1077,9 @@ size_t xStreamBufferReceive( StreamBufferHandle_t xStreamBuffer,
     }
     else if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_BATCHING_BUFFER ) != ( uint8_t ) 0 )
     {
-        /* Force task to block if the batching buffer contains less bytes than
+        /* Force task to block if the batching buffer contains fewer bytes than
          * the trigger level. */
-        xBytesToStoreMessageLength = pxStreamBuffer->xTriggerLevelBytes;
+        xBytesToStoreMessageLength = pxStreamBuffer->xTriggerLevelBytes - 1U;
     }
     else
     {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This change reduces the differences between traditional stream/message buffers and batching stream buffers. Batching stream buffers are updated to trigger and read data when enough data is present to EQUAL the threshold rather than exceed it.
 
Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Not tested yet - will need to introduce a unit testing PR.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
* https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1375
* Alternative implementation which retains threshold behavior - https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1396

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
