### PR TITLE
Fix spurious heap_5 assert when allocation search reaches end marker

### DIFF
--- a/portable/MemMang/heap_5.c
+++ b/portable/MemMang/heap_5.c
@@ -284,7 +284,14 @@ void * pvPortMalloc( size_t xWantedSize )
                 {
                     pxPreviousBlock = pxBlock;
                     pxBlock = heapPROTECT_BLOCK_POINTER( pxBlock->pxNextFreeBlock );
-                    heapVALIDATE_BLOCK_POINTER( pxBlock );
+
+                    /* pxEnd is the end marker of the free list. It is located at
+                     * pucHeapHighAddress and is not part of the usable heap, so it
+                     * must be excluded from the heap block pointer validation. */
+                    if( pxBlock != pxEnd )
+                    {
+                        heapVALIDATE_BLOCK_POINTER( pxBlock );
+                    }
                 }
 
                 /* If the end marker was reached then a block of adequate size


### PR DESCRIPTION
## Description

When `configENABLE_HEAP_PROTECTOR` is `1`, a `pvPortMalloc()` request that
cannot be satisfied by any free block triggers a spurious
`heapVALIDATE_BLOCK_POINTER()` assert instead of failing gracefully.

### Root cause

The free-list search in `pvPortMalloc()` walks the list until it finds a
block large enough or reaches the end marker `pxEnd`. When no block is large
enough, the loop advances onto `pxEnd` and validates it:

```c
pxBlock = heapPROTECT_BLOCK_POINTER( pxBlock->pxNextFreeBlock );
heapVALIDATE_BLOCK_POINTER( pxBlock );
```

`pxEnd` is positioned at the very top of the highest heap region, so its
address equals `pucHeapHighAddress` (in `vPortDefineHeapRegions()`,
`pucHeapHighAddress = pxFirstFreeBlockInRegion + xBlockSize`, which lands
exactly on `pxEnd`). The validation macro uses a strict upper bound:

```c
( ( uint8_t * ) ( pxBlock ) < pucHeapHighAddress )
```

so validating `pxEnd` fails the assert. This fires on an ordinary
out-of-memory condition, when the code should instead fall through and call
the malloc-failed hook.

### Fix

Exclude the end marker from validation inside the search loop. `pxEnd` is a
known sentinel (zero size, NULL next) and is not part of the usable heap, so
it should not be bounds-checked. Real blocks are still validated exactly as
before, keeping the strict `<` bound intact.

This was reported by a customer on an MT79XX / Cortex-M4 target.

## Test Steps

Verified with a standalone harness that compiles `heap_5.c` against the POSIX
(GCC) port with `configENABLE_HEAP_PROTECTOR=1` and
`configUSE_MALLOC_FAILED_HOOK=1`:

1. Fragment the heap so total free space exceeds the request but no single
   free block does, forcing the search to reach `pxEnd`.
2. Request an allocation that fits in the combined free space only.

- **Before:** `heapVALIDATE_BLOCK_POINTER` assert fires on the OOM request.
- **After:** `pvPortMalloc()` returns `NULL` and `vApplicationMallocFailedHook()`
  is invoked; no assert. A normal allocation is unaffected.

## Checklist

- [x] I have tested my changes. No regression observed.
- [x] I have modified the source only; no behavioural change for valid blocks.

## Related Issue

Customer-reported heap pointer validation issue in `heap_5.c`.

---

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.
