### PR TITLE
Reduce SVCall priority on ARMv8-M

### DIFF
--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2286,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/ARMv8M/non_secure/port.c
+++ b/portable/ARMv8M/non_secure/port.c
@@ -2194,7 +2194,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2202,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2238,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23/non_secure/port.c
+++ b/portable/GCC/ARM_CM23/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM23_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33/non_secure/port.c
+++ b/portable/GCC/ARM_CM33/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM33_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM35P_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM52/non_secure/port.c
+++ b/portable/GCC/ARM_CM52/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM52/non_secure/port.c
+++ b/portable/GCC/ARM_CM52/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM52/non_secure/port.c
+++ b/portable/GCC/ARM_CM52/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM52_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55/non_secure/port.c
+++ b/portable/GCC/ARM_CM55/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM55_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85/non_secure/port.c
+++ b/portable/GCC/ARM_CM85/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_CM85_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/GCC/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23/non_secure/port.c
+++ b/portable/IAR/ARM_CM23/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM23_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33/non_secure/port.c
+++ b/portable/IAR/ARM_CM33/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM33_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM35P_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM52/non_secure/port.c
+++ b/portable/IAR/ARM_CM52/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM52/non_secure/port.c
+++ b/portable/IAR/ARM_CM52/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM52/non_secure/port.c
+++ b/portable/IAR/ARM_CM52/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM52_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55/non_secure/port.c
+++ b/portable/IAR/ARM_CM55/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM55_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85/non_secure/port.c
+++ b/portable/IAR/ARM_CM85/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_CM85_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_STAR_MC3/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;

--- a/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -103,6 +103,7 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -2194,7 +2195,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
 {
     #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) )
     {
-        volatile uint32_t ulImplementedPrioBits = 0;
+        volatile uint32_t ulNumPreemptPrioBits = 0;
         volatile uint8_t ucMaxPriorityValue;
 
         /* Determine the maximum priority from which ISR safe FreeRTOS API
@@ -2202,12 +2203,30 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * "FromISR". FreeRTOS maintains separate thread and ISR API functions to
         * ensure interrupt entry is as fast and simple as possible.
         *
-        * First, determine the number of priority bits available. Write to all
-        * possible bits in the priority setting for SVCall. */
-        portNVIC_SHPR2_REG = 0xFF000000;
+        * First, determine the number of preemption priority bits available.
+        * Write to all 7 possible bits in the priority setting for SVCall. If
+        * the hardware implements 8 bits, the least-significant bit is used for
+        * sub-priority, not preemption priority, so we don't need check that
+        * bit. */
+        portNVIC_SHPR2_REG = 0xFE000000;
 
         /* Read the value back to see how many bits stuck. */
-        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFF000000 ) >> 24 );
+        ucMaxPriorityValue = ( uint8_t ) ( ( portNVIC_SHPR2_REG & 0xFE000000 ) >> 24 );
+
+        #if ( configENABLE_TRUSTZONE == 1 )
+        {
+            /* In TrustZone applications, the maximum value must not use the
+            * least-significant bit of preemption priority. That bit must be
+            * zero because the hardware ignores it during de-prioritization of
+            * non-secure exceptions. */
+            ucMaxPriorityValue <<= ( uint8_t ) 0x01;
+
+            /* Initialize the counter of preemption-priority bits to 1 instead
+            * of 0. The work of counting the implemented preemption-priority
+            * bits continues further below. */
+            ulNumPreemptPrioBits = 1;
+        }
+        #endif /* #if ( configENABLE_TRUSTZONE == 1 ) */
 
         /* Use the same mask on the maximum system call priority. */
         ucMaxSysCallPriority = configMAX_SYSCALL_INTERRUPT_PRIORITY & ucMaxPriorityValue;
@@ -2220,44 +2239,42 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
         * See https://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html */
         configASSERT( ucMaxSysCallPriority );
 
