### PR TITLE
Add uxTaskCallForEachTask, and refactor uxTaskGetSystemState to use it.

### DIFF
--- a/include/task.h
+++ b/include/task.h
@@ -2231,7 +2231,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  * boot. pulTotalRunTime can be set to NULL to omit the total run time
  * information.
  *
- * @return The number of TaskStatus_t snapshots provided to the callback.
+ * @return The number tasks provided to the callback.
  */
     UBaseType_t uxTaskCallForEachTask( void (* pxCallbackFunction)( TaskHandle_t xTask,
                                                                     eTaskState eState,

--- a/include/task.h
+++ b/include/task.h
@@ -184,6 +184,13 @@ typedef struct xTASK_STATUS
     #endif
 } TaskStatus_t;
 
+/* Callback type used by uxTaskCallForEachTask(). The callback receives one
+ * task handle and state at a time, plus an opaque caller-supplied context
+ * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
+typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
+                                               eTaskState eState,
+                                               void * pvCallbackContext );
+
 /* Possible return values for eTaskConfirmSleepModeStatus(). */
 typedef enum
 {
@@ -2211,12 +2218,6 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
                                       const UBaseType_t uxArraySize,
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 
-/* Callback type used by uxTaskCallForEachTask(). The callback receives one
- * task handle and state at a time, plus an opaque caller-supplied context
- * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
-    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
-                                                   eTaskState eState,
-                                                   void * pvCallbackContext );
 
 /**
  * For each task, call pxCallbackFunction with the task's handle and state,

--- a/include/task.h
+++ b/include/task.h
@@ -2211,6 +2211,13 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
                                       const UBaseType_t uxArraySize,
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 
+/* Callback type used by uxTaskCallForEachTask(). The callback receives one
+ * task handle and state at a time, plus an opaque caller-supplied context
+ * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
+    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
+                                                   eTaskState eState,
+                                                   void * pvCallbackContext );
+
 /**
  * For each task, call pxCallbackFunction with the task's handle and state,
  * and the provided context.
@@ -2219,6 +2226,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  * the scheduler for an extended period. The callback runs while the
  * scheduler is suspended, so it must return quickly and must not perform
  * blocking operations.
+ * 
+ * NOTE: This API is privileged-only (it invokes a user callback from
+ * privileged context).
  *
  * @param pxCallbackFunction Callback to invoke once for each task (passing
  * the task's handle, state, and the pvCallbackContext).
@@ -2233,9 +2243,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  *
  * @return The number tasks provided to the callback.
  */
-    UBaseType_t uxTaskCallForEachTask( void ( * pxCallbackFunction )( TaskHandle_t xTask,
-                                                                      eTaskState eState,
-                                                                      void * pvCallbackContext ),
+    UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 

--- a/include/task.h
+++ b/include/task.h
@@ -2233,13 +2233,13 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  *
  * @return The number of TaskStatus_t snapshots provided to the callback.
  */
-    UBaseType_t uxTaskCallForEachTask( void (* pxCallbackFunction)( TaskHandle_t xTask,
-                                                                    eTaskState eState,
-                                                                    void * pvCallbackContext ),
+    UBaseType_t uxTaskCallForEachTask( void ( * pxCallbackFunction )( TaskHandle_t xTask,
+                                                                      eTaskState eState,
+                                                                      void * pvCallbackContext ),
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 
-#endif
+#endif /* if ( configUSE_TRACE_FACILITY == 1 ) */
 
 /**
  * task. h

--- a/include/task.h
+++ b/include/task.h
@@ -185,9 +185,10 @@ typedef struct xTASK_STATUS
 } TaskStatus_t;
 
 #if ( configUSE_TRACE_FACILITY == 1 )
-    /* Callback type used by uxTaskCallForEachTask(). The callback receives one
-     * task handle and state at a time, plus an opaque caller-supplied context
-     * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
+
+/* Callback type used by uxTaskCallForEachTask(). The callback receives one
+ * task handle and state at a time, plus an opaque caller-supplied context
+ * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
     typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
                                                    eTaskState eState,
                                                    void * pvCallbackContext );
@@ -2195,28 +2196,29 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
     UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
                                       const UBaseType_t uxArraySize,
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
-    /**
-     * For each task, call pxCallbackFunction with the task's handle and state,
-     * and the provided context.
-     *
-     * NOTE: This function is intended for debugging use only as it suspends
-     * the scheduler for an extended period. The callback runs while the
-     * scheduler is suspended, so it must return quickly and must not perform
-     * blocking operations.
-     *
-     * @param pxCallbackFunction Callback to invoke once for each task (passing
-     * the task's handle, state, and the pvCallbackContext). 
-     *
-     * @param pvCallbackContext Opaque caller-provided context passed through to
-     * each callback invocation.
-     *
-     * @param pulTotalRunTime If configGENERATE_RUN_TIME_STATS is set to 1 in
-     * FreeRTOSConfig.h then *pulTotalRunTime is set to the total run time since
-     * boot. pulTotalRunTime can be set to NULL to omit the total run time
-     * information.
-     *
-     * @return The number of TaskStatus_t snapshots provided to the callback.
-     */
+
+/**
+ * For each task, call pxCallbackFunction with the task's handle and state,
+ * and the provided context.
+ *
+ * NOTE: This function is intended for debugging use only as it suspends
+ * the scheduler for an extended period. The callback runs while the
+ * scheduler is suspended, so it must return quickly and must not perform
+ * blocking operations.
+ *
+ * @param pxCallbackFunction Callback to invoke once for each task (passing
+ * the task's handle, state, and the pvCallbackContext).
+ *
+ * @param pvCallbackContext Opaque caller-provided context passed through to
+ * each callback invocation.
+ *
+ * @param pulTotalRunTime If configGENERATE_RUN_TIME_STATS is set to 1 in
+ * FreeRTOSConfig.h then *pulTotalRunTime is set to the total run time since
+ * boot. pulTotalRunTime can be set to NULL to omit the total run time
+ * information.
+ *
+ * @return The number of TaskStatus_t snapshots provided to the callback.
+ */
     UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;

--- a/include/task.h
+++ b/include/task.h
@@ -2226,7 +2226,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  * the scheduler for an extended period. The callback runs while the
  * scheduler is suspended, so it must return quickly and must not perform
  * blocking operations.
- * 
+ *
  * NOTE: This API is privileged-only (it invokes a user callback from
  * privileged context).
  *

--- a/include/task.h
+++ b/include/task.h
@@ -184,6 +184,15 @@ typedef struct xTASK_STATUS
     #endif
 } TaskStatus_t;
 
+#if ( configUSE_TRACE_FACILITY == 1 )
+    /* Callback type used by uxTaskCallForEachTask(). The callback receives one
+     * task handle and state at a time, plus an opaque caller-supplied context
+     * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
+    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
+                                                   eTaskState eState,
+                                                   void * pvCallbackContext );
+#endif
+
 /* Possible return values for eTaskConfirmSleepModeStatus(). */
 typedef enum
 {
@@ -2186,6 +2195,32 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
     UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
                                       const UBaseType_t uxArraySize,
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
+    /**
+     * For each task, call pxCallbackFunction with the task's handle and state,
+     * and the provided context.
+     *
+     * NOTE: This function is intended for debugging use only as it suspends
+     * the scheduler for an extended period. The callback runs while the
+     * scheduler is suspended, so it must return quickly and must not perform
+     * blocking operations.
+     *
+     * @param pxCallbackFunction Callback to invoke once for each task (passing
+     * the task's handle, state, and the pvCallbackContext). 
+     *
+     * @param pvCallbackContext Opaque caller-provided context passed through to
+     * each callback invocation.
+     *
+     * @param pulTotalRunTime If configGENERATE_RUN_TIME_STATS is set to 1 in
+     * FreeRTOSConfig.h then *pulTotalRunTime is set to the total run time since
+     * boot. pulTotalRunTime can be set to NULL to omit the total run time
+     * information.
+     *
+     * @return The number of TaskStatus_t snapshots provided to the callback.
+     */
+    UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
+                                       void * pvCallbackContext,
+                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
+
 #endif
 
 /**

--- a/include/task.h
+++ b/include/task.h
@@ -184,6 +184,15 @@ typedef struct xTASK_STATUS
     #endif
 } TaskStatus_t;
 
+#if ( configUSE_TRACE_FACILITY == 1 )
+    /* Callback type used by uxTaskCallForEachTask(). The callback receives one
+     * task handle and state at a time, plus an opaque caller-supplied context
+     * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
+    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
+                                                   eTaskState eState,
+                                                   void * pvCallbackContext );
+#endif
+
 /* Possible return values for eTaskConfirmSleepModeStatus(). */
 typedef enum
 {
@@ -2210,6 +2219,32 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
     UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
                                       const UBaseType_t uxArraySize,
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
+    /**
+     * For each task, call pxCallbackFunction with the task's handle and state,
+     * and the provided context.
+     *
+     * NOTE: This function is intended for debugging use only as it suspends
+     * the scheduler for an extended period. The callback runs while the
+     * scheduler is suspended, so it must return quickly and must not perform
+     * blocking operations.
+     *
+     * @param pxCallbackFunction Callback to invoke once for each task (passing
+     * the task's handle, state, and the pvCallbackContext). 
+     *
+     * @param pvCallbackContext Opaque caller-provided context passed through to
+     * each callback invocation.
+     *
+     * @param pulTotalRunTime If configGENERATE_RUN_TIME_STATS is set to 1 in
+     * FreeRTOSConfig.h then *pulTotalRunTime is set to the total run time since
+     * boot. pulTotalRunTime can be set to NULL to omit the total run time
+     * information.
+     *
+     * @return The number of TaskStatus_t snapshots provided to the callback.
+     */
+    UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
+                                       void * pvCallbackContext,
+                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
+
 #endif
 
 /**

--- a/include/task.h
+++ b/include/task.h
@@ -184,16 +184,6 @@ typedef struct xTASK_STATUS
     #endif
 } TaskStatus_t;
 
-#if ( configUSE_TRACE_FACILITY == 1 )
-
-/* Callback type used by uxTaskCallForEachTask(). The callback receives one
- * task handle and state at a time, plus an opaque caller-supplied context
- * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
-    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
-                                                   eTaskState eState,
-                                                   void * pvCallbackContext );
-#endif
-
 /* Possible return values for eTaskConfirmSleepModeStatus(). */
 typedef enum
 {
@@ -2243,7 +2233,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  *
  * @return The number of TaskStatus_t snapshots provided to the callback.
  */
-    UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
+    UBaseType_t uxTaskCallForEachTask( void (* pxCallbackFunction)( TaskHandle_t xTask,
+                                                                    eTaskState eState,
+                                                                    * pvCallbackContext ),
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 

--- a/include/task.h
+++ b/include/task.h
@@ -184,16 +184,6 @@ typedef struct xTASK_STATUS
     #endif
 } TaskStatus_t;
 
-#if ( configUSE_TRACE_FACILITY == 1 )
-
-/* Callback type used by uxTaskCallForEachTask(). The callback receives one
- * task handle and state at a time, plus an opaque caller-supplied context
- * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
-    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
-                                                   eTaskState eState,
-                                                   void * pvCallbackContext );
-#endif
-
 /* Possible return values for eTaskConfirmSleepModeStatus(). */
 typedef enum
 {
@@ -2219,7 +2209,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  *
  * @return The number of TaskStatus_t snapshots provided to the callback.
  */
-    UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
+    UBaseType_t uxTaskCallForEachTask( void (* pxCallbackFunction)( TaskHandle_t xTask,
+                                                                    eTaskState eState,
+                                                                    * pvCallbackContext ),
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 

--- a/include/task.h
+++ b/include/task.h
@@ -2235,7 +2235,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  */
     UBaseType_t uxTaskCallForEachTask( void (* pxCallbackFunction)( TaskHandle_t xTask,
                                                                     eTaskState eState,
-                                                                    * pvCallbackContext ),
+                                                                    void * pvCallbackContext ),
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 

--- a/include/task.h
+++ b/include/task.h
@@ -2211,7 +2211,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
  */
     UBaseType_t uxTaskCallForEachTask( void (* pxCallbackFunction)( TaskHandle_t xTask,
                                                                     eTaskState eState,
-                                                                    * pvCallbackContext ),
+                                                                    void * pvCallbackContext ),
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
 

--- a/include/task.h
+++ b/include/task.h
@@ -185,9 +185,10 @@ typedef struct xTASK_STATUS
 } TaskStatus_t;
 
 #if ( configUSE_TRACE_FACILITY == 1 )
-    /* Callback type used by uxTaskCallForEachTask(). The callback receives one
-     * task handle and state at a time, plus an opaque caller-supplied context
-     * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
+
+/* Callback type used by uxTaskCallForEachTask(). The callback receives one
+ * task handle and state at a time, plus an opaque caller-supplied context
+ * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
     typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
                                                    eTaskState eState,
                                                    void * pvCallbackContext );
@@ -2219,28 +2220,29 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery ) PRIVILEGED_FUNCTION;
     UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
                                       const UBaseType_t uxArraySize,
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;
-    /**
-     * For each task, call pxCallbackFunction with the task's handle and state,
-     * and the provided context.
-     *
-     * NOTE: This function is intended for debugging use only as it suspends
-     * the scheduler for an extended period. The callback runs while the
-     * scheduler is suspended, so it must return quickly and must not perform
-     * blocking operations.
-     *
-     * @param pxCallbackFunction Callback to invoke once for each task (passing
-     * the task's handle, state, and the pvCallbackContext). 
-     *
-     * @param pvCallbackContext Opaque caller-provided context passed through to
-     * each callback invocation.
-     *
-     * @param pulTotalRunTime If configGENERATE_RUN_TIME_STATS is set to 1 in
-     * FreeRTOSConfig.h then *pulTotalRunTime is set to the total run time since
-     * boot. pulTotalRunTime can be set to NULL to omit the total run time
-     * information.
-     *
-     * @return The number of TaskStatus_t snapshots provided to the callback.
-     */
+
+/**
+ * For each task, call pxCallbackFunction with the task's handle and state,
+ * and the provided context.
+ *
+ * NOTE: This function is intended for debugging use only as it suspends
+ * the scheduler for an extended period. The callback runs while the
+ * scheduler is suspended, so it must return quickly and must not perform
+ * blocking operations.
+ *
+ * @param pxCallbackFunction Callback to invoke once for each task (passing
+ * the task's handle, state, and the pvCallbackContext).
+ *
+ * @param pvCallbackContext Opaque caller-provided context passed through to
+ * each callback invocation.
+ *
+ * @param pulTotalRunTime If configGENERATE_RUN_TIME_STATS is set to 1 in
+ * FreeRTOSConfig.h then *pulTotalRunTime is set to the total run time since
+ * boot. pulTotalRunTime can be set to NULL to omit the total run time
+ * information.
+ *
+ * @return The number of TaskStatus_t snapshots provided to the callback.
+ */
     UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
                                        void * pvCallbackContext,
                                        configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime ) PRIVILEGED_FUNCTION;

--- a/tasks.c
+++ b/tasks.c
@@ -4551,7 +4551,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
             /* Is there a space in the array for each task in the system? */
             if( uxArraySize >= uxCurrentNumberOfTasks )
             {
-                TaskStatusArrayWriterContext_t xContext = { pxTaskStatusArray, 0 };
+                TaskStatusArrayWriterContext_t xContext; /* Nope, not in ancient C89: = { pxTaskStatusArray, 0 }; */
+                xContext.pxTaskStatusArray = pxTaskStatusArray;
+                xContext.uxIndex = 0;
                 uxTask = prvCallForEachTask( prvTaskStatusArrayWriter, &xContext );
                 prvGetTotalRunTime( pulTotalRunTime );
             }

--- a/tasks.c
+++ b/tasks.c
@@ -3678,9 +3678,9 @@ STATIC BaseType_t prvCreateIdleTasks( void )
                 #if ( ( configIDLE_AFFINITY == 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
                 {
                     xIdleTaskHandles[ xCoreID ]->uxCoreAffinityMask = ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID );
+                }
+                #endif /* #if ( ( configIDLE_AFFINITY == 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */ 
             }
-            #endif
-        }
             #endif /* if ( configNUMBER_OF_CORES == 1 ) */
         }
     }

--- a/tasks.c
+++ b/tasks.c
@@ -4441,19 +4441,26 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
 
 #if ( configUSE_TRACE_FACILITY == 1 )
 
+/* Callback type used by uxTaskCallForEachTask(). The callback receives one
+ * task handle and state at a time, plus an opaque caller-supplied context
+ * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
+    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
+                                                   eTaskState eState,
+                                                   void * pvCallbackContext );
+
     STATIC UBaseType_t prvForEachTaskInList( List_t * pxList,
                                              eTaskState eState,
                                              TaskStatusCallbackFunction_t pxCallbackFunction,
                                              void * pvCallbackContext );
 
-/* for uxTaskGetSystemState callback: write position into TaskStatusArray */
+/* for uxTaskGetSystemState callback context: current write position into TaskStatusArray */
     typedef struct xTASK_STATUS_ARRAY_WRITER_CONTEXT
     {
         TaskStatus_t * pxTaskStatusArray;
         UBaseType_t uxIndex;
     } TaskStatusArrayWriterContext_t;
 
-/* callback for uxTaskGetSystemState: write the task status for one task into TaskStatusArray */
+/* callback for uxTaskGetSystemState: write one task's status into TaskStatusArray */
     STATIC void prvTaskStatusArrayWriter( TaskHandle_t xTask,
                                           eTaskState eState,
                                           void * pvCallbackContext )

--- a/tasks.c
+++ b/tasks.c
@@ -644,22 +644,6 @@ STATIC void prvAddCurrentTaskToDelayedList( TickType_t xTicksToWait,
                                             const BaseType_t xCanBlockIndefinitely ) PRIVILEGED_FUNCTION;
 
 /*
- * Fills an TaskStatus_t structure with information on each task that is
- * referenced from the pxList list (which may be a ready list, a delayed list,
- * a suspended list, etc.).
- *
- * THIS FUNCTION IS INTENDED FOR DEBUGGING ONLY, AND SHOULD NOT BE CALLED FROM
- * NORMAL APPLICATION CODE.
- */
-#if ( configUSE_TRACE_FACILITY == 1 )
-
-    STATIC UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
-                                                     List_t * pxList,
-                                                     eTaskState eState ) PRIVILEGED_FUNCTION;
-
-#endif
-
-/*
  * Searches pxList for a task with name pcNameToQuery - returning a handle to
  * the task if it is found, or NULL if the task is not found.
  */
@@ -3694,9 +3678,9 @@ STATIC BaseType_t prvCreateIdleTasks( void )
                 #if ( ( configIDLE_AFFINITY == 1 ) && ( configUSE_CORE_AFFINITY == 1 ) )
                 {
                     xIdleTaskHandles[ xCoreID ]->uxCoreAffinityMask = ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID );
-                }
-                #endif
             }
