### PR TITLE
docs(tasks): fix typo in xTaskGenericNotifyWait comment (ucNotifyValue -> ucNotifyState)

### DIFF
--- a/tasks.c
+++ b/tasks.c
@@ -7930,7 +7930,7 @@ TickType_t uxTaskResetEventItemValue( void )
                 *pulNotificationValue = pxCurrentTCB->ulNotifiedValue[ uxIndexToWaitOn ];
             }
 
-            /* If ucNotifyValue is set then either the task never entered the
+            /* If ucNotifyState is set then either the task never entered the
              * blocked state (because a notification was already pending) or the
              * task unblocked because of a notification.  Otherwise the task
              * unblocked because of a timeout. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes a minor typographical error in a code comment inside `xTaskGenericNotifyWait()` within `tasks.c`.

- **Current comment:** `If ucNotifyValue is set then either the task never entered...`
- **Corrected comment:** `If ucNotifyState is set then either the task never entered...`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
