### PR TITLE
Added missing stack protection offsets.

### DIFF
--- a/portable/GCC/MicroBlazeV9/portasm.S
+++ b/portable/GCC/MicroBlazeV9/portasm.S
@@ -38,19 +38,49 @@
 back into the caller stack. */
 #if defined (__arch64__)
 #if( XPAR_MICROBLAZE_USE_FPU != 0 )
-	#define portCONTEXT_SIZE 272
-	#define portMINUS_CONTEXT_SIZE -272
+	#define portFSR_OFFSET 264
+	#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+		#define portSLR_OFFSET 272
+		#define portSHR_OFFSET 280
+		#define portCONTEXT_SIZE 288
+		#define portMINUS_CONTEXT_SIZE -288
+	#else
+		#define portCONTEXT_SIZE 272
+		#define portMINUS_CONTEXT_SIZE -272
+	#endif
 #else
-	#define portCONTEXT_SIZE 264
-	#define portMINUS_CONTEXT_SIZE -264
+	#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+		#define portSLR_OFFSET 264
+		#define portSHR_OFFSET 272
+		#define portCONTEXT_SIZE 280
+		#define portMINUS_CONTEXT_SIZE -280
+	#else
+		#define portCONTEXT_SIZE 264
+		#define portMINUS_CONTEXT_SIZE -264
+	#endif
 #endif
 #else
 #if( XPAR_MICROBLAZE_USE_FPU != 0 )
-	#define portCONTEXT_SIZE 136
-	#define portMINUS_CONTEXT_SIZE -136
+	#define portFSR_OFFSET 132
+	#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+		#define portSLR_OFFSET 136
+		#define portSHR_OFFSET 140
+		#define portCONTEXT_SIZE 144
+		#define portMINUS_CONTEXT_SIZE -144
+	#else
+		#define portCONTEXT_SIZE 136
+		#define portMINUS_CONTEXT_SIZE -136
+	#endif
 #else
-	#define portCONTEXT_SIZE 132
-	#define portMINUS_CONTEXT_SIZE -132
+	#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+		#define portSLR_OFFSET 132
+		#define portSHR_OFFSET 136
+		#define portCONTEXT_SIZE 140
+		#define portMINUS_CONTEXT_SIZE -140
+	#else
+		#define portCONTEXT_SIZE 132
+		#define portMINUS_CONTEXT_SIZE -132
+	#endif
 #endif
 #endif
 
@@ -88,7 +118,6 @@ back into the caller stack. */
 #define portR2_OFFSET	240
 #define portCRITICAL_NESTING_OFFSET 248
 #define portMSR_OFFSET 256
-#define portFSR_OFFSET 264
 #else
 #define portR31_OFFSET	4
 #define portR30_OFFSET	8
@@ -122,7 +151,6 @@ back into the caller stack. */
 #define portR2_OFFSET	120
 #define portCRITICAL_NESTING_OFFSET 124
 #define portMSR_OFFSET 128
-#define portFSR_OFFSET 132
 
 #endif
 


### PR DESCRIPTION
<!---Fix: Define missing stack protection symbols for MicroBlaze -->
Fix: Define missing stack protection symbols for MicroBlaze 

Description
-----------
Added missing 'portSLR_OFFSET' and 'portSHR_OFFSET' definitions to 'portasm.S' for the MicroBlaze port. These symbols were being referenced but were not defined, causing compilation errors when stack protection is enabled in FreeRTOS Kernel v11.3.0.

Test Steps
-----------
Set up a MicroBlaze project using Xilinx Vivado/Vitis.

Upgrade the FreeRTOS Kernel to v11.3.0.

Enable stack protection.

Attempt to compile the project. (Observe the 'undefined symbol' error before the fix).

Apply this fix and verify that the project compiles successfully and stack protection functions as expected.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
 Fixes #1416 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
