### PR TITLE
Conditionally save FPU context in IRQ, and preserve vApplicationFPUSa…

### DIFF
--- a/portable/GCC/ARM_CA9/port.c
+++ b/portable/GCC/ARM_CA9/port.c
@@ -168,7 +168,8 @@ static void prvTaskExitError( void );
 
 /*
  * If the application provides an implementation of vApplicationIRQHandler(),
- * then it will get called directly without saving the FPU registers on
+ * then it will get called directly without saving the FPU registers
+ * when there is no FPU context to preserve on
  * interrupt entry, and this weak implementation of
  * vApplicationFPUSafeIRQHandler() is just provided to remove linkage errors -
  * it should never actually get called so its implementation contains a
@@ -179,11 +180,16 @@ static void prvTaskExitError( void );
  * vApplicationIRQHandler() provided in portASM.S will save the FPU registers
  * before calling it.
  *
- * Therefore, if the application writer wants FPU registers to be saved on
+ * Therefore, if the application writer wants FPU registers to always be saved on
  * interrupt entry their IRQ handler must be called
  * vApplicationFPUSafeIRQHandler(), and if the application writer does not want
  * FPU registers to be saved on interrupt entry their IRQ handler must be
  * called vApplicationIRQHandler().
+ * 
+ * Note that for ARM Cortex A9, the FPU might be used for memory operations,
+ * depending on the C library used for memcpy, memcmp or memset. For instance,
+ * glibc uses the FPU, hence always saving it might be preferable when using it.
+ * See https://freertos.org/Using-FreeRTOS-on-Cortex-A-Embedded-Processors#important-note-for-gcc-and-possibly-other-compiler-users
  */
 void vApplicationFPUSafeIRQHandler( uint32_t ulICCIAR ) __attribute__( ( weak ) );
 

--- a/portable/GCC/ARM_CA9/portASM.S
+++ b/portable/GCC/ARM_CA9/portASM.S
@@ -197,6 +197,18 @@ FreeRTOS_IRQ_Handler:
     LDR     r2, [r2]
     LDR     r0, [r2]
 
+    /* Does the task have a floating point context that needs saving?  If
+    ulPortTaskHasFPUContext is 0 then no. */
+    LDR     r12, ulPortTaskHasFPUContextConst
+    LDR     r4, [r12]
+    CMP     r4, #0 /* r4 contains ulPortTaskHasFPUContext */
+
+    /* Save the floating point context, if any. */
+    FMRXNE  r12, FPSCR
+    VPUSHNE {d0-d15}
+    VPUSHNE {d16-d31}
+    PUSHNE  {r12} /* r12 contains FPSCR */
+
     /* Ensure bit 2 of the stack pointer is clear.  r2 holds the bit 2 value for
     future use.  _RB_ Does this ever actually need to be done provided the start
     of the stack is 8-byte aligned? */
@@ -204,7 +216,7 @@ FreeRTOS_IRQ_Handler:
     AND     r2, r2, #4
     SUB     sp, sp, r2
 
-    /* Call the interrupt handler.  r4 pushed to maintain alignment. */
+    /* Call the interrupt handler. */
     PUSH    {r0-r4, lr}
     LDR     r1, vApplicationIRQHandlerConst
     BLX     r1
@@ -214,6 +226,13 @@ FreeRTOS_IRQ_Handler:
     CPSID   i
     DSB
     ISB
+
+    /* Restore the floating point context, if any. */
+    CMP     r4, #0 /* r4 contains ulPortTaskHasFPUContext */
+    POPNE   {r12}  /* r12 contains FPSCR */
+    VPOPNE  {d16-d31}
+    VPOPNE  {d0-d15}
+    VMSRNE  FPSCR, r12
 
     /* Write the value read from ICCIAR to ICCEOIR. */
     LDR     r4, ulICCEOIRConst
