### PR TITLE
Fix MISRA C 2012 Rule 20.4: Replace `#define static` with STATIC macro

### DIFF
--- a/croutine.c
+++ b/croutine.c
@@ -38,24 +38,26 @@
  * than file scope.
  */
     #ifdef portREMOVE_STATIC_QUALIFIER
-        #define static
+        #define STATIC
+    #else
+        #define STATIC    static
     #endif
 
 
 /* Lists for ready and blocked co-routines. --------------------*/
-    static List_t pxReadyCoRoutineLists[ configMAX_CO_ROUTINE_PRIORITIES ]; /**< Prioritised ready co-routines. */
-    static List_t xDelayedCoRoutineList1;                                   /**< Delayed co-routines. */
-    static List_t xDelayedCoRoutineList2;                                   /**< Delayed co-routines (two lists are used - one for delays that have overflowed the current tick count. */
-    static List_t * pxDelayedCoRoutineList = NULL;                          /**< Points to the delayed co-routine list currently being used. */
-    static List_t * pxOverflowDelayedCoRoutineList = NULL;                  /**< Points to the delayed co-routine list currently being used to hold co-routines that have overflowed the current tick count. */
-    static List_t xPendingReadyCoRoutineList;                               /**< Holds co-routines that have been readied by an external event.  They cannot be added directly to the ready lists as the ready lists cannot be accessed by interrupts. */
+    STATIC List_t pxReadyCoRoutineLists[ configMAX_CO_ROUTINE_PRIORITIES ]; /**< Prioritised ready co-routines. */
+    STATIC List_t xDelayedCoRoutineList1;                                   /**< Delayed co-routines. */
+    STATIC List_t xDelayedCoRoutineList2;                                   /**< Delayed co-routines (two lists are used - one for delays that have overflowed the current tick count. */
+    STATIC List_t * pxDelayedCoRoutineList = NULL;                          /**< Points to the delayed co-routine list currently being used. */
+    STATIC List_t * pxOverflowDelayedCoRoutineList = NULL;                  /**< Points to the delayed co-routine list currently being used to hold co-routines that have overflowed the current tick count. */
+    STATIC List_t xPendingReadyCoRoutineList;                               /**< Holds co-routines that have been readied by an external event.  They cannot be added directly to the ready lists as the ready lists cannot be accessed by interrupts. */
 
 /* Other file private variables. --------------------------------*/
     CRCB_t * pxCurrentCoRoutine = NULL;
-    static UBaseType_t uxTopCoRoutineReadyPriority = ( UBaseType_t ) 0U;
-    static TickType_t xCoRoutineTickCount = ( TickType_t ) 0U;
-    static TickType_t xLastTickCount = ( TickType_t ) 0U;
-    static TickType_t xPassedTicks = ( TickType_t ) 0U;
+    STATIC UBaseType_t uxTopCoRoutineReadyPriority = ( UBaseType_t ) 0U;
+    STATIC TickType_t xCoRoutineTickCount = ( TickType_t ) 0U;
+    STATIC TickType_t xLastTickCount = ( TickType_t ) 0U;
+    STATIC TickType_t xPassedTicks = ( TickType_t ) 0U;
 
 /* The initial state of the co-routine when it is created. */
     #define corINITIAL_STATE    ( 0 )
@@ -80,7 +82,7 @@
  * Utility to ready all the lists used by the scheduler.  This is called
  * automatically upon the creation of the first co-routine.
  */
-    static void prvInitialiseCoRoutineLists( void );
+    STATIC void prvInitialiseCoRoutineLists( void );
 
 /*
  * Co-routines that are readied by an interrupt cannot be placed directly into
@@ -88,7 +90,7 @@
  * in the pending ready list in order that they can later be moved to the ready
  * list by the co-routine scheduler.
  */
-    static void prvCheckPendingReadyList( void );
+    STATIC void prvCheckPendingReadyList( void );
 
 /*
  * Macro that looks at the list of co-routines that are currently delayed to
@@ -98,7 +100,7 @@
  * meaning once one co-routine has been found whose timer has not expired
  * we need not look any further down the list.
  */
-    static void prvCheckDelayedList( void );
+    STATIC void prvCheckDelayedList( void );
 
 /*-----------------------------------------------------------*/
 
