### PR TITLE
docs: fix typos in RISC-V port assembly comments

### DIFF
--- a/portable/GCC/RISC-V/portASM.S
+++ b/portable/GCC/RISC-V/portASM.S
@@ -45,7 +45,7 @@
  *   that do not include a standard CLINT or do add to the base set of RISC-V
  *   registers.
  *
- * CARE MUST BE TAKEN TO INCLDUE THE CORRECT
+ * CARE MUST BE TAKEN TO INCLUDE THE CORRECT
  * freertos_risc_v_chip_specific_extensions.h HEADER FILE FOR THE CHIP
  * IN USE.  To include the correct freertos_risc_v_chip_specific_extensions.h
  * header file ensure the path to the correct header file is in the assembler's
@@ -364,7 +364,7 @@ asynchronous_interrupt:
     j handle_interrupt
 
 synchronous_exception:
-    addi a1, a1, 4                      /* Synchronous so update exception return address to the instruction after the instruction that generated the exeption. */
+    addi a1, a1, 4                      /* Synchronous so update exception return address to the instruction after the instruction that generated the exception. */
     store_x a1, 0( sp )                 /* Save updated exception return address. */
     load_x sp, xISRStackTop             /* Switch to ISR stack. */
     j handle_exception

--- a/portable/IAR/RISC-V/portASM.s
+++ b/portable/IAR/RISC-V/portASM.s
@@ -45,7 +45,7 @@
  *   that do not include a standard CLINT or do add to the base set of RISC-V
  *   registers.
  *
- * CARE MUST BE TAKEN TO INCLDUE THE CORRECT
+ * CARE MUST BE TAKEN TO INCLUDE THE CORRECT
  * freertos_risc_v_chip_specific_extensions.h HEADER FILE FOR THE CHIP
  * IN USE.  To include the correct freertos_risc_v_chip_specific_extensions.h
  * header file ensure the path to the correct header file is in the assembler's
@@ -357,7 +357,7 @@ asynchronous_interrupt:
     j handle_interrupt
 
 synchronous_exception:
-    addi a1, a1, 4                      /* Synchronous so update exception return address to the instruction after the instruction that generated the exeption. */
+    addi a1, a1, 4                      /* Synchronous so update exception return address to the instruction after the instruction that generated the exception. */
     store_x a1, 0( sp )                 /* Save updated exception return address. */
     load_x sp, xISRStackTop             /* Switch to ISR stack. */
     j handle_exception


### PR DESCRIPTION
Description
-----------
Fix typos in RISC-V port assembly comments for the GCC and IAR ports.

This updates `INCLUDE` in place of `INCLDUE` and `exception` in place of
`exeption` in the shared RISC-V port comments. These are comment-only changes
and do not affect runtime behavior.

Test Steps
-----------
Not applicable; comment-only change. No kernel behavior, assembler logic, or build configuration was modified.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None.
