### PR TITLE
Add ownership check when giving a mutex

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -966,6 +966,20 @@ BaseType_t xQueueGenericSend( QueueHandle_t xQueue,
     }
     #endif
 
+    #if ( configUSE_MUTEXES == 1 )
+    {
+        /* If the queue is a mutex and is held, only the owner can give it. */
+        if( ( pxQueue->uxQueueType == queueQUEUE_IS_MUTEX ) &&
+            ( pxQueue->u.xSemaphore.xMutexHolder != NULL ) &&
+            ( pxQueue->u.xSemaphore.xMutexHolder != xTaskGetCurrentTaskHandle() ) )
+        {
+            traceRETURN_xQueueGenericSend( pdFAIL );
+
+            return pdFAIL;
+        }
+    }
+    #endif /* configUSE_MUTEXES */
+
     for( ; ; )
     {
         taskENTER_CRITICAL();


### PR DESCRIPTION

<!--- Title -->
Add ownership check when giving a mutex

Description
-----------
<!--- Describe your changes in detail. -->

In `xQueueGenericSend` (from `xSemaphoreGive`), when the queue's type is a mutex and that mutex is held, check its holder against the current task. Only allow the holding task to give the mutex.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Scenario:
Task A and Task B with equal priorities, preemption enabled.
1. Create a mutex.
2. Start the scheduler, switch to Task A.
3. Take the mutex (`xSemaphoreTake`) as Task A.
4. Preempt Task A, switch to Task B.
5. Give the mutex (`xSemaphoreGive`) as Task B.

Without this change: Task B's `xSemaphoreGive` succeeds, the mutex is marked available, no longer taken by Task A.
With this change: Task B's `xSeamphoreGive` fails, the mutex remains taken, and it is still taken by Task A.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
> Note: CMock tests will be added in a commit to FreeRTOS/FreeRTOS.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