@@ -212,7 +214,7 @@
     }
 /*-----------------------------------------------------------*/
 
-    static void prvCheckPendingReadyList( void )
+    STATIC void prvCheckPendingReadyList( void )
     {
         /* Are there any co-routines waiting to get moved to the ready list?  These
          * are co-routines that have been readied by an ISR.  The ISR cannot access
@@ -235,7 +237,7 @@
     }
 /*-----------------------------------------------------------*/
 
-    static void prvCheckDelayedList( void )
+    STATIC void prvCheckDelayedList( void )
     {
         CRCB_t * pxCRCB;
 
@@ -333,7 +335,7 @@
     }
 /*-----------------------------------------------------------*/
 
-    static void prvInitialiseCoRoutineLists( void )
+    STATIC void prvInitialiseCoRoutineLists( void )
     {
         UBaseType_t uxPriority;
 

--- a/tasks.c
+++ b/tasks.c
@@ -609,9 +609,11 @@ STATIC void prvInitialiseTaskLists( void ) PRIVILEGED_FUNCTION;
  * void prvPassiveIdleTask( void *pvParameters );
  *
  */
-STATIC portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
+STATIC portTASK_FUNCTION_PROTO( prvIdleTask,
+                                pvParameters ) PRIVILEGED_FUNCTION;
 #if ( configNUMBER_OF_CORES > 1 )
-    STATIC portTASK_FUNCTION_PROTO( prvPassiveIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
+    STATIC portTASK_FUNCTION_PROTO( prvPassiveIdleTask,
+                                    pvParameters ) PRIVILEGED_FUNCTION;
 #endif
 
 /*
@@ -5746,7 +5748,8 @@ void vTaskMissedYield( void )
  */
 
 #if ( configNUMBER_OF_CORES > 1 )
-    STATIC portTASK_FUNCTION( prvPassiveIdleTask, pvParameters )
+    STATIC portTASK_FUNCTION( prvPassiveIdleTask,
+                              pvParameters )
     {
         ( void ) pvParameters;
 
@@ -5816,7 +5819,8 @@ void vTaskMissedYield( void )
  *
  */
 
-STATIC portTASK_FUNCTION( prvIdleTask, pvParameters )
+STATIC portTASK_FUNCTION( prvIdleTask,
+                          pvParameters )
 {
     /* Stop warnings. */
     ( void ) pvParameters;

--- a/tasks.c
+++ b/tasks.c
@@ -148,7 +148,9 @@
  * global, rather than file scope.
  */
 #ifdef portREMOVE_STATIC_QUALIFIER
-    #define static
+    #define STATIC
+#else
+    #define STATIC    static
 #endif
 
 /* The name allocated to the Idle task.  This can be overridden by defining
@@ -473,23 +475,23 @@ typedef tskTCB TCB_t;
  * xDelayedTaskList1 and xDelayedTaskList2 could be moved to function scope but
  * doing so breaks some kernel aware debuggers and debuggers that rely on removing
  * the static qualifier. */
-PRIVILEGED_DATA static List_t pxReadyTasksLists[ configMAX_PRIORITIES ]; /**< Prioritised ready tasks. */
-PRIVILEGED_DATA static List_t xDelayedTaskList1;                         /**< Delayed tasks. */
-PRIVILEGED_DATA static List_t xDelayedTaskList2;                         /**< Delayed tasks (two lists are used - one for delays that have overflowed the current tick count. */
-PRIVILEGED_DATA static List_t * volatile pxDelayedTaskList;              /**< Points to the delayed task list currently being used. */
-PRIVILEGED_DATA static List_t * volatile pxOverflowDelayedTaskList;      /**< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
-PRIVILEGED_DATA static List_t xPendingReadyList;                         /**< Tasks that have been readied while the scheduler was suspended.  They will be moved to the ready list when the scheduler is resumed. */
+PRIVILEGED_DATA STATIC List_t pxReadyTasksLists[ configMAX_PRIORITIES ]; /**< Prioritised ready tasks. */
+PRIVILEGED_DATA STATIC List_t xDelayedTaskList1;                         /**< Delayed tasks. */
+PRIVILEGED_DATA STATIC List_t xDelayedTaskList2;                         /**< Delayed tasks (two lists are used - one for delays that have overflowed the current tick count. */
+PRIVILEGED_DATA STATIC List_t * volatile pxDelayedTaskList;              /**< Points to the delayed task list currently being used. */
+PRIVILEGED_DATA STATIC List_t * volatile pxOverflowDelayedTaskList;      /**< Points to the delayed task list currently being used to hold tasks that have overflowed the current tick count. */
+PRIVILEGED_DATA STATIC List_t xPendingReadyList;                         /**< Tasks that have been readied while the scheduler was suspended.  They will be moved to the ready list when the scheduler is resumed. */
 
 #if ( INCLUDE_vTaskDelete == 1 )
 
-    PRIVILEGED_DATA static List_t xTasksWaitingTermination; /**< Tasks that have been deleted - but their memory not yet freed. */
-    PRIVILEGED_DATA static volatile UBaseType_t uxDeletedTasksWaitingCleanUp = ( UBaseType_t ) 0U;
+    PRIVILEGED_DATA STATIC List_t xTasksWaitingTermination; /**< Tasks that have been deleted - but their memory not yet freed. */
+    PRIVILEGED_DATA STATIC volatile UBaseType_t uxDeletedTasksWaitingCleanUp = ( UBaseType_t ) 0U;
 
 #endif
 
 #if ( INCLUDE_vTaskSuspend == 1 )
 
-    PRIVILEGED_DATA static List_t xSuspendedTaskList; /**< Tasks that are currently suspended. */
+    PRIVILEGED_DATA STATIC List_t xSuspendedTaskList; /**< Tasks that are currently suspended. */
 
 #endif
 
@@ -500,21 +502,21 @@ PRIVILEGED_DATA static List_t xPendingReadyList;                         /**< Ta
 #endif
 
 /* Other file private variables. --------------------------------*/
-PRIVILEGED_DATA static volatile UBaseType_t uxCurrentNumberOfTasks = ( UBaseType_t ) 0U;
-PRIVILEGED_DATA static volatile TickType_t xTickCount = ( TickType_t ) configINITIAL_TICK_COUNT;
-PRIVILEGED_DATA static volatile UBaseType_t uxTopReadyPriority = tskIDLE_PRIORITY;
-PRIVILEGED_DATA static volatile BaseType_t xSchedulerRunning = pdFALSE;
-PRIVILEGED_DATA static volatile TickType_t xPendedTicks = ( TickType_t ) 0U;
-PRIVILEGED_DATA static volatile BaseType_t xYieldPendings[ configNUMBER_OF_CORES ] = { pdFALSE };
-PRIVILEGED_DATA static volatile BaseType_t xNumOfOverflows = ( BaseType_t ) 0;
-PRIVILEGED_DATA static UBaseType_t uxTaskNumber = ( UBaseType_t ) 0U;
-PRIVILEGED_DATA static volatile TickType_t xNextTaskUnblockTime = ( TickType_t ) 0U; /* Initialised to portMAX_DELAY before the scheduler starts. */
-PRIVILEGED_DATA static TaskHandle_t xIdleTaskHandles[ configNUMBER_OF_CORES ];       /**< Holds the handles of the idle tasks.  The idle tasks are created automatically when the scheduler is started. */
+PRIVILEGED_DATA STATIC volatile UBaseType_t uxCurrentNumberOfTasks = ( UBaseType_t ) 0U;
+PRIVILEGED_DATA STATIC volatile TickType_t xTickCount = ( TickType_t ) configINITIAL_TICK_COUNT;
+PRIVILEGED_DATA STATIC volatile UBaseType_t uxTopReadyPriority = tskIDLE_PRIORITY;
+PRIVILEGED_DATA STATIC volatile BaseType_t xSchedulerRunning = pdFALSE;
+PRIVILEGED_DATA STATIC volatile TickType_t xPendedTicks = ( TickType_t ) 0U;
+PRIVILEGED_DATA STATIC volatile BaseType_t xYieldPendings[ configNUMBER_OF_CORES ] = { pdFALSE };
+PRIVILEGED_DATA STATIC volatile BaseType_t xNumOfOverflows = ( BaseType_t ) 0;
+PRIVILEGED_DATA STATIC UBaseType_t uxTaskNumber = ( UBaseType_t ) 0U;
+PRIVILEGED_DATA STATIC volatile TickType_t xNextTaskUnblockTime = ( TickType_t ) 0U; /* Initialised to portMAX_DELAY before the scheduler starts. */
+PRIVILEGED_DATA STATIC TaskHandle_t xIdleTaskHandles[ configNUMBER_OF_CORES ];       /**< Holds the handles of the idle tasks.  The idle tasks are created automatically when the scheduler is started. */
 
 /* Improve support for OpenOCD. The kernel tracks Ready tasks via priority lists.
  * For tracking the state of remote threads, OpenOCD uses uxTopUsedPriority
  * to determine the number of priority lists to read back from the remote target. */
-static const volatile UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
+STATIC const volatile UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
 
 /* Context switches are held pending while the scheduler is suspended.  Also,
  * interrupts must not manipulate the xStateListItem of a TCB, or any of the
@@ -528,14 +530,14 @@ static const volatile UBaseType_t uxTopUsedPriority = configMAX_PRIORITIES - 1U;
  * Updates to uxSchedulerSuspended must be protected by both the task lock and the ISR lock
  * and must not be done from an ISR. Reads must be protected by either lock and may be done
  * from either an ISR or a task. */
-PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t ) 0U;
+PRIVILEGED_DATA STATIC volatile UBaseType_t uxSchedulerSuspended = ( UBaseType_t ) 0U;
 
 #if ( configGENERATE_RUN_TIME_STATS == 1 )
 
 /* Do not move these variables to function scope as doing so prevents the
  * code working with debuggers that need to remove the static qualifier. */
-PRIVILEGED_DATA static configRUN_TIME_COUNTER_TYPE ulTaskSwitchedInTime[ configNUMBER_OF_CORES ] = { 0U };    /**< Holds the value of a timer/counter the last time a task was switched in. */
-PRIVILEGED_DATA static volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ configNUMBER_OF_CORES ] = { 0U }; /**< Holds the total amount of execution time as defined by the run time counter clock. */
+PRIVILEGED_DATA STATIC configRUN_TIME_COUNTER_TYPE ulTaskSwitchedInTime[ configNUMBER_OF_CORES ] = { 0U };    /**< Holds the value of a timer/counter the last time a task was switched in. */
+PRIVILEGED_DATA STATIC volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ configNUMBER_OF_CORES ] = { 0U }; /**< Holds the total amount of execution time as defined by the run time counter clock. */
 
 #endif
 
@@ -546,7 +548,7 @@ PRIVILEGED_DATA static volatile configRUN_TIME_COUNTER_TYPE ulTotalRunTime[ conf
 /*
  * Creates the idle tasks during scheduler start.
  */
-static BaseType_t prvCreateIdleTasks( void );
+STATIC BaseType_t prvCreateIdleTasks( void );
 
 #if ( configNUMBER_OF_CORES > 1 )
 
@@ -554,7 +556,7 @@ static BaseType_t prvCreateIdleTasks( void );
  * Checks to see if another task moved the current task out of the ready
  * list while it was waiting to enter a critical section and yields, if so.
  */
-    static void prvCheckForRunStateChange( void );
+    STATIC void prvCheckForRunStateChange( void );
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 #if ( configNUMBER_OF_CORES > 1 )
@@ -563,7 +565,7 @@ static BaseType_t prvCreateIdleTasks( void );
  * Yields a core, or cores if multiple priorities are not allowed to run
  * simultaneously, to allow the task pxTCB to run.
  */
-    static void prvYieldForTask( const TCB_t * pxTCB );
+    STATIC void prvYieldForTask( const TCB_t * pxTCB );
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 #if ( configNUMBER_OF_CORES > 1 )
@@ -571,7 +573,7 @@ static BaseType_t prvCreateIdleTasks( void );
 /*
  * Selects the highest priority available task for the given core.
  */
-    static void prvSelectHighestPriorityTask( BaseType_t xCoreID );
+    STATIC void prvSelectHighestPriorityTask( BaseType_t xCoreID );
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
 /**
@@ -581,7 +583,7 @@ static BaseType_t prvCreateIdleTasks( void );
  */
 #if ( INCLUDE_vTaskSuspend == 1 )
 
-    static BaseType_t prvTaskIsTaskSuspended( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
+    STATIC BaseType_t prvTaskIsTaskSuspended( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;
 
 #endif /* INCLUDE_vTaskSuspend */
 
@@ -589,7 +591,7 @@ static BaseType_t prvCreateIdleTasks( void );
  * Utility to ready all the lists used by the scheduler.  This is called
  * automatically upon the creation of the first task.
  */
-static void prvInitialiseTaskLists( void ) PRIVILEGED_FUNCTION;
+STATIC void prvInitialiseTaskLists( void ) PRIVILEGED_FUNCTION;
 
 /*
  * The idle task, which as all tasks is implemented as a never ending loop.
@@ -607,9 +609,9 @@ static void prvInitialiseTaskLists( void ) PRIVILEGED_FUNCTION;
  * void prvPassiveIdleTask( void *pvParameters );
  *
  */
-static portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
+STATIC portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
 #if ( configNUMBER_OF_CORES > 1 )
-    static portTASK_FUNCTION_PROTO( prvPassiveIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
+    STATIC portTASK_FUNCTION_PROTO( prvPassiveIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
 #endif
 
 /*
@@ -621,7 +623,7 @@ static portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
  */
 #if ( INCLUDE_vTaskDelete == 1 )
 
-    static void prvDeleteTCB( TCB_t * pxTCB ) PRIVILEGED_FUNCTION;
+    STATIC void prvDeleteTCB( TCB_t * pxTCB ) PRIVILEGED_FUNCTION;
 
 #endif
 
@@ -630,13 +632,13 @@ static portTASK_FUNCTION_PROTO( prvIdleTask, pvParameters ) PRIVILEGED_FUNCTION;
  * in the list of tasks waiting to be deleted.  If so the task is cleaned up
  * and its TCB deleted.
  */
-static void prvCheckTasksWaitingTermination( void ) PRIVILEGED_FUNCTION;
+STATIC void prvCheckTasksWaitingTermination( void ) PRIVILEGED_FUNCTION;
 
 /*
  * The currently executing task is entering the Blocked state.  Add the task to
  * either the current or the overflow delayed task list.
  */
-static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
+STATIC void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
                                             const BaseType_t xCanBlockIndefinitely ) PRIVILEGED_FUNCTION;
 
 /*
@@ -649,7 +651,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  */
 #if ( configUSE_TRACE_FACILITY == 1 )
 
-    static UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
+    STATIC UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
                                                      List_t * pxList,
                                                      eTaskState eState ) PRIVILEGED_FUNCTION;
 
@@ -661,7 +663,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  */
 #if ( INCLUDE_xTaskGetHandle == 1 )
 
-    static TCB_t * prvSearchForNameWithinSingleList( List_t * pxList,
+    STATIC TCB_t * prvSearchForNameWithinSingleList( List_t * pxList,
                                                      const char pcNameToQuery[] ) PRIVILEGED_FUNCTION;
 
 #endif
@@ -673,7 +675,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  */
 #if ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark2 == 1 ) )
 
-    static configSTACK_DEPTH_TYPE prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte ) PRIVILEGED_FUNCTION;
+    STATIC configSTACK_DEPTH_TYPE prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte ) PRIVILEGED_FUNCTION;
 
 #endif
 
@@ -689,7 +691,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  */
 #if ( configUSE_TICKLESS_IDLE != 0 )
 
-    static TickType_t prvGetExpectedIdleTime( void ) PRIVILEGED_FUNCTION;
+    STATIC TickType_t prvGetExpectedIdleTime( void ) PRIVILEGED_FUNCTION;
 
 #endif
 
@@ -697,7 +699,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
  * Set xNextTaskUnblockTime to the time at which the next Blocked state task
  * will exit the Blocked state.
  */
-static void prvResetNextTaskUnblockTime( void ) PRIVILEGED_FUNCTION;
+STATIC void prvResetNextTaskUnblockTime( void ) PRIVILEGED_FUNCTION;
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )
 
@@ -714,7 +716,7 @@ static void prvResetNextTaskUnblockTime( void ) PRIVILEGED_FUNCTION;
  * Called after a Task_t structure has been allocated either statically or
  * dynamically to fill in the structure's members.
  */
-static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
+STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                                   const char * const pcName,
                                   const configSTACK_DEPTH_TYPE uxStackDepth,
                                   void * const pvParameters,
@@ -727,14 +729,14 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
  * Called after a new task has been created and initialised to place the task
  * under the control of the scheduler.
  */
-static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
+STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
 /*
  * Create a task with static buffer for both TCB and stack. Returns a handle to
  * the task if it is created successfully. Otherwise, returns NULL.
  */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
-    static TCB_t * prvCreateStaticTask( TaskFunction_t pxTaskCode,
+    STATIC TCB_t * prvCreateStaticTask( TaskFunction_t pxTaskCode,
                                         const char * const pcName,
                                         const configSTACK_DEPTH_TYPE uxStackDepth,
                                         void * const pvParameters,
@@ -749,7 +751,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
  * a handle to the task if it is created successfully. Otherwise, returns NULL.
  */
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
-    static TCB_t * prvCreateRestrictedStaticTask( const TaskParameters_t * const pxTaskDefinition,
+    STATIC TCB_t * prvCreateRestrictedStaticTask( const TaskParameters_t * const pxTaskDefinition,
                                                   TaskHandle_t * const pxCreatedTask ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) ) */
 
@@ -759,7 +761,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
  * returns NULL.
  */
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
-    static TCB_t * prvCreateRestrictedTask( const TaskParameters_t * const pxTaskDefinition,
+    STATIC TCB_t * prvCreateRestrictedTask( const TaskParameters_t * const pxTaskDefinition,
                                             TaskHandle_t * const pxCreatedTask ) PRIVILEGED_FUNCTION;
 #endif /* #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) ) */
 
@@ -768,7 +770,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
  * the task if it is created successfully. Otherwise, returns NULL.
  */
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
-    static TCB_t * prvCreateTask( TaskFunction_t pxTaskCode,
+    STATIC TCB_t * prvCreateTask( TaskFunction_t pxTaskCode,
                                   const char * const pcName,
                                   const configSTACK_DEPTH_TYPE uxStackDepth,
                                   void * const pvParameters,
@@ -783,7 +785,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
  */
 #ifdef FREERTOS_TASKS_C_ADDITIONS_INIT
 
-    static void freertos_tasks_c_additions_init( void ) PRIVILEGED_FUNCTION;
+    STATIC void freertos_tasks_c_additions_init( void ) PRIVILEGED_FUNCTION;
 
 #endif
 
@@ -813,14 +815,14 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
  * and less than the supplied buffer length, the string has been
  * completely written.
  */
-    static size_t prvSnprintfReturnValueToCharsWritten( int iSnprintfReturnValue,
+    STATIC size_t prvSnprintfReturnValueToCharsWritten( int iSnprintfReturnValue,
                                                         size_t n );
 
 #endif /* #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) ) */
 /*-----------------------------------------------------------*/
 
 #if ( configNUMBER_OF_CORES > 1 )
-    static void prvCheckForRunStateChange( void )
+    STATIC void prvCheckForRunStateChange( void )
     {
         UBaseType_t uxPrevCriticalNesting;
         const TCB_t * pxThisTCB;
@@ -888,7 +890,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( configNUMBER_OF_CORES > 1 )
-    static void prvYieldForTask( const TCB_t * pxTCB )
+    STATIC void prvYieldForTask( const TCB_t * pxTCB )
     {
         BaseType_t xLowestPriorityToPreempt;
         BaseType_t xCurrentCoreTaskPriority;
@@ -1003,7 +1005,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( configNUMBER_OF_CORES > 1 )
-    static void prvSelectHighestPriorityTask( BaseType_t xCoreID )
+    STATIC void prvSelectHighestPriorityTask( BaseType_t xCoreID )
     {
         UBaseType_t uxCurrentPriority = uxTopReadyPriority;
         BaseType_t xTaskScheduled = pdFALSE;
@@ -1274,7 +1276,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
 
-    static TCB_t * prvCreateStaticTask( TaskFunction_t pxTaskCode,
+    STATIC TCB_t * prvCreateStaticTask( TaskFunction_t pxTaskCode,
                                         const char * const pcName,
                                         const configSTACK_DEPTH_TYPE uxStackDepth,
                                         void * const pvParameters,
@@ -1405,7 +1407,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_STATIC_ALLOCATION == 1 ) )
-    static TCB_t * prvCreateRestrictedStaticTask( const TaskParameters_t * const pxTaskDefinition,
+    STATIC TCB_t * prvCreateRestrictedStaticTask( const TaskParameters_t * const pxTaskDefinition,
                                                   TaskHandle_t * const pxCreatedTask )
     {
         TCB_t * pxNewTCB;
@@ -1521,7 +1523,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( portUSING_MPU_WRAPPERS == 1 ) && ( configSUPPORT_DYNAMIC_ALLOCATION == 1 ) )
-    static TCB_t * prvCreateRestrictedTask( const TaskParameters_t * const pxTaskDefinition,
+    STATIC TCB_t * prvCreateRestrictedTask( const TaskParameters_t * const pxTaskDefinition,
                                             TaskHandle_t * const pxCreatedTask )
     {
         TCB_t * pxNewTCB;
@@ -1640,7 +1642,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
-    static TCB_t * prvCreateTask( TaskFunction_t pxTaskCode,
+    STATIC TCB_t * prvCreateTask( TaskFunction_t pxTaskCode,
                                   const char * const pcName,
                                   const configSTACK_DEPTH_TYPE uxStackDepth,
                                   void * const pvParameters,
@@ -1813,7 +1815,7 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
 #endif /* configSUPPORT_DYNAMIC_ALLOCATION */
 /*-----------------------------------------------------------*/
 
-static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
+STATIC void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
                                   const char * const pcName,
                                   const configSTACK_DEPTH_TYPE uxStackDepth,
                                   void * const pvParameters,
@@ -2049,7 +2051,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #if ( configNUMBER_OF_CORES == 1 )
 
-    static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
+    STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         /* Ensure interrupts don't access the task lists while the lists are being
          * updated. */
@@ -2127,7 +2129,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #else /* #if ( configNUMBER_OF_CORES == 1 ) */
 
-    static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
+    STATIC void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
     {
         /* Ensure interrupts don't access the task lists while the lists are being
          * updated. */
@@ -2188,7 +2190,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) && ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 ) )
 
-    static size_t prvSnprintfReturnValueToCharsWritten( int iSnprintfReturnValue,
+    STATIC size_t prvSnprintfReturnValueToCharsWritten( int iSnprintfReturnValue,
                                                         size_t n )
     {
         size_t uxCharsWritten;
@@ -3320,7 +3322,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 
 #if ( INCLUDE_vTaskSuspend == 1 )
 
-    static BaseType_t prvTaskIsTaskSuspended( const TaskHandle_t xTask )
+    STATIC BaseType_t prvTaskIsTaskSuspended( const TaskHandle_t xTask )
     {
         BaseType_t xReturn = pdFALSE;
         const TCB_t * const pxTCB = xTask;
@@ -3548,7 +3550,7 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
 #endif /* ( ( INCLUDE_xTaskResumeFromISR == 1 ) && ( INCLUDE_vTaskSuspend == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvCreateIdleTasks( void )
+STATIC BaseType_t prvCreateIdleTasks( void )
 {
     BaseType_t xReturn = pdPASS;
     BaseType_t xCoreID;
@@ -3962,7 +3964,7 @@ void vTaskSuspendAll( void )
 
 #if ( configUSE_TICKLESS_IDLE != 0 )
 
-    static TickType_t prvGetExpectedIdleTime( void )
+    STATIC TickType_t prvGetExpectedIdleTime( void )
     {
         TickType_t xReturn;
         BaseType_t xHigherPriorityReadyTasks = pdFALSE;
@@ -4257,7 +4259,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_xTaskGetHandle == 1 )
-    static TCB_t * prvSearchForNameWithinSingleList( List_t * pxList,
+    STATIC TCB_t * prvSearchForNameWithinSingleList( List_t * pxList,
                                                      const char pcNameToQuery[] )
     {
         TCB_t * pxReturn = NULL;
@@ -5744,7 +5746,7 @@ void vTaskMissedYield( void )
  */
 
 #if ( configNUMBER_OF_CORES > 1 )
-    static portTASK_FUNCTION( prvPassiveIdleTask, pvParameters )
+    STATIC portTASK_FUNCTION( prvPassiveIdleTask, pvParameters )
     {
         ( void ) pvParameters;
 
@@ -5814,7 +5816,7 @@ void vTaskMissedYield( void )
  *
  */
 
-static portTASK_FUNCTION( prvIdleTask, pvParameters )
+STATIC portTASK_FUNCTION( prvIdleTask, pvParameters )
 {
     /* Stop warnings. */
     ( void ) pvParameters;
@@ -6080,7 +6082,7 @@ static portTASK_FUNCTION( prvIdleTask, pvParameters )
 #endif /* portUSING_MPU_WRAPPERS */
 /*-----------------------------------------------------------*/
 
-static void prvInitialiseTaskLists( void )
+STATIC void prvInitialiseTaskLists( void )
 {
     UBaseType_t uxPriority;
 
@@ -6112,7 +6114,7 @@ static void prvInitialiseTaskLists( void )
 }
 /*-----------------------------------------------------------*/
 
-static void prvCheckTasksWaitingTermination( void )
+STATIC void prvCheckTasksWaitingTermination( void )
 {
     /** THIS FUNCTION IS CALLED FROM THE RTOS IDLE TASK **/
 
@@ -6338,7 +6340,7 @@ static void prvCheckTasksWaitingTermination( void )
 
 #if ( configUSE_TRACE_FACILITY == 1 )
 
-    static UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
+    STATIC UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
                                                      List_t * pxList,
                                                      eTaskState eState )
     {
@@ -6377,7 +6379,7 @@ static void prvCheckTasksWaitingTermination( void )
 
 #if ( ( configUSE_TRACE_FACILITY == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark == 1 ) || ( INCLUDE_uxTaskGetStackHighWaterMark2 == 1 ) )
 
-    static configSTACK_DEPTH_TYPE prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte )
+    STATIC configSTACK_DEPTH_TYPE prvTaskCheckFreeStackSpace( const uint8_t * pucStackByte )
     {
         configSTACK_DEPTH_TYPE uxCount = 0U;
 
@@ -6475,7 +6477,7 @@ static void prvCheckTasksWaitingTermination( void )
 
 #if ( INCLUDE_vTaskDelete == 1 )
 
-    static void prvDeleteTCB( TCB_t * pxTCB )
+    STATIC void prvDeleteTCB( TCB_t * pxTCB )
     {
         /* This call is required specifically for the TriCore port.  It must be
          * above the vPortFree() calls.  The call is also used by ports/demos that
@@ -6528,7 +6530,7 @@ static void prvCheckTasksWaitingTermination( void )
 #endif /* INCLUDE_vTaskDelete */
 /*-----------------------------------------------------------*/
 
-static void prvResetNextTaskUnblockTime( void )
+STATIC void prvResetNextTaskUnblockTime( void )
 {
     if( listLIST_IS_EMPTY( pxDelayedTaskList ) != pdFALSE )
     {
@@ -7276,7 +7278,7 @@ static void prvResetNextTaskUnblockTime( void )
 
 #if ( configUSE_STATS_FORMATTING_FUNCTIONS > 0 )
 
-    static char * prvWriteNameToBuffer( char * pcBuffer,
+    STATIC char * prvWriteNameToBuffer( char * pcBuffer,
                                         const char * pcTaskName )
     {
         size_t x;
@@ -8592,7 +8594,7 @@ TickType_t uxTaskResetEventItemValue( void )
 #endif /* if ( ( configGENERATE_RUN_TIME_STATS == 1 ) && ( INCLUDE_xTaskGetIdleTaskHandle == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
+STATIC void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
                                             const BaseType_t xCanBlockIndefinitely )
 {
     TickType_t xTimeToWake;
@@ -8744,7 +8746,7 @@ static void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
     #include "freertos_tasks_c_additions.h"
 
     #ifdef FREERTOS_TASKS_C_ADDITIONS_INIT
-        static void freertos_tasks_c_additions_init( void )
+        STATIC void freertos_tasks_c_additions_init( void )
         {
             FREERTOS_TASKS_C_ADDITIONS_INIT();
         }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Replace `#define static` with `#define STATIC static` to prevent the macro from shadowing the C `static` keyword. This also ensures static variables in `vApplicationGetIdleTaskMemory()` and `vApplicationGetPassiveIdleTaskMemory()` remain static even when portREMOVE_STATIC_QUALIFIER is defined, preventing use-after-free bugs from stack-allocated storage.

Test Steps
-----------
Define `portREMOVE_STATIC_QUALIFIER ` in `FreeRTOSConfig.h` then FreeRTOS could fail initialization.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
