### PR TITLE
Fix incorrect #endif preprocessor comments in croutine.c and queue.c

### DIFF
--- a/croutine.c
+++ b/croutine.c
@@ -402,4 +402,4 @@
     }
 /*-----------------------------------------------------------*/
 
-#endif /* configUSE_CO_ROUTINES == 0 */
+#endif /* configUSE_CO_ROUTINES != 0 */

--- a/queue.c
+++ b/queue.c
@@ -563,7 +563,7 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         return pxNewQueue;
     }
 
-#endif /* configSUPPORT_STATIC_ALLOCATION */
+#endif /* configSUPPORT_DYNAMIC_ALLOCATION */
 /*-----------------------------------------------------------*/
 
 static void prvInitialiseNewQueue( const UBaseType_t uxQueueLength,


### PR DESCRIPTION
Description
-----------
Fix two `#endif` preprocessor comments that don't match their corresponding `#if` conditions:

1. **croutine.c:405** — The `#if` condition is `( configUSE_CO_ROUTINES != 0 )` but the `#endif` comment incorrectly says `== 0`, reversing the logic.

2. **queue.c:566** — The `#if` condition is `( configSUPPORT_DYNAMIC_ALLOCATION == 1 )` but the `#endif` comment incorrectly says `configSUPPORT_STATIC_ALLOCATION`, naming the wrong configuration option.

These are purely cosmetic comment fixes with zero runtime impact.

Test Steps
-----------
- Changes are limited to preprocessor comment text only.
- No behavioral change — verified by successful build with `-Wall -Wextra`.
- Self-explanatory by examining the `#if` / `#endif` pairs in the diff.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request. *(N/A — comment-only change)*

Related Issue
-----------
*None*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.