### PR TITLE
fix: correct duplicate words in code comments

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -369,7 +369,7 @@ typedef enum
  * TaskHandle_t xHandle = NULL;
  *
  *   // Create the task, storing the handle.  Note that the passed parameter ucParameterToPass
- *   // must exist for the lifetime of the task, so in this case is declared static.  If it was just an
+ *   // must exist for the lifetime of the task, so in this case is declared static.  If it was just
  *   // an automatic stack variable it might no longer exist, or at least have been corrupted, by the time
  *   // the new task attempts to access it.
  *   xTaskCreate( vTaskCode, "NAME", STACK_SIZE, &ucParameterToPass, tskIDLE_PRIORITY, &xHandle );

--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -272,7 +272,7 @@ static BaseType_t prvBytesInBufferMeetTriggerLevel( const StreamBuffer_t * const
  * the length and data bytes are written in two separate chunks, and we don't want
  * the reader to see the buffer as having grown until after all data is copied over.
  * This function takes a custom xHead value to indicate where to write to (necessary
- * for chaining) and returns the the resulting xHead position.
+ * for chaining) and returns the resulting xHead position.
  * To mark the write as complete, manually set the buffer's xHead field with the
  * returned xHead from this function.
  */
@@ -314,7 +314,7 @@ static size_t prvWriteMessageToBuffer( StreamBuffer_t * const pxStreamBuffer,
  * the writer to see the buffer as having more free space until after all data is
  * copied over, especially if we have to abort the read due to insufficient receiving space.
  * This function takes a custom xTail value to indicate where to read from (necessary
- * for chaining) and returns the the resulting xTail position.
+ * for chaining) and returns the resulting xTail position.
  * To mark the read as complete, manually set the buffer's xTail field with the
  * returned xTail from this function.
  */


### PR DESCRIPTION
## Description

Fix three duplicate-word typos in code comments:

| File | Change |
|------|--------|
| `include/task.h:372` | "just an // an automatic" → "just // an automatic" |
| `stream_buffer.c:275` | "the the resulting xHead" → "the resulting xHead" |
| `stream_buffer.c:317` | "the the resulting xTail" → "the resulting xTail" |

## Type

Documentation-only change — no functional impact.