### PR TITLE
Switch to 32-bit tick width to avoid windows compile warnings

### DIFF
--- a/examples/template_configuration/FreeRTOSConfig.h
+++ b/examples/template_configuration/FreeRTOSConfig.h
@@ -136,7 +136,7 @@
  *
  * Defining configTICK_TYPE_WIDTH_IN_BITS as TICK_TYPE_WIDTH_64_BITS causes
  * TickType_t to be defined (typedef'ed) as an unsigned 64-bit type. */
-#define configTICK_TYPE_WIDTH_IN_BITS              TICK_TYPE_WIDTH_64_BITS
+#define configTICK_TYPE_WIDTH_IN_BITS              TICK_TYPE_WIDTH_32_BITS
 
 /* Set configIDLE_SHOULD_YIELD to 1 to have the Idle task yield to an
  * application task if there is an Idle priority (priority 0) application task


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Windows defines a long as a 32-bit value regardless if a 32 or 64 bit OS is used. This makes a 64-bit tick an `unsigned long long` which was introduced after C90.

Test Steps
-----------
Verified in https://forums.freertos.org/t/cmake-build-error-for-cmake-example-in-freertosv202604-00-lts/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
See https://forums.freertos.org/t/cmake-build-error-for-cmake-example-in-freertosv202604-00-lts/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