-        /* Check that the bits not implemented in hardware are zero in
-        * configMAX_SYSCALL_INTERRUPT_PRIORITY. */
+        /* Check that the bits not implemented in hardware as preemption-
+        * priority bits are zero in configMAX_SYSCALL_INTERRUPT_PRIORITY.
+        *
+        * In TrustZone applications, this check also ensures that the least-
+        * significant preemption-priority bit is zero in
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY. The hardware ignores that bit
+        * when de-prioritizing non-secure exceptions, so it must be zero to
+        * ensure that the maximum system call priority is not higher than the
+        * application writer expects.
+        *
+        * This check also ensures that the sub-priority bit (if present) is
+        * zero in configMAX_SYSCALL_INTERRUPT_PRIORITY. When the hardware
+        * implements 8 priority bits, there is no way for the software to
+        * configure PRIGROUP to not have sub-priorities. As a result, the
+        * least significant bit is always used for sub-priority, and there are
+        * 128 preemption priorities and 2 sub-priorities.
+        *
+        * This may cause some confusion in some cases - for example, if
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
+        * priority interrupts will be masked in Critical Sections as those
+        * are at the same preemption priority. This may appear confusing as
+        * 4 is higher (numerically lower) priority than
+        * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
+        * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
+        * to 4, this confusion does not happen and the behaviour remains the same. */
         configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & ( uint8_t ) ( ~( uint32_t ) ucMaxPriorityValue ) ) == 0U );
 
         /* Calculate the maximum acceptable priority group value for the number
-        * of bits read back. */
+        * of preemption-priority bits implemented in the hardware. */
         while( ( ucMaxPriorityValue & portTOP_BIT_OF_BYTE ) == portTOP_BIT_OF_BYTE )
         {
-            ulImplementedPrioBits++;
+            ulNumPreemptPrioBits++;
             ucMaxPriorityValue <<= ( uint8_t ) 0x01;
         }
 
-        if( ulImplementedPrioBits == 8 )
-        {
-            /* When the hardware implements 8 priority bits, there is no way for
-            * the software to configure PRIGROUP to not have sub-priorities. As
-            * a result, the least significant bit is always used for sub-priority
-            * and there are 128 preemption priorities and 2 sub-priorities.
-            *
-            * This may cause some confusion in some cases - for example, if
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is set to 5, both 5 and 4
-            * priority interrupts will be masked in Critical Sections as those
-            * are at the same preemption priority. This may appear confusing as
-            * 4 is higher (numerically lower) priority than
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY and therefore, should not
-            * have been masked. Instead, if we set configMAX_SYSCALL_INTERRUPT_PRIORITY
-            * to 4, this confusion does not happen and the behaviour remains the same.
-            *
-            * The following assert ensures that the sub-priority bit in the
-            * configMAX_SYSCALL_INTERRUPT_PRIORITY is clear to avoid the above mentioned
-            * confusion. */
-            configASSERT( ( configMAX_SYSCALL_INTERRUPT_PRIORITY & 0x1U ) == 0U );
-            ulMaxPRIGROUPValue = 0;
-        }
-        else
-        {
-            ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulImplementedPrioBits;
-        }
+        ulMaxPRIGROUPValue = portMAX_PRIGROUP_BITS - ulNumPreemptPrioBits;
 
         /* Shift the priority group value back to its position within the AIRCR
         * register. */
@@ -2270,7 +2287,7 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     * the highest priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = 0;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -103,7 +103,8 @@ typedef void ( * portISR_t )( void );
 #define portMIN_INTERRUPT_PRIORITY            ( 255UL )
 #define portNVIC_PENDSV_PRI                   ( portMIN_INTERRUPT_PRIORITY << 16UL )
 #define portNVIC_SYSTICK_PRI                  ( portMIN_INTERRUPT_PRIORITY << 24UL )
-#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
+#define portNVIC_SVC_PRI                      ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY << 24UL ) )
+#define portNVIC_SVC_PRI_TO_START_FIRST_TASK  ( ( ( uint32_t ) configMAX_SYSCALL_INTERRUPT_PRIORITY - 1UL ) << 24UL )
 /*-----------------------------------------------------------*/
 
 /**
@@ -1225,6 +1226,12 @@ void vPortSVCHandler_C( uint32_t * pulCallerStackAddress ) /* PRIVILEGED_FUNCTIO
                 }
                 #endif /* configENABLE_FPU */
 
+                /* Reduce the priority of SVC to its permanent setting. The new
+                 * setting takes effect with the next invocation of SVC, not the
+                 * one currently underway. The temporary, high priority is used
+                 * only to start the first task. */
+                portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+
                 /* Setup the context of the first task so that the first task starts
                  * executing. */
                 vRestoreContextOfFirstTask();
@@ -2284,10 +2291,11 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
     /* Make PendSV and SysTick the lowest priority interrupts, and configure
-     * SVCall for sufficient preemption priority. */
+     * SVCall temporarily for sufficient priority to preempt the critical
+     * section from which we start the first task. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
-    portNVIC_SHPR2_REG = portNVIC_SVC_PRI;
+    portNVIC_SHPR2_REG = portNVIC_SVC_PRI_TO_START_FIRST_TASK;
 }
 /*-----------------------------------------------------------*/
 

