### PR TITLE
Fix RP2040 task lock acquire ordering

### DIFF
--- a/portable/ThirdParty/GCC/RP2040/include/portmacro.h
+++ b/portable/ThirdParty/GCC/RP2040/include/portmacro.h
@@ -237,6 +237,11 @@ static inline void vPortRecursiveLock( BaseType_t xCoreID,
             }
             spin_lock_unsafe_blocking(pxSpinLock);
         }
+        else
+        {
+            /* spin_try_lock_unsafe() does not provide acquire ordering on the fast path. */
+            __mem_fence_acquire();
+        }
         configASSERT( ucRecursionCountByLock[ ulLockNum ] == 0 );
         ucRecursionCountByLock[ ulLockNum ] = 1;
         ucOwnedByCore[ xCoreID ][ ulLockNum ] = 1;


### PR DESCRIPTION
Description
-----------
Fixes #1430.

`vPortRecursiveLock()` used `spin_try_lock_unsafe()` for the uncontended RP2040 task/ISR lock path, then immediately read lock-protected bookkeeping. The blocking path already gets acquire ordering from `spin_lock_unsafe_blocking()`, but the successful try-lock path did not.

This adds an acquire fence only on the try-lock success path. The contended path is left unchanged so it does not receive a duplicate fence.

Test Steps
-----------
- Inspected the RP2040 lock flow in `portable/ThirdParty/GCC/RP2040/include/portmacro.h`.
- Compared against pico-sdk `spin_lock_unsafe_blocking()` / `spin_try_lock_unsafe()` definitions to confirm only the try-lock fast path lacks acquire ordering.
- Ran `git diff HEAD~1 HEAD --check`.
- Verified the modified file uses CRLF line endings.

Not run: RP2040 hardware build/runtime test; the local Windows environment does not have `cmake` or `arm-none-eabi-gcc` installed.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1430

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.