+            #endif
+        }
             #endif /* if ( configNUMBER_OF_CORES == 1 ) */
         }
     }
@@ -4457,11 +4441,100 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
 
 #if ( configUSE_TRACE_FACILITY == 1 )
 
+    STATIC UBaseType_t prvForEachTaskInList( List_t * pxList,
+                                             eTaskState eState,
+                                             TaskStatusCallbackFunction_t pxCallbackFunction,
+                                             void * pvCallbackContext );
+
+    /* for uxTaskGetSystemState callback: write position into TaskStatusArray */
+    typedef struct xTASK_STATUS_ARRAY_WRITER_CONTEXT
+    {
+        TaskStatus_t * pxTaskStatusArray;
+        UBaseType_t uxIndex;
+    } TaskStatusArrayWriterContext_t;
+
+    /* callback for uxTaskGetSystemState: write the task status for one task into TaskStatusArray */
+    STATIC void prvTaskStatusArrayWriter( TaskHandle_t xTask,
+                                          eTaskState eState,
+                                          void * pvCallbackContext )
+    {
+        TaskStatusArrayWriterContext_t * pxContext = ( TaskStatusArrayWriterContext_t * ) pvCallbackContext;
+        vTaskGetInfo( xTask, &( pxContext->pxTaskStatusArray[ pxContext->uxIndex++ ] ), pdTRUE, eState );
+    }
+
+    STATIC void prvGetTotalRunTime( configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
+    {
+        if( pulTotalRunTime != NULL )
+        {
+            #if ( configGENERATE_RUN_TIME_STATS == 1 )
+                #ifdef portALT_GET_RUN_TIME_COUNTER_VALUE
+                    portALT_GET_RUN_TIME_COUNTER_VALUE( ( *pulTotalRunTime ) );
+                #else
+                    *pulTotalRunTime = ( configRUN_TIME_COUNTER_TYPE ) portGET_RUN_TIME_COUNTER_VALUE();
+                #endif
+            #else
+                *pulTotalRunTime = 0;
+            #endif /* if ( configGENERATE_RUN_TIME_STATS == 1 ) */
+        }
+    }
+
+    /* For each task, call the provided callback function (passing the provided context). */
+    STATIC UBaseType_t prvCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
+                                           void * pvCallbackContext )
+    {
+        UBaseType_t uxTask = 0, uxQueue = configMAX_PRIORITIES;
+
+        /* Visit each task in the Ready state. */
+        do
+        {
+            uxQueue--;
+            uxTask = ( UBaseType_t ) ( uxTask + prvForEachTaskInList( &( pxReadyTasksLists[ uxQueue ] ), eReady, pxCallbackFunction, pvCallbackContext ) );
+        } while( uxQueue > ( UBaseType_t ) tskIDLE_PRIORITY );
+
+        /* Visit each task in the Blocked state. */
+        uxTask = ( UBaseType_t ) ( uxTask + prvForEachTaskInList( ( List_t * ) pxDelayedTaskList, eBlocked, pxCallbackFunction, pvCallbackContext ) );
+        uxTask = ( UBaseType_t ) ( uxTask + prvForEachTaskInList( ( List_t * ) pxOverflowDelayedTaskList, eBlocked, pxCallbackFunction, pvCallbackContext ) );
+
+        #if ( INCLUDE_vTaskDelete == 1 )
+        {
+            /* Visit each task that has been deleted but not yet cleaned up. */
+            uxTask = ( UBaseType_t ) ( uxTask + prvForEachTaskInList( &xTasksWaitingTermination, eDeleted, pxCallbackFunction, pvCallbackContext ) );
+        }
+        #endif
+
+        #if ( INCLUDE_vTaskSuspend == 1 )
+        {
+            /* Visit each task in the Suspended state. */
+            uxTask = ( UBaseType_t ) ( uxTask + prvForEachTaskInList( &xSuspendedTaskList, eSuspended, pxCallbackFunction, pvCallbackContext ) );
+        }
+        #endif
+
+        return uxTask;
+    }
+
+    UBaseType_t uxTaskCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
+                                       void * pvCallbackContext,
+                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
+    {
+        UBaseType_t uxTask;
+
+        configASSERT( pxCallbackFunction != NULL );
+
+        vTaskSuspendAll();
+        {
+            uxTask = prvCallForEachTask( pxCallbackFunction, pvCallbackContext );
+            prvGetTotalRunTime( pulTotalRunTime );
+        }
+        ( void ) xTaskResumeAll();
+
+        return uxTask;
+    }
+
     UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
                                       const UBaseType_t uxArraySize,
                                       configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
     {
-        UBaseType_t uxTask = 0, uxQueue = configMAX_PRIORITIES;
+        UBaseType_t uxTask = 0;
 
         traceENTER_uxTaskGetSystemState( pxTaskStatusArray, uxArraySize, pulTotalRunTime );
 
@@ -4470,54 +4543,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
             /* Is there a space in the array for each task in the system? */
             if( uxArraySize >= uxCurrentNumberOfTasks )
             {
-                /* Fill in an TaskStatus_t structure with information on each
-                 * task in the Ready state. */
-                do
-                {
-                    uxQueue--;
-                    uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &( pxReadyTasksLists[ uxQueue ] ), eReady ) );
-                } while( uxQueue > ( UBaseType_t ) tskIDLE_PRIORITY );
-
-                /* Fill in an TaskStatus_t structure with information on each
-                 * task in the Blocked state. */
-                uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxDelayedTaskList, eBlocked ) );
-                uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), ( List_t * ) pxOverflowDelayedTaskList, eBlocked ) );
-
-                #if ( INCLUDE_vTaskDelete == 1 )
-                {
-                    /* Fill in an TaskStatus_t structure with information on
-                     * each task that has been deleted but not yet cleaned up. */
-                    uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &xTasksWaitingTermination, eDeleted ) );
-                }
-                #endif
-
-                #if ( INCLUDE_vTaskSuspend == 1 )
-                {
-                    /* Fill in an TaskStatus_t structure with information on
-                     * each task in the Suspended state. */
-                    uxTask = ( UBaseType_t ) ( uxTask + prvListTasksWithinSingleList( &( pxTaskStatusArray[ uxTask ] ), &xSuspendedTaskList, eSuspended ) );
-                }
-                #endif
-
-                #if ( configGENERATE_RUN_TIME_STATS == 1 )
-                {
-                    if( pulTotalRunTime != NULL )
-                    {
-                        #ifdef portALT_GET_RUN_TIME_COUNTER_VALUE
-                            portALT_GET_RUN_TIME_COUNTER_VALUE( ( *pulTotalRunTime ) );
-                        #else
-                            *pulTotalRunTime = ( configRUN_TIME_COUNTER_TYPE ) portGET_RUN_TIME_COUNTER_VALUE();
-                        #endif
-                    }
-                }
-                #else /* if ( configGENERATE_RUN_TIME_STATS == 1 ) */
-                {
-                    if( pulTotalRunTime != NULL )
-                    {
-                        *pulTotalRunTime = 0;
-                    }
-                }
-                #endif /* if ( configGENERATE_RUN_TIME_STATS == 1 ) */
+                TaskStatusArrayWriterContext_t xContext = { pxTaskStatusArray, 0 };
+                uxTask = prvCallForEachTask( prvTaskStatusArrayWriter, &xContext );
+                prvGetTotalRunTime( pulTotalRunTime );
             }
             else
             {
@@ -6344,9 +6372,10 @@ STATIC void prvCheckTasksWaitingTermination( void )
 
 #if ( configUSE_TRACE_FACILITY == 1 )
 
-    STATIC UBaseType_t prvListTasksWithinSingleList( TaskStatus_t * pxTaskStatusArray,
-                                                     List_t * pxList,
-                                                     eTaskState eState )
+    STATIC UBaseType_t prvForEachTaskInList( List_t * pxList,
+                                             eTaskState eState,
+                                             TaskStatusCallbackFunction_t pxCallbackFunction,
+                                             void * pvCallbackContext )
     {
         UBaseType_t uxTask = 0;
         const ListItem_t * pxEndMarker = listGET_END_MARKER( pxList );
@@ -6355,10 +6384,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
 
         if( listCURRENT_LIST_LENGTH( pxList ) > ( UBaseType_t ) 0 )
         {
-            /* Populate an TaskStatus_t structure within the
-             * pxTaskStatusArray array for each task that is referenced from
-             * pxList.  See the definition of TaskStatus_t in task.h for the
-             * meaning of each TaskStatus_t structure member. */
+            /* Hand the callback each task handle referenced from pxList. */
             for( pxIterator = listGET_HEAD_ENTRY( pxList ); pxIterator != pxEndMarker; pxIterator = listGET_NEXT( pxIterator ) )
             {
                 /* MISRA Ref 11.5.3 [Void pointer assignment] */
@@ -6366,7 +6392,7 @@ STATIC void prvCheckTasksWaitingTermination( void )
                 /* coverity[misra_c_2012_rule_11_5_violation] */
                 pxTCB = listGET_LIST_ITEM_OWNER( pxIterator );
 
-                vTaskGetInfo( ( TaskHandle_t ) pxTCB, &( pxTaskStatusArray[ uxTask ] ), pdTRUE, eState );
+                pxCallbackFunction( ( TaskHandle_t ) pxTCB, eState, pvCallbackContext );
                 uxTask++;
             }
         }

--- a/tasks.c
+++ b/tasks.c
@@ -3679,7 +3679,7 @@ STATIC BaseType_t prvCreateIdleTasks( void )
                 {
                     xIdleTaskHandles[ xCoreID ]->uxCoreAffinityMask = ( ( UBaseType_t ) 1U << ( UBaseType_t ) xCoreID );
                 }
-                #endif /* #if ( ( configIDLE_AFFINITY == 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */ 
+                #endif /* #if ( ( configIDLE_AFFINITY == 1 ) && ( configUSE_CORE_AFFINITY == 1 ) ) */
             }
             #endif /* if ( configNUMBER_OF_CORES == 1 ) */
         }
