### PR TITLE
Fix MicroBlaze stack protection context layout

### DIFF
--- a/portable/GCC/MicroBlazeV9/portasm.S
+++ b/portable/GCC/MicroBlazeV9/portasm.S
@@ -37,12 +37,31 @@
 /* The context is oversized to allow functions called from the ISR to write
 back into the caller stack. */
 #if defined (__arch64__)
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+#if( XPAR_MICROBLAZE_USE_FPU != 0 )
+	#define portCONTEXT_SIZE 288
+	#define portMINUS_CONTEXT_SIZE -288
+#else
+	#define portCONTEXT_SIZE 280
+	#define portMINUS_CONTEXT_SIZE -280
+#endif
+#else
 #if( XPAR_MICROBLAZE_USE_FPU != 0 )
 	#define portCONTEXT_SIZE 272
 	#define portMINUS_CONTEXT_SIZE -272
 #else
 	#define portCONTEXT_SIZE 264
 	#define portMINUS_CONTEXT_SIZE -264
+#endif
+#endif
+#else
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+#if( XPAR_MICROBLAZE_USE_FPU != 0 )
+	#define portCONTEXT_SIZE 144
+	#define portMINUS_CONTEXT_SIZE -144
+#else
+	#define portCONTEXT_SIZE 140
+	#define portMINUS_CONTEXT_SIZE -140
 #endif
 #else
 #if( XPAR_MICROBLAZE_USE_FPU != 0 )
@@ -51,6 +70,7 @@ back into the caller stack. */
 #else
 	#define portCONTEXT_SIZE 132
 	#define portMINUS_CONTEXT_SIZE -132
+#endif
 #endif
 #endif
 
@@ -88,7 +108,16 @@ back into the caller stack. */
 #define portR2_OFFSET	240
 #define portCRITICAL_NESTING_OFFSET 248
 #define portMSR_OFFSET 256
+#if( XPAR_MICROBLAZE_USE_FPU != 0 )
 #define portFSR_OFFSET 264
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+#define portSLR_OFFSET 272
+#define portSHR_OFFSET 280
+#endif
+#elif( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+#define portSLR_OFFSET 264
+#define portSHR_OFFSET 272
+#endif
 #else
 #define portR31_OFFSET	4
 #define portR30_OFFSET	8
@@ -122,7 +151,16 @@ back into the caller stack. */
 #define portR2_OFFSET	120
 #define portCRITICAL_NESTING_OFFSET 124
 #define portMSR_OFFSET 128
+#if( XPAR_MICROBLAZE_USE_FPU != 0 )
 #define portFSR_OFFSET 132
+#if( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+#define portSLR_OFFSET 136
+#define portSHR_OFFSET 140
+#endif
+#elif( XPAR_MICROBLAZE_USE_STACK_PROTECTION )
+#define portSLR_OFFSET 132
+#define portSHR_OFFSET 136
+#endif
 
 #endif
 


### PR DESCRIPTION
## Summary

Fixes #1416.

This updates the MicroBlazeV9 assembly context layout so `XPAR_MICROBLAZE_USE_STACK_PROTECTION` has valid save/restore slots for the stack limit registers:

- adds `portSLR_OFFSET` and `portSHR_OFFSET` for 32-bit and `__arch64__` layouts
- grows `portCONTEXT_SIZE` / `portMINUS_CONTEXT_SIZE` when stack protection is enabled
- keeps existing FPU/no-FPU layouts unchanged when stack protection is disabled

## Root cause

`portSAVE_CONTEXT` and `portRESTORE_CONTEXT` already save and restore `rslr` / `rshr` under `XPAR_MICROBLAZE_USE_STACK_PROTECTION`, but the offsets were not defined and the task context frame size did not include those fields.

## Validation

- Local red check confirmed `portSLR_OFFSET` / `portSHR_OFFSET` were missing before the patch.
- Local static layout check passed for the 32-bit and `__arch64__` FPU/no-FPU stack-protection combinations.
- `git diff --check`

I could not run the full MicroBlaze compile locally because `mb-gcc` is not installed in this Windows environment. The repository GitHub Actions workflow has a dedicated MicroBlazeV9 compile step that should cover this path.
