### PR TITLE
fix: TOCTOU race condition in vTaskListTasks()

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -7362,7 +7362,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         /* MISRA Ref 11.5.1 [Malloc memory assignment] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
         /* coverity[misra_c_2012_rule_11_5_violation] */
-        pxTaskStatusArray = pvPortMalloc( uxCurrentNumberOfTasks * sizeof( TaskStatus_t ) );
+        pxTaskStatusArray = pvPortMalloc( uxArraySize * sizeof( TaskStatus_t ) );
 
         if( pxTaskStatusArray != NULL )
         {
@@ -7531,7 +7531,7 @@ STATIC void prvResetNextTaskUnblockTime( void )
         /* MISRA Ref 11.5.1 [Malloc memory assignment] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#rule-115 */
         /* coverity[misra_c_2012_rule_11_5_violation] */
-        pxTaskStatusArray = pvPortMalloc( uxCurrentNumberOfTasks * sizeof( TaskStatus_t ) );
+        pxTaskStatusArray = pvPortMalloc( uxArraySize * sizeof( TaskStatus_t ) );
 
         if( pxTaskStatusArray != NULL )
         {


### PR DESCRIPTION
## Description

vTaskListTasks() and vTaskList() read the volatile uxCurrentNumberOfTasks twice: once for the zero-check and once for pvPortMalloc(). If a task is created between the two reads, the allocated buffer is undersized, causing a potential buffer overflow in uxTaskGetSystemState().

## Fix

Use the local variable uxArraySize (already assigned from uxCurrentNumberOfTasks) for the pvPortMalloc() call instead of re-reading the volatile.

## Changes

- tasks.c: 2 lines changed (line 7359 and 7528)

Split from #1409 per reviewer request to separate the bug fix from .editorconfig changes.