### PR TITLE
Fix vPortFreeSecureContext to read xSecureContext at correct offset

### DIFF
--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM23/portasm.c
@@ -48,6 +48,12 @@
 #endif
 
 #if ( configENABLE_MPU == 1 )
+    #define SECURE_CONTEXT_OFFSET   -20
+#else
+    #define SECURE_CONTEXT_OFFSET   0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -590,15 +596,16 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   adds r2, r2, %0                                 \n" /* r2 = r2 + SECURE_CONTEXT_OFFSET. */
+        "   ldr r1, [r2]                                    \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   bne free_secure_context                         \n" /* Branch if r1 != 0. */
         "   bx lr                                           \n" /* There is no secure context (xSecureContext is NULL). */
         " free_secure_context:                              \n"
-        "   svc %0                                          \n" /* Secure context is freed in the supervisor call. */
+        "   svc %1                                          \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
+++ b/portable/ARMv8M/non_secure/portable/GCC/ARM_CM33/portasm.c
@@ -46,6 +46,16 @@
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -609,13 +619,13 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   ldr r1, [r2, %0]                                \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   it ne                                           \n"
-        "   svcne %0                                        \n" /* Secure context is freed in the supervisor call. */
+        "   svcne %1                                        \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM23/portasm.s
@@ -40,6 +40,12 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #define SECURE_CONTEXT_OFFSET   -20
+#else
+    #define SECURE_CONTEXT_OFFSET   0
+#endif
+
 
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
@@ -512,8 +518,9 @@ SVC_Handler:
 /*-----------------------------------------------------------*/
 
 vPortFreeSecureContext:
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    adds r2, r2, #SECURE_CONTEXT_OFFSET     /* r2 = r2 + SECURE_CONTEXT_OFFSET. */
+    ldr r1, [r2]                            /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     bne free_secure_context                 /* Branch if r1 != 0. */
     bx lr                                   /* There is no secure context (xSecureContext is NULL). */

--- a/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
+++ b/portable/ARMv8M/non_secure/portable/IAR/ARM_CM33/portasm.s
@@ -41,6 +41,16 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
     EXTERN vTaskSwitchContext
