### PR TITLE
Fix copy-paste comment typos in xTaskGetApplicationTaskTag[FromISR]

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -5035,11 +5035,11 @@ BaseType_t xTaskIncrementTick( void )
 
         traceENTER_xTaskGetApplicationTaskTag( xTask );
 
-        /* If xTask is NULL then set the calling task's hook. */
+        /* If xTask is NULL then get the calling task's hook. */
         pxTCB = prvGetTCBFromHandle( xTask );
         configASSERT( pxTCB != NULL );
 
-        /* Save the hook function in the TCB.  A critical section is required as
+        /* Access the hook function in the TCB.  A critical section is required as
          * the value can be accessed from an interrupt. */
         taskENTER_CRITICAL();
         {
@@ -5065,11 +5065,11 @@ BaseType_t xTaskIncrementTick( void )
 
         traceENTER_xTaskGetApplicationTaskTagFromISR( xTask );
 
-        /* If xTask is NULL then set the calling task's hook. */
+        /* If xTask is NULL then get the calling task's hook. */
         pxTCB = prvGetTCBFromHandle( xTask );
         configASSERT( pxTCB != NULL );
 
-        /* Save the hook function in the TCB.  A critical section is required as
+        /* Access the hook function in the TCB.  A critical section is required as
          * the value can be accessed from an interrupt. */
         /* MISRA Ref 4.7.1 [Return value shall be checked] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/main/MISRA.md#dir-47 */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR corrects copy-paste comment errors in both `xTaskGetApplicationTaskTag()` and `xTaskGetApplicationTaskTagFromISR()` within the task management module (`tasks.c`).

The comments in these getter functions were accidentally copied from the setter counterpart (`vTaskSetApplicationTaskTag()`), leading to misleading terminology in a read-only context

In `tasks.c`:
- **For `xTaskGetApplicationTaskTag` & `xTaskGetApplicationTaskTagFromISR`**:
  - Updated `/* If xTask is NULL then set the calling task's hook. */` 
    → `/* If xTask is NULL then get the calling task's hook. */`
  - Updated `/* Save the hook function in the TCB. ... */` 
    → `/* Access the hook function in the TCB. ... */`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
