### PR TITLE
Add usage assertions when deleting a queue

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -2261,6 +2261,8 @@ void vQueueDelete( QueueHandle_t xQueue )
     traceENTER_vQueueDelete( xQueue );
 
     configASSERT( pxQueue );
+    configASSERT( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToSend ) ) );
+    configASSERT( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) );
     traceQUEUE_DELETE( pxQueue );
 
     #if ( configQUEUE_REGISTRY_SIZE > 0 )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Adds an assertion which helps to verify
a queue is not in use before deletion.

Test Steps
-----------
Verified with a simple C program which directly called the queue with the list not-empty.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
  - Not adding a UT for a simple assertion

Related Issue
-----------
Requested by user


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
