### PR TITLE
docs: fix typo in pull request process guide

### DIFF
--- a/.github/pull_request_process.md
+++ b/.github/pull_request_process.md
@@ -14,7 +14,7 @@ This document explains the stages that a Pull Request (PR) goes through when a p
 
 **Assignee**: The Assignee is an AWS Employee who is responsible for identifying reviewers  and managing the PR. They track the progress of pull requests and ensure that they are reviewed and merged in a timely manner. 
 
-**Reviewer**: Reviewers are responsible for reviewing pull requests and providing feedback to the contributor. Two approving reviews, one of which must be from the CODEOWNER of the reposiroty, are required for a PR to be merged. 
+**Reviewer**: Reviewers are responsible for reviewing pull requests and providing feedback to the contributor. Two approving reviews, one of which must be from the CODEOWNER of the repository, are required for a PR to be merged. 
 
 
 ## ****Pull Request Life-Cycle****


### PR DESCRIPTION
Description
-----------
Fix a typo in the pull request process guide.

This updates `repository` in place of `reposiroty` in the reviewer requirements
section of `.github/pull_request_process.md`.

Test Steps
-----------
Not applicable; documentation-only change. No kernel behavior or build logic was modified.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None.
