### PR TITLE
Add configASSERT to queue metadata accessor functions

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -2308,6 +2308,8 @@ void vQueueDelete( QueueHandle_t xQueue )
     {
         traceENTER_uxQueueGetQueueNumber( xQueue );
 
+        configASSERT( xQueue );
+
         traceRETURN_uxQueueGetQueueNumber( ( ( Queue_t * ) xQueue )->uxQueueNumber );
 
         return ( ( Queue_t * ) xQueue )->uxQueueNumber;
@@ -2323,6 +2325,8 @@ void vQueueDelete( QueueHandle_t xQueue )
     {
         traceENTER_vQueueSetQueueNumber( xQueue, uxQueueNumber );
 
+        configASSERT( xQueue );
+
         ( ( Queue_t * ) xQueue )->uxQueueNumber = uxQueueNumber;
 
         traceRETURN_vQueueSetQueueNumber();
@@ -2337,6 +2341,8 @@ void vQueueDelete( QueueHandle_t xQueue )
     {
         traceENTER_ucQueueGetQueueType( xQueue );
 
+        configASSERT( xQueue );
+
         traceRETURN_ucQueueGetQueueType( ( ( Queue_t * ) xQueue )->ucQueueType );
 
         return ( ( Queue_t * ) xQueue )->ucQueueType;
@@ -2349,6 +2355,8 @@ UBaseType_t uxQueueGetQueueItemSize( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTI
 {
     traceENTER_uxQueueGetQueueItemSize( xQueue );
 
+    configASSERT( xQueue );
+
     traceRETURN_uxQueueGetQueueItemSize( ( ( Queue_t * ) xQueue )->uxItemSize );
 
     return ( ( Queue_t * ) xQueue )->uxItemSize;
@@ -2358,6 +2366,8 @@ UBaseType_t uxQueueGetQueueItemSize( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTI
 UBaseType_t uxQueueGetQueueLength( QueueHandle_t xQueue ) /* PRIVILEGED_FUNCTION */
 {
     traceENTER_uxQueueGetQueueLength( xQueue );
+
+    configASSERT( xQueue );
 
     traceRETURN_uxQueueGetQueueLength( ( ( Queue_t * ) xQueue )->uxLength );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Several queue.c accessor functions dereference `xQueue` without first
validating it with `configASSERT`, unlike comparable functions in the
same file (e.g. `uxQueueMessagesWaiting()`, `uxQueueSpacesAvailable()`).

This PR adds `configASSERT( xQueue )` to:
- `uxQueueGetQueueNumber()`
- `vQueueSetQueueNumber()`
- `ucQueueGetQueueType()`
- `uxQueueGetQueueItemSize()`
- `uxQueueGetQueueLength()`

This is a pure consistency fix with no behavioral change when
`configASSERT` is disabled (the default), and only adds a debug-time
check when `configASSERT` is enabled.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
