### PR TITLE
docs: fix SWI handler comment typos in IAR ports

### DIFF
--- a/portable/IAR/AtmelSAM7S64/portasm.s79
+++ b/portable/IAR/AtmelSAM7S64/portasm.s79
@@ -46,7 +46,7 @@ vPortStartFirstTask:
     portRESTORE_CONTEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Manual context switch function.  This is the SWI hander.
+; Manual context switch function.  This is the SWI handler.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 vPortYieldProcessor:
     ADD     LR, LR, #4          ; Add 4 to the LR to make the LR appear exactly

--- a/portable/IAR/AtmelSAM9XE/portasm.s79
+++ b/portable/IAR/AtmelSAM9XE/portasm.s79
@@ -43,7 +43,7 @@ vPortStartFirstTask:
     portRESTORE_CONTEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Manual context switch function.  This is the SWI hander.
+; Manual context switch function.  This is the SWI handler.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 vPortYieldProcessor:
     ADD     LR, LR, #4          ; Add 4 to the LR to make the LR appear exactly

--- a/portable/IAR/LPC2000/portasm.s79
+++ b/portable/IAR/LPC2000/portasm.s79
@@ -47,7 +47,7 @@ vPortStartFirstTask:
     portRESTORE_CONTEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Manual context switch function.  This is the SWI hander.
+; Manual context switch function.  This is the SWI handler.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 vPortYieldProcessor:
     ADD     LR, LR, #4          ; Add 4 to the LR to make the LR appear exactly

--- a/portable/IAR/STR71x/portasm.s79
+++ b/portable/IAR/STR71x/portasm.s79
@@ -46,7 +46,7 @@ vPortStartFirstTask:
     portRESTORE_CONTEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Manual context switch function.  This is the SWI hander.
+; Manual context switch function.  This is the SWI handler.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 vPortYieldProcessor:
     ADD     LR, LR, #4          ; Add 4 to the LR to make the LR appear exactly

--- a/portable/IAR/STR75x/portasm.s79
+++ b/portable/IAR/STR75x/portasm.s79
@@ -45,7 +45,7 @@ vPortStartFirstTask:
     portRESTORE_CONTEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Manual context switch function.  This is the SWI hander.
+; Manual context switch function.  This is the SWI handler.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 vPortYieldProcessor:
     ADD     LR, LR, #4          ; Add 4 to the LR to make the LR appear exactly

--- a/portable/IAR/STR91x/portasm.s79
+++ b/portable/IAR/STR91x/portasm.s79
@@ -44,7 +44,7 @@ vPortStartFirstTask:
     portRESTORE_CONTEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Manual context switch function.  This is the SWI hander.
+; Manual context switch function.  This is the SWI handler.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 vPortYieldProcessor:
     ADD     LR, LR, #4          ; Add 4 to the LR to make the LR appear exactly


### PR DESCRIPTION
Description
-----------
Fix a repeated typo in IAR port assembly comments.

This updates `handler` in place of `hander` in the SWI context switch comment
across several IAR port assembly files. These are comment-only changes and do
not affect runtime behavior.

Test Steps
-----------
Not applicable; comment-only change. No kernel behavior, port logic, or build configuration was modified.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None.