@@ -532,8 +542,8 @@ SVC_Handler:
 
 vPortFreeSecureContext:
     /* r0 = uint32_t *pulTCB. */
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    ldr r1, [r2, #SECURE_CONTEXT_OFFSET]    /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     it ne
     svcne 101                               /* Secure context is freed in the supervisor call. portSVC_FREE_SECURE_CONTEXT = 101. */

--- a/portable/GCC/ARM_CM23/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM23/non_secure/portasm.c
@@ -48,6 +48,12 @@
 #endif
 
 #if ( configENABLE_MPU == 1 )
+    #define SECURE_CONTEXT_OFFSET   -20
+#else
+    #define SECURE_CONTEXT_OFFSET   0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -590,15 +596,16 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   adds r2, r2, %0                                 \n" /* r2 = r2 + SECURE_CONTEXT_OFFSET. */
+        "   ldr r1, [r2]                                    \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   bne free_secure_context                         \n" /* Branch if r1 != 0. */
         "   bx lr                                           \n" /* There is no secure context (xSecureContext is NULL). */
         " free_secure_context:                              \n"
-        "   svc %0                                          \n" /* Secure context is freed in the supervisor call. */
+        "   svc %1                                          \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -46,6 +46,16 @@
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -609,13 +619,13 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   ldr r1, [r2, %0]                                \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   it ne                                           \n"
-        "   svcne %0                                        \n" /* Secure context is freed in the supervisor call. */
+        "   svcne %1                                        \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM35P/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM35P/non_secure/portasm.c
@@ -46,6 +46,16 @@
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -609,13 +619,13 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   ldr r1, [r2, %0]                                \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   it ne                                           \n"
-        "   svcne %0                                        \n" /* Secure context is freed in the supervisor call. */
+        "   svcne %1                                        \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM52/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM52/non_secure/portasm.c
@@ -46,6 +46,16 @@
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -609,13 +619,13 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   ldr r1, [r2, %0]                                \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   it ne                                           \n"
-        "   svcne %0                                        \n" /* Secure context is freed in the supervisor call. */
+        "   svcne %1                                        \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM55/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM55/non_secure/portasm.c
@@ -46,6 +46,16 @@
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -609,13 +619,13 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   ldr r1, [r2, %0]                                \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   it ne                                           \n"
-        "   svcne %0                                        \n" /* Secure context is freed in the supervisor call. */
+        "   svcne %1                                        \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_CM85/non_secure/portasm.c
+++ b/portable/GCC/ARM_CM85/non_secure/portasm.c
@@ -46,6 +46,16 @@
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -609,13 +619,13 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   ldr r1, [r2, %0]                                \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   it ne                                           \n"
-        "   svcne %0                                        \n" /* Secure context is freed in the supervisor call. */
+        "   svcne %1                                        \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/GCC/ARM_STAR_MC3/non_secure/portasm.c
+++ b/portable/GCC/ARM_STAR_MC3/non_secure/portasm.c
@@ -46,6 +46,16 @@
 #undef MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 
 #if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
+#if ( configENABLE_MPU == 1 )
 
     void vRestoreContextOfFirstTask( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
     {
@@ -609,13 +619,13 @@ void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PR
     (
         "   .syntax unified                                 \n"
         "                                                   \n"
-        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the top of the stack. */
-        "   ldr r1, [r2]                                    \n" /* The first item on the stack is the task's xSecureContext. */
+        "   ldr r2, [r0]                                    \n" /* The first item in the TCB is the stored context location. */
+        "   ldr r1, [r2, %0]                                \n" /* Read xSecureContext from the task's context. */
         "   cmp r1, #0                                      \n" /* Raise svc if task's xSecureContext is not NULL. */
         "   it ne                                           \n"
-        "   svcne %0                                        \n" /* Secure context is freed in the supervisor call. */
+        "   svcne %1                                        \n" /* Secure context is freed in the supervisor call. */
         "   bx lr                                           \n" /* Return. */
-        ::"i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
+        ::"i" ( SECURE_CONTEXT_OFFSET ), "i" ( portSVC_FREE_SECURE_CONTEXT ) : "memory"
     );
 }
 /*-----------------------------------------------------------*/

--- a/portable/IAR/ARM_CM23/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM23/non_secure/portasm.s
@@ -40,6 +40,12 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #define SECURE_CONTEXT_OFFSET   -20
+#else
+    #define SECURE_CONTEXT_OFFSET   0
+#endif
+
 
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
@@ -512,8 +518,9 @@ SVC_Handler:
 /*-----------------------------------------------------------*/
 
 vPortFreeSecureContext:
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    adds r2, r2, #SECURE_CONTEXT_OFFSET     /* r2 = r2 + SECURE_CONTEXT_OFFSET. */
+    ldr r1, [r2]                            /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     bne free_secure_context                 /* Branch if r1 != 0. */
     bx lr                                   /* There is no secure context (xSecureContext is NULL). */

--- a/portable/IAR/ARM_CM33/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM33/non_secure/portasm.s
@@ -41,6 +41,16 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
     EXTERN vTaskSwitchContext
@@ -532,8 +542,8 @@ SVC_Handler:
 
 vPortFreeSecureContext:
     /* r0 = uint32_t *pulTCB. */
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    ldr r1, [r2, #SECURE_CONTEXT_OFFSET]    /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     it ne
     svcne 101                               /* Secure context is freed in the supervisor call. portSVC_FREE_SECURE_CONTEXT = 101. */

--- a/portable/IAR/ARM_CM35P/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM35P/non_secure/portasm.s
@@ -41,6 +41,16 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
     EXTERN vTaskSwitchContext
@@ -532,8 +542,8 @@ SVC_Handler:
 
 vPortFreeSecureContext:
     /* r0 = uint32_t *pulTCB. */
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    ldr r1, [r2, #SECURE_CONTEXT_OFFSET]    /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     it ne
     svcne 101                               /* Secure context is freed in the supervisor call. portSVC_FREE_SECURE_CONTEXT = 101. */

--- a/portable/IAR/ARM_CM52/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM52/non_secure/portasm.s
@@ -41,6 +41,16 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
     EXTERN vTaskSwitchContext
@@ -532,8 +542,8 @@ SVC_Handler:
 
 vPortFreeSecureContext:
     /* r0 = uint32_t *pulTCB. */
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    ldr r1, [r2, #SECURE_CONTEXT_OFFSET]    /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     it ne
     svcne 101                               /* Secure context is freed in the supervisor call. portSVC_FREE_SECURE_CONTEXT = 101. */

--- a/portable/IAR/ARM_CM55/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM55/non_secure/portasm.s
@@ -41,6 +41,16 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
     EXTERN vTaskSwitchContext
@@ -532,8 +542,8 @@ SVC_Handler:
 
 vPortFreeSecureContext:
     /* r0 = uint32_t *pulTCB. */
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    ldr r1, [r2, #SECURE_CONTEXT_OFFSET]    /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     it ne
     svcne 101                               /* Secure context is freed in the supervisor call. portSVC_FREE_SECURE_CONTEXT = 101. */

--- a/portable/IAR/ARM_CM85/non_secure/portasm.s
+++ b/portable/IAR/ARM_CM85/non_secure/portasm.s
@@ -41,6 +41,16 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
     EXTERN vTaskSwitchContext
@@ -532,8 +542,8 @@ SVC_Handler:
 
 vPortFreeSecureContext:
     /* r0 = uint32_t *pulTCB. */
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    ldr r1, [r2, #SECURE_CONTEXT_OFFSET]    /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     it ne
     svcne 101                               /* Secure context is freed in the supervisor call. portSVC_FREE_SECURE_CONTEXT = 101. */

--- a/portable/IAR/ARM_STAR_MC3/non_secure/portasm.s
+++ b/portable/IAR/ARM_STAR_MC3/non_secure/portasm.s
@@ -41,6 +41,16 @@ files (__ICCARM__ is defined by the IAR C compiler but not by the IAR assembler.
     #define configUSE_MPU_WRAPPERS_V1 0
 #endif
 
+#if ( configENABLE_MPU == 1 )
+    #if ( configENABLE_PAC == 1 )
+        #define SECURE_CONTEXT_OFFSET   -36
+    #else
+        #define SECURE_CONTEXT_OFFSET   -20
+    #endif
+#else
+    #define SECURE_CONTEXT_OFFSET       0
+#endif
+
     EXTERN pxCurrentTCB
     EXTERN xSecureContext
     EXTERN vTaskSwitchContext
@@ -532,8 +542,8 @@ SVC_Handler:
 
 vPortFreeSecureContext:
     /* r0 = uint32_t *pulTCB. */
-    ldr r2, [r0]                            /* The first item in the TCB is the top of the stack. */
-    ldr r1, [r2]                            /* The first item on the stack is the task's xSecureContext. */
+    ldr r2, [r0]                            /* The first item in the TCB is the stored context location. */
+    ldr r1, [r2, #SECURE_CONTEXT_OFFSET]    /* Read xSecureContext from the task's context. */
     cmp r1, #0                              /* Raise svc if task's xSecureContext is not NULL. */
     it ne
     svcne 101                               /* Secure context is freed in the supervisor call. portSVC_FREE_SECURE_CONTEXT = 101. */


### PR DESCRIPTION
Description
-----------
When MPU is enabled, the first item in the TCB is not the top of the stack but the stored context location. As a result, `xSecureContext` is located at a negative offset from that position rather than at offset 0. The current implementation unconditionally reads `xSecureContext` at offset 0, which returns an incorrect value when MPU is enabled.

This commit updates `vPortFreeSecureContext` to read `xSecureContext` at the correct offset based on the port configuration:
- CM33/CM35P/CM52/CM55/CM85/STAR_MC3: -20 (or -36 with PAC enabled)
- CM23: -20 (no PAC support)
- Without MPU: 0 (`xSecureContext` remains at the top of stack)

Test Steps
-----------
Tested using [CORTEX_MPU_M33F_Nordic_NRF9160_SES](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS/Demo/CORTEX_MPU_M33F_Nordic_NRF9160_SES) demo.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
