### PR TITLE
Fix comment and example typos in list.h, queue.h and task.h

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -219,7 +219,7 @@ typedef struct xLIST
  * Access macro to retrieve the value of the list item at the head of a given
  * list.
  *
- * \page listGET_LIST_ITEM_VALUE listGET_LIST_ITEM_VALUE
+ * \page listGET_ITEM_VALUE_OF_HEAD_ENTRY listGET_ITEM_VALUE_OF_HEAD_ENTRY
  * \ingroup LinkedList
  */
 #define listGET_ITEM_VALUE_OF_HEAD_ENTRY( pxList )        ( ( ( pxList )->xListEnd ).pxNext->xItemValue )

--- a/include/queue.h
+++ b/include/queue.h
@@ -604,7 +604,7 @@ typedef struct QueueDefinition   * QueueSetMemberHandle_t;
  * BaseType_t xQueueGenericSend(
  *                                  QueueHandle_t xQueue,
  *                                  const void * pvItemToQueue,
- *                                  TickType_t xTicksToWait
+ *                                  TickType_t xTicksToWait,
  *                                  BaseType_t xCopyPosition
  *                              );
  * @endcode
@@ -1189,7 +1189,7 @@ void vQueueDelete( QueueHandle_t xQueue ) PRIVILEGED_FUNCTION;
  *
  *  // ...
  *
- *  if( xHigherPrioritytaskWoken == pdTRUE )
+ *  if( xHigherPriorityTaskWoken == pdTRUE )
  *  {
  *      // Writing to the queue caused a task to unblock and the unblocked task
  *      // has a priority higher than or equal to the priority of the currently
@@ -1451,7 +1451,7 @@ BaseType_t xQueueGiveFromISR( QueueHandle_t xQueue,
  *      // task will be woken.
  *  }
  *
- *  if( xHigherPrioritytaskWoken == pdTRUE );
+ *  if( xHigherPriorityTaskWoken == pdTRUE )
  *  {
  *      // As xHigherPriorityTaskWoken is now set to pdTRUE then a context
  *      // switch should be requested. The macro used is port specific and

--- a/include/task.h
+++ b/include/task.h
@@ -3270,7 +3270,7 @@ uint32_t ulTaskGenericNotifyTake( UBaseType_t uxIndexToWaitOn,
 /**
  * task. h
  * @code{c}
- * BaseType_t xTaskNotifyStateClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToCLear );
+ * BaseType_t xTaskNotifyStateClearIndexed( TaskHandle_t xTask, UBaseType_t uxIndexToClear );
  *
  * BaseType_t xTaskNotifyStateClear( TaskHandle_t xTask );
  * @endcode


### PR DESCRIPTION
Fix several documentation and example-code issues in the kernel header comments:

 * queue.h: remove a stray semicolon after the 'if' and correct the xHigherPriorityTaskWoken variable casing in the xQueueReceiveFromISR() example; add the missing comma between parameters in the xQueueGenericSend() prototype example.
 * list.h: correct the doxygen \page tag for listGET_ITEM_VALUE_OF_HEAD_ENTRY.
 * task.h: fix the uxIndexToCLear typo (-> uxIndexToClear).

These are documentation/example only changes that do not affect the compiled library.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