@@ -281,13 +300,13 @@ switch_before_exit:
 /******************************************************************************
  * If the application provides an implementation of vApplicationIRQHandler(),
  * then it will get called directly without saving the FPU registers on
- * interrupt entry, and this weak implementation of
+ * interrupt entry when the FPU is not used, and this weak implementation of
  * vApplicationIRQHandler() will not get called.
  *
  * If the application provides its own implementation of
  * vApplicationFPUSafeIRQHandler() then this implementation of
- * vApplicationIRQHandler() will be called, save the FPU registers, and then
- * call vApplicationFPUSafeIRQHandler().
+ * vApplicationIRQHandler() will be called, save the FPU registers if not done
+ * already, and then call vApplicationFPUSafeIRQHandler().
  *
  * Therefore, if the application writer wants FPU registers to be saved on
  * interrupt entry their IRQ handler must be called
@@ -301,18 +320,36 @@ switch_before_exit:
 .type vApplicationIRQHandler, %function
 vApplicationIRQHandler:
     PUSH    {LR}
-    FMRX    R1,  FPSCR
-    VPUSH   {D0-D7}
-    VPUSH   {D16-D31}
-    PUSH    {R1}
+
+    /* Does the task have a floating point context that has been saved already?  If
+    ulPortTaskHasFPUContext is 1 then yes. */
+    LDR     r12, ulPortTaskHasFPUContextConst
+    LDR     r4, [r12]
+
+    /* If there is an FPU context, it was already saved. */
+    CMP     r4, #1 /* If equal, the FPU context was saved by the caller. */
+    FMRXNE  r1,  FPSCR
+    VPUSHNE {d0-d7}
+    VPUSHNE {d16-d31}
+    PUSHNE  {r1}
+    PUSHNE  {r1} /* Push FPSCR twice to keep memory alignment */
+
+    /* Store ulPortTaskHasFPUContext */
+    PUSH    {r4}
 
     LDR     r1, vApplicationFPUSafeIRQHandlerConst
     BLX     r1
 
-    POP     {R0}
-    VPOP    {D16-D31}
-    VPOP    {D0-D7}
-    VMSR    FPSCR, R0
+    /* Restore ulPortTaskHasFPUContext */
+    POP     {r4}
+
+    /* Skip the FPU register reset if there is an FPU context, the IRQ handler will do it. */
+    CMP     r4, #1 /* If true, the FPU registers will be restored by the caller. */
+    POPNE   {r0}
+    POPNE   {r0} /* FPSCR was pushed twice for alignment purposes */
+    VPOPNE  {d16-d31}
+    VPOPNE  {d0-d7}
+    VMSRNE  FPSCR, r0
 
     POP {PC}
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
On the ARM Cortex A9 port of the FreeRTOS kernel, the FPU is never saved when the application provides an implementation of vApplicationIRQHandler, even though configUSE_TASK_FPU_SUPPORT can be set to 1 or 2.

This is the case with Xilinx's FreeRTOS port for Zynq 7000 (tested on 7020 here).

It is important to save these registers, even if the FPU should never be used in the IRQ handler: memcpy, memset or memcmp might use it -- https://freertos.org/Using-FreeRTOS-on-Cortex-A-Embedded-Processors#important-note-for-gcc-and-possibly-other-compiler-users.

In other words, using stream_buffers, queues or other memory APIs from FreeRTOS leads to FPU corruption when using GCC in an interrupt context. 

For this reason, it makes sense to check ulPortTaskHasFPUContext, and save the FPU registers if necessary.

This issue was discussed (on the forum)[https://forums.freertos.org/t/floating-context-not-saved-properly-on-zynq7020/13250] for the Zynq 7020.

The patch is structured as followed:
1. Check ulPortTaskHasFPUContext and save the FPU context if necessary in FreeRTOS_IRQ_Handler.
2. Call vApplicationIRQHandler.
3. Optional: If vApplicationFPUSafeIRQHandler is provided only save/restore the FPU context in weak vApplicationIRQHandler when ulPortTaskHasFPUContext is false -- it preserves existing behavior, and avoids an unecessary double save.
5. Back in FreeRTOS_IRQ_Handler, restore the FPU context if ulPortTaskHasFPUContext is true.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. The stack consumption and timing will get worse

Related Issue
-----------
<!-- If any, please provide issue ID. -->
Two PR for other architecture targeted a similar issue:

- for AARCH64 : https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1048
- for Cortex R5 : https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/584

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
