### PR TITLE
Disallow unprivileged critical sections with MPU wrappers v2

### DIFF
--- a/portable/GCC/ARM_CM3_MPU/port.c
+++ b/portable/GCC/ARM_CM3_MPU/port.c
@@ -55,9 +55,19 @@
     #define portNVIC_SYSTICK_CLK    ( 0 )
 #endif
 
+/* Unprivileged critical sections are not supported when using MPU wrappers
+ * version 2. Default the option to 0 and reject an explicit value of 1. */
 #ifndef configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS
-    #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
-    #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #if ( configUSE_MPU_WRAPPERS_V1 == 0 )
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    0
+    #else
+        #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #endif
+#else
+    #if ( ( configUSE_MPU_WRAPPERS_V1 == 0 ) && ( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 ) )
+        #error configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not supported with MPU wrappers version 2 ( configUSE_MPU_WRAPPERS_V1 == 0 ).
+    #endif
 #endif
 
 /* Prototype of all Interrupt Service Routines (ISRs). */

--- a/portable/GCC/ARM_CM4_MPU/port.c
+++ b/portable/GCC/ARM_CM4_MPU/port.c
@@ -59,9 +59,19 @@
     #define portNVIC_SYSTICK_CLK    ( 0 )
 #endif
 
+/* Unprivileged critical sections are not supported when using MPU wrappers
+ * version 2. Default the option to 0 and reject an explicit value of 1. */
 #ifndef configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS
-    #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
-    #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #if ( configUSE_MPU_WRAPPERS_V1 == 0 )
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    0
+    #else
+        #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #endif
+#else
+    #if ( ( configUSE_MPU_WRAPPERS_V1 == 0 ) && ( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 ) )
+        #error configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not supported with MPU wrappers version 2 ( configUSE_MPU_WRAPPERS_V1 == 0 ).
+    #endif
 #endif
 
 /* Prototype of all Interrupt Service Routines (ISRs). */

--- a/portable/IAR/ARM_CM4F_MPU/port.c
+++ b/portable/IAR/ARM_CM4F_MPU/port.c
@@ -66,9 +66,19 @@
     #define portNVIC_SYSTICK_CLK_BIT    ( 0 )
 #endif
 
+/* Unprivileged critical sections are not supported when using MPU wrappers
+ * version 2. Default the option to 0 and reject an explicit value of 1. */
 #ifndef configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS
-    #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
-    #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #if ( configUSE_MPU_WRAPPERS_V1 == 0 )
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    0
+    #else
+        #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #endif
+#else
+    #if ( ( configUSE_MPU_WRAPPERS_V1 == 0 ) && ( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 ) )
+        #error configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not supported with MPU wrappers version 2 ( configUSE_MPU_WRAPPERS_V1 == 0 ).
+    #endif
 #endif
 
 /* Prototype of all Interrupt Service Routines (ISRs). */

--- a/portable/RVDS/ARM_CM4_MPU/port.c
+++ b/portable/RVDS/ARM_CM4_MPU/port.c
@@ -48,9 +48,19 @@
 
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
+/* Unprivileged critical sections are not supported when using MPU wrappers
+ * version 2. Default the option to 0 and reject an explicit value of 1. */
 #ifndef configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS
-    #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
-    #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #if ( configUSE_MPU_WRAPPERS_V1 == 0 )
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    0
+    #else
+        #warning "configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not defined. We recommend defining it to 0 in FreeRTOSConfig.h for better security."
+        #define configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS    1
+    #endif
+#else
+    #if ( ( configUSE_MPU_WRAPPERS_V1 == 0 ) && ( configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS == 1 ) )
+        #error configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS is not supported with MPU wrappers version 2 ( configUSE_MPU_WRAPPERS_V1 == 0 ).
+    #endif
 #endif
 
 /* Prototype of all Interrupt Service Routines (ISRs). */


### PR DESCRIPTION
## Description

When using MPU wrappers version 2 (`configUSE_MPU_WRAPPERS_V1 == 0`), unprivileged tasks cannot safely enter critical sections, but the current ARMv7-M MPU ports allow it and fail silently.

`vPortEnterCritical()`/`vPortExitCritical()` handle an unprivileged caller by raising privilege via `portRAISE_PRIVILEGE()` before writing `BASEPRI`. `portRAISE_PRIVILEGE()` issues `svc portSVC_RAISE_PRIVILEGE`, but the `portSVC_RAISE_PRIVILEGE` case in the SVC handler is compiled only for MPU wrappers v1 (`#if ( configUSE_MPU_WRAPPERS_V1 == 1 )`). Under v2 the SVC falls through to the no-op `default` case, privilege is never raised, and the subsequent `BASEPRI` write from unprivileged mode is ignored by the hardware. The critical section appears to succeed but never masks interrupts, producing latent, hard-to-debug faults.

This is made worse by the defaults: `configUSE_MPU_WRAPPERS_V1` defaults to `0` (v2) and `configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS` defaults to `1`, so the dangerous combination is the out-of-the-box configuration.

## Changes

In the four ARMv7-M MPU ports (`GCC/ARM_CM3_MPU`, `GCC/ARM_CM4_MPU`, `IAR/ARM_CM4F_MPU`, `RVDS/ARM_CM4_MPU`):

- When `configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS` is left undefined under v2, it now defaults to `0` (instead of `1`), so the default configuration is safe.
- When it is explicitly set to `1` under v2, a compile-time `#error` rejects the unsupported configuration loudly rather than letting it fail silently at run time.
- Behaviour under MPU wrappers v1 is unchanged (still defaults to `1` with the existing security `#warning`, and explicit `0`/`1` are both honoured).

ARMv8-M ports are unaffected: they do not expose `configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS` and their critical-section primitives are `PRIVILEGED_FUNCTION`s that never attempt the privilege raise.

Fixes #1378

## Test Steps

Verified the preprocessor logic across all relevant config permutations:

| `configUSE_MPU_WRAPPERS_V1` | `configALLOW_UNPRIVILEGED_CRITICAL_SECTIONS` | Result |
| --- | --- | --- |
| 0 (v2) | undefined | defaults to `0`, no error |
| 0 (v2) | `1` | compile-time `#error` |
| 0 (v2) | `0` | `0`, no error |
| 1 (v1) | undefined | `1` + existing `#warning` |
| 1 (v1) | `1` | `1`, no error |

## Checklist:

- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

> N/A — this is a compile-time configuration guard; verified via preprocessor evaluation of all config permutations (table above).

## Related Issue

https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1378

## By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
