### PR TITLE
Fix unreachable trigger level validation for stream batching buffers

### DIFF
--- a/stream_buffer.c
+++ b/stream_buffer.c
@@ -371,7 +371,26 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
             configASSERT( xBufferSizeBytes > 0 );
         }
 
-        configASSERT( xTriggerLevelBytes <= xBufferSizeBytes );
+        /* A batching buffer only unblocks a reader when the number of bytes
+         * in the buffer becomes strictly greater than the trigger level (see
+         * prvBytesInBufferMeetTriggerLevel()), whereas a stream/message
+         * buffer unblocks a reader when the number of bytes is greater than
+         * or equal to the trigger level.  The maximum number of bytes any of
+         * these buffers can ever hold is one less than their length (a
+         * full/empty ring buffer ambiguity - see prvBytesInBuffer()), which
+         * is compensated for non-batching buffers so xBufferSizeBytes bytes
+         * can be used (see the xBufferSizeBytes++ below).  A batching
+         * buffer's trigger level must therefore be strictly less than
+         * xBufferSizeBytes, otherwise it could never be satisfied even when
+         * the buffer is completely full. */
+        if( ( ucFlags & sbFLAGS_IS_BATCHING_BUFFER ) != ( uint8_t ) 0 )
+        {
+            configASSERT( xTriggerLevelBytes < xBufferSizeBytes );
+        }
+        else
+        {
+            configASSERT( xTriggerLevelBytes <= xBufferSizeBytes );
+        }
 
         /* A trigger level of 0 would cause a waiting task to unblock even when
          * the buffer was empty. */
@@ -452,14 +471,6 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
 
         configASSERT( pucStreamBufferStorageArea );
         configASSERT( pxStaticStreamBuffer );
-        configASSERT( xTriggerLevelBytes <= xBufferSizeBytes );
-
-        /* A trigger level of 0 would cause a waiting task to unblock even when
-         * the buffer was empty. */
-        if( xTriggerLevelBytes == ( size_t ) 0 )
-        {
-            xTriggerLevelBytes = ( size_t ) 1;
-        }
 
         /* In case the stream buffer is going to be used as a message buffer
          * (that is, it will hold discrete messages with a little meta data that
@@ -482,6 +493,31 @@ static void prvInitialiseNewStreamBuffer( StreamBuffer_t * const pxStreamBuffer,
         {
             /* Statically allocated stream buffer. */
             ucFlags = sbFLAGS_IS_STATICALLY_ALLOCATED;
+        }
+
+        /* Unlike the dynamically allocated path, a statically allocated
+         * buffer's xLength is exactly xBufferSizeBytes (there is no "+1"
+         * compensation - see xStreamBufferGenericCreate()), so the maximum
+         * number of bytes it can ever hold is (xBufferSizeBytes - 1).  A
+         * batching buffer only unblocks a reader when the number of bytes in
+         * the buffer becomes strictly greater than the trigger level (see
+         * prvBytesInBufferMeetTriggerLevel()), so its trigger level must be
+         * strictly less than that maximum, otherwise it could never be
+         * satisfied even when the buffer is completely full. */
+        if( ( ucFlags & sbFLAGS_IS_BATCHING_BUFFER ) != ( uint8_t ) 0 )
+        {
+            configASSERT( xTriggerLevelBytes < ( xBufferSizeBytes - 1U ) );
+        }
+        else
+        {
+            configASSERT( xTriggerLevelBytes <= xBufferSizeBytes );
+        }
+
+        /* A trigger level of 0 would cause a waiting task to unblock even when
+         * the buffer was empty. */
+        if( xTriggerLevelBytes == ( size_t ) 0 )
+        {
+            xTriggerLevelBytes = ( size_t ) 1;
         }
 
         #if ( configASSERT_DEFINED == 1 )
