### PR TITLE
Optional PRIVILEGED_DATA wrapper + Partner-Supported-Ports submodule update

### DIFF
--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -280,6 +280,12 @@
     #define PRIVILEGED_DATA         __attribute__( ( section( "privileged_data" ) ) )
     #define FREERTOS_SYSTEM_CALL    __attribute__( ( section( "freertos_system_calls" ) ) )
 
+#elif ( defined portMOVE_PRIVILEGED_DATA )
+
+    #define PRIVILEGED_FUNCTION
+    #define PRIVILEGED_DATA         portMOVE_PRIVILEGED_DATA
+    #define FREERTOS_SYSTEM_CALL
+
 #else /* portUSING_MPU_WRAPPERS */
 
     #define PRIVILEGED_FUNCTION

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -284,6 +284,12 @@
     #define PRIVILEGED_DATA         __attribute__( ( section( "privileged_data" ) ) )
     #define FREERTOS_SYSTEM_CALL    __attribute__( ( section( "freertos_system_calls" ) ) )
 
+#elif ( defined portMOVE_PRIVILEGED_DATA )
+
+    #define PRIVILEGED_FUNCTION
+    #define PRIVILEGED_DATA         portMOVE_PRIVILEGED_DATA
+    #define FREERTOS_SYSTEM_CALL
+
 #else /* portUSING_MPU_WRAPPERS */
 
     #define PRIVILEGED_FUNCTION

--- a/include/mpu_wrappers.h
+++ b/include/mpu_wrappers.h
@@ -284,17 +284,19 @@
     #define PRIVILEGED_DATA         __attribute__( ( section( "privileged_data" ) ) )
     #define FREERTOS_SYSTEM_CALL    __attribute__( ( section( "freertos_system_calls" ) ) )
 
-#elif ( defined portMOVE_PRIVILEGED_DATA )
-
-    #define PRIVILEGED_FUNCTION
-    #define PRIVILEGED_DATA         portMOVE_PRIVILEGED_DATA
-    #define FREERTOS_SYSTEM_CALL
-
 #else /* portUSING_MPU_WRAPPERS */
 
-    #define PRIVILEGED_FUNCTION
-    #define PRIVILEGED_DATA
-    #define FREERTOS_SYSTEM_CALL
+    #ifndef PRIVILEGED_FUNCTION
+        #define PRIVILEGED_FUNCTION
+    #endif
+
+    #ifndef PRIVILEGED_DATA
+        #define PRIVILEGED_DATA
+    #endif
+
+    #ifndef FREERTOS_SYSTEM_CALL
+        #define FREERTOS_SYSTEM_CALL
+    #endif
 
 #endif /* portUSING_MPU_WRAPPERS */
 


### PR DESCRIPTION
Support moving PRIVILEGED_DATA via an optional MPU wrapper:
- User can define portMOVE_PRIVILEGED_DATA as a section attribute to move the PRIVILEGED_DATA section arbitrarily.
- Allows critical data to be placed in port-specific location for improved performance, notably for cache-coherent SMP.
- Does not require enabling the full MPU wrappers.

Increment Partner-Supported-Ports submodule to the latest commit
- Xtensa Port v3.13 Updates (PR #31)

Passed regression testing with 100+ Xtensa configurations (SMP and single-core) 

Checklist:
----------
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.