### PR TITLE
Add configUSE_SCHEDULER_CORE_MASK and vTaskSetSchedulerCoreMask API

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -547,6 +547,14 @@
 #define configUSE_TASK_PREEMPTION_DISABLE         0
 
 /* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
+ * configUSE_SCHEDULER_CORE_MASK to 1 to enable the scheduler core mask feature.
+ * When enabled, the vTaskSetSchedulerCoreMask and uxTaskGetSchedulerCoreMask
+ * APIs can be used to control which cores are allowed to run non-idle tasks
+ * system-wide at run time. Set to 0 to exclude this feature from the build.
+ * Defaults to 1 if left undefined. */
+#define configUSE_SCHEDULER_CORE_MASK             1
+
+/* When using SMP (i.e. configNUMBER_OF_CORES is greater than one), set
  * configUSE_PASSIVE_IDLE_HOOK to 1 to allow the application writer to use
  * the passive idle task hook to add background functionality without the
  * overhead of a separate task. Defaults to 0 if left undefined. */

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -512,6 +512,10 @@
     #define configUSE_CORE_AFFINITY    0
 #endif /* configUSE_CORE_AFFINITY */
 
+#ifndef configUSE_SCHEDULER_CORE_MASK
+    #define configUSE_SCHEDULER_CORE_MASK    1
+#endif /* configUSE_SCHEDULER_CORE_MASK */
+
 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
     #ifndef configTASK_DEFAULT_CORE_AFFINITY
         #define configTASK_DEFAULT_CORE_AFFINITY    tskNO_AFFINITY
@@ -2900,6 +2904,10 @@
 
 #if ( ( configNUMBER_OF_CORES == 1 ) && ( configUSE_CORE_AFFINITY != 0 ) )
     #error configUSE_CORE_AFFINITY is not supported in single core FreeRTOS
+#endif
+
+#if ( ( configNUMBER_OF_CORES == 1 ) && ( configUSE_SCHEDULER_CORE_MASK != 0 ) )
+    #error configUSE_SCHEDULER_CORE_MASK is not supported in single core FreeRTOS
 #endif
 
 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PORT_OPTIMISED_TASK_SELECTION != 0 ) )

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -513,7 +513,11 @@
 #endif /* configUSE_CORE_AFFINITY */
 
 #ifndef configUSE_SCHEDULER_CORE_MASK
-    #define configUSE_SCHEDULER_CORE_MASK    1
+    #if ( configNUMBER_OF_CORES > 1 )
+        #define configUSE_SCHEDULER_CORE_MASK    1
+    #else
+        #define configUSE_SCHEDULER_CORE_MASK    0
+    #endif
 #endif /* configUSE_SCHEDULER_CORE_MASK */
 
 #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )

--- a/include/FreeRTOS.h
+++ b/include/FreeRTOS.h
@@ -1854,6 +1854,22 @@
     #define traceRETURN_vTaskCoreAffinityGet( uxCoreAffinityMask )
 #endif
 
+#ifndef traceENTER_vTaskSetSchedulerCoreMask
+    #define traceENTER_vTaskSetSchedulerCoreMask( uxCoreMask )
+#endif
+
+#ifndef traceRETURN_vTaskSetSchedulerCoreMask
+    #define traceRETURN_vTaskSetSchedulerCoreMask()
+#endif
+
+#ifndef traceENTER_uxTaskGetSchedulerCoreMask
+    #define traceENTER_uxTaskGetSchedulerCoreMask()
+#endif
+
+#ifndef traceRETURN_uxTaskGetSchedulerCoreMask
+    #define traceRETURN_uxTaskGetSchedulerCoreMask( uxCoreMask )
+#endif
+
 #ifndef traceENTER_vTaskPreemptionDisable
     #define traceENTER_vTaskPreemptionDisable( xTask )
 #endif

--- a/include/task.h
+++ b/include/task.h
@@ -1420,6 +1420,45 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
     UBaseType_t vTaskCoreAffinityGet( ConstTaskHandle_t xTask );
 #endif
 