@@ -743,8 +779,26 @@ BaseType_t xStreamBufferSetTriggerLevel( StreamBufferHandle_t xStreamBuffer,
     }
 
     /* The trigger level is the number of bytes that must be in the stream
-     * buffer before a task that is waiting for data is unblocked. */
-    if( xTriggerLevel < pxStreamBuffer->xLength )
+     * buffer before a task that is waiting for data is unblocked.  A batching
+     * buffer only unblocks a reader when the number of bytes in the buffer
+     * becomes strictly greater than the trigger level (see
+     * prvBytesInBufferMeetTriggerLevel()), so its trigger level must be kept
+     * strictly less than the maximum number of bytes the buffer can ever hold
+     * (xLength - 1), otherwise it could never be satisfied even when the
+     * buffer is completely full. */
+    if( ( pxStreamBuffer->ucFlags & sbFLAGS_IS_BATCHING_BUFFER ) != ( uint8_t ) 0 )
+    {
+        if( xTriggerLevel < ( pxStreamBuffer->xLength - 1U ) )
+        {
+            pxStreamBuffer->xTriggerLevelBytes = xTriggerLevel;
+            xReturn = pdPASS;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+    }
+    else if( xTriggerLevel < pxStreamBuffer->xLength )
     {
         pxStreamBuffer->xTriggerLevelBytes = xTriggerLevel;
         xReturn = pdPASS;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fixes #1450.

A stream **batching** buffer only unblocks a waiting reader when the number of bytes in the buffer becomes **strictly greater than** its trigger level (`prvBytesInBufferMeetTriggerLevel()`), unlike a plain stream/message buffer, which unblocks when the byte count is **greater than or equal to** the trigger level. The maximum number of bytes any stream buffer can ever hold is one less than its internal length (`xLength - 1`, a full/empty ring-buffer ambiguity).

None of the three places that validate a trigger level knew about this stricter batching-buffer requirement, so it was possible - using only documented, `configASSERT`-accepted arguments - to set a batching buffer's trigger level equal to its own maximum achievable occupancy. Once set, the wake predicate could never be satisfied, so a reader blocked in `xStreamBufferReceive()` would hang forever even after the buffer was completely filled:

* `xStreamBufferGenericCreate()` (dynamic allocation) - trigger level accepted up to `xBufferSizeBytes` for every buffer type, including batching buffers, where it needs to be strictly less.
* `xStreamBufferGenericCreateStatic()` (static allocation) - same check, and additionally a statically allocated buffer's usable capacity is `xBufferSizeBytes - 1` (it does not get the dynamic path's internal `xBufferSizeBytes++` compensation), so the existing bound was one too many even before considering batching buffers.
* `xStreamBufferSetTriggerLevel()` - accepted any value `< xLength`, again without a stricter bound for batching buffers.

This PR adds a batching-buffer-specific bound at all three sites: the trigger level must be strictly less than the buffer's maximum achievable occupancy, otherwise creation fails via `configASSERT` (or `xStreamBufferSetTriggerLevel()` returns `pdFALSE`). Plain stream and message buffers are unaffected - their existing bounds are untouched.

Test Steps
-----------
I compiled the real, unmodified `tasks.c` / `list.c` / `stream_buffer.c` / `heap_4.c` against the FreeRTOS POSIX/GCC simulator port (`portable/ThirdParty/GCC/Posix`) and ran real FreeRTOS tasks under a real preemptive scheduler (not a re-implementation of the logic in isolation), both **before** and **after** this patch, using a `configASSERT` that reports the file/line and exits instead of looping forever, so failures are directly observable:

**Before the fix** (6 scenarios, one buffer/reader/writer pair each, writer fills the buffer to its documented maximum capacity, reader waits up to 1.5 s):

| # | Buffer | trigger | Result |
|---|--------|---------|--------|
| 0 | dynamic batching, size=25 | 25 (== size) | **Reader hangs, 0/25 bytes after full 1500 ms timeout** |
| 1 | dynamic batching, size=25 | 24 (correct bound) | Reader wakes after 100 ms, 25/25 bytes |
| 2 | dynamic plain, size=25 | 25 | Reader wakes after 100 ms, 25/25 bytes (control - unaffected) |
| 3 | static batching, rawSize=25 | 24 (== max achievable for static) | **Reader hangs, 0/24 bytes after full 1500 ms timeout** |
| 4 | static batching, rawSize=25 | 23 (correct bound) | Reader wakes after 100 ms, 24/24 bytes |
| 5 | static plain, rawSize=25 | 25 | Reader eventually gets data only after the full 1500 ms timeout (separate, pre-existing plain-buffer quirk, intentionally left out of scope for this PR - see note in #1450) |

**After the fix**, same 6 scenarios:

| # | Result |
|---|--------|
| 0 | `configASSERT` fires at buffer-creation time (`stream_buffer.c:388`) - bad configuration now rejected instead of silently hanging |
| 1 | Unchanged: wakes after 100 ms, 25/25 bytes |
| 2 | Unchanged: wakes after 100 ms, 25/25 bytes |
| 3 | `configASSERT` fires at buffer-creation time (`stream_buffer.c:509`) - the "residual", one-byte-tighter static-allocation case is also now rejected |
| 4 | Unchanged: wakes after 100 ms, 24/24 bytes |
| 5 | Unchanged (out of scope, see above) |

I also compiled the patched `stream_buffer.c` standalone with `gcc -Wall -Wextra` (no new warnings) and ran it through the project's `uncrustify.cfg` (no formatting diff produced).

- [x] I have tested my changes. No regression in existing tests (verified manually against real FreeRTOS tasks/scheduler as described above; I do not have the CMock unit-test repository checked out locally to run the full existing suite, but the change is narrowly scoped to three validation sites and I've included explicit before/after regression checks for the untouched plain-buffer paths).
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1450

---

**Disclosure:** I used Claude (Anthropic) to help audit `stream_buffer.c`, build the POSIX-port reproduction/verification harness described above, and draft this PR. I reviewed the analysis, the reproduction results, and the code change myself before submitting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