@@ -4446,19 +4446,20 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
                                              TaskStatusCallbackFunction_t pxCallbackFunction,
                                              void * pvCallbackContext );
 
-    /* for uxTaskGetSystemState callback: write position into TaskStatusArray */
+/* for uxTaskGetSystemState callback: write position into TaskStatusArray */
     typedef struct xTASK_STATUS_ARRAY_WRITER_CONTEXT
     {
         TaskStatus_t * pxTaskStatusArray;
         UBaseType_t uxIndex;
     } TaskStatusArrayWriterContext_t;
 
-    /* callback for uxTaskGetSystemState: write the task status for one task into TaskStatusArray */
+/* callback for uxTaskGetSystemState: write the task status for one task into TaskStatusArray */
     STATIC void prvTaskStatusArrayWriter( TaskHandle_t xTask,
                                           eTaskState eState,
                                           void * pvCallbackContext )
     {
         TaskStatusArrayWriterContext_t * pxContext = ( TaskStatusArrayWriterContext_t * ) pvCallbackContext;
+
         vTaskGetInfo( xTask, &( pxContext->pxTaskStatusArray[ pxContext->uxIndex++ ] ), pdTRUE, eState );
     }
 
@@ -4478,7 +4479,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
         }
     }
 
-    /* For each task, call the provided callback function (passing the provided context). */
+/* For each task, call the provided callback function (passing the provided context). */
     STATIC UBaseType_t prvCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
                                            void * pvCallbackContext )
     {

--- a/tasks.c
+++ b/tasks.c
@@ -4441,13 +4441,6 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
 
 #if ( configUSE_TRACE_FACILITY == 1 )
 
-/* Callback type used by uxTaskCallForEachTask(). The callback receives one
- * task handle and state at a time, plus an opaque caller-supplied context
- * pointer. The callback may call vTaskGetInfo() if it needs a TaskStatus_t. */
-    typedef void (* TaskStatusCallbackFunction_t)( TaskHandle_t xTask,
-                                                   eTaskState eState,
-                                                   void * pvCallbackContext );
-
     STATIC UBaseType_t prvForEachTaskInList( List_t * pxList,
                                              eTaskState eState,
                                              TaskStatusCallbackFunction_t pxCallbackFunction,
@@ -4487,6 +4480,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
     }
 
 /* For each task, call the provided callback function (passing the provided context). */
+/* Caller must suspend the scheduler around use of this function. */
     STATIC UBaseType_t prvCallForEachTask( TaskStatusCallbackFunction_t pxCallbackFunction,
                                            void * pvCallbackContext )
     {
@@ -4527,6 +4521,7 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
         UBaseType_t uxTask;
 
         configASSERT( pxCallbackFunction != NULL );
+        if( pxCallbackFunction == NULL ) return 0;
 
         vTaskSuspendAll();
         {

--- a/tasks.c
+++ b/tasks.c
@@ -4551,7 +4551,9 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
             /* Is there a space in the array for each task in the system? */
             if( uxArraySize >= uxCurrentNumberOfTasks )
             {
-                TaskStatusArrayWriterContext_t xContext = { pxTaskStatusArray, 0 };
+                TaskStatusArrayWriterContext_t xContext;
+                xContext.pxTaskStatusArray = pxTaskStatusArray;
+                xContext.uxIndex = 0;
                 uxTask = prvCallForEachTask( prvTaskStatusArrayWriter, &xContext );
                 prvGetTotalRunTime( pulTotalRunTime );
             }

--- a/tasks.c
+++ b/tasks.c
@@ -4521,7 +4521,11 @@ char * pcTaskGetName( TaskHandle_t xTaskToQuery )
         UBaseType_t uxTask;
 
         configASSERT( pxCallbackFunction != NULL );
-        if( pxCallbackFunction == NULL ) return 0;
+
+        if( pxCallbackFunction == NULL )
+        {
+            return 0;
+        }
 
         vTaskSuspendAll();
         {


### PR DESCRIPTION
Get task statistics for all tasks with less memory use, by doing it one task at a time.
Provide a public iterator over all tasks for diagnostics.

@aggarg - This is a better refactoring and does not increase stack space use (from #1424):
- The public iterator function is cleaner (passes task handle and state plus context to callback).
- Does not replicate task location code as in your suggested patch.
- Based on the latest development head for easier merge.
- Retested in my application.

Hope you approve!


Description
-----------
Add uxTaskCallForEachTask, which is the iteration portion of last released uxTaskGetSystemState. uxTaskCallForEachTask calls a user-provided callback once for each task (with the task handle and state, plus a context).

Refactor uxTaskGetSystemState so that it uses uxTaskCallForEachTask to fill in the pre-allocated array of TaskStatus_t, preserving the existing uxTaskGetSystemState API for current users.

Test Steps
-----------
1. Use uxTaskCallForEachTask to observe task statistics for each task in the system.
2. Compare existing uxTaskGetSystemState output to new version.

Checklist:
----------
- [x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Discussed on forum but no Github Issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
