### PR TITLE
Fix POSIX thread marker failure handling

### DIFF
--- a/portable/ThirdParty/GCC/Posix/port.c
+++ b/portable/ThirdParty/GCC/Posix/port.c
@@ -112,6 +112,7 @@ static pthread_t hTimerTickThread;
 static bool xTimerTickThreadShouldRun;
 static uint64_t prvStartTimeNs;
 static pthread_key_t xThreadKey = 0;
+static int iThreadKeyCreateResult = 0;
 /*-----------------------------------------------------------*/
 
 static void prvSetupSignalsAndSchedulerPolicy( void );
@@ -129,6 +130,8 @@ static void prvInitThreadKey( void );
 static void prvMarkAsFreeRTOSThread( void );
 static BaseType_t prvIsFreeRTOSThread( void );
 static void prvDestroyThreadKey( void );
+static void prvFatalError( const char * pcCall,
+                           int iErrno ) __attribute__( ( __noreturn__ ) );
 /*-----------------------------------------------------------*/
 
 static void prvThreadKeyDestructor( void * pvData )
@@ -139,24 +142,49 @@ static void prvThreadKeyDestructor( void * pvData )
 
 static void prvInitThreadKey( void )
 {
-    pthread_key_create( &xThreadKey, prvThreadKeyDestructor );
-    /* Destroy xThreadKey when the process exits. */
-    atexit( prvDestroyThreadKey );
+    iThreadKeyCreateResult = pthread_key_create( &xThreadKey, prvThreadKeyDestructor );
+
+    if( iThreadKeyCreateResult == 0 )
+    {
+        /* Destroy xThreadKey when the process exits. */
+        atexit( prvDestroyThreadKey );
+    }
 }
 /*-----------------------------------------------------------*/
 
 static void prvMarkAsFreeRTOSThread( void )
 {
     uint8_t * pucThreadData = NULL;
+    int iRet;
 
-    ( void ) pthread_once( &hThreadKeyOnce, prvInitThreadKey );
+    iRet = pthread_once( &hThreadKeyOnce, prvInitThreadKey );
+
+    if( iRet != 0 )
+    {
+        prvFatalError( "pthread_once", iRet );
+    }
+
+    if( iThreadKeyCreateResult != 0 )
+    {
+        prvFatalError( "pthread_key_create", iThreadKeyCreateResult );
+    }
 
     pucThreadData = malloc( 1 );
-    configASSERT( pucThreadData != NULL );
+
+    if( pucThreadData == NULL )
+    {
+        prvFatalError( "malloc", ENOMEM );
+    }
 
     *pucThreadData = 1;
 
-    pthread_setspecific( xThreadKey, pucThreadData );
+    iRet = pthread_setspecific( xThreadKey, pucThreadData );
+
+    if( iRet != 0 )
+    {
+        free( pucThreadData );
+        prvFatalError( "pthread_setspecific", iRet );
+    }
 }
 /*-----------------------------------------------------------*/
 
@@ -164,8 +192,19 @@ static BaseType_t prvIsFreeRTOSThread( void )
 {
     uint8_t * pucThreadData = NULL;
     BaseType_t xRet = pdFALSE;
+    int iRet;
 
-    ( void ) pthread_once( &hThreadKeyOnce, prvInitThreadKey );
+    iRet = pthread_once( &hThreadKeyOnce, prvInitThreadKey );
+
+    if( iRet != 0 )
+    {
+        prvFatalError( "pthread_once", iRet );
+    }
+
+    if( iThreadKeyCreateResult != 0 )
+    {
+        prvFatalError( "pthread_key_create", iThreadKeyCreateResult );
+    }
 
     pucThreadData = ( uint8_t * ) pthread_getspecific( xThreadKey );
 
@@ -183,9 +222,6 @@ static void prvDestroyThreadKey( void )
     pthread_key_delete( xThreadKey );
 }
 /*-----------------------------------------------------------*/
-
-static void prvFatalError( const char * pcCall,
-                           int iErrno ) __attribute__( ( __noreturn__ ) );
 
 void prvFatalError( const char * pcCall,
                     int iErrno )


### PR DESCRIPTION
Description
-----------

Handle failures while creating and storing the POSIX port's per-thread marker.

The marker is required to distinguish FreeRTOS-owned pthreads. Continuing after
`pthread_key_create()` or `pthread_setspecific()` fails leaves that identity
invalid. The latter failure also leaks the allocated marker because no TLS
destructor will receive it.

This change:

- records and checks the result of the one-time TLS key initialization;
- treats `pthread_once()`, `pthread_key_create()`, and marker allocation failures
  as fatal instead of continuing with invalid state; and
- frees the marker before reporting a `pthread_setspecific()` failure.

Test Steps
-----------

1. Compiled the updated, unmodified `port.c` on Ubuntu 24.04 with GCC using
   `-std=gnu11 -Wall -Wextra -Werror -pthread` and the kernel, POSIX port, and
   template-configuration include paths.
2. Linked that same object into a host failure-injection harness using linker
   wrappers for the relevant POSIX and allocation calls.
3. Verified the normal path stores a marker byte with value `1`.
4. Injected failures for `pthread_once()`, `pthread_key_create()`, `malloc()`,
   and `pthread_setspecific()` and verified each reaches its matching fatal
   path. The `pthread_setspecific()` case additionally verifies that the exact
   allocated marker is freed before fatal handling.
5. Ran `git diff --check` successfully.

Checklist:
----------

- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Fixes #1447

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
