### PR TITLE
Make vPortYield weak in ARM_CRx_No_GIC port

### DIFF
--- a/portable/GCC/ARM_CRx_No_GIC/portASM.S
+++ b/portable/GCC/ARM_CRx_No_GIC/portASM.S
@@ -50,7 +50,7 @@
     .global vPortRestoreTaskContext
     .global vPortInitialiseFPSCR
     .global ulReadAPSR
-    .global vPortYield
+    .weak   vPortYield
     .global vPortEnableInterrupts
     .global vPortDisableInterrupts
     .global ulPortSetInterruptMaskFromISR


### PR DESCRIPTION
This change makes `vPortYield` a weak symbol so platforms with a dedicated software interrupt mechanism can substitute their own yield trigger by providing a strong `vPortYield` definition.

Default behaviour is unchanged. When no strong override is linked, the weak
default in `portASM.S` emits `SVC 0` dispatched by `FreeRTOS_SVC_Handler`.

Test Steps
-----------

This patch has been tested using the `ARM_CRx_No_GIC` Example.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.