### PR TITLE
Fix duplicate Doxygen \defgroup id for uxTaskBasePriorityGet

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -1050,7 +1050,7 @@ UBaseType_t uxTaskPriorityGetFromISR( const TaskHandle_t xTask ) PRIVILEGED_FUNC
  *
  * @return The base priority of xTask.
  *
- * \defgroup uxTaskPriorityGet uxTaskBasePriorityGet
+ * \defgroup uxTaskBasePriorityGet uxTaskBasePriorityGet
  * \ingroup TaskCtrl
  */
 UBaseType_t uxTaskBasePriorityGet( const TaskHandle_t xTask ) PRIVILEGED_FUNCTION;


### PR DESCRIPTION
## Description

`uxTaskBasePriorityGet()` in `include/task.h` declared its Doxygen group with `\defgroup uxTaskPriorityGet uxTaskBasePriorityGet` — reusing the group id `uxTaskPriorityGet` that is already defined by `uxTaskPriorityGet()`, but with a different title.

When building the documentation with Doxygen this produces:

```
task.h: warning: group uxTaskPriorityGet: ignoring title "uxTaskBasePriorityGet" that does not match old title "uxTaskPriorityGet"
```

As a result `uxTaskBasePriorityGet` is not documented under its own group. This change gives it its own group id (`uxTaskBasePriorityGet`), matching the convention used by every other API in the file.

Reported on the FreeRTOS forums: https://forums.freertos.org/t/doxygen-errors-galor/25035

## Test Steps

Documentation-comment-only change; no functional/code impact. Verified the warning no longer triggers and that no other duplicate `\defgroup` ids exist in `task.h`.

## Checklist:

- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified the documentation accordingly.

## Related Issue

N/A (forum-reported)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT licensing terms.