### PR TITLE
Fix long path errors on Windows demos

### DIFF
--- a/.github/workflows/kernel-demos.yml
+++ b/.github/workflows/kernel-demos.yml
@@ -13,6 +13,10 @@ jobs:
     name: WIN32 MSVC
     runs-on: windows-latest
     steps:
+      - name: Enable long paths on Windows
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Checkout the FreeRTOS/FreeRTOS Repository
         uses: actions/checkout@v4.1.1
         with:
@@ -42,6 +46,10 @@ jobs:
     name: WIN32 MingW
     runs-on: windows-latest
     steps:
+      - name: Enable long paths on Windows
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Checkout the FreeRTOS/FreeRTOS Repository
         uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Both the WIN32-MSVC and WIN32-MingW demos
are failing due to long file paths. This is
because of a transitive dependency path which is
submodules further extending the path length. Enabling windows long path support fixes this.

Test Steps
-----------
Testing through the demos workflows. This should pass. Currently all PRs fail the MSVC and MingW checks ([example](https://github.com/FreeRTOS/FreeRTOS-Kernel/actions/runs/24793760631/job/72557996445?pr=1406#logs)).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
  - Not applicable

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