--- a/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
+++ b/portable/IAR/ARM_STAR_MC3_NTZ/non_secure/port.c
@@ -2283,8 +2283,8 @@ void vPortConfigureInterruptPriorities( void ) /* PRIVILEGED_FUNCTION */
     }
     #endif /* #if ( ( configASSERT_DEFINED == 1 ) && ( portHAS_ARMV8M_MAIN_EXTENSION == 1 ) ) */
 
-    /* Make PendSV and SysTick the lowest priority interrupts, and make SVCall
-    * the highest priority. */
+    /* Make PendSV and SysTick the lowest priority interrupts, and configure
+     * SVCall for sufficient preemption priority. */
     portNVIC_SHPR3_REG |= portNVIC_PENDSV_PRI;
     portNVIC_SHPR3_REG |= portNVIC_SYSTICK_PRI;
     portNVIC_SHPR2_REG = portNVIC_SVC_PRI;


### PR DESCRIPTION
Description
-----------
Instead of using the maximum priority for SVCall, use a priority just sufficient for:

1. Preemption wherever SVCall may be used
2. Automatic critical section for SVC execution

This PR sets the SVCall priority slightly above configMAX_SYSCALL_INTERRUPT_PRIORITY when starting the scheduler, then reduces the priority to be equal to configMAX_SYSCALL_INTERRUPT_PRIORITY afterward.

After this change, the developer can now assign some interrupts to higher priorities than SVC.  This change aligns the ARMv8-M port more closely with FreeRTOS documentation about Cortex M ports.  Specifically, the documentation indicates that these ports do not mask interrupts at priorities above configMAX_SYSCALL_INTERRUPT_PRIORITY.

Additional Change
-------------
Also require configMAX_SYSCALL_INTERRUPT_PRIORITY to have a zero in the least-significant implemented preemption-priority bit in TrustZone applications.  This change prevents confusion caused by the hardware de-prioritizing non-secure interrupts, which coalesces neighboring preemption priority groups.  This additional change also simplifies the determination of the optimal priority setting for SVCall during OS startup.  Even with de-prioritizing, the optimal priority setting still preempts the critical section from which FreeRTOS starts.

How SVCall is Used in the ARMv8-M Port
-----------------
The ARMv8-M port uses SVCall to:
- Start the scheduler
- Allocate/Free Secure Contexts in TZ applications
- Raise MPU privilege for system calls in MPU applications (only in unprivileged tasks)
- Task Yield (but not from an ISR) in MPU applications

Sufficient SVCall Priority
----------
The only time SVCall needs a priority above configMAX_SYSCALL_INTERRUPT_PRIORITY is when starting the scheduler.  By design, the scheduler starts from within a critical section.  The SVC instruction must preempt execution immediately, so its priority must be higher than the level masked for FreeRTOS critical sections in order to start the scheduler.  

The other uses of SVCall occur only in task code, not from ISRs, and not from critical sections either.  So there is no further need for SVCall to have a priority above configMAX_SYSCALL_INTERRUPT_PRIORITY after FreeRTOS starts.  ISRs don't allocate/free secure contexts, and ISRs already have MPU privilege, and ISRs don't use the yield call intended for task code.  Further, users don't allocate/free secure contexts from critical sections, and they don't try to raise MPU privilege from critical sections either.  That's because unprivileged tasks can't create a critical section.  Finally, any attempt to yield from a critical section doesn't really make sense, MPU enabled or not.  If a privileged task in an MPU application attempts to yield from within a critical section, they will rightly encounter the Hard Fault that comes when SVC cannot preempt execution.  And if that user actually intended the yield to be delayed until after the critical section, that user has plenty of trivial workarounds.

Automatic Critical Section for SVCall execution
--------------
Setting the SVCall priority at configMAX_SYSCALL_INTERRUPT_PRIORITY allows the SVCall handler(s) to forgo creating a critical section manually.  This slightly reduces execution time for any SVCall execution that actually needs a critical section.  And by nature, SVCall executions are very fast, so any SVCall executions that *don't* need a critical section won't impact the system very much by effectively executing within one.  And finally, future authors of SVCall services may unknowingly assume their code is already running with interrupts masked.  With all of these considerations, we don't feel motivated to reduce the SVCall priority even further, for example to the minimum interrupt priority like PendSV uses.

Test Steps
-----------
Tested two existing applications - one TZ and one non-TZ.  (Neither uses the MPU though.)

Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.
- (N/A) I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1470

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