+#if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) )
+
+/**
+ *
+ * Controls which cores are allowed to run non-idle tasks system-wide.
+ * Bit N = 1 means core N may run tasks; bit N = 0 means core N will only
+ * run its idle task.  configNUMBER_OF_CORES must be greater than 1 for this
+ * function to be available.
+ *
+ * If a core that is currently running a non-idle task becomes disabled by
+ * the new mask, it is yielded immediately so the scheduler can replace the
+ * running task with the idle task.
+ *
+ * @param uxCoreMask Bitmask of cores to enable.  Cores are numbered 0 to
+ * configNUMBER_OF_CORES - 1.  Pass ( tskNO_AFFINITY ) to re-enable all cores.
+ *
+ * Example usage (4-core system, exclude core 2):
+ *
+ *     // Allow scheduling on cores 0, 1 and 3 only.
+ *     vTaskSetSchedulerCoreMask( ( 1 << 0 ) | ( 1 << 1 ) | ( 1 << 3 ) );
+ *
+ *     // Later, restore all four cores.
+ *     vTaskSetSchedulerCoreMask( ( 1 << 0 ) | ( 1 << 1 ) | ( 1 << 2 ) | ( 1 << 3 ) );
+ */
+    void vTaskSetSchedulerCoreMask( UBaseType_t uxCoreMask ) PRIVILEGED_FUNCTION;
+
+/**
+ * @brief Gets the current global scheduler core mask.
+ *
+ * @return Bitmask where bit N = 1 means core N is currently allowed to run
+ * non-idle tasks.
+ *
+ * Example usage:
+ *
+ *     UBaseType_t uxMask = uxTaskGetSchedulerCoreMask();
+ */
+    UBaseType_t uxTaskGetSchedulerCoreMask( void ) PRIVILEGED_FUNCTION;
+#endif
+
 #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
 
 /**

--- a/include/task.h
+++ b/include/task.h
@@ -1425,9 +1425,18 @@ BaseType_t xTaskResumeFromISR( TaskHandle_t xTaskToResume ) PRIVILEGED_FUNCTION;
 /**
  *
  * Controls which cores are allowed to run non-idle tasks system-wide.
- * Bit N = 1 means core N may run tasks; bit N = 0 means core N will only
- * run its idle task.  configNUMBER_OF_CORES must be greater than 1 for this
- * function to be available.
+ * Bit N = 1 means core N may run non-idle tasks; bit N = 0 means core N will
+ * only run its idle task.  configNUMBER_OF_CORES must be greater than 1 for
+ * this function to be available.
+ *
+ * Masking a core (including core 0) does NOT power it off or stop its tick
+ * ISR and scheduler from executing.  All cores remain active; the mask only
+ * controls whether the scheduler may dispatch a non-idle task onto a core.
+ * A masked core continues to service its tick interrupt and enters the
+ * scheduler normally, but will always be assigned the idle task.
+ *
+ * Passing 0 as the mask is valid; every core will run only its idle task
+ * until a new mask is applied.
  *
  * If a core that is currently running a non-idle task becomes disabled by
  * the new mask, it is yielded immediately so the scheduler can replace the

--- a/tasks.c
+++ b/tasks.c
@@ -3140,8 +3140,14 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         BaseType_t xCoreID;
         UBaseType_t uxOldMask;
         UBaseType_t uxDisabledCores;
+        UBaseType_t uxEnabledCores;
 
         traceENTER_vTaskSetSchedulerCoreMask( uxCoreMask );
+
+        /* Verify that uxCoreMask does not reference cores beyond the number of
+         * physical cores available.  Any bit at position configNUMBER_OF_CORES
+         * or higher is invalid. */
+        configASSERT( ( uxCoreMask & ~( ( UBaseType_t ) ( ~( UBaseType_t ) 0U ) >> ( ( sizeof( UBaseType_t ) * ( size_t ) 8U ) - ( size_t ) configNUMBER_OF_CORES ) ) ) == 0U );
 
         taskENTER_CRITICAL();
         {
@@ -3158,17 +3164,32 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             {
                 /* For each core that was just disabled (was allowed, now disallowed),
                  * yield it immediately if it is running a non-idle task so the
-                 * scheduler re-selects the idle task on that core. */
+                 * scheduler re-selects the idle task on that core.  For each core
+                 * that was just enabled (was disallowed, now allowed), request a
+                 * context switch immediately so it stops idling and promptly starts
+                 * executing any available ready tasks.  The two masks are mutually
+                 * exclusive so a single loop suffices. */
                 uxDisabledCores = uxOldMask & ~uxSchedulerCoreMask;
+                uxEnabledCores = ~uxOldMask & uxSchedulerCoreMask;
 
                 for( xCoreID = ( BaseType_t ) 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
                 {
-                    if( ( uxDisabledCores & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U )
+                    UBaseType_t uxCoreBit = ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID;
+
+                    if( ( uxDisabledCores & uxCoreBit ) != 0U )
                     {
                         if( ( pxCurrentTCBs[ xCoreID ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) == 0U )
                         {
                             prvYieldCore( xCoreID );
                         }
+                    }
+                    else if( ( uxEnabledCores & uxCoreBit ) != 0U )
+                    {
+                        prvYieldCore( xCoreID );
+                    }
+                    else
+                    {
+                        mtCOVERAGE_TEST_MARKER();
                     }
                 }
             }

--- a/tasks.c
+++ b/tasks.c
@@ -511,6 +511,14 @@ PRIVILEGED_DATA static UBaseType_t uxTaskNumber = ( UBaseType_t ) 0U;
 PRIVILEGED_DATA static volatile TickType_t xNextTaskUnblockTime = ( TickType_t ) 0U; /* Initialised to portMAX_DELAY before the scheduler starts. */
 PRIVILEGED_DATA static TaskHandle_t xIdleTaskHandles[ configNUMBER_OF_CORES ];       /**< Holds the handles of the idle tasks.  The idle tasks are created automatically when the scheduler is started. */
 
+#if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) )
+    /* Global scheduler core mask.  Bit N = 1 means core N is allowed to run
+     * non-idle tasks.  Defaults to all cores enabled.  Use
+     * vTaskSetSchedulerCoreMask() / uxTaskGetSchedulerCoreMask() to change it
+     * at run time. */
+    PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerCoreMask = ( UBaseType_t ) ( ( 1UL << configNUMBER_OF_CORES ) - 1UL );
+#endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) ) */
+
 /* Improve support for OpenOCD. The kernel tracks Ready tasks via priority lists.
  * For tracking the state of remote threads, OpenOCD uses uxTopUsedPriority
  * to determine the number of priority lists to read back from the remote target. */
@@ -941,12 +949,19 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                                 if( ( pxTCB->uxCoreAffinityMask & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U )
                             #endif
                             {
-                                #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
-                                    if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE )
+                                #if ( configUSE_SCHEDULER_CORE_MASK == 1 )
+                                    /* Non-idle tasks may not be scheduled on disabled cores. */
+                                    if( ( ( pxTCB->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U ) ||
+                                        ( ( uxSchedulerCoreMask & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U ) )
                                 #endif
                                 {
-                                    xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
-                                    xLowestPriorityCore = xCoreID;
+                                    #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+                                        if( pxCurrentTCBs[ xCoreID ]->xPreemptionDisable == pdFALSE )
+                                    #endif
+                                    {
+                                        xLowestPriorityToPreempt = xCurrentCoreTaskPriority;
+                                        xLowestPriorityCore = xCoreID;
+                                    }
                                 }
                             }
                         }
@@ -1090,14 +1105,21 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             if( ( pxTCB->uxCoreAffinityMask & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U )
                         #endif
                         {
-                            /* If the task is not being executed by any core swap it in. */
-                            pxCurrentTCBs[ xCoreID ]->xTaskRunState = taskTASK_NOT_RUNNING;
-                            #if ( configUSE_CORE_AFFINITY == 1 )
-                                pxPreviousTCB = pxCurrentTCBs[ xCoreID ];
+                            #if ( configUSE_SCHEDULER_CORE_MASK == 1 )
+                                /* Non-idle tasks may not run on scheduler-disabled cores. */
+                                if( ( ( pxTCB->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U ) ||
+                                    ( ( uxSchedulerCoreMask & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U ) )
                             #endif
-                            pxTCB->xTaskRunState = xCoreID;
-                            pxCurrentTCBs[ xCoreID ] = pxTCB;
-                            xTaskScheduled = pdTRUE;
+                            {
+                                /* If the task is not being executed by any core swap it in. */
+                                pxCurrentTCBs[ xCoreID ]->xTaskRunState = taskTASK_NOT_RUNNING;
+                                #if ( configUSE_CORE_AFFINITY == 1 )
+                                    pxPreviousTCB = pxCurrentTCBs[ xCoreID ];
+                                #endif
+                                pxTCB->xTaskRunState = xCoreID;
+                                pxCurrentTCBs[ xCoreID ] = pxTCB;
+                                xTaskScheduled = pdTRUE;
+                            }
                         }
                     }
                     else if( pxTCB == pxCurrentTCBs[ xCoreID ] )
@@ -1108,9 +1130,16 @@ static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB ) PRIVILEGED_FUNCTION;
                             if( ( pxTCB->uxCoreAffinityMask & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U )
                         #endif
                         {
-                            /* The task is already running on this core, mark it as scheduled. */
-                            pxTCB->xTaskRunState = xCoreID;
-                            xTaskScheduled = pdTRUE;
+                            #if ( configUSE_SCHEDULER_CORE_MASK == 1 )
+                                /* Non-idle tasks may not continue on scheduler-disabled cores. */
+                                if( ( ( pxTCB->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) != 0U ) ||
+                                    ( ( uxSchedulerCoreMask & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U ) )
+                            #endif
+                            {
+                                /* The task is already running on this core, mark it as scheduled. */
+                                pxTCB->xTaskRunState = xCoreID;
+                                xTaskScheduled = pdTRUE;
+                            }
                         }
                     }
                     else
@@ -3096,6 +3125,62 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         return uxCoreAffinityMask;
     }
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
+
+/*-----------------------------------------------------------*/
+
+#if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) )
+    void vTaskSetSchedulerCoreMask( UBaseType_t uxCoreMask )
+    {
+        BaseType_t xCoreID;
+        UBaseType_t uxOldMask;
+        UBaseType_t uxDisabledCores;
+
+        taskENTER_CRITICAL();
+        {
+            uxOldMask = uxSchedulerCoreMask;
+
+            /* Clamp to the number of physical cores so stray bits are ignored. */
+            uxSchedulerCoreMask = uxCoreMask & ( UBaseType_t ) ( ( 1UL << configNUMBER_OF_CORES ) - 1UL );
+
+            if( xSchedulerRunning != pdFALSE )
+            {
+                /* For each core that was just disabled (was allowed, now disallowed),
+                 * yield it immediately if it is running a non-idle task so the
+                 * scheduler re-selects the idle task on that core. */
+                uxDisabledCores = uxOldMask & ~uxSchedulerCoreMask;
+
+                for( xCoreID = ( BaseType_t ) 0; xCoreID < ( BaseType_t ) configNUMBER_OF_CORES; xCoreID++ )
+                {
+                    if( ( uxDisabledCores & ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID ) ) != 0U )
+                    {
+                        if( ( pxCurrentTCBs[ xCoreID ]->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) == 0U )
+                        {
+                            prvYieldCore( xCoreID );
+                        }
+                    }
+                }
+            }
+        }
+        taskEXIT_CRITICAL();
+    }
+#endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) ) */
+
+/*-----------------------------------------------------------*/
+
+#if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) )
+    UBaseType_t uxTaskGetSchedulerCoreMask( void )
+    {
+        UBaseType_t uxCoreMask;
+
+        portBASE_TYPE_ENTER_CRITICAL();
+        {
+            uxCoreMask = uxSchedulerCoreMask;
+        }
+        portBASE_TYPE_EXIT_CRITICAL();
+
+        return uxCoreMask;
+    }
+#endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) ) */
 
 /*-----------------------------------------------------------*/
 

--- a/tasks.c
+++ b/tasks.c
@@ -3135,6 +3135,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         UBaseType_t uxOldMask;
         UBaseType_t uxDisabledCores;
 
+        traceENTER_vTaskSetSchedulerCoreMask( uxCoreMask );
+
         taskENTER_CRITICAL();
         {
             uxOldMask = uxSchedulerCoreMask;
@@ -3162,6 +3164,8 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
             }
         }
         taskEXIT_CRITICAL();
+
+        traceRETURN_vTaskSetSchedulerCoreMask();
     }
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) ) */
 
@@ -3172,11 +3176,15 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
     {
         UBaseType_t uxCoreMask;
 
+        traceENTER_uxTaskGetSchedulerCoreMask();
+
         portBASE_TYPE_ENTER_CRITICAL();
         {
             uxCoreMask = uxSchedulerCoreMask;
         }
         portBASE_TYPE_EXIT_CRITICAL();
+
+        traceRETURN_uxTaskGetSchedulerCoreMask( uxCoreMask );
 
         return uxCoreMask;
     }

--- a/tasks.c
+++ b/tasks.c
@@ -515,8 +515,14 @@ PRIVILEGED_DATA static TaskHandle_t xIdleTaskHandles[ configNUMBER_OF_CORES ];  
     /* Global scheduler core mask.  Bit N = 1 means core N is allowed to run
      * non-idle tasks.  Defaults to all cores enabled.  Use
      * vTaskSetSchedulerCoreMask() / uxTaskGetSchedulerCoreMask() to change it
-     * at run time. */
-    PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerCoreMask = ( UBaseType_t ) ( ( 1UL << configNUMBER_OF_CORES ) - 1UL );
+     * at run time.
+     *
+     * The mask is derived by right-shifting ~0 rather than left-shifting 1,
+     * because left-shifting by a value equal to the type width is undefined
+     * behaviour in C (C11 §6.5.7).  Using UBaseType_t throughout also avoids
+     * the assumption that unsigned long is at least as wide as UBaseType_t. */
+    PRIVILEGED_DATA static volatile UBaseType_t uxSchedulerCoreMask =
+        ( ( UBaseType_t ) ( ~( UBaseType_t ) 0U ) >> ( ( sizeof( UBaseType_t ) * ( size_t ) 8U ) - ( size_t ) configNUMBER_OF_CORES ) );
 #endif /* #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_SCHEDULER_CORE_MASK == 1 ) ) */
 
 /* Improve support for OpenOCD. The kernel tracks Ready tasks via priority lists.
@@ -3141,8 +3147,12 @@ static void prvInitialiseNewTask( TaskFunction_t pxTaskCode,
         {
             uxOldMask = uxSchedulerCoreMask;
 
-            /* Clamp to the number of physical cores so stray bits are ignored. */
-            uxSchedulerCoreMask = uxCoreMask & ( UBaseType_t ) ( ( 1UL << configNUMBER_OF_CORES ) - 1UL );
+            /* Clamp to the number of physical cores so stray bits are ignored.
+             * The valid-core mask is derived by right-shifting ~0 to avoid
+             * left-shift UB and unsigned long width assumptions (see the
+             * uxSchedulerCoreMask initialiser for a full explanation). */
+            uxSchedulerCoreMask = uxCoreMask &
+                                  ( ( UBaseType_t ) ( ~( UBaseType_t ) 0U ) >> ( ( sizeof( UBaseType_t ) * ( size_t ) 8U ) - ( size_t ) configNUMBER_OF_CORES ) );
 
             if( xSchedulerRunning != pdFALSE )
             {


### PR DESCRIPTION
# Add configUSE_SCHEDULER_CORE_MASK and vTaskSetSchedulerCoreMask API

Description
-----------
Adds a new SMP-only feature that lets the application control which
cores the FreeRTOS scheduler is permitted to run non-idle tasks on, at run
time, without stopping the scheduler.

The primary use cases are:

1. **Dynamic load management** -- exclude one or more cores from scheduling
   non-idle work so they can be idled or throttled without stopping the
   scheduler on the remaining cores.

2. **Core power-off preparation** -- before powering off a secondary core
   (cores 1..N-1), clear that core's bit in the scheduler mask so the
   scheduler stops assigning new tasks to it.  Once the core's current task
   yields and the core is running only its idle task, the platform power
   management layer can safely gate the clock or cut power to that core.
   Core 0 must never be masked out because it owns the tick and the
   scheduler entry point.

A new configuration macro `configUSE_SCHEDULER_CORE_MASK` gates the entire
feature.  Setting it to `0` produces a clean preprocessor rollback to the
original code with zero overhead.

**Files changed:**

| File | Change |
|---|---|
| `tasks.c` | +113 / -14 |
| `include/task.h` | +38 / 0 |
| `include/FreeRTOS.h` | +8 / 0 |
| `examples/template_configuration/FreeRTOSConfig.h` | +8 / 0 |

**Details:**

`include/FreeRTOS.h`: added default `#define configUSE_SCHEDULER_CORE_MASK 1`
and a compile-time `#error` that blocks use on single-core builds.

`include/task.h`: added declarations for both new API functions under the
combined `configNUMBER_OF_CORES > 1 && configUSE_SCHEDULER_CORE_MASK == 1` guard.

`tasks.c`: added the `uxSchedulerCoreMask` static variable; added three
`#if ( configUSE_SCHEDULER_CORE_MASK == 1 )` checks inside the SMP task
selection loop so that non-idle tasks are never assigned to or kept on a
masked core; added implementations of both API functions.

`examples/template_configuration/FreeRTOSConfig.h`: added
`configUSE_SCHEDULER_CORE_MASK 1` to the SMP section.

**Opt-out:** set `#define configUSE_SCHEDULER_CORE_MASK 0` in `FreeRTOSConfig.h`.
Every added line is inside a preprocessor guard, so the build is identical
to the unpatched kernel.

**New API** (available when `configNUMBER_OF_CORES > 1` and
`configUSE_SCHEDULER_CORE_MASK == 1`):

```c
/* Bit N = 1 means core N may run non-idle tasks.
 * Bit N = 0 means core N runs only its idle task.
 * Pass ( tskNO_AFFINITY ) to re-enable all cores. */
void vTaskSetSchedulerCoreMask( UBaseType_t uxCoreMask );

/* Returns the current global scheduler core mask. */
UBaseType_t uxTaskGetSchedulerCoreMask( void );
```

Usage example -- power off core 2 on a 4-core system:

Note: masking core 0 is valid at the scheduler level (core 0 will just run
only its idle task). What must not be done is powering off the core that
hosts the tick source (typically core 0), because the kernel tick and
scheduler entry point depend on it. Masking is a safe prerequisite step
before powering off any secondary core.

```c
/* Step 1: stop the scheduler from assigning tasks to core 2. */
UBaseType_t uxMask = uxTaskGetSchedulerCoreMask();
uxMask &= ~( ( UBaseType_t ) 1U << 2U );
vTaskSetSchedulerCoreMask( uxMask );

/* Step 2: wait (platform-specific) until core 2 is running only idle. */
waitForCoreIdle( 2 );

/* Step 3: power off core 2 via the BSP. */
bspCorePowerOff( 2 );

/* To bring it back: power on, then re-enable in the mask. */
bspCorePowerOn( 2 );
vTaskSetSchedulerCoreMask( tskNO_AFFINITY );
```

Test Steps
-----------
1. Build an SMP application with `configNUMBER_OF_CORES > 1` and
   `configUSE_SCHEDULER_CORE_MASK 1` (default).  Confirm it compiles and
   links without warnings.
2. Call `vTaskSetSchedulerCoreMask( 1U )` at run time (only core 0 enabled).
   Confirm that tasks on cores 1..N-1 are no longer scheduled and those
   cores run only their idle tasks.
3. Call `vTaskSetSchedulerCoreMask( tskNO_AFFINITY )`.  Confirm normal
   scheduling resumes on all cores.
4. Build with `configUSE_SCHEDULER_CORE_MASK 0`.  Confirm it compiles
   cleanly and that neither `vTaskSetSchedulerCoreMask` nor
   `uxTaskGetSchedulerCoreMask` is referenced in the output binary.
5. Build with `configNUMBER_OF_CORES 1` and any non-zero value of
   `configUSE_SCHEDULER_CORE_MASK`.  Confirm the expected `#error` fires.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.