### PR TITLE
Add affinity to IDLE tasks in SMP systems

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -558,6 +558,13 @@
  * tskNO_AFFINITY if left undefined. */
 #define configTIMER_SERVICE_TASK_CORE_AFFINITY    tskNO_AFFINITY
 
+/* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
+ * configIDLE_AFFINITY to 1 to pin each Idle task to its corresponding
+ * core. When set to 1, Idle task N will only run on core N, using an affinity
+ * mask of (1 << N).  Set to 0 to allow the scheduler to run Idle tasks on any
+ * available core.  Defaults to 0 if left undefined. */
+#define configIDLE_AFFINITY                       0
+
 /******************************************************************************/
 /* ARMv8-M secure side port related definitions. ******************************/
 /******************************************************************************/

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -377,6 +377,10 @@
     #define configIDLE_SHOULD_YIELD    1
 #endif
 
+#ifndef configIDLE_AFFINITY
+    #define configIDLE_AFFINITY    0
+#endif
+
 #if configMAX_TASK_NAME_LEN < 1
     #error configMAX_TASK_NAME_LEN must be set to a minimum of 1 in FreeRTOSConfig.h
 #endif

--- a/tasks.c
+++ b/tasks.c
@@ -3687,8 +3687,13 @@ static BaseType_t prvCreateIdleTasks( void )
                 /* Assign idle task to each core before SMP scheduler is running. */
                 xIdleTaskHandles[ xCoreID ]->xTaskRunState = xCoreID;
                 pxCurrentTCBs[ xCoreID ] = xIdleTaskHandles[ xCoreID ];
+                #if ( ( configIDLE_AFFINITY == 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
+                {
+                    xIdleTaskHandles[ xCoreID ]->uxCoreAffinityMask = ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID );
+                }
+                #endif
             }
-            #endif
+            #endif /* if ( configNUMBER_OF_CORES == 1 ) */
         }
     }
 


### PR DESCRIPTION
Add affinity to IDLE tasks in SMP systems

Description
-----------
currently in FreeRTOS idle threads created without affinity

that means it not possible to get idle percentage of specific core in SMP system via vTaskGetRunTimeStatistics. all IDLE threads will have almost same % time

also vApplicationIdleHook may be called from any cpu core, that may create unexpected conditions.

Test Steps
-----------
set configIDLE_AFFINITY to 1

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
