### PR TITLE
Fix MPU wrapper macro mapping for ARMv8M ports

### DIFF
--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/ARMv8M/non_secure/portmacrocommon.h
+++ b/portable/ARMv8M/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM52/non_secure/port.c
+++ b/portable/GCC/ARM_CM52/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM52/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM52/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM52_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM52_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_STAR_MC3/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_STAR_MC3/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/portmacrocommon.h
+++ b/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM52/non_secure/port.c
+++ b/portable/IAR/ARM_CM52/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM52/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM52/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM52_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM52_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_STAR_MC3/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_STAR_MC3/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**

--- a/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -550,6 +550,11 @@ portDONT_DISCARD void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) PRIV
     extern BaseType_t configWAKE_SECONDARY_CORES( void );
 
 #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
+
+/**
+ * @brief Configures interrupt priorities.
+ */
+void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 #if ( ( configENABLE_MPU == 1 ) && ( configUSE_MPU_WRAPPERS_V1 == 0 ) )

--- a/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/portmacrocommon.h
+++ b/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/portmacrocommon.h
@@ -30,8 +30,6 @@
 #ifndef PORTMACROCOMMON_H
 #define PORTMACROCOMMON_H
 
-#include "mpu_wrappers.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
@@ -153,11 +151,6 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
     void vApplicationGenerateTaskRandomPacKey( uint32_t * pulTaskPacKey );
 
 #endif /* configENABLE_PAC */
-
-/**
- * @brief Configures interrupt priorities.
- */
-void vPortConfigureInterruptPriorities( void ) PRIVILEGED_FUNCTION;
 /*-----------------------------------------------------------*/
 
 /**


### PR DESCRIPTION
Description
-----------
Remove `#include "mpu_wrappers.h"` from `portmacrocommon.h`. The header was being included before `portUSING_MPU_WRAPPERS` is defined, which prevented the pre-processor macro mapping of FreeRTOS APIs to their MPU_ variants and broke unprivileged tasks.

Move the `vPortConfigureInterruptPriorities()` declaration from `portmacrocommon.h` into `port.c` since it relies on the `PRIVILEGED_FUNCTION` attribute defined via `mpu_wrappers.h`.

Test Steps
-----------
Tested using `FreeRTOS/Demo/CORTEX_MPU_M33F_NTZ_Nordic_NRF9160_SES` demo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